### PR TITLE
Making a New Type for Serializable Map Data structures

### DIFF
--- a/src/emulator/serialization.hpp
+++ b/src/emulator/serialization.hpp
@@ -13,7 +13,7 @@
 #include <map>
 
 template <typename... Args>
-using serialized_map = std::map<Args...>;
+using serializable_map = std::map<Args...>;
 
 namespace utils
 {

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -167,7 +167,7 @@ class handle_store : public generic_handle_store
 {
   public:
     using index_type = uint32_t;
-    using value_map = serialized_map<index_type, T>;
+    using value_map = serializable_map<index_type, T>;
 
     bool block_mutation(bool blocked)
     {

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -61,7 +61,7 @@ class memory_manager : public memory_interface
         nt_memory_permission permissions{};
     };
 
-    using committed_region_map = serialized_map<uint64_t, committed_region>;
+    using committed_region_map = serializable_map<uint64_t, committed_region>;
 
     struct reserved_region
     {
@@ -71,7 +71,7 @@ class memory_manager : public memory_interface
         memory_region_kind kind{memory_region_kind::private_allocation};
     };
 
-    using reserved_region_map = serialized_map<uint64_t, reserved_region>;
+    using reserved_region_map = serializable_map<uint64_t, reserved_region>;
 
     void read_memory(uint64_t address, void* data, size_t size) const final;
     bool try_read_memory(uint64_t address, void* data, size_t size) const final;

--- a/src/windows-emulator/module/mapped_module.hpp
+++ b/src/windows-emulator/module/mapped_module.hpp
@@ -19,7 +19,7 @@ struct imported_symbol
 using exported_symbols = std::vector<exported_symbol>;
 using imported_symbols = std::unordered_map<uint64_t, imported_symbol>;
 using imported_module_list = std::vector<std::string>;
-using address_name_mapping = serialized_map<uint64_t, std::string>;
+using address_name_mapping = serializable_map<uint64_t, std::string>;
 
 struct mapped_section
 {

--- a/src/windows-emulator/module/module_manager.hpp
+++ b/src/windows-emulator/module/module_manager.hpp
@@ -87,7 +87,7 @@ class module_manager
         utils::optional_function<void(mapped_module& mod)> on_module_unload{};
     };
 
-    using module_map = serialized_map<uint64_t, mapped_module>;
+    using module_map = serializable_map<uint64_t, mapped_module>;
 
     module_manager(memory_manager& memory, file_system& file_sys, callbacks& cb);
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -139,7 +139,7 @@ struct process_context
     user_handle_store<handle_types::window, window> windows{user_handles};
     handle_store<handle_types::timer, timer> timers{};
     handle_store<handle_types::registry, registry_key, 2> registry_keys{};
-    serialized_map<uint16_t, atom_entry> atoms{};
+    serializable_map<uint16_t, atom_entry> atoms{};
 
     std::vector<std::byte> default_register_set{};
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -35,7 +35,7 @@ class syscall_dispatcher
     }
 
   private:
-    serialized_map<uint64_t, syscall_handler_entry> handlers_{};
+    serializable_map<uint64_t, syscall_handler_entry> handlers_{};
 
     static void add_handlers(std::map<std::string, syscall_handler>& handler_mapping);
     void add_handlers();

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -142,7 +142,7 @@ class user_handle_store : public generic_handle_store
 {
   public:
     using index_type = uint32_t;
-    using value_map = serialized_map<index_type, T>;
+    using value_map = serializable_map<index_type, T>;
 
     explicit user_handle_store(user_handle_table& table)
         : table_(&table)

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -85,7 +85,7 @@ struct window : user_object<USER_WINDOW>
     int32_t height{};
     int32_t x{};
     int32_t y{};
-    serialized_map<std::u16string, uint64_t> props;
+    serializable_map<std::u16string, uint64_t> props;
 
     window(memory_interface& memory)
         : user_object(memory)


### PR DESCRIPTION
I thought this would be better, as to avoid failing serialization tests, most maps are std::map and that's correct, however as newcomer to the project I didn't thought about it and I am used to use std::unordered_map more.