### PR TITLE
Embedder facing hooks for logs, stop classification, and fake environment   

### DIFF
--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -13,7 +13,7 @@ constexpr auto KUSD_BUFFER_SIZE = page_align_up(KUSD_SIZE);
 
 namespace
 {
-    void setup_kusd(KUSER_SHARED_DATA64& kusd, const windows_version_manager& version)
+    void setup_kusd(KUSER_SHARED_DATA64& kusd, const windows_version_manager& version, const fake_environment_config& fake_env)
     {
         memset(reinterpret_cast<void*>(&kusd), 0, sizeof(kusd));
 
@@ -32,7 +32,7 @@ namespace
         kusd.RNGSeedVersion = 0;
         kusd.TimeZoneBiasStamp = 0x00000004;
         kusd.NtBuildNumber = version.get_windows_build_number();
-        kusd.NtProductType = NtProductWinNt;
+        kusd.NtProductType = static_cast<NT_PRODUCT_TYPE>(fake_env.nt_product_type);
         kusd.ProductTypeIsValid = 0x01;
         kusd.NativeProcessorArchitecture = 0x0009;
         kusd.NtMajorVersion = version.get_major_version();
@@ -121,9 +121,9 @@ kusd_mmio::kusd_mmio(utils::buffer_deserializer& buffer)
 {
 }
 
-void kusd_mmio::setup(const windows_version_manager& version)
+void kusd_mmio::setup(const windows_version_manager& version, const fake_environment_config& fake_env)
 {
-    setup_kusd(this->kusd_, version);
+    setup_kusd(this->kusd_, version, fake_env);
     this->register_mmio();
 }
 

--- a/src/windows-emulator/kusd_mmio.hpp
+++ b/src/windows-emulator/kusd_mmio.hpp
@@ -8,6 +8,7 @@
 #include <utils/time.hpp>
 
 struct process_context;
+struct fake_environment_config;
 class windows_emulator;
 class windows_version_manager;
 
@@ -39,7 +40,7 @@ class kusd_mmio
 
     static uint64_t address();
 
-    void setup(const windows_version_manager& version);
+    void setup(const windows_version_manager& version, const fake_environment_config& fake_env);
 
   private:
     memory_manager* memory_{};

--- a/src/windows-emulator/logger.cpp
+++ b/src/windows-emulator/logger.cpp
@@ -139,6 +139,14 @@ logger::~logger()
 
 void logger::print_message(const color c, const std::string_view message, const bool force) const
 {
+    // Sinks observe all log activity, regardless of disable_output_. That lets
+    // consumers capture a full structured log even when they've silenced the
+    // terminal (e.g. --silent, or a Python wrapper capturing via callback).
+    if (this->sink_)
+    {
+        this->sink_(c, message);
+    }
+
     if (!force && this->disable_output_)
     {
         return;

--- a/src/windows-emulator/logger.cpp
+++ b/src/windows-emulator/logger.cpp
@@ -142,10 +142,7 @@ void logger::print_message(const color c, const std::string_view message, const 
     // Sinks observe all log activity, regardless of disable_output_. That lets
     // consumers capture a full structured log even when they've silenced the
     // terminal (e.g. --silent, or a Python wrapper capturing via callback).
-    if (this->sink_)
-    {
-        this->sink_(c, message);
-    }
+    this->sink_(c, message);
 
     if (!force && this->disable_output_)
     {

--- a/src/windows-emulator/logger.hpp
+++ b/src/windows-emulator/logger.hpp
@@ -1,9 +1,19 @@
 #pragma once
 #include "generic_logger.hpp"
 
+#include <functional>
+#include <string_view>
+
 class logger : public generic_logger
 {
   public:
+    // Sink receives every formatted log line before it is written to stdout.
+    // The color argument doubles as a level tag: red = error (force-printed),
+    // yellow = warn, cyan = info, green = success, gray = log, pink = force-
+    // print from external code (e.g. gdb bindings). Sinks run even when
+    // output is disabled, so they observe all log activity.
+    using sink = std::function<void(color c, std::string_view message)>;
+
 #ifdef OS_WINDOWS
     logger();
     ~logger() override;
@@ -27,10 +37,18 @@ class logger : public generic_logger
         return this->disable_output_;
     }
 
+    // Install a sink callback. Passing an empty std::function clears it.
+    // Single-sink: installing replaces any previously installed sink.
+    void set_sink(sink s)
+    {
+        this->sink_ = std::move(s);
+    }
+
   private:
 #ifdef OS_WINDOWS
     UINT old_cp{};
 #endif
     bool disable_output_{false};
+    sink sink_{};
     void print_message(color c, std::string_view message, bool force = false) const;
 };

--- a/src/windows-emulator/logger.hpp
+++ b/src/windows-emulator/logger.hpp
@@ -12,7 +12,7 @@ class logger : public generic_logger
     // yellow = warn, cyan = info, green = success, gray = log, pink = force-
     // print from external code (e.g. gdb bindings). Sinks run even when
     // output is disabled, so they observe all log activity.
-    using sink = std::function<void(color c, std::string_view message)>;
+    using sink = utils::optional_function<void(color c, std::string_view message)>;
 
 #ifdef OS_WINDOWS
     logger();

--- a/src/windows-emulator/logger.hpp
+++ b/src/windows-emulator/logger.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "generic_logger.hpp"
 
-#include <functional>
+#include <utils/function.hpp>
 #include <string_view>
 
 class logger : public generic_logger

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -290,14 +290,15 @@ namespace
 }
 
 void process_context::setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
-                            windows_version_manager& version, const application_settings& app_settings, const mapped_module& executable,
-                            const mapped_module& ntdll, const apiset::container& apiset_container, const mapped_module* ntdll32)
+                            windows_version_manager& version, const fake_environment_config& fake_env,
+                            const application_settings& app_settings, const mapped_module& executable, const mapped_module& ntdll,
+                            const apiset::container& apiset_container, const mapped_module* ntdll32)
 {
     this->sid = get_sid(registry);
 
     setup_gdt(emu, memory);
 
-    this->kusd.setup(version);
+    this->kusd.setup(version, fake_env);
 
     this->base_allocator = create_allocator(memory, PEB_SEGMENT_SIZE, this->is_wow64_process);
     auto& allocator = this->base_allocator;
@@ -384,7 +385,7 @@ void process_context::setup(x86_64_emulator& emu, memory_manager& memory, regist
         p.HeapDeCommitFreeBlockThreshold = 0x0000000000001000;
         p.NumberOfHeaps = 0x00000000;
         p.MaximumNumberOfHeaps = 0x00000010;
-        p.NumberOfProcessors = 4;
+        p.NumberOfProcessors = fake_env.number_of_processors;
         p.ImageSubsystemMajorVersion = 6;
 
         p.OSPlatformId = 2;
@@ -476,7 +477,7 @@ void process_context::setup(x86_64_emulator& emu, memory_manager& memory, regist
             p32.HeapDeCommitFreeBlockThreshold = 0x00001000;
             p32.NumberOfHeaps = 0;
             p32.MaximumNumberOfHeaps = 0x10;
-            p32.NumberOfProcessors = 4;
+            p32.NumberOfProcessors = fake_env.number_of_processors;
             p32.ImageSubsystemMajorVersion = 6;
 
             p32.OSPlatformId = 2;

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -18,6 +18,8 @@
 
 #include "apiset/apiset.hpp"
 
+struct fake_environment_config;
+
 #define PEB_SEGMENT_SIZE        (20 << 20) // 20 MB
 #define GS_SEGMENT_SIZE         (1 << 20)  // 1 MB
 
@@ -133,8 +135,9 @@ struct process_context
     }
 
     void setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
-               windows_version_manager& version, const application_settings& app_settings, const mapped_module& executable,
-               const mapped_module& ntdll, const apiset::container& apiset_container, const mapped_module* ntdll32 = nullptr);
+               windows_version_manager& version, const fake_environment_config& fake_env, const application_settings& app_settings,
+               const mapped_module& executable, const mapped_module& ntdll, const apiset::container& apiset_container,
+               const mapped_module* ntdll32 = nullptr);
 
     handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size, uint32_t create_flags,
                          bool initial_thread = false);

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -2,6 +2,8 @@
 #include "syscall_dispatcher.hpp"
 #include "syscall_utils.hpp"
 
+#include <utils/string.hpp>
+
 static void serialize(utils::buffer_serializer& buffer, const syscall_handler_entry& obj)
 {
     buffer.write(obj.name);
@@ -85,6 +87,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
         if (entry == this->handlers_.end())
         {
             win_emu.log.error("Unknown syscall: 0x%X (raw: 0x%X)\n", syscall_id, raw_syscall_id);
+            win_emu.record_stop(stop_reason::unknown_syscall, "0x" + utils::string::to_hex_number(syscall_id));
             c.emu.reg<uint64_t>(x86_register::rax, STATUS_NOT_SUPPORTED);
             c.emu.stop();
             return;
@@ -99,6 +102,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
         if (!entry->second.handler)
         {
             win_emu.log.error("Unimplemented syscall: %s - 0x%X (raw: 0x%X)\n", entry->second.name.c_str(), syscall_id, raw_syscall_id);
+            win_emu.record_stop(stop_reason::unimplemented_syscall, entry->second.name);
             c.emu.reg<uint64_t>(x86_register::rax, STATUS_NOT_SUPPORTED);
             c.emu.stop();
             return;
@@ -112,6 +116,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
     {
         win_emu.log.error("Syscall %s threw an exception: 0x%X (raw: 0x%X) (0x%" PRIx64 ") - %s\n", syscall_name, syscall_id,
                           raw_syscall_id, address, e.what());
+        win_emu.record_stop(stop_reason::syscall_exception, std::string(syscall_name) + ": " + e.what());
         emu.reg<uint64_t>(x86_register::rax, STATUS_UNSUCCESSFUL);
         emu.stop();
     }
@@ -119,6 +124,7 @@ void syscall_dispatcher::dispatch(windows_emulator& win_emu)
     {
         win_emu.log.error("Syscall %s threw an unknown exception: 0x%X (raw: 0x%X) (0x%" PRIx64 ")\n", syscall_name, syscall_id,
                           raw_syscall_id, address);
+        win_emu.record_stop(stop_reason::syscall_exception, std::string(syscall_name) + ": <unknown exception>");
         emu.reg<uint64_t>(x86_register::rax, STATUS_UNSUCCESSFUL);
         emu.stop();
     }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -315,6 +315,7 @@ windows_emulator::windows_emulator(std::unique_ptr<x86_64_emulator> emu, const e
       dns_lookup_(get_dns_lookup(interfaces)),
       socket_factory_(get_socket_factory(interfaces)),
       emulation_root{settings.emulation_root.empty() ? settings.emulation_root : absolute(settings.emulation_root)},
+      fake_env(settings.fake_env),
       callbacks(std::move(callbacks)),
       file_sys(emulation_root.empty() ? emulation_root : emulation_root / "filesys"),
       memory(*this->emu_),
@@ -372,8 +373,8 @@ void windows_emulator::setup_process()
 
     const auto apiset_data = apiset::obtain(this->emulation_root);
 
-    this->process.setup(this->emu(), this->memory, this->registry, this->file_sys, this->version, this->application_settings_, *executable,
-                        *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32);
+    this->process.setup(this->emu(), this->memory, this->registry, this->file_sys, this->version, this->fake_env,
+                        this->application_settings_, *executable, *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32);
 
     const auto ntdll_data = emu.read_memory(ntdll->image_base, static_cast<size_t>(ntdll->size_of_image));
     const auto win32u_data = emu.read_memory(win32u->image_base, static_cast<size_t>(win32u->size_of_image));

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -568,6 +568,8 @@ void windows_emulator::setup_hooks()
 void windows_emulator::start(size_t count)
 {
     this->should_stop = false;
+    this->last_stop_reason_ = stop_reason::none;
+    this->last_stop_detail_.clear();
     this->setup_process_if_necessary();
 
     const auto use_count = count > 0;

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -42,6 +42,21 @@ struct emulator_callbacks : module_manager::callbacks, process_context::callback
     opt_func<void(io_device& device, std::u16string_view device_name, ULONG code)> on_ioctrl{};
 };
 
+// Typed reason the most recent start() returned. Today callers can only
+// infer "why we stopped" by parsing log strings written by the syscall
+// dispatcher, which is fragile and loses context. Internal error paths
+// record a reason via windows_emulator::record_stop(); callers read it
+// with last_stop_reason() post-start(). `none` covers clean exits,
+// external stop() calls, and instruction-cap exhaustion — the caller
+// already knows about those from exit_status and its own flags.
+enum class stop_reason : uint8_t
+{
+    none,
+    unknown_syscall,
+    unimplemented_syscall,
+    syscall_exception,
+};
+
 struct application_settings
 {
     windows_path application{};
@@ -174,6 +189,25 @@ class windows_emulator
         return this->executed_instructions_;
     }
 
+    stop_reason last_stop_reason() const
+    {
+        return this->last_stop_reason_;
+    }
+
+    const std::string& last_stop_detail() const
+    {
+        return this->last_stop_detail_;
+    }
+
+    // Called by internal paths that force a stop due to an error (syscall
+    // dispatcher unknown/unimplemented/exception). Public so future error
+    // paths can record themselves without friending everyone.
+    void record_stop(stop_reason r, std::string detail = {})
+    {
+        this->last_stop_reason_ = r;
+        this->last_stop_detail_ = std::move(detail);
+    }
+
     void setup_process_if_necessary();
 
     void start(size_t count = 0);
@@ -237,6 +271,9 @@ class windows_emulator
 
     std::vector<std::byte> process_snapshot_{};
     // std::optional<process_context> process_snapshot_{};
+
+    stop_reason last_stop_reason_{stop_reason::none};
+    std::string last_stop_detail_{};
 
     void setup_hooks();
     void setup_process();

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -81,6 +81,19 @@ struct application_settings
     }
 };
 
+// Knobs for values the emulator exposes to the emulated process that don't
+// depend on the host environment. Samples (particularly anti-analysis
+// payloads) probe these to detect VM/sandbox; today they are hardcoded in
+// process_context.cpp (PEB.NumberOfProcessors = 4) and kusd_mmio.cpp
+// (KUSER_SHARED_DATA.NtProductType = NtProductWinNt). Defaults match the
+// legacy hardcoded values — behavior is unchanged when consumers leave
+// this field at its default.
+struct fake_environment_config
+{
+    uint32_t number_of_processors{4};
+    uint8_t nt_product_type{1}; // NtProductWinNt
+};
+
 struct emulator_settings
 {
     bool disable_logging{false};
@@ -91,6 +104,8 @@ struct emulator_settings
 
     std::unordered_map<uint16_t, uint16_t> port_mappings{};
     std::unordered_map<windows_path, std::filesystem::path> path_mappings{};
+
+    fake_environment_config fake_env{};
 };
 
 struct emulator_interfaces
@@ -113,6 +128,7 @@ class windows_emulator
 
   public:
     const std::filesystem::path emulation_root{};
+    const fake_environment_config fake_env{};
     emulator_callbacks callbacks{};
     logger log{};
     file_system file_sys;


### PR DESCRIPTION
When building external tools on top of the emulator (not analyzer binary), the current public API requires several workarounds:

- Capturing full diagnostic output requires reparenting `stdout`
- Determining why emulation stopped requires parsing log strings
- Spoofing values such as `PEB.NumberOfProcessors` or `KUSER_SHARED_DATA.NtProductType` requires patching library source

This PR introduces three additive hooks to improve embeddability and observability, no behavior changes for existing callers or analyzer.

## 1. Structured Logging Sink

Adds:

```cpp
logger::set_sink(std::function<void(color, string_view)>)
```

* Invoked for every formatted log line (including under `--silent`)
* Default sink is empty
* Zero overhead when unused

This enables structured log capture without redirecting `stdout`.

##  2. Typed `stop_reason` for Emulation Failures

Adds:

* `stop_reason` enum:

  * `none`
  * `unknown_syscall`
  * `unimplemented_syscall`
  * `syscall_exception`
* `last_stop_reason()`
* `last_stop_detail()`

Details:

* Set by `syscall_dispatcher::dispatch()` on existing failure paths
* Eliminates the need to parse log strings to classify stop conditions

## 3. Configurable Fake Environment (PEB / KUSD)

Adds:

```cpp
fake_environment_config emulator_settings::fake_env;
```

With fields:

* `number_of_processors`
* `nt_product_type`

Plumbed through:

* `process_context::setup()`
* `kusd_mmio::setup()`

Defaults preserve existing behavior:

* `number_of_processors = 4`
* `nt_product_type = NtProductWinNt`

This allows controlled environment spoofing without modifying library code. Bit out of scope for the PR but better this than a ton of one line PRs and required if you want to fake a domain controller.
