### PR TITLE
Always use release windows artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,7 +323,7 @@ jobs:
         uses: pyTooling/download-artifact@v4
         if: "${{ matrix.platform != 'Windows x86_64' }}"
         with:
-          name: Windows x86_64 ${{matrix.configuration}} Artifacts
+          name: Windows x86_64 Release Artifacts
           path: build/${{matrix.preset}}/artifacts
   
       - name: Download Emulation Root
@@ -388,7 +388,7 @@ jobs:
       - name: Download Windows Artifacts
         uses: pyTooling/download-artifact@v4
         with:
-          name: Windows x86_64 ${{matrix.configuration}} Artifacts
+          name: Windows x86_64 Release Artifacts
           path: build/${{matrix.preset}}/artifacts
   
       - name: Download Emulation Root


### PR DESCRIPTION
This will always use the windows release test sample artifacts. It doesn't really make sense to test the debug artifacts. They're just slower and do the same.

This will still run debug artifacts on windows.
The change only applies to non-windows platforms