### PR TITLE
Fix MMIO updates on the WHP backend

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -816,6 +816,7 @@ namespace whp
 
                 while (!this->stop_requested_)
                 {
+                    this->expire_mmio_read_grace_pages();
                     WHV_RUN_VP_EXIT_CONTEXT exit_context{};
                     const auto start_rip = this->read_instruction_pointer();
                     this->run_active_ = true;
@@ -1090,6 +1091,9 @@ namespace whp
                 for (size_t offset = size; offset > 0; offset -= page_size)
                 {
                     const auto guest_address = address + offset - page_size;
+
+                    this->revoke_mmio_read_grace(guest_address);
+
                     const auto entry = this->mapped_pages_.find(guest_address);
                     if (entry == this->mapped_pages_.end())
                     {
@@ -1519,6 +1523,7 @@ namespace whp
             std::unordered_map<emulator_hook*, memory_access_hook_entry> memory_write_hooks_{};
             std::unordered_map<uint64_t, mmio_region> mmio_regions_{};
             std::optional<pending_mmio_step> pending_mmio_step_{};
+            std::unordered_map<uint64_t, std::chrono::steady_clock::time_point> mmio_read_grace_deadlines_{};
             instruction_hook_entry* syscall_hook_ = nullptr;
             void ensure_platform_support()
             {
@@ -1934,6 +1939,51 @@ namespace whp
                 return nullptr;
             }
 
+            void grant_mmio_read_grace(const uint64_t page_base)
+            {
+                constexpr std::chrono::milliseconds mmio_read_grace_period_{4};
+                this->mmio_read_grace_deadlines_[page_base] = std::chrono::steady_clock::now() + mmio_read_grace_period_;
+            }
+
+            void revoke_mmio_read_grace(const uint64_t page_base)
+            {
+                this->mmio_read_grace_deadlines_.erase(page_base);
+            }
+
+            void expire_mmio_read_grace_pages()
+            {
+                if (this->pending_mmio_step_.has_value())
+                {
+                    return;
+                }
+
+                const auto now = std::chrono::steady_clock::now();
+
+                for (auto it = this->mmio_read_grace_deadlines_.begin(); it != this->mmio_read_grace_deadlines_.end();)
+                {
+                    const auto page_base = it->first;
+                    const auto deadline = it->second;
+
+                    if (deadline > now)
+                    {
+                        ++it;
+                        continue;
+                    }
+
+                    auto page_it = this->mapped_pages_.find(page_base);
+                    if (page_it != this->mapped_pages_.end() && page_it->second)
+                    {
+                        if (this->find_mmio_region(page_base) != nullptr)
+                        {
+                            page_it->second->permissions = memory_permission::none;
+                            this->remap_page(*page_it->second);
+                        }
+                    }
+
+                    it = this->mmio_read_grace_deadlines_.erase(it);
+                }
+            }
+
             void refresh_mmio_page(const mmio_region& region, const uint64_t page_base)
             {
                 auto entry = this->mapped_pages_.find(page_base);
@@ -2025,6 +2075,7 @@ namespace whp
 
                 const auto state = std::move(*this->pending_mmio_step_);
                 this->pending_mmio_step_.reset();
+                this->revoke_mmio_read_grace(state.page_base);
 
                 const auto entry = this->mapped_pages_.find(state.page_base);
                 if (entry == this->mapped_pages_.end() || !entry->second)
@@ -2043,8 +2094,17 @@ namespace whp
                 entry->second->permissions = memory_permission::none;
                 this->remap_page(*entry->second);
 
-                WHV_REGISTER_VALUE rflags{};
-                rflags.Reg64 = state.original_rflags;
+                auto rflags = this->get_register(WHvX64RegisterRflags);
+
+                if (state.had_trap_flag)
+                {
+                    rflags.Reg64 |= 0x100ull;
+                }
+                else
+                {
+                    rflags.Reg64 &= ~0x100ull;
+                }
+
                 this->set_register(WHvX64RegisterRflags, rflags);
 
                 return !state.allow_debug_delivery;
@@ -2373,10 +2433,25 @@ namespace whp
                         throw std::runtime_error("MMIO page backing is missing");
                     }
 
-                    page_it->second->permissions = is_write ? memory_permission::read_write : memory_permission::read;
+                    if (is_write)
+                    {
+                        this->revoke_mmio_read_grace(page_base);
+                        page_it->second->permissions = memory_permission::read_write;
+                    }
+                    else
+                    {
+                        page_it->second->permissions = memory_permission::read;
+                    }
+
                     this->remap_page(*page_it->second);
 
-                    if (is_write && !this->arm_mmio_single_step(page_base, true))
+                    if (!is_write)
+                    {
+                        this->grant_mmio_read_grace(page_base);
+                        return true;
+                    }
+
+                    if (!this->arm_mmio_single_step(page_base, is_write))
                     {
                         throw std::runtime_error("Nested WHP MMIO single-step state is not supported");
                     }

--- a/src/samples/test-sample/CMakeLists.txt
+++ b/src/samples/test-sample/CMakeLists.txt
@@ -9,7 +9,7 @@ list(SORT SRC_FILES)
 add_executable(test-sample ${SRC_FILES})
 
 if(WIN)
-  target_link_libraries(test-sample PRIVATE dnsapi ws2_32)
+  target_link_libraries(test-sample PRIVATE dnsapi ws2_32 winmm)
 endif()
 
 momo_assign_source_group(${SRC_FILES})

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -29,8 +29,6 @@
 #include <knownfolders.h>
 #include <sddl.h>
 
-#pragma comment(lib, "winmm.lib")
-
 using namespace std::literals;
 
 // Externally visible and potentially modifiable state

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1396,8 +1396,19 @@ namespace
     bool test_mmio()
     {
         const auto t0 = timeGetTime();
-        Sleep(16);
-        return timeGetTime() - t0 >= 16;
+
+        // waste a bit of time
+        auto dummy = std::thread([] {
+            for (int i = 0; i < 1024; i++)
+            {
+                std::this_thread::yield();
+            }
+        });
+        dummy.join();
+
+        const auto t1 = timeGetTime();
+
+        return t1 != t0;
     }
 }
 

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -20,6 +20,7 @@
 #include <intrin.h>
 
 #include <windows.h>
+#include <timeapi.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windns.h>
@@ -27,6 +28,8 @@
 #include <combaseapi.h>
 #include <knownfolders.h>
 #include <sddl.h>
+
+#pragma comment(lib, "winmm.lib")
 
 using namespace std::literals;
 
@@ -1391,6 +1394,13 @@ namespace
         ReleaseActCtx(ctx);
         return true;
     }
+
+    bool test_mmio()
+    {
+        const auto t0 = timeGetTime();
+        Sleep(16);
+        return timeGetTime() - t0 >= 16;
+    }
 }
 
 #define RUN_TEST(func, name)                 \
@@ -1446,6 +1456,7 @@ int main(const int argc, const char* argv[])
 #endif
     RUN_TEST(test_private_namespace, "Private Namespace")
     RUN_TEST(test_actctx, "Activation Context")
+    RUN_TEST(test_mmio, "MMIO")
 
     return valid ? 0 : 1;
 }


### PR DESCRIPTION
This PR fixes MMIO updates on the WHP backend. Before this change, updates on read were only triggered once and then never again.

However, this works a bit differently from the other backends: updating on every single read causes a significant performance hit, so as a compromise, updates are limited to once every 4ms and are armed on VM exits. This keeps the performance impact negligible.