### PR TITLE
Fix `std::chrono::system_clock::now()`

### DIFF
--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -51,8 +51,10 @@ namespace
         kusd.Cookie = 0;
         kusd.ConsoleSessionForegroundProcessId = 0x00000000000028f4;
         kusd.TimeUpdateLock = 0x0000000002b28586;
-        kusd.BaselineSystemTimeQpc = 0x0000004b17cd596c;
-        kusd.BaselineInterruptTimeQpc = 0x0000004b17cd596c;
+        // This is the QPC time when `SystemTime` is set
+        // We set it to UINT64_MAX, so `SystemTime` won't get adjusted in `RtlGetSystemTimePrecise`
+        kusd.BaselineSystemTimeQpc = 0xFFFFFFFFFFFFFFFF;
+        kusd.BaselineInterruptTimeQpc = 0xFFFFFFFFFFFFFFFF;
         kusd.QpcSystemTimeIncrement = 0x8000000000000000;
         kusd.QpcInterruptTimeIncrement = 0x8000000000000000;
         kusd.QpcSystemTimeIncrementShift = 0x01;


### PR DESCRIPTION
In `ntdll!RtlGetSystemTimePrecise`, `kusd.SystemTime` is queried first, and QPC offset (`QPC() - kusd.BaselineSystemTimeQpc`) is added if it's larger than 0.
Setting `kusd.BaselineSystemTimeQpc` to `UINT64_MAX` avoids the adjustment, so incorrect adjustments won't happen.

Alternatively, We can update `kusd.BaselineSystemTimeQpc` to be the QPC value just when `kusd.SystemTime` changes, but that's not possible, because we cannot monitor `kusd.SystemTime` for change.

----------

Notes
1. With current values, this misalignment happens only when the system is up for a long time.
2. Should I leave the comment there, or we can remove it and `git blame` later instead?
