### PR TITLE
Return NTSTATUS for invalid NtAllocateVirtualMemory flags

### DIFF
--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -248,7 +248,7 @@ namespace syscalls
 
         if ((allocation_type & ~(MEM_RESERVE | MEM_COMMIT | MEM_TOP_DOWN | MEM_WRITE_WATCH)) || (!commit && !reserve))
         {
-            throw std::runtime_error("Unsupported allocation type!");
+            return STATUS_INVALID_PARAMETER;
         }
 
         if (commit && !reserve && c.win_emu.memory.commit_memory(potential_base, static_cast<size_t>(allocation_bytes), *protection))


### PR DESCRIPTION
## Summary
- return `STATUS_INVALID_PARAMETER` for unsupported `AllocationType` combinations in `NtAllocateVirtualMemoryEx`
- stop treating guest-controlled allocation flags as a fatal C++ exception path
- preserve normal syscall failure behavior instead of stopping emulation

## Notes
- This PR intentionally fixes only the `NtAllocateVirtualMemory` unsupported-flag exception path.
- The related `NtFreeVirtualMemory` bad-flag throw remains separate and should be handled in its own follow-up PR.