### PR TITLE
Fix AFD poll event filtering and initialize WOW64 FP state

### DIFF
--- a/src/windows-emulator/devices/afd_endpoint.cpp
+++ b/src/windows-emulator/devices/afd_endpoint.cpp
@@ -308,9 +308,16 @@ namespace
             }
         }
 
-        if ((socket_events & (POLLHUP | POLLERR)) == (POLLHUP | POLLERR) && afd_poll_events & (AFD_POLL_CONNECT_FAIL | AFD_POLL_ABORT))
+        if ((socket_events & (POLLHUP | POLLERR)) == (POLLHUP | POLLERR))
         {
-            afd_events |= (AFD_POLL_CONNECT_FAIL | AFD_POLL_ABORT);
+            if (afd_poll_events & AFD_POLL_CONNECT_FAIL)
+            {
+                afd_events |= AFD_POLL_CONNECT_FAIL;
+            }
+            if (afd_poll_events & AFD_POLL_ABORT)
+            {
+                afd_events |= AFD_POLL_ABORT;
+            }
         }
         else if (socket_events & POLLHUP && afd_poll_events & AFD_POLL_DISCONNECT)
         {

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -344,9 +344,23 @@ emulator_thread::emulator_thread(memory_manager& memory, const process_context& 
         // EFlags - standard initial flags
         ctx.Context.EFlags = 0x202; // IF (Interrupt Flag) set
 
-        // Extended state - initialize to zero
+        // Seed WOW64 floating-point state with sane defaults
         memset(&ctx.Context.FloatSave, 0, sizeof(ctx.Context.FloatSave));
+        ctx.Context.FloatSave.ControlWord = 0x037F;
+        ctx.Context.FloatSave.StatusWord = 0;
+        ctx.Context.FloatSave.TagWord = 0xFFFF;
+        ctx.Context.FloatSave.Cr0NpxState = 0;
+
+        XMM_SAVE_AREA32 xmm_state{};
+        xmm_state.ControlWord = 0x037F;
+        xmm_state.StatusWord = 0;
+        xmm_state.TagWord = 0xFF;
+        xmm_state.MxCsr = 0x1F80;
+        xmm_state.MxCsr_Mask = 0xFFFFFFFF;
+
         memset(&ctx.Context.ExtendedRegisters, 0, sizeof(ctx.Context.ExtendedRegisters));
+        static_assert(sizeof(xmm_state) <= sizeof(ctx.Context.ExtendedRegisters));
+        memcpy(ctx.Context.ExtendedRegisters, &xmm_state, sizeof(xmm_state));
     });
 }
 


### PR DESCRIPTION
This PR does two things:

- [Fixes the default FP state for WoW64](https://github.com/momo5502/sogen/commit/80b869687528b63de19ec8b8e45571e909b2824b). This appears to fix a WHP guest crash when running WoW64.
- [Fixes AFD poll event filtering for HUP/ERR sockets](https://github.com/momo5502/sogen/commit/6b2ed4e2f2f5e00ffa11a14020b149bac6e39dc2). This fixes a rare crash that occurred when socket connection attempts failed with an error.