### PR TITLE
Exposing high level callbacks

### DIFF
--- a/src/windows-emulator-test/emulation_test_utils.hpp
+++ b/src/windows-emulator-test/emulation_test_utils.hpp
@@ -20,10 +20,10 @@
 
 namespace test
 {
-    inline windows_emulator create_sample_emulator(emulator_settings settings)
+    inline windows_emulator create_sample_emulator(emulator_settings settings, emulator_callbacks callbacks = {})
     {
         settings.application = "./test-sample.exe";
-        return windows_emulator{std::move(settings)};
+        return windows_emulator{std::move(settings), std::move(callbacks)};
     }
 
     inline windows_emulator create_sample_emulator()

--- a/src/windows-emulator-test/time_test.cpp
+++ b/src/windows-emulator-test/time_test.cpp
@@ -6,14 +6,17 @@ namespace test
     {
         std::string output_buffer{};
 
+        emulator_callbacks callbacks{
+            .stdout_callback = [&output_buffer](const std::string_view data) { output_buffer.append(data); },
+        };
+
         const emulator_settings settings{
             .arguments = {u"-time"},
-            .stdout_callback = [&output_buffer](const std::string_view data) { output_buffer.append(data); },
             .disable_logging = true,
             .use_relative_time = false,
         };
 
-        auto emu = create_sample_emulator(settings);
+        auto emu = create_sample_emulator(settings, callbacks);
         emu.start();
 
         constexpr auto prefix = "Time: "sv;

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -91,6 +91,8 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
         const auto* mod = context.mod_manager.find_by_address(address);
         if (mod != context.ntdll && mod != context.win32u)
         {
+            win_emu.on_inline_syscall(syscall_id, address, mod ? mod->name.c_str() : "<N/A>",
+                                      entry->second.name.c_str());
             win_emu.log.print(color::blue, "Executing inline syscall: %s (0x%X) at 0x%" PRIx64 " (%s)\n",
                               entry->second.name.c_str(), syscall_id, address, mod ? mod->name.c_str() : "<N/A>");
         }
@@ -109,6 +111,9 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
             else
             {
                 const auto* previous_mod = context.mod_manager.find_by_address(context.previous_ip);
+                win_emu.on_outofline_syscall(syscall_id, address, mod ? mod->name.c_str() : "<N/A>",
+                                             entry->second.name.c_str(), context.previous_ip,
+                                             previous_mod ? previous_mod->name.c_str() : "<N/A>");
                 win_emu.log.print(color::blue,
                                   "Crafted out-of-line syscall: %s (0x%X) at 0x%" PRIx64 " (%s) via 0x%" PRIx64
                                   " (%s)\n",

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -16,7 +16,8 @@ struct emulator_callbacks
                        std::string_view syscall_name)>
         inline_syscall{};
     std::function<void(uint32_t syscall_id, x64_emulator::pointer_type address, std::string_view mod_name,
-                       std::string_view syscall_name, x64_emulator::pointer_type prev_address, std::string_view prev_mod_name)>
+                       std::string_view syscall_name, x64_emulator::pointer_type prev_address,
+                       std::string_view prev_mod_name)>
         outofline_syscall{};
 };
 
@@ -127,7 +128,6 @@ class windows_emulator
     bool silent_until_main_{false};
     std::unique_ptr<x64_emulator> emu_{};
     std::vector<instruction_hook_callback> syscall_hooks_{};
-    std::function<void(std::string_view)> stdout_callback_{};
 
     process_context process_;
     syscall_dispatcher dispatcher_;

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -9,6 +9,17 @@
 
 std::unique_ptr<x64_emulator> create_default_x64_emulator();
 
+struct emulator_callbacks
+{
+    std::function<void(std::string_view)> stdout_callback{};
+    std::function<void(uint32_t syscall_id, x64_emulator::pointer_type address, std::string_view mod_name,
+                       std::string_view syscall_name)>
+        inline_syscall{};
+    std::function<void(uint32_t syscall_id, x64_emulator::pointer_type address, std::string_view mod_name,
+                       std::string_view syscall_name, x64_emulator::pointer_type prev_address, std::string_view prev_mod_name)>
+        outofline_syscall{};
+};
+
 // TODO: Split up into application and emulator settings
 struct emulator_settings
 {
@@ -16,7 +27,6 @@ struct emulator_settings
     std::filesystem::path working_directory{};
     std::filesystem::path registry_directory{"./registry"};
     std::vector<std::u16string> arguments{};
-    std::function<void(std::string_view)> stdout_callback{};
     bool disable_logging{false};
     bool silent_until_main{false};
     bool use_relative_time{false};
@@ -26,7 +36,8 @@ class windows_emulator
 {
   public:
     windows_emulator(std::unique_ptr<x64_emulator> emu = create_default_x64_emulator());
-    windows_emulator(emulator_settings settings, std::unique_ptr<x64_emulator> emu = create_default_x64_emulator());
+    windows_emulator(emulator_settings settings, emulator_callbacks callbacks = {},
+                     std::unique_ptr<x64_emulator> emu = create_default_x64_emulator());
 
     windows_emulator(windows_emulator&&) = delete;
     windows_emulator(const windows_emulator&) = delete;
@@ -88,13 +99,12 @@ class windows_emulator
         this->syscall_hooks_.push_back(std::move(callback));
     }
 
-    void on_stdout(const std::string_view data) const
-    {
-        if (this->stdout_callback_)
-        {
-            this->stdout_callback_(data);
-        }
-    }
+    void on_stdout(const std::string_view data) const;
+    void on_inline_syscall(uint32_t syscall_id, const x64_emulator::pointer_type address,
+                           const std::string_view mod_name, const std::string_view name);
+    void on_outofline_syscall(uint32_t syscall_id, x64_emulator::pointer_type address, std::string_view mod_name,
+                              std::string_view syscall_name, x64_emulator::pointer_type prev_address,
+                              std::string_view prev_mod_name);
 
     logger log{};
     bool verbose{false};
@@ -112,6 +122,7 @@ class windows_emulator
     }
 
   private:
+    emulator_callbacks callbacks_{};
     bool use_relative_time_{false};
     bool silent_until_main_{false};
     std::unique_ptr<x64_emulator> emu_{};


### PR DESCRIPTION
The idea here is to start exposing various high level callbacks from various sub components (syscalls, device io, etc.).

Consumer of `windows_emulator` can then hook into any callback.


Please give your feedback on this initial commit.