### PR TITLE
Add temp environment variables to fix GetTempPath(2)W

### DIFF
--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -119,6 +119,10 @@ namespace
         env_map[u"USERNAME"] = u"momo";
         env_map[u"SystemDrive"] = u"C:";
         env_map[u"SystemRoot"] = u"C:\\WINDOWS";
+        env_map[u"SystemTemp"] = u"C:\\Windows\\SystemTemp";
+        env_map[u"TMP"] = u"C:\\Users\\momo\\AppData\\Temp";
+        env_map[u"TEMP"] = u"C:\\Users\\momo\\AppData\\Temp";
+        env_map[u"USERPROFILE"] = u"C:\\Users\\momo";
 
         for (const auto& key : keys_to_expand)
         {


### PR DESCRIPTION
`GetTempPathW` in the following code will fail to retrieve a path from `TMP`, `TEMP`, then `USERPROFILE` environment variables (and `SystemTemp` in `GetTempPath2W`):
```
if ( GetTempPathW(0x104u, &PathName) - 1 > 0x102 || !GetTempFileNameW(&PathName, L"xx", 0, p_LibFileName) )
    return 3;
```

`GetTempFileNameW` will then call `CreateFileW` **many** times, before giving up (see [ReactOS implementation](https://doxygen.reactos.org/da/d76/filename_8c.html#a0963043522ee3e70101d2a764f2153e0)): 

![failed](https://github.com/user-attachments/assets/1f029d0c-b0a9-4ba3-b5ed-3dc2ef2d9a49)

Adding the environment variables to the process context appears to resolve this:

![success](https://github.com/user-attachments/assets/3af1434b-6a2a-43fb-ab3c-654565f0c261)
