### PR TITLE
Implement file renaming and relative path handling in NtQueryAttributesFile

### DIFF
--- a/src/windows-emulator/network/socket_wrapper.cpp
+++ b/src/windows-emulator/network/socket_wrapper.cpp
@@ -111,7 +111,7 @@ namespace network
         const auto res = ::recvfrom(this->socket_.get_socket(), reinterpret_cast<char*>(data.data()), static_cast<send_size>(data.size()),
                                     0, &source.get_addr(), &source_length);
 
-        assert(source.get_size() == source_length);
+        assert(res < 0 || source.get_size() == source_length);
 
         return res;
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -132,6 +132,7 @@ namespace syscalls
                                         emulator_pointer buffer, ULONG number_of_bytes_to_read,
                                         emulator_object<ULONG> number_of_bytes_read);
     NTSTATUS handle_NtSetInformationVirtualMemory();
+    BOOL handle_NtLockVirtualMemory();
 
     // syscalls/mutant.cpp:
     NTSTATUS handle_NtReleaseMutant(const syscall_context& c, handle mutant_handle, emulator_object<LONG> previous_count);
@@ -961,6 +962,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtQuerySystemInformation);
     add_handler(NtCreateEvent);
     add_handler(NtProtectVirtualMemory);
+    add_handler(NtLockVirtualMemory);
     add_handler(NtOpenDirectoryObject);
     add_handler(NtTraceEvent);
     add_handler(NtAllocateVirtualMemoryEx);

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -295,4 +295,9 @@ namespace syscalls
     {
         return STATUS_NOT_SUPPORTED;
     }
+
+    BOOL handle_NtLockVirtualMemory()
+    {
+        return TRUE;
+    }
 }

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -186,6 +186,7 @@ struct file : ref_counted_object
     utils::file_handle handle{};
     std::u16string name{};
     std::optional<file_enumeration_state> enumeration_state{};
+    std::optional<std::u16string> deferred_rename;
 
     bool is_file() const
     {


### PR DESCRIPTION
This PR introduces several enhancements, mainly to the file system syscalls:

- Implements file renaming via `NtSetInformationFile` by adding a deferred rename mechanism to `file_handle`. The rename operation occurs when the file handle is closed.
- Adds support for the `RootDirectory` parameter in `NtQueryAttributesFile` to handle relative file paths.
- Adds support for opening the console output device (`\\??\\CONOUT$`).
- Stubs out the `NtLockVirtualMemory` syscall.
- Fixes an incorrect assertion in `socket_wrapper` that could fire on `recvfrom` errors.