### PR TITLE
Fix user_handle_table memory handling

### DIFF
--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -420,7 +420,7 @@ void process_context::setup(x86_64_emulator& emu, memory_manager& memory, regist
 
     this->default_register_set = emu.save_registers();
 
-    this->user_handles.setup();
+    this->user_handles.setup(is_wow64_process);
 
     auto [h, monitor_obj] = this->user_handles.allocate_object<USER_MONITOR>(handle_types::monitor);
     this->default_monitor_handle = h;


### PR DESCRIPTION
This PR fixes `user_handle_table` for WOW64. Otherwise we get AV during 32-bit `user32.dll` initialization.