### PR TITLE
Revert "module manager: safer ldr init block setup"

### DIFF
--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -285,10 +285,10 @@ void module_manager::load_wow64_modules(const windows_path& executable_path, con
 
     // Set up LdrSystemDllInitBlock structure
     PS_SYSTEM_DLL_INIT_BLOCK init_block = {};
-    constexpr uint64_t system_dll_init_block_size = sizeof(PS_SYSTEM_DLL_INIT_BLOCK);
+    constexpr uint64_t symtem_dll_init_block_fix_size = 0xF0; // Wine or WIN10
 
     // Basic structure initialization
-    init_block.Size = system_dll_init_block_size;
+    init_block.Size = symtem_dll_init_block_fix_size;
 
     // Calculate relocation values
     // SystemDllWowRelocation = mapped_base - original_imagebase for 32-bit ntdll
@@ -344,11 +344,8 @@ void module_manager::load_wow64_modules(const windows_path& executable_path, con
         return;
     }
 
-    const auto write_size = static_cast<uint32_t>(system_dll_init_block_size);
-    init_block.Size = write_size;
-
     // Write the initialized structure to the export address
-    this->memory_->write_memory(ldr_init_block_addr, &init_block, write_size);
+    this->memory_->write_memory(ldr_init_block_addr, &init_block, symtem_dll_init_block_fix_size);
 
     logger.info("Successfully initialized LdrSystemDllInitBlock at 0x%" PRIx64 "\n", ldr_init_block_addr);
 


### PR DESCRIPTION
The change from fixed size 0xF0 to sizeof(PS_SYSTEM_DLL_INIT_BLOCK) (which is 0x128 for V3 struct) causes memory corruption when using Windows 10 system files. 

**Before (working):**
```
constexpr uint64_t symtem_dll_init_block_fix_size = 0xF0; // Wine or WIN10
init_block.Size = symtem_dll_init_block_fix_size;
// ...
this->memory_->write_memory(ldr_init_block_addr, &init_block, symtem_dll_init_block_fix_size);
```

**After (broken):**
```
constexpr uint64_t system_dll_init_block_size = sizeof(PS_SYSTEM_DLL_INIT_BLOCK);  // = 0x128
init_block.Size = system_dll_init_block_size;
// ...
this->memory_->write_memory(ldr_init_block_addr, &init_block, write_size);
```

**Symptom:**
```
Executing syscall: NtQueryVirtualMemory (0x23) at 0x18009d442 via 0x1800d4920 (ntdll.dll)
Interrupt 41
Suspicious: Breakpoint at 0x1800ac7d8 (via 0x1800ac7d5)
Executing syscall: NtQueryVirtualMemory (0x23) at 0x18009d442 via 0x180033579 (ntdll.dll)
Executing syscall: NtQueryVirtualMemory (0x23) at 0x18009d442 via 0x180033579 (ntdll.dll)
Executing syscall: NtQueryVirtualMemory (0x23) at 0x18009d442 via 0x180033579 (ntdll.dll)
Executing syscall: NtQueryVirtualMemory (0x23) at 0x18009d442 via 0x180033579 (ntdll.dll)
Bad address for memory image request: 0x5f0000
Executing syscall: NtRaiseException (0x168) at 0x18009fcd2 via 0x1800a0ee3 (ntdll.dll)
!!! NtRaiseException: Code=0x80000003, Flags=0x0, Address=0x1800ac7d7, NumParams=0, HandleException=0
Emulation terminated without status!
```

**Root cause:** PS_SYSTEM_DLL_INIT_BLOCK has different sizes across Windows versions. It needs to detect the Windows version from ntdll and use the appropriate size. I will submit a PR to fix this issue soon.