### PR TITLE
Introducing reflection levels concept into core components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required(VERSION 3.26.4)
 option(MOMO_ENABLE_SANITIZER "Enable sanitizer" OFF)
 option(MOMO_BUILD_AS_LIBRARY "Configure and Build the emulator as a shared library (without the samples and tests)" OFF)
 
+set(MOMO_REFLECTION_LEVEL "0" CACHE STRING "Reflection level for the build")
+message(STATUS "Reflection level is set to: ${MOMO_REFLECTION_LEVEL}")
+add_compile_definitions(MOMO_REFLECTION_LEVEL=${MOMO_REFLECTION_LEVEL})
+
 if(MOMO_BUILD_AS_LIBRARY)
     add_compile_definitions(MOMO_BUILD_AS_LIBRARY=1)
 else()

--- a/src/emulator/memory_manager.cpp
+++ b/src/emulator/memory_manager.cpp
@@ -214,6 +214,11 @@ bool memory_manager::protect_memory(const uint64_t address, const size_t size, c
     }
 
     merge_regions(committed_regions);
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
+
     return true;
 }
 
@@ -236,6 +241,10 @@ bool memory_manager::allocate_mmio(const uint64_t address, const size_t size, mm
                            .first;
 
     entry->second.committed_regions[address] = committed_region{size, memory_permission::read_write};
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
 
     return true;
 }
@@ -260,6 +269,10 @@ bool memory_manager::allocate_memory(const uint64_t address, const size_t size, 
         this->map_memory(address, size, permissions);
         entry->second.committed_regions[address] = committed_region{size, memory_permission::read_write};
     }
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
 
     return true;
 }
@@ -320,6 +333,11 @@ bool memory_manager::commit_memory(const uint64_t address, const size_t size, co
     }
 
     merge_regions(committed_regions);
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
+
     return true;
 }
 
@@ -365,6 +383,10 @@ bool memory_manager::decommit_memory(const uint64_t address, const size_t size)
 
         ++i;
     }
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
 
     return true;
 }
@@ -418,6 +440,10 @@ bool memory_manager::release_memory(const uint64_t address, size_t size)
     }
 
     this->reserved_regions_.erase(entry);
+
+#if MOMO_REFLECTION_LEVEL > 0
+    inc_memory_layout_state_ver();
+#endif
     return true;
 }
 

--- a/src/emulator/memory_manager.cpp
+++ b/src/emulator/memory_manager.cpp
@@ -215,9 +215,7 @@ bool memory_manager::protect_memory(const uint64_t address, const size_t size, c
 
     merge_regions(committed_regions);
 
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
 
     return true;
 }
@@ -242,9 +240,7 @@ bool memory_manager::allocate_mmio(const uint64_t address, const size_t size, mm
 
     entry->second.committed_regions[address] = committed_region{size, memory_permission::read_write};
 
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
 
     return true;
 }
@@ -270,9 +266,7 @@ bool memory_manager::allocate_memory(const uint64_t address, const size_t size, 
         entry->second.committed_regions[address] = committed_region{size, memory_permission::read_write};
     }
 
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
 
     return true;
 }
@@ -334,9 +328,7 @@ bool memory_manager::commit_memory(const uint64_t address, const size_t size, co
 
     merge_regions(committed_regions);
 
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
 
     return true;
 }
@@ -384,9 +376,7 @@ bool memory_manager::decommit_memory(const uint64_t address, const size_t size)
         ++i;
     }
 
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
 
     return true;
 }
@@ -440,10 +430,7 @@ bool memory_manager::release_memory(const uint64_t address, size_t size)
     }
 
     this->reserved_regions_.erase(entry);
-
-#if MOMO_REFLECTION_LEVEL > 0
-    inc_memory_layout_state_ver();
-#endif
+    invalidate_memory_layout_state_version();
     return true;
 }
 

--- a/src/emulator/memory_manager.hpp
+++ b/src/emulator/memory_manager.hpp
@@ -1,9 +1,7 @@
 #pragma once
 #include <map>
-#if MOMO_REFLECTION_LEVEL > 0
 #include <atomic>
 #include <cstdint>
-#endif
 
 #include "memory_region.hpp"
 #include "address_utils.hpp"
@@ -127,12 +125,10 @@ class memory_manager
         return reserved_regions_;
     }
 
-#if MOMO_REFLECTION_LEVEL > 0
     std::uint64_t get_memory_layout_state_ver() const
     {
-        return memory_layout_state_ver_.load(std::memory_order_relaxed);
+        return memory_layout_state_version_.load(std::memory_order_relaxed);
     }
-#endif
 
   private:
     reserved_region_map reserved_regions_{};
@@ -144,14 +140,14 @@ class memory_manager
     virtual void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) = 0;
 
   protected:
-#if MOMO_REFLECTION_LEVEL > 0
-    std::atomic<std::uint64_t> memory_layout_state_ver_{0};
+    std::atomic<std::uint64_t> memory_layout_state_version_{0};
 
-    void inc_memory_layout_state_ver()
+    void invalidate_memory_layout_state_version()
     {
-        memory_layout_state_ver_.fetch_add(1, std::memory_order_relaxed);
-    }
+#if MOMO_REFLECTION_LEVEL > 0
+        memory_layout_state_version_.fetch_add(1, std::memory_order_relaxed);
 #endif
+    }
 
     void serialize_memory_state(utils::buffer_serializer& buffer, bool is_snapshot) const;
     void deserialize_memory_state(utils::buffer_deserializer& buffer, bool is_snapshot);

--- a/src/emulator/memory_manager.hpp
+++ b/src/emulator/memory_manager.hpp
@@ -1,5 +1,9 @@
 #pragma once
 #include <map>
+#if MOMO_REFLECTION_LEVEL > 0
+#include <atomic>
+#include <cstdint>
+#endif
 
 #include "memory_region.hpp"
 #include "address_utils.hpp"
@@ -123,6 +127,13 @@ class memory_manager
         return reserved_regions_;
     }
 
+#if MOMO_REFLECTION_LEVEL > 0
+    std::uint64_t get_memory_layout_state_ver() const
+    {
+        return memory_layout_state_ver_.load(std::memory_order_relaxed);
+    }
+#endif
+
   private:
     reserved_region_map reserved_regions_{};
 
@@ -133,6 +144,15 @@ class memory_manager
     virtual void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) = 0;
 
   protected:
+#if MOMO_REFLECTION_LEVEL > 0
+    std::atomic<std::uint64_t> memory_layout_state_ver_{0};
+
+    void inc_memory_layout_state_ver()
+    {
+        memory_layout_state_ver_.fetch_add(1, std::memory_order_relaxed);
+    }
+#endif
+
     void serialize_memory_state(utils::buffer_serializer& buffer, bool is_snapshot) const;
     void deserialize_memory_state(utils::buffer_deserializer& buffer, bool is_snapshot);
 };


### PR DESCRIPTION
The idea is to allow as much internal information into inner components. to not burden all builds, the reflection level can be controlled via the MOMO_REFLECTION_LEVEL (where 0 means no reflection code is included).

more reflection variables will be introduced as needed.

For now, the memory manager's layout state version is used to track whether the memory layout is changed or not (at the lowest level). the win_emu API consumer can use this reflection to decide to whether to refresh or not expensive computations