### PR TITLE
Translate file paths before usage in `section.cpp`

### DIFF
--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -138,7 +138,7 @@ namespace syscalls
         if ((allocation_attributes & SEC_IMAGE) && !s.file_name.empty())
         {
             std::vector<std::byte> file_data;
-            if (utils::io::read_file(s.file_name, &file_data))
+            if (utils::io::read_file(c.win_emu.file_sys.translate(s.file_name), &file_data))
             {
                 section::image_info info{};
 
@@ -355,7 +355,7 @@ namespace syscalls
 
         if (!section_entry->file_name.empty())
         {
-            if (!utils::io::read_file(section_entry->file_name, &file_data))
+            if (!utils::io::read_file(c.win_emu.file_sys.translate(section_entry->file_name), &file_data))
             {
                 return STATUS_INVALID_PARAMETER;
             }


### PR DESCRIPTION
Emulated applications are currently able to access files from the host system, rather than being restricted to the virtualized file system, by using `Section` related Syscalls. This behavior appears to have been introduced in:

- 2024-12-13: [Prepare better section support (syscalls.cpp:582)](https://github.com/momo5502/sogen/commit/719a50444e988a985362be31025c1f71230935ba#diff-96c7de348bdc06e650bdc371a600a91f80594d4201afd7a28ffa160fa755be9dR582)
- 2025-10-13: [Comprehensive WOW64 subsystem implementation (section.cpp:141)](https://github.com/momo5502/sogen/commit/65eecf1cfd69b845081699292722ba60bd1c096f#diff-415eed3b4b314dc10cc9f7926687770be53799766bc9a4edca2a7f4a45477169R141))

Because the emulator is [advertised for malware analysis](https://github.com/momo5502/sogen/blob/main/README.md), this unintended access path could be considered a security concern.

This PR only fixes two current misuses of an API that interacts with the host system. As a long term solution, APIs that interact with host resources should consistently use C++ types that enforce translation of resource identifiers (e.g., file and registry paths) into their emulated equivalents. This would help prevent future misuse and ensure that emulated applications remain isolated from the host environment.