### PR TITLE
Match windows syscall id wraparound behaviour

### DIFF
--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -68,7 +68,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
 
     const auto address = emu.read_instruction_pointer();
     const auto raw_syscall_id = emu.reg<uint32_t>(x86_register::eax);
-    const auto syscall_id = raw_syscall_id & 0xFFFF; // Only take low bits for WOW64 compatibility
+    const auto syscall_id = raw_syscall_id & 0x3FFF; // Only take low bits for WOW64 compatibility, (edit: match windows more faithfully as at 0x4000 syscall ids get wrapped around to beginning)
 
     const auto entry = this->handlers_.find(syscall_id);
     const auto* syscall_name = (entry != this->handlers_.end()) ? entry->second.name.c_str() : "<unknown>";

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -68,7 +68,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
 
     const auto address = emu.read_instruction_pointer();
     const auto raw_syscall_id = emu.reg<uint32_t>(x86_register::eax);
-    const auto syscall_id = raw_syscall_id & 0x3FFF; // Only take low bits for WOW64 compatibility, (edit: match windows more faithfully as at 0x4000 syscall ids get wrapped around to beginning)
+    const auto syscall_id = raw_syscall_id & 0x3FFF; // Only take low bits for WOW64 compatibility, match windoows wraparound
 
     const auto entry = this->handlers_.find(syscall_id);
     const auto* syscall_name = (entry != this->handlers_.end()) ? entry->second.name.c_str() : "<unknown>";


### PR DESCRIPTION
Mask syscall ids with 0x3FFF instead of 0xFFFF
Windows wraps syscall ids every 0x4000, so higher bits are ignored
This aligns syscall handling with actual Windows behavior and avoids incorrect id resolution.

Fixes a emulator crash when higher syscall ids are used (e.g. EAX=0x4025). The emulator previously used the full value as an index, leading to out of bounds lookup since Windows wraps this to 0x0025.