### PR TITLE
Return NTSTATUS for invalid NtFreeVirtualMemory flags

### DIFF
--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -356,7 +356,7 @@ namespace syscalls
             return success ? STATUS_SUCCESS : STATUS_MEMORY_NOT_ALLOCATED;
         }
 
-        throw std::runtime_error("Bad free type");
+        return STATUS_INVALID_PARAMETER_4;
     }
 
     NTSTATUS handle_NtReadVirtualMemory(const syscall_context& c, const handle process_handle, const emulator_pointer base_address,


### PR DESCRIPTION
## Summary
- return `STATUS_INVALID_PARAMETER_4` for invalid `FreeType` combinations in `NtFreeVirtualMemory`
- stop treating guest-controlled free flags as a fatal C++ exception path
- preserve normal syscall failure behavior instead of stopping emulation

## Notes
- This PR intentionally fixes only the invalid-`FreeType` exception path.
- The separate `MEM_RELEASE` partial-release bug remains for a follow-up PR.