### PR TITLE
Support SystemEmulationProcessorInformation

### DIFF
--- a/src/common/platform/win_pefile.hpp
+++ b/src/common/platform/win_pefile.hpp
@@ -94,6 +94,7 @@
 #define IMAGE_FILE_MACHINE_CEE         0xC0EE
 #endif
 
+#define PROCESSOR_ARCHITECTURE_INTEL 0
 #define PROCESSOR_ARCHITECTURE_AMD64 9
 
 enum class PEMachineType : std::uint16_t

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -199,12 +199,14 @@ namespace syscalls
                                                                   });
 
         case SystemProcessorInformation:
-            return handle_query<SYSTEM_PROCESSOR_INFORMATION64>(c.emu, system_information, system_information_length, return_length,
-                                                                [&](SYSTEM_PROCESSOR_INFORMATION64& info) {
-                                                                    memset(&info, 0, sizeof(info));
-                                                                    info.MaximumProcessors = 2;
-                                                                    info.ProcessorArchitecture = PROCESSOR_ARCHITECTURE_AMD64;
-                                                                });
+        case SystemEmulationProcessorInformation:
+            return handle_query<SYSTEM_PROCESSOR_INFORMATION64>(
+                c.emu, system_information, system_information_length, return_length, [&](SYSTEM_PROCESSOR_INFORMATION64& info) {
+                    memset(&info, 0, sizeof(info));
+                    info.MaximumProcessors = 2;
+                    info.ProcessorArchitecture =
+                        (info_class == SystemProcessorInformation ? PROCESSOR_ARCHITECTURE_AMD64 : PROCESSOR_ARCHITECTURE_INTEL);
+                });
 
         case SystemNumaProcessorMap:
             return handle_query<SYSTEM_NUMA_INFORMATION64>(c.emu, system_information, system_information_length, return_length,


### PR DESCRIPTION
This PR implements `SystemEmulationProcessorInformation`. It is used, for example, in 32-bit `ole32.dll`.