### PR TITLE
Fix thread exit status and DeallocationStack

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -152,6 +152,7 @@ emulator_thread::emulator_thread(memory_manager& memory, const process_context& 
 
             teb_obj.ClientId.UniqueProcess = 1ul;
             teb_obj.ClientId.UniqueThread = static_cast<uint64_t>(this->id);
+            teb_obj.DeallocationStack = this->stack_base;
             teb_obj.NtTib.StackLimit = this->stack_base;
             teb_obj.NtTib.StackBase = this->stack_base + this->stack_size;
             teb_obj.NtTib.Self = this->teb64->value();
@@ -215,6 +216,7 @@ emulator_thread::emulator_thread(memory_manager& memory, const process_context& 
         teb_obj.ClientId.UniqueThread = static_cast<uint64_t>(this->id);
 
         // Native 64-bit stack
+        teb_obj.DeallocationStack = this->stack_base;
         teb_obj.NtTib.StackLimit = this->stack_base;
         teb_obj.NtTib.StackBase = wow64_cpureserved_base;
         teb_obj.NtTib.Self = this->teb64->value();

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -313,6 +313,10 @@ namespace syscalls
 
             const emulator_object<THREAD_BASIC_INFORMATION64> info{c.emu, thread_information};
             info.access([&](THREAD_BASIC_INFORMATION64& i) {
+                if (thread->exit_status)
+                {
+                    i.ExitStatus = *thread->exit_status;
+                }
                 i.TebBaseAddress = thread->teb64->value();
                 i.ClientId = thread->teb64->read().ClientId;
             });


### PR DESCRIPTION
This PR fixes two little issues:

- [Fixes TEB DeallocationStack](https://github.com/momo5502/sogen/commit/58e5bdab9feb35cd723fb6a777356451712e925c). It wasn’t being set before.
- [Fixes the thread exit status](https://github.com/momo5502/sogen/commit/074bd29c620ca011ef2d9803994dc3c4dd2cdf9e). It also wasn’t being set before.