### PR TITLE
Fix NtOpenSection and add 3 new syscall handlers

### DIFF
--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -651,7 +651,7 @@ namespace syscalls
 
     NTSTATUS handle_NtUserGetProcessWindowStation()
     {
-        return NULL;
+        return 0;
     }
 }
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -109,6 +109,8 @@ namespace syscalls
                                     emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
                                     ULONG fs_control_code, uint64_t input_buffer, ULONG input_buffer_length,
                                     uint64_t output_buffer, ULONG output_buffer_length);
+    NTSTATUS handle_NtFlushBuffersFile(const syscall_context& c, handle file_handle,
+                                       emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> /*io_status_block*/);
 
     // syscalls/locale.cpp:
     NTSTATUS handle_NtInitializeNlsFiles(const syscall_context& c, emulator_object<uint64_t> base_address,
@@ -269,6 +271,9 @@ namespace syscalls
     NTSTATUS handle_NtQueryInformationThread(const syscall_context& c, handle thread_handle, uint32_t info_class,
                                              uint64_t thread_information, uint32_t thread_information_length,
                                              emulator_object<uint32_t> return_length);
+    NTSTATUS handle_NtOpenThread(const syscall_context&, handle thread_handle, ACCESS_MASK /*desired_access*/,
+                                 emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,
+                                 emulator_pointer /*client_id*/);
     NTSTATUS handle_NtOpenThreadToken(const syscall_context&, handle thread_handle, ACCESS_MASK /*desired_access*/,
                                       BOOLEAN /*open_as_self*/, emulator_object<handle> token_handle);
     NTSTATUS handle_NtOpenThreadTokenEx(const syscall_context& c, handle thread_handle, ACCESS_MASK desired_access,
@@ -643,6 +648,11 @@ namespace syscalls
     {
         return 0;
     }
+
+    NTSTATUS handle_NtUserGetProcessWindowStation()
+    {
+        return NULL;
+    }
 }
 
 void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& handler_mapping)
@@ -663,6 +673,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtSetInformationVirtualMemory);
     add_handler(NtFreeVirtualMemory);
     add_handler(NtQueryVirtualMemory);
+    add_handler(NtOpenThread);
     add_handler(NtOpenThreadToken);
     add_handler(NtOpenThreadTokenEx);
     add_handler(NtQueryPerformanceCounter);
@@ -788,6 +799,8 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtCreateNamedPipeFile);
     add_handler(NtFsControlFile);
     add_handler(NtQueryFullAttributesFile);
+    add_handler(NtFlushBuffersFile);
+    add_handler(NtUserGetProcessWindowStation);
 
 #undef add_handler
 }

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -847,8 +847,9 @@ namespace syscalls
         return STATUS_NOT_SUPPORTED;
     }
 
-    NTSTATUS handle_NtFlushBuffersFile(const syscall_context& c, const handle file_handle,
-                                       const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> /*io_status_block*/)
+    NTSTATUS handle_NtFlushBuffersFile(
+        const syscall_context& c, const handle file_handle,
+        const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> /*io_status_block*/)
     {
         if (file_handle == STDOUT_HANDLE)
         {

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -846,4 +846,22 @@ namespace syscalls
 
         return STATUS_NOT_SUPPORTED;
     }
+
+    NTSTATUS handle_NtFlushBuffersFile(const syscall_context& c, const handle file_handle,
+                                       const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> /*io_status_block*/)
+    {
+        if (file_handle == STDOUT_HANDLE)
+        {
+            return STATUS_SUCCESS;
+        }
+
+        const auto* f = c.proc.files.get(file_handle);
+        if (!f)
+        {
+            return STATUS_INVALID_HANDLE;
+        }
+
+        (void)fflush(f->handle);
+        return STATUS_SUCCESS;
+    }
 }

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -82,7 +82,8 @@ namespace syscalls
             return STATUS_NOT_SUPPORTED;
         }
 
-        if (attributes.RootDirectory != KNOWN_DLLS_DIRECTORY)
+        if (attributes.RootDirectory != KNOWN_DLLS_DIRECTORY &&
+            attributes.RootDirectory != BASE_NAMED_OBJECTS_DIRECTORY)
         {
             c.win_emu.log.error("Unsupported section\n");
             c.emu.stop();

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -239,6 +239,13 @@ namespace syscalls
         return STATUS_NOT_SUPPORTED;
     }
 
+    NTSTATUS handle_NtOpenThread(const syscall_context&, handle /*thread_handle*/, ACCESS_MASK /*desired_access*/,
+                                 emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,
+                                 emulator_pointer /*client_id*/)
+    {
+        return STATUS_NOT_SUPPORTED;
+    }
+
     NTSTATUS handle_NtOpenThreadToken(const syscall_context&, const handle thread_handle,
                                       const ACCESS_MASK /*desired_access*/, const BOOLEAN /*open_as_self*/,
                                       const emulator_object<handle> token_handle)


### PR DESCRIPTION
This PR aims to fix an issue with NtOpenSection where it would fail with "Unsupported section" if the RootDirectory was "BASE_NAMED_OBJECTS_DIRECTORY", it also adds handlers for "NtOpenThread" (stub), "NtUserGetProcessWindowStation" (stub) and "NtFlushBuffersFile".

As you can see from the changes, the `NtOpenThread` handler simply returns `STATUS_NOT_SUPPORTED`. I don't know if there's anything better I could do, but this was enough to get around it in the executable I was trying to run.