### PR TITLE
Fix deserialization of optional WOW64 emulator_object members

### DIFF
--- a/src/windows-emulator/emulator_utils.hpp
+++ b/src/windows-emulator/emulator_utils.hpp
@@ -66,6 +66,8 @@ class emulator_object
   public:
     using value_type = T;
 
+    emulator_object() = default;
+
     emulator_object(const x64_emulator_wrapper& wrapper, const uint64_t address = 0)
         : emulator_object(wrapper.get(), address)
     {
@@ -156,6 +158,11 @@ class emulator_object
     void set_address(const uint64_t address)
     {
         this->address_ = address;
+    }
+
+    void set_memory_interface(memory_interface& memory)
+    {
+        this->memory_ = &memory;
     }
 
     emulator_object<T> shift(const int64_t offset) const

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -481,6 +481,15 @@ void process_context::deserialize(utils::buffer_deserializer& buffer)
     buffer.read_optional(this->process_params32);
     buffer.read(this->kusd);
 
+    if (this->peb32.has_value())
+    {
+        this->peb32->set_memory_interface(*this->peb64.get_memory_interface());
+    }
+    if (this->process_params32.has_value())
+    {
+        this->process_params32->set_memory_interface(*this->peb64.get_memory_interface());
+    }
+
     buffer.read(this->is_wow64_process);
     buffer.read(this->ntdll_image_base);
     buffer.read(this->ldr_initialize_thunk);


### PR DESCRIPTION
Adds default constructor to `emulator_object` for optional member deserialization.
Restores `memory_interface` pointer for WOW64 structures after deserialization.