### PR TITLE
Fix utf8 output on Windows

### DIFF
--- a/src/windows-emulator/logger.cpp
+++ b/src/windows-emulator/logger.cpp
@@ -124,6 +124,19 @@ namespace
     }
 }
 
+#ifdef OS_WINDOWS
+logger::logger()
+{
+    old_cp = GetConsoleOutputCP();
+    SetConsoleOutputCP(CP_UTF8);
+}
+
+logger::~logger()
+{
+    SetConsoleOutputCP(old_cp);
+}
+#endif
+
 void logger::print_message(const color c, const std::string_view message, const bool force) const
 {
     if (!force && this->disable_output_)

--- a/src/windows-emulator/logger.hpp
+++ b/src/windows-emulator/logger.hpp
@@ -4,6 +4,10 @@
 class logger : public generic_logger
 {
   public:
+#ifdef OS_WINDOWS
+    logger();
+    ~logger() override;
+#endif
     void print(color c, std::string_view message) override;
     void print(color c, const char* message, ...) override FORMAT_ATTRIBUTE(3, 4);
     void force_print(color c, const char* message, ...) FORMAT_ATTRIBUTE(3, 4);
@@ -24,6 +28,9 @@ class logger : public generic_logger
     }
 
   private:
+#ifdef OS_WINDOWS
+    UINT old_cp{};
+#endif
     bool disable_output_{false};
     void print_message(color c, std::string_view message, bool force = false) const;
 };


### PR DESCRIPTION
Printing `UTF-8` text on Windows does not work. This PR fixes that by setting console output code page to `UTF-8`.