### PR TITLE
Fix getting subkey with trailing or duplacate backslashes

### DIFF
--- a/src/windows-emulator/registry/hive_parser.hpp
+++ b/src/windows-emulator/registry/hive_parser.hpp
@@ -107,6 +107,11 @@ class hive_parser
 
         for (const auto& key_part : key)
         {
+            if (key_part.empty())
+            {
+                continue;
+            }
+
             if (!current_key)
             {
                 return nullptr;


### PR DESCRIPTION
This PR fixes opening a registry key with trailing or repeating backslashes.

For example, the following code should open the key without any error:

`RegOpenKeyExW(HKEY_LOCAL_MACHINE, LR"(SOFTWARE\Microsoft\\Windows\CurrentVersion\\Run\)", 0, KEY_READ, &hKey);`