### PR TITLE
Route named pipe I/O through shared per-name queues

### DIFF
--- a/src/windows-emulator/devices/named_pipe.hpp
+++ b/src/windows-emulator/devices/named_pipe.hpp
@@ -5,7 +5,6 @@ class named_pipe : public io_device_container
 {
   public:
     std::u16string name;
-    std::deque<std::string> write_queue;
     ACCESS_MASK access = 0;
     ULONG pipe_type;
     ULONG read_mode;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -601,6 +601,7 @@ void process_context::serialize(utils::buffer_serializer& buffer) const
     buffer.write(this->events);
     buffer.write(this->files);
     buffer.write_map(this->file_locks);
+    buffer.write_map(this->named_pipe_messages);
     buffer.write(this->sections);
     buffer.write(this->devices);
     buffer.write(this->semaphores);
@@ -667,6 +668,7 @@ void process_context::deserialize(utils::buffer_deserializer& buffer)
     buffer.read(this->events);
     buffer.read(this->files);
     buffer.read_map(this->file_locks);
+    buffer.read_map(this->named_pipe_messages);
     buffer.read(this->sections);
     buffer.read(this->devices);
     buffer.read(this->semaphores);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -80,6 +80,21 @@ struct file_lock_ranges
     }
 };
 
+struct named_pipe_messages
+{
+    std::vector<std::string> messages{};
+
+    void serialize(utils::buffer_serializer& buffer) const
+    {
+        buffer.write_vector(this->messages);
+    }
+
+    void deserialize(utils::buffer_deserializer& buffer)
+    {
+        buffer.read_vector(this->messages);
+    }
+};
+
 struct process_context
 {
     struct callbacks
@@ -205,6 +220,7 @@ struct process_context
     handle_store<handle_types::event, event> events{};
     handle_store<handle_types::file, file> files{};
     utils::insensitive_u16string_map<file_lock_ranges> file_locks{};
+    utils::insensitive_u16string_map<named_pipe_messages> named_pipe_messages{};
     handle_store<handle_types::section, section> sections{};
     handle_store<handle_types::device, io_device_container> devices{};
     handle_store<handle_types::semaphore, semaphore> semaphores{};

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -80,7 +80,7 @@ struct file_lock_ranges
     }
 };
 
-struct named_pipe_messages
+struct named_pipe_message_queue
 {
     std::vector<std::string> messages{};
 
@@ -220,7 +220,7 @@ struct process_context
     handle_store<handle_types::event, event> events{};
     handle_store<handle_types::file, file> files{};
     utils::insensitive_u16string_map<file_lock_ranges> file_locks{};
-    utils::insensitive_u16string_map<named_pipe_messages> named_pipe_messages{};
+    utils::insensitive_u16string_map<named_pipe_message_queue> named_pipe_messages{};
     handle_store<handle_types::section, section> sections{};
     handle_store<handle_types::device, io_device_container> devices{};
     handle_store<handle_types::semaphore, semaphore> semaphores{};

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1111,20 +1111,21 @@ namespace syscalls
         {
             if (auto* pipe = container->get_internal_device<named_pipe>())
             {
-                if (!pipe->write_queue.empty())
+                auto& messages = c.proc.named_pipe_messages[pipe->name].messages;
+                if (!messages.empty())
                 {
-                    std::string_view data = pipe->write_queue.front();
+                    std::string_view data = messages.front();
                     const size_t to_copy = std::min<size_t>(data.size(), length);
 
                     commit_file_data(data.substr(0, to_copy), c.emu, io_status_block, buffer);
 
                     if (to_copy == data.size())
                     {
-                        pipe->write_queue.pop_front();
+                        messages.erase(messages.begin());
                     }
                     else
                     {
-                        pipe->write_queue.front().erase(0, to_copy);
+                        messages.front().erase(0, to_copy);
                     }
 
                     return STATUS_SUCCESS;
@@ -1175,10 +1176,8 @@ namespace syscalls
         {
             if (auto* pipe = container->get_internal_device<named_pipe>())
             {
-                (void)pipe; // For future use: suppressing compiler issues
-                // TODO c.win_emu.callbacks.on_named_pipe_write(pipe->name, temp_buffer);
-
-                // TODO pipe->write_queue.push_back(temp_buffer);
+                c.win_emu.callbacks.on_generic_access("Writing named pipe", pipe->name);
+                c.proc.named_pipe_messages[pipe->name].messages.push_back(temp_buffer);
 
                 if (io_status_block)
                 {


### PR DESCRIPTION
## Summary
- route named-pipe reads and writes through shared per-name queues in `process_context`
- stop acknowledging named-pipe writes while discarding the payload
- serialize the shared named-pipe message state with the rest of process state

## Notes
- This PR keeps the fix scoped to truthful named-pipe data flow.
- It does not attempt to fully model native named-pipe server/client semantics beyond shared same-name message queues.