### PR TITLE
feat: spoof rdtsc timings

### DIFF
--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -40,16 +40,13 @@ namespace utils
         /// TODO: find better solution for ARM and Figure out better CPU base frequency heuristics
         virtual uint64_t timestamp_counter()
         {
-#if defined(_MSC_VER)
-#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)
-            return __rdtsc(); // 64-bit with MSVC intrinsic
-#endif
-
-#elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__) // If we are using clang or gcc
-            return __rdtsc(); // 64-bit with clang/gcc intrinsic
-#endif
-            int64_t count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__) || \
+    defined(__amd64__)
+            return __rdtsc(); // any x86 system will have this instrinsic
+#else
+            const auto count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
             return static_cast<uint64_t>((count * 38LL) / 10LL);
+#endif
         }
     };
 

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -6,6 +6,8 @@
 #if defined(_MSC_VER)
 #include <intrin.h>
 #pragma intrinsic(__rdtsc)
+#elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__)
+#include <x86intrin.h>
 #endif
 
 constexpr auto HUNDRED_NANOSECONDS_IN_ONE_SECOND = 10000000LL;
@@ -44,12 +46,10 @@ namespace utils
 #endif
 
 #elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__) // If we are using clang or gcc
-            unsigned int lo, hi;
-            __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-            return ((uint64_t)hi << 32) | lo;
+            return __rdtsc(); // 64-bit with clang/gcc intrinsic
 #endif
-            return static_cast<uint64_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()) *
-                   3.8; // should be base cpu frequency here;
+            int64_t count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+            return static_cast<uint64_t>((count * 38LL) / 10LL);
         }
     };
 

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -36,7 +36,7 @@ namespace utils
             return std::chrono::steady_clock::now();
         }
 
-        // Returnds the current timestamp counter value. RDTSC on x86/x64, or just time since epoch for ARM
+        // Returns the current timestamp counter value. RDTSC on x86/x64, or just time since epoch for ARM
         /// TODO: find better solution for ARM and Figure out better CPU base frequency heuristics
         virtual uint64_t timestamp_counter()
         {

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -4,11 +4,9 @@
 
 #include "../platform/platform.hpp"
 #if defined(_MSC_VER)
-#define ARCH_x86
 #include <intrin.h>
 #pragma intrinsic(__rdtsc)
 #elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__)
-#define ARCH_x86
 #include <x86intrin.h>
 #endif
 
@@ -42,10 +40,14 @@ namespace utils
         /// TODO: find better solution for ARM and Figure out better CPU base frequency heuristics
         virtual uint64_t timestamp_counter()
         {
-#if defined(ARCH_x86)
-            return __rdtsc(); 
-#endif // We are using x86, regardless of compiler the instrinsic is the same
+#if defined(_MSC_VER)
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)
+            return __rdtsc(); // 64-bit with MSVC intrinsic
+#endif
 
+#elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__) // If we are using clang or gcc
+            return __rdtsc(); // 64-bit with clang/gcc intrinsic
+#endif
             int64_t count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
             return static_cast<uint64_t>((count * 38LL) / 10LL);
         }

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -3,6 +3,10 @@
 #include <chrono>
 
 #include "../platform/platform.hpp"
+#if defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(__rdtsc)
+#endif
 
 constexpr auto HUNDRED_NANOSECONDS_IN_ONE_SECOND = 10000000LL;
 constexpr auto EPOCH_DIFFERENCE_1601_TO_1970_SECONDS = 11644473600LL;
@@ -28,6 +32,24 @@ namespace utils
         virtual steady_time_point steady_now()
         {
             return std::chrono::steady_clock::now();
+        }
+
+        // Returnds the current timestamp counter value. RDTSC on x86/x64, or just time since epoch for ARM
+        /// TODO: find better solution for ARM and Figure out better CPU base frequency heuristics
+        virtual uint64_t timestamp_counter()
+        {
+#if defined(_MSC_VER)
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)
+            return __rdtsc(); // 64-bit with MSVC intrinsic
+#endif
+
+#elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__) // If we are using clang or gcc
+            unsigned int lo, hi;
+            __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+            return ((uint64_t)hi << 32) | lo;
+#endif
+            return static_cast<uint64_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()) *
+                   3.8; // should be base cpu frequency here;
         }
     };
 

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -4,9 +4,11 @@
 
 #include "../platform/platform.hpp"
 #if defined(_MSC_VER)
+#define ARCH_x86
 #include <intrin.h>
 #pragma intrinsic(__rdtsc)
 #elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__)
+#define ARCH_x86
 #include <x86intrin.h>
 #endif
 
@@ -40,14 +42,10 @@ namespace utils
         /// TODO: find better solution for ARM and Figure out better CPU base frequency heuristics
         virtual uint64_t timestamp_counter()
         {
-#if defined(_MSC_VER)
-#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)
-            return __rdtsc(); // 64-bit with MSVC intrinsic
-#endif
+#if defined(ARCH_x86)
+            return __rdtsc(); 
+#endif // We are using x86, regardless of compiler the instrinsic is the same
 
-#elif defined(__x86_64__) || defined(__i386__) || defined(__amd64__) // If we are using clang or gcc
-            return __rdtsc(); // 64-bit with clang/gcc intrinsic
-#endif
             int64_t count = std::chrono::high_resolution_clock::now().time_since_epoch().count();
             return static_cast<uint64_t>((count * 38LL) / 10LL);
         }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -449,18 +449,8 @@ void windows_emulator::setup_hooks()
 
     this->emu().hook_instruction(x64_hookable_instructions::rdtsc, [&] {
         uint64_t ticks = this->clock_->timestamp_counter();
-        static uint64_t fake_ticks = ticks;
-        static uint64_t prev_ticks = 0;
-
-        if (ticks > prev_ticks)
-        {
-            fake_ticks += (ticks - prev_ticks);
-        }
-        fake_ticks = std::min(fake_ticks, ticks);
-        prev_ticks = ticks;
-
-        this->emu().reg(x64_register::rax, fake_ticks & 0xFFFFFFFF);
-        this->emu().reg(x64_register::rdx, (fake_ticks >> 32) & 0xFFFFFFFF);
+        this->emu().reg(x64_register::rax, ticks & 0xFFFFFFFF);
+        this->emu().reg(x64_register::rdx, (ticks >> 32) & 0xFFFFFFFF);
         return instruction_hook_continuation::skip_instruction;
     });
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -448,7 +448,7 @@ void windows_emulator::setup_hooks()
     });
 
     this->emu().hook_instruction(x64_hookable_instructions::rdtsc, [&] {
-        uint64_t ticks = this->clock_->timestamp_counter();
+        const auto ticks = this->clock_->timestamp_counter();
         this->emu().reg(x64_register::rax, ticks & 0xFFFFFFFF);
         this->emu().reg(x64_register::rdx, (ticks >> 32) & 0xFFFFFFFF);
         return instruction_hook_continuation::skip_instruction;

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -448,21 +448,15 @@ void windows_emulator::setup_hooks()
     });
 
     this->emu().hook_instruction(x64_hookable_instructions::rdtsc, [&] {
-        uint64_t ticks = this->clock_.get()->timestamp_counter();
+        uint64_t ticks = this->clock_->timestamp_counter();
         static uint64_t fake_ticks = ticks;
         static uint64_t prev_ticks = 0;
 
-        if (prev_ticks != 0)
+        if (ticks > prev_ticks)
         {
-            if (ticks > prev_ticks)
-            {
-                fake_ticks += (ticks - prev_ticks); 
-            }
+            fake_ticks += (ticks - prev_ticks);
         }
-        if (fake_ticks > ticks)
-        { 
-            fake_ticks = ticks;
-        }
+        fake_ticks = std::min(fake_ticks, ticks);
         prev_ticks = ticks;
 
         this->emu().reg(x64_register::rax, fake_ticks & 0xFFFFFFFF);


### PR DESCRIPTION
Previously, RDTSC in the VM always returned a constant value of 4, which broke any timing-based operations, or caused detections in heuristics of malware and ANTI-VM tools.

This patch introduces a spoofed rdtsc_fake counter that tracks and adjusts timing deltas to simulate realistic TSC increments. Can be extended to simulate rdtsc timings based on CPU clock speed.