### PR TITLE
Fix PEB32

### DIFF
--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -17,21 +17,18 @@
 
 #include "apiset/apiset.hpp"
 
-#define PEB_SEGMENT_SIZE              (20 << 20) // 20 MB
-#define GS_SEGMENT_SIZE               (1 << 20)  // 1 MB
+#define PEB_SEGMENT_SIZE        (20 << 20) // 20 MB
+#define GS_SEGMENT_SIZE         (1 << 20)  // 1 MB
 
-#define STACK_SIZE                    0x40000ULL // 256KB
+#define STACK_SIZE              0x40000ULL // 256KB
 
-#define GDT_ADDR                      0x35000
-#define GDT_LIMIT                     0x1000
-#define GDT_ENTRY_SIZE                0x8
+#define GDT_ADDR                0x35000
+#define GDT_LIMIT               0x1000
+#define GDT_ENTRY_SIZE          0x8
 
 // TODO: Get rid of that
-#define WOW64_PEB32_PROCESS_PARA_BASE 0x30000
-#define WOW64_PEB32_PROCESS_PARA_SIZE 0x5000
-#define WOW64_NATIVE_STACK_BASE       0x98000
-#define WOW64_NATIVE_STACK_SIZE       0x8000
-#define WOW64_32BIT_STACK_SIZE        (1 << 20)
+#define WOW64_NATIVE_STACK_SIZE 0x8000
+#define WOW64_32BIT_STACK_SIZE  (1 << 20)
 
 struct emulator_settings;
 struct application_settings;


### PR DESCRIPTION
When emulating `WOW64` samples sometimes you can see a garbige like this:

```
Executing syscall: NtQueryAttributesFile (0x3D) at 0x18009dd42 via 0x100037f1c (wow64.dll)
--> Querying file attributes: \??\C:\SH╠мхЯЦэР╜р░АC:\Windows\SYSTEM32\VCRUNTIME140.dll
```

This is because of incorrect `PEB32` creation that leads to damaging several `UNICODE_STRING` fields in `ProcessParameters`. 
This PR fixes that.
