### PR TITLE
Add SID and .Default mappings for user registry hive

### DIFF
--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -2,6 +2,7 @@
 #include "process_context.hpp"
 
 #include "emulator_utils.hpp"
+#include "registry/registry_utils.hpp"
 #include "syscall_utils.hpp"
 #include "windows_emulator.hpp"
 #include "version/windows_version_manager.hpp"
@@ -58,40 +59,6 @@ namespace
         }
 
         return result;
-    }
-
-    std::string get_user_sid_string(registry_manager& registry)
-    {
-        const std::filesystem::path profile_list_path = R"(\Registry\Machine\Software\Microsoft\Windows NT\CurrentVersion\ProfileList)";
-
-        const auto profile_list_key = registry.get_key(profile_list_path);
-        if (!profile_list_key)
-        {
-            throw std::runtime_error("Failed to get ProfileList registry key");
-        }
-
-        for (size_t i = 0;; ++i)
-        {
-            const auto value = registry.get_sub_key_name(*profile_list_key, i);
-            if (!value.has_value())
-            {
-                break;
-            }
-
-            const auto profile_key = registry.get_key(profile_list_path / *value);
-            if (!profile_key.has_value())
-            {
-                continue;
-            }
-
-            const auto full_profile = registry.get_value(*profile_key, "FullProfile");
-            if (full_profile && full_profile->as_dword().value_or(0) == 1)
-            {
-                return std::string(*value);
-            }
-        }
-
-        return "S-1-5-18";
     }
 
     std::vector<uint8_t> get_sid(registry_manager& registry)

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -1,5 +1,6 @@
 #include "../std_include.hpp"
 #include "registry_manager.hpp"
+#include "registry_utils.hpp"
 
 #include <serialization_helper.hpp>
 
@@ -77,6 +78,7 @@ void registry_manager::setup()
 
     const std::filesystem::path root = R"(\registry)";
     const std::filesystem::path machine = root / "machine";
+    const std::filesystem::path user = root / "user";
 
     register_hive(this->hives_, machine / "system", this->hive_path_ / "SYSTEM");
     register_hive(this->hives_, machine / "security", this->hive_path_ / "SECURITY");
@@ -86,6 +88,9 @@ void registry_manager::setup()
     register_optional_hive(this->hives_, machine / "hardware", this->hive_path_ / "HARDWARE");
 
     register_hive(this->hives_, root / "user", this->hive_path_ / "NTUSER.DAT");
+
+    this->add_path_mapping(user / get_user_sid_string(*this), user);
+    this->add_path_mapping(user / ".Default", user);
 
     this->add_path_mapping(machine / "system" / "CurrentControlSet", machine / "system" / "ControlSet001");
     this->add_path_mapping(machine / "system" / "ControlSet001" / "Control" / "ComputerName" / "ActiveComputerName",
@@ -263,7 +268,7 @@ std::optional<registry_key> registry_manager::get_key(const utils::path_key& key
 {
     const auto normal_key = this->normalize_path(key);
 
-    if (is_subpath(normal_key, utils::path_key{"\\registry\\machine"}))
+    if (is_subpath(normal_key, utils::path_key{"\\registry\\machine"}) || is_subpath(normal_key, utils::path_key{"\\registry\\user"}))
     {
         registry_key reg_key{};
         reg_key.hive = normal_key;

--- a/src/windows-emulator/registry/registry_utils.hpp
+++ b/src/windows-emulator/registry/registry_utils.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "registry_manager.hpp"
+
+inline std::string get_user_sid_string(registry_manager& registry)
+{
+    const std::filesystem::path profile_list_path = R"(\Registry\Machine\Software\Microsoft\Windows NT\CurrentVersion\ProfileList)";
+
+    const auto profile_list_key = registry.get_key(profile_list_path);
+    if (!profile_list_key)
+    {
+        throw std::runtime_error("Failed to get ProfileList registry key");
+    }
+
+    for (size_t i = 0;; ++i)
+    {
+        const auto value = registry.get_sub_key_name(*profile_list_key, i);
+        if (!value.has_value())
+        {
+            break;
+        }
+
+        const auto profile_key = registry.get_key(profile_list_path / *value);
+        if (!profile_key.has_value())
+        {
+            continue;
+        }
+
+        const auto full_profile = registry.get_value(*profile_key, "FullProfile");
+        if (full_profile && full_profile->as_dword().value_or(0) == 1)
+        {
+            return std::string(*value);
+        }
+    }
+
+    return "S-1-5-18";
+}


### PR DESCRIPTION
This PR adds the missing registry mappings for the User SID and `.Default` under `HKU`.