### PR TITLE
Fix file operations

### DIFF
--- a/src/common/platform/file_management.hpp
+++ b/src/common/platform/file_management.hpp
@@ -78,17 +78,24 @@
     (FILE_WRITE_THROUGH | FILE_SEQUENTIAL_ONLY | FILE_NO_INTERMEDIATE_BUFFERING | FILE_SYNCHRONOUS_IO_ALERT | \
      FILE_SYNCHRONOUS_IO_NONALERT | FILE_DELETE_ON_CLOSE)
 
-#define FILE_ATTRIBUTE_NORMAL    0x00000080
-#define FILE_ATTRIBUTE_DIRECTORY 0x00000010
+#define FILE_ATTRIBUTE_NORMAL                      0x00000080
+#define FILE_ATTRIBUTE_DIRECTORY                   0x00000010
 
-#define PS_ATTRIBUTE_NUMBER_MASK 0x0000ffff
-#define PS_ATTRIBUTE_THREAD      0x00010000 // may be used with thread creation
-#define PS_ATTRIBUTE_INPUT       0x00020000 // input only
-#define PS_ATTRIBUTE_ADDITIVE    0x00040000 // "accumulated" e.g. bitmasks, counters, etc.
+#define FILE_DISPOSITION_DO_NOT_DELETE             (0x00000000)
+#define FILE_DISPOSITION_DELETE                    (0x00000001)
+#define FILE_DISPOSITION_POSIX_SEMANTICS           (0x00000002)
+#define FILE_DISPOSITION_FORCE_IMAGE_SECTION_CHECK (0x00000004)
+#define FILE_DISPOSITION_ON_CLOSE                  (0x00000008)
+#define FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE (0x00000010)
 
-#define SL_RESTART_SCAN          0x01
-#define SL_RETURN_SINGLE_ENTRY   0x02
-#define SL_NO_CURSOR_UPDATE      0x10
+#define PS_ATTRIBUTE_NUMBER_MASK                   0x0000ffff
+#define PS_ATTRIBUTE_THREAD                        0x00010000 // may be used with thread creation
+#define PS_ATTRIBUTE_INPUT                         0x00020000 // input only
+#define PS_ATTRIBUTE_ADDITIVE                      0x00040000 // "accumulated" e.g. bitmasks, counters, etc.
+
+#define SL_RESTART_SCAN                            0x01
+#define SL_RETURN_SINGLE_ENTRY                     0x02
+#define SL_NO_CURSOR_UPDATE                        0x10
 
 #ifndef SEC_IMAGE
 #define SEC_HUGE_PAGES             0x00020000
@@ -506,6 +513,11 @@ typedef struct _FILE_DISPOSITION_INFORMATION
 {
     BOOLEAN DeleteFile;
 } FILE_DISPOSITION_INFORMATION, *PFILE_DISPOSITION_INFORMATION;
+
+struct FILE_DISPOSITION_INFORMATION_EX
+{
+    ULONG Flags;
+};
 
 typedef struct _FILE_STREAM_INFORMATION
 {

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -108,9 +108,39 @@ namespace syscalls
                 return STATUS_BUFFER_OVERFLOW;
             }
 
+            if (!(f->access_mask & DELETE))
+            {
+                return STATUS_ACCESS_DENIED;
+            }
+
             const auto info = c.emu.read_memory<FILE_DISPOSITION_INFORMATION>(file_information);
 
             f->handle.defer_delete(info.DeleteFile ? c.win_emu.file_sys.translate(f->name) : std::filesystem::path{});
+
+            return STATUS_SUCCESS;
+        }
+
+        if (info_class == FileDispositionInformationEx)
+        {
+            if (length < sizeof(FILE_DISPOSITION_INFORMATION_EX))
+            {
+                return STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            if (!(f->access_mask & DELETE))
+            {
+                return STATUS_ACCESS_DENIED;
+            }
+
+            const auto info = c.emu.read_memory<FILE_DISPOSITION_INFORMATION_EX>(file_information);
+
+            if (info.Flags & ~FILE_DISPOSITION_DELETE)
+            {
+                return STATUS_NOT_SUPPORTED;
+            }
+
+            f->handle.defer_delete((info.Flags & FILE_DISPOSITION_DELETE) ? c.win_emu.file_sys.translate(f->name)
+                                                                          : std::filesystem::path{});
 
             return STATUS_SUCCESS;
         }
@@ -1415,6 +1445,11 @@ namespace syscalls
                 return STATUS_ACCESS_DENIED;
             }
 
+            mode = u"rb";
+        }
+
+        if (mode.empty() && (desired_access & DELETE))
+        {
             mode = u"rb";
         }
 

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1407,6 +1407,17 @@ namespace syscalls
 
         std::u16string mode = map_mode(desired_access, create_disposition);
 
+        if (mode.empty() && create_disposition == FILE_CREATE)
+        {
+            std::ofstream touch(host_path, std::ios::binary | std::ios::app);
+            if (!touch)
+            {
+                return STATUS_ACCESS_DENIED;
+            }
+
+            mode = u"rb";
+        }
+
         if (mode.empty() || path.is_relative())
         {
             return STATUS_NOT_SUPPORTED;

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -495,7 +495,7 @@ namespace syscalls
 
         if (info_class == FileAttributeTagInformation)
         {
-            if (!f->handle)
+            if (!f->handle && !f->is_directory())
             {
                 return ret(STATUS_NOT_SUPPORTED);
             }


### PR DESCRIPTION
Several basic file operations do not work:
1. `GetTempFileName`
2. `DeleteFile`
3. `RemoveDirectory` / `CreateDirectory`

This PR fixes them.