### PR TITLE
Only alert current NtWaitForAlertByThreadId waiters

### DIFF
--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -521,7 +521,10 @@ namespace syscalls
         {
             if (t.id == thread_id)
             {
-                t.alerted = true;
+                if (t.waiting_for_alert)
+                {
+                    t.alerted = true;
+                }
                 return STATUS_SUCCESS;
             }
         }


### PR DESCRIPTION
## Summary
- only latch `alerted` when the target thread is currently in `NtWaitForAlertByThreadId`
- stop preserving alerts for unrelated future waits
- keep the change scoped to the `NtAlertThreadByThreadId` state transition

## Notes
- This PR intentionally fixes only the sticky-alert behavior.
- The separate alertable-wait/APC status-overwrite issue remains for a follow-up PR.