### PR TITLE
Fix AVX instructions in the WHP backend

### DIFF
--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -598,6 +598,7 @@ namespace
         watch_system_objects(context, options.modules, options.verbose_logging, options.concise_logging);
 
         const auto& exe = *win_emu->mod_manager.executable;
+        const auto is_whp = win_emu->emu().get_name() == "Windows Hypervisor Platform";
 
         win_emu->emu().hook_instruction(x86_hookable_instructions::cpuid, [&] {
             auto& emu = win_emu->emu();
@@ -611,7 +612,7 @@ namespace
                 context.emit_observation<cpuid_event>([&](auto& event) { event.leaf = leaf; });
             }
 
-            if (leaf == 1)
+            if (leaf == 1 && !is_whp)
             {
                 // NOTE: We hard-code these values to disable SSE4.x and AVX
                 //       See: https://github.com/momo5502/sogen/issues/560

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <utils/object.hpp>
+#include <utils/cpu_features.hpp>
 
 namespace whp
 {
@@ -1609,6 +1610,10 @@ namespace whp
                     names.push_back(WHvX64RegisterXCr0);
                     WHV_REGISTER_VALUE xcr0{};
                     xcr0.Reg64 = 0x3ull;
+                    if (utils::cpu_features::avx_enabled())
+                    {
+                        xcr0.Reg64 |= 0x4ull; // Enable YMM state
+                    }
                     values.push_back(xcr0);
                 }
 

--- a/src/common/utils/cpu_features.hpp
+++ b/src/common/utils/cpu_features.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+#include <intrin.h>
+#elif defined(__i386__) || defined(__x86_64__)
+#include <cpuid.h>
+#endif
+
+namespace utils::cpu_features
+{
+    namespace detail
+    {
+        using CpuidRegs = std::array<std::uint32_t, 4>;
+
+        [[nodiscard]] inline CpuidRegs cpuid(std::uint32_t leaf, std::uint32_t subleaf = 0) noexcept
+        {
+            CpuidRegs regs{};
+
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+            int out[4]{};
+            __cpuidex(out, static_cast<int>(leaf), static_cast<int>(subleaf));
+
+            regs[0] = static_cast<std::uint32_t>(out[0]); // EAX
+            regs[1] = static_cast<std::uint32_t>(out[1]); // EBX
+            regs[2] = static_cast<std::uint32_t>(out[2]); // ECX
+            regs[3] = static_cast<std::uint32_t>(out[3]); // EDX
+#elif defined(__i386__) || defined(__x86_64__)
+            std::uint32_t eax{};
+            std::uint32_t ebx{};
+            std::uint32_t ecx{};
+            std::uint32_t edx{};
+
+            __cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);
+
+            regs = {eax, ebx, ecx, edx};
+#endif
+
+            return regs;
+        }
+
+        [[nodiscard]] inline std::uint64_t xgetbv(std::uint32_t index) noexcept
+        {
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+            return _xgetbv(index);
+#elif defined(__i386__) || defined(__x86_64__)
+            std::uint32_t eax{};
+            std::uint32_t edx{};
+
+            __asm__ volatile("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+
+            return (static_cast<std::uint64_t>(edx) << 32) | eax;
+#else
+            return 0;
+#endif
+        }
+    }
+
+    [[nodiscard]] inline bool avx_enabled() noexcept
+    {
+#if defined(_MSC_VER) || defined(__i386__) || defined(__x86_64__)
+        const auto regs = detail::cpuid(1);
+        const auto ecx = regs[2];
+
+        constexpr std::uint32_t xsave_bit = 1u << 26;
+        constexpr std::uint32_t osxsave_bit = 1u << 27;
+        constexpr std::uint32_t avx_bit = 1u << 28;
+
+        constexpr std::uint32_t required_cpu_bits = xsave_bit | osxsave_bit | avx_bit;
+
+        if ((ecx & required_cpu_bits) != required_cpu_bits)
+        {
+            return false;
+        }
+
+        const auto xcr0 = detail::xgetbv(0);
+
+        constexpr std::uint64_t xmm_state = 1ull << 1;
+        constexpr std::uint64_t ymm_state = 1ull << 2;
+
+        return (xcr0 & (xmm_state | ymm_state)) == (xmm_state | ymm_state);
+#else
+        return false;
+#endif
+    }
+}

--- a/src/common/utils/cpu_features.hpp
+++ b/src/common/utils/cpu_features.hpp
@@ -20,8 +20,8 @@ namespace utils::cpu_features
             CpuidRegs regs{};
 
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
-            int out[4]{};
-            __cpuidex(out, static_cast<int>(leaf), static_cast<int>(subleaf));
+            std::array<int, 4> out{};
+            __cpuidex(out.data(), static_cast<int>(leaf), static_cast<int>(subleaf));
 
             regs[0] = static_cast<std::uint32_t>(out[0]); // EAX
             regs[1] = static_cast<std::uint32_t>(out[1]); // EBX


### PR DESCRIPTION
This PR fixes AVX instructions in the WHP backend. The issue was caused by the XCR0 register being initialized to 0x3, which only enables x87 and SSE state. AVX instructions also require the YMM state bit to be enabled, so XCR0 needs to be initialized to 0x7 instead.