### PR TITLE
Improve virtual memory query and allocation behavior

### DIFF
--- a/src/windows-emulator/memory_manager.cpp
+++ b/src/windows-emulator/memory_manager.cpp
@@ -568,26 +568,85 @@ uint64_t memory_manager::allocate_memory(const size_t size, const nt_memory_perm
 
 uint64_t memory_manager::find_free_allocation_base(const size_t size, const uint64_t start) const
 {
-    uint64_t start_address = std::max(static_cast<uint64_t>(MIN_ALLOCATION_ADDRESS), start ? start : this->default_allocation_address_);
-    start_address = align_up(start_address, ALLOCATION_GRANULARITY);
+    return this->find_free_allocation_base(size, start, ALLOCATION_GRANULARITY, MIN_ALLOCATION_ADDRESS, MAX_ALLOCATION_END_EXCL - 1);
+}
+
+namespace
+{
+    bool is_power_of_two(const uint64_t value)
+    {
+        return value != 0 && (value & (value - 1)) == 0;
+    }
+
+    std::optional<uint64_t> checked_align_up(const uint64_t value, const uint64_t alignment)
+    {
+        if (!is_power_of_two(alignment) || value > UINT64_MAX - (alignment - 1))
+        {
+            return std::nullopt;
+        }
+
+        return align_up(value, alignment);
+    }
+}
+
+uint64_t memory_manager::find_free_allocation_base(const size_t size, const uint64_t start, uint64_t alignment, uint64_t lowest_address,
+                                                   uint64_t highest_address) const
+{
+    if (!is_power_of_two(alignment) || alignment < ALLOCATION_GRANULARITY || size == 0)
+    {
+        return 0;
+    }
+
+    lowest_address = std::max<uint64_t>(lowest_address, MIN_ALLOCATION_ADDRESS);
+    highest_address = std::min<uint64_t>(highest_address ? highest_address : MAX_ALLOCATION_END_EXCL - 1, MAX_ALLOCATION_END_EXCL - 1);
+    if (lowest_address > highest_address)
+    {
+        return 0;
+    }
+
+    auto candidate = start ? start : this->default_allocation_address_;
+    if (candidate < lowest_address || candidate > highest_address)
+    {
+        candidate = lowest_address;
+    }
+
+    auto aligned_start = checked_align_up(candidate, alignment);
+    if (!aligned_start.has_value())
+    {
+        return 0;
+    }
+
+    uint64_t start_address = *aligned_start;
 
     // Since reserved_regions_ is a sorted map, we can iterate through it
     // and find gaps between regions
-    while (start_address + size <= MAX_ALLOCATION_END_EXCL)
+    while (start_address <= highest_address)
     {
+        const auto end_address = start_address + size;
+        if (end_address < start_address || end_address > MAX_ALLOCATION_END_EXCL || end_address - 1 > highest_address)
+        {
+            return 0;
+        }
+
         bool conflict = false;
 
         // Check if the proposed range [start_address, start_address+size) conflicts with any existing region
         for (const auto& region : this->reserved_regions_)
         {
+            const auto region_end = region.first + region.second.length;
+            if (region_end < region.first)
+            {
+                return 0;
+            }
+
             // If this region ends before our start, skip it
-            if (region.first + region.second.length <= start_address)
+            if (region_end <= start_address)
             {
                 continue;
             }
 
             // If this region starts after our end, we're done checking (map is sorted)
-            if (region.first >= start_address + size)
+            if (region.first >= end_address)
             {
                 break;
             }
@@ -595,7 +654,13 @@ uint64_t memory_manager::find_free_allocation_base(const size_t size, const uint
             // Otherwise, we have a conflict
             conflict = true;
             // Move start_address past this conflicting region
-            start_address = align_up(region.first + region.second.length, ALLOCATION_GRANULARITY);
+            aligned_start = checked_align_up(region_end, alignment);
+            if (!aligned_start.has_value())
+            {
+                return 0;
+            }
+
+            start_address = *aligned_start;
             break;
         }
 
@@ -612,7 +677,7 @@ uint64_t memory_manager::find_free_allocation_base(const size_t size, const uint
 region_info memory_manager::get_region_info(const uint64_t address)
 {
     region_info result{};
-    result.start = MIN_ALLOCATION_ADDRESS;
+    result.start = page_align_down(address);
     result.length = static_cast<size_t>(MAX_ALLOCATION_END_EXCL - result.start);
     result.permissions = nt_memory_permission();
     result.initial_permissions = nt_memory_permission();
@@ -634,25 +699,29 @@ region_info memory_manager::get_region_info(const uint64_t address)
     }
 
     const auto entry = --upper_bound;
-    const auto lower_end = entry->first + entry->second.length;
-    if (lower_end <= address)
+    const auto reserved_end = entry->first + entry->second.length;
+
+    if (reserved_end <= address)
     {
-        result.start = lower_end;
-        result.length = static_cast<size_t>(MAX_ALLOCATION_END_EXCL - result.start);
+        auto next = std::next(entry);
+
+        result.start = page_align_down(address);
+        result.length = next == this->reserved_regions_.end() ? static_cast<size_t>(MAX_ALLOCATION_END_EXCL - result.start)
+                                                              : static_cast<size_t>(next->first - result.start);
+
         return result;
     }
 
-    // We have a reserved region
     const auto& reserved_region = entry->second;
     const auto& committed_regions = reserved_region.committed_regions;
 
     result.is_reserved = true;
     result.allocation_base = entry->first;
     result.allocation_length = reserved_region.length;
-    result.start = result.allocation_base;
-    result.length = result.allocation_length;
-    result.initial_permissions = entry->second.initial_permission;
+    result.initial_permissions = reserved_region.initial_permission;
     result.kind = reserved_region.kind;
+    result.start = page_align_down(address);
+    result.length = static_cast<size_t>(reserved_end - result.start);
 
     if (committed_regions.empty())
     {
@@ -667,18 +736,21 @@ region_info memory_manager::get_region_info(const uint64_t address)
     }
 
     const auto committed_entry = --committed_bound;
-    const auto committed_lower_end = committed_entry->first + committed_entry->second.length;
-    if (committed_lower_end <= address)
+    const auto committed_end = committed_entry->first + committed_entry->second.length;
+
+    if (committed_end <= address)
     {
-        result.start = committed_lower_end;
-        result.length = static_cast<size_t>(lower_end - result.start);
+        auto next_committed = std::next(committed_entry);
+
+        result.length = next_committed == committed_regions.end() ? static_cast<size_t>(reserved_end - result.start)
+                                                                  : static_cast<size_t>(next_committed->first - result.start);
+
         return result;
     }
 
     result.is_committed = true;
-    result.start = committed_entry->first;
-    result.length = committed_entry->second.length;
     result.permissions = committed_entry->second.permissions;
+    result.length = static_cast<size_t>(committed_end - result.start);
 
     return result;
 }

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -21,7 +21,8 @@ enum class memory_region_kind : uint8_t
 {
     free = 0,
     private_allocation,
-    section_view,
+    file_section_view,
+    pagefile_section_view,
     section_image,
     mmio,
 };
@@ -149,7 +150,8 @@ namespace memory_region_policy
 {
     constexpr bool is_section_kind(const memory_region_kind kind)
     {
-        return kind == memory_region_kind::section_view || kind == memory_region_kind::section_image;
+        return kind == memory_region_kind::pagefile_section_view || kind == memory_region_kind::file_section_view ||
+               kind == memory_region_kind::section_image;
     }
 
     constexpr bool is_mapped_memory_kind(const memory_region_kind kind)
@@ -163,7 +165,8 @@ namespace memory_region_policy
         {
         case memory_region_kind::section_image:
             return MEM_IMAGE;
-        case memory_region_kind::section_view:
+        case memory_region_kind::pagefile_section_view:
+        case memory_region_kind::file_section_view:
             return MEM_MAPPED;
         case memory_region_kind::mmio:
             return MEM_MAPPED;

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -95,6 +95,8 @@ class memory_manager : public memory_interface
                              memory_region_kind kind = memory_region_kind::private_allocation);
 
     uint64_t find_free_allocation_base(size_t size, uint64_t start = 0) const;
+    uint64_t find_free_allocation_base(size_t size, uint64_t start, uint64_t alignment, uint64_t lowest_address,
+                                       uint64_t highest_address) const;
 
     region_info get_region_info(uint64_t address);
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -133,7 +133,9 @@ namespace syscalls
                                            emulator_object<uint32_t> old_protection);
     NTSTATUS handle_NtAllocateVirtualMemoryEx(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
                                               emulator_object<uint64_t> bytes_to_allocate, uint32_t allocation_type,
-                                              uint32_t page_protection);
+                                              uint32_t page_protection,
+                                              emulator_object<MEM_EXTENDED_PARAMETER64> extended_parameters,
+                                              ULONG extended_parameter_count);
     NTSTATUS handle_NtAllocateVirtualMemory(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
                                             uint64_t zero_bits, emulator_object<uint64_t> bytes_to_allocate, uint32_t allocation_type,
                                             uint32_t page_protection);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -133,8 +133,7 @@ namespace syscalls
                                            emulator_object<uint32_t> old_protection);
     NTSTATUS handle_NtAllocateVirtualMemoryEx(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
                                               emulator_object<uint64_t> bytes_to_allocate, uint32_t allocation_type,
-                                              uint32_t page_protection,
-                                              emulator_object<MEM_EXTENDED_PARAMETER64> extended_parameters,
+                                              uint32_t page_protection, emulator_object<MEM_EXTENDED_PARAMETER64> extended_parameters,
                                               ULONG extended_parameter_count);
     NTSTATUS handle_NtAllocateVirtualMemory(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
                                             uint64_t zero_bits, emulator_object<uint64_t> bytes_to_allocate, uint32_t allocation_type,

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -360,9 +360,15 @@ namespace syscalls
             const auto reset_size = requested_allocation_bytes;
 
             const auto region_info = c.win_emu.memory.get_region_info(reset_base);
-            const auto region_end = checked_add(region_info.start, region_info.length);
-            if (!region_info.is_reserved || region_info.kind != memory_region_kind::private_allocation || region_info.start > reset_base ||
-                !region_end.has_value() || *region_end < *reset_end)
+            const auto is_valid_kind =
+                region_info.kind == memory_region_kind::private_allocation || region_info.kind == memory_region_kind::pagefile_section_view;
+            if (!region_info.is_reserved || !is_valid_kind || region_info.allocation_base > reset_base)
+            {
+                return STATUS_MEMORY_NOT_ALLOCATED;
+            }
+
+            const auto allocation_end = checked_add(region_info.allocation_base, region_info.allocation_length);
+            if (!allocation_end.has_value() || *allocation_end < *reset_end)
             {
                 return STATUS_MEMORY_NOT_ALLOCATED;
             }

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -7,6 +7,114 @@
 
 namespace syscalls
 {
+    namespace
+    {
+        struct allocation_address_requirements
+        {
+            uint64_t lowest_address = MIN_ALLOCATION_ADDRESS;
+            uint64_t highest_address = MAX_ALLOCATION_END_EXCL - 1;
+            uint64_t alignment = ALLOCATION_GRANULARITY;
+            bool present = false;
+            bool has_non_default_values = false;
+        };
+
+        bool is_power_of_two(const uint64_t value)
+        {
+            return value != 0 && (value & (value - 1)) == 0;
+        }
+
+        std::optional<uint64_t> checked_add(const uint64_t lhs, const uint64_t rhs)
+        {
+            if (lhs > UINT64_MAX - rhs)
+            {
+                return std::nullopt;
+            }
+
+            return lhs + rhs;
+        }
+
+        NTSTATUS parse_allocation_address_requirements(const syscall_context& c,
+                                                       const emulator_object<MEM_EXTENDED_PARAMETER64> extended_parameters,
+                                                       const ULONG extended_parameter_count, allocation_address_requirements& requirements)
+        {
+            if (!extended_parameters)
+            {
+                return extended_parameter_count == 0 ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER;
+            }
+
+            for (ULONG i = 0; i < extended_parameter_count; ++i)
+            {
+                const auto param = extended_parameters.try_read(i);
+                if (!param.has_value())
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const auto param_type = static_cast<MEM_EXTENDED_PARAMETER_TYPE>(param->Type & 0xFF);
+                if (param_type != MemExtendedParameterAddressRequirements)
+                {
+                    continue;
+                }
+
+                if (requirements.present)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                if (!param->Pointer)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const emulator_object<MEM_ADDRESS_REQUIREMENTS64> address_requirements{c.emu, param->Pointer};
+                const auto req = address_requirements.try_read();
+                if (!req.has_value())
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                if (req->LowestStartingAddress != 0 &&
+                    (req->LowestStartingAddress < MIN_ALLOCATION_ADDRESS || req->LowestStartingAddress % ALLOCATION_GRANULARITY != 0))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                if (req->HighestEndingAddress != 0)
+                {
+                    if (req->HighestEndingAddress > MAX_ALLOCATION_ADDRESS)
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    const auto highest_end_plus_one = req->HighestEndingAddress + 1;
+                    if (highest_end_plus_one % ALLOCATION_GRANULARITY != 0)
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+                }
+
+                if (req->Alignment != 0 && (!is_power_of_two(req->Alignment) || req->Alignment < ALLOCATION_GRANULARITY))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                requirements.present = true;
+                requirements.has_non_default_values =
+                    req->LowestStartingAddress != 0 || req->HighestEndingAddress != 0 || req->Alignment != 0;
+                requirements.lowest_address = req->LowestStartingAddress ? req->LowestStartingAddress : MIN_ALLOCATION_ADDRESS;
+                requirements.highest_address = req->HighestEndingAddress ? req->HighestEndingAddress : MAX_ALLOCATION_END_EXCL - 1;
+                requirements.alignment = req->Alignment ? req->Alignment : ALLOCATION_GRANULARITY;
+
+                if (requirements.lowest_address > requirements.highest_address)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+            }
+
+            return STATUS_SUCCESS;
+        }
+    }
+
     NTSTATUS handle_NtQueryVirtualMemory(const syscall_context& c, const handle process_handle, const uint64_t base_address,
                                          const uint32_t info_class, const uint64_t memory_information,
                                          const uint64_t memory_information_length, const emulator_object<uint64_t> return_length)
@@ -191,7 +299,9 @@ namespace syscalls
     NTSTATUS handle_NtAllocateVirtualMemoryEx(const syscall_context& c, const handle process_handle,
                                               const emulator_object<uint64_t> base_address,
                                               const emulator_object<uint64_t> bytes_to_allocate, const uint32_t allocation_type,
-                                              const uint32_t page_protection)
+                                              const uint32_t page_protection,
+                                              const emulator_object<MEM_EXTENDED_PARAMETER64> extended_parameters,
+                                              const ULONG extended_parameter_count)
     {
         if (process_handle != CURRENT_PROCESS)
         {
@@ -204,6 +314,9 @@ namespace syscalls
         {
             return STATUS_INVALID_PARAMETER;
         }
+
+        const auto requested_base = base_address.read();
+        const auto requested_allocation_bytes = allocation_bytes;
 
         allocation_bytes = page_align_up(allocation_bytes);
         bytes_to_allocate.write(allocation_bytes);
@@ -220,10 +333,66 @@ namespace syscalls
             return STATUS_INVALID_PAGE_PROTECTION;
         }
 
-        auto potential_base = base_address.read();
+        if (allocation_type & MEM_RESET)
+        {
+            if (allocation_type & ~MEM_RESET)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (requested_base != page_align_down(requested_base))
+            {
+                return STATUS_CONFLICTING_ADDRESSES;
+            }
+
+            if (requested_allocation_bytes != page_align_up(requested_allocation_bytes))
+            {
+                return STATUS_CONFLICTING_ADDRESSES;
+            }
+
+            const auto reset_end = checked_add(requested_base, requested_allocation_bytes);
+            if (!reset_end.has_value())
+            {
+                return STATUS_CONFLICTING_ADDRESSES;
+            }
+
+            const auto reset_base = requested_base;
+            const auto reset_size = requested_allocation_bytes;
+
+            const auto region_info = c.win_emu.memory.get_region_info(reset_base);
+            const auto region_end = checked_add(region_info.start, region_info.length);
+            if (!region_info.is_reserved || region_info.kind != memory_region_kind::private_allocation || region_info.start > reset_base ||
+                !region_end.has_value() || *region_end < *reset_end)
+            {
+                return STATUS_MEMORY_NOT_ALLOCATED;
+            }
+
+            base_address.write(reset_base);
+            bytes_to_allocate.write(reset_size);
+
+            // Real Windows may discard page contents, we just return success.
+            return STATUS_SUCCESS;
+        }
+
+        allocation_address_requirements address_requirements{};
+        const auto parse_status =
+            parse_allocation_address_requirements(c, extended_parameters, extended_parameter_count, address_requirements);
+        if (parse_status != STATUS_SUCCESS)
+        {
+            return parse_status;
+        }
+
+        if (requested_base != 0 && address_requirements.present && address_requirements.has_non_default_values)
+        {
+            return STATUS_INVALID_PARAMETER;
+        }
+
+        auto potential_base = requested_base;
         if (!potential_base)
         {
-            potential_base = c.win_emu.memory.find_free_allocation_base(static_cast<size_t>(allocation_bytes));
+            potential_base =
+                c.win_emu.memory.find_free_allocation_base(static_cast<size_t>(allocation_bytes), 0, address_requirements.alignment,
+                                                           address_requirements.lowest_address, address_requirements.highest_address);
         }
         else
         {
@@ -269,7 +438,8 @@ namespace syscalls
                                             const emulator_object<uint64_t> bytes_to_allocate, const uint32_t allocation_type,
                                             const uint32_t page_protection)
     {
-        return handle_NtAllocateVirtualMemoryEx(c, process_handle, base_address, bytes_to_allocate, allocation_type, page_protection);
+        return handle_NtAllocateVirtualMemoryEx(c, process_handle, base_address, bytes_to_allocate, allocation_type, page_protection,
+                                                emulator_object<MEM_EXTENDED_PARAMETER64>{c.emu}, 0);
     }
 
     NTSTATUS handle_NtFreeVirtualMemory(const syscall_context& c, const handle process_handle, const emulator_object<uint64_t> base_address,

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -189,7 +189,7 @@ namespace syscalls
 
             const auto address = c.win_emu.memory.find_free_allocation_base(shared_section_size);
             c.win_emu.memory.allocate_memory(address, shared_section_size, memory_permission::read_write, false,
-                                             memory_region_kind::section_view);
+                                             memory_region_kind::pagefile_section_view);
             c.proc.shared_section_address = address;
             c.proc.shared_section_size = shared_section_size;
 
@@ -203,7 +203,7 @@ namespace syscalls
 
             const auto address = c.win_emu.memory.find_free_allocation_base(dbwin_buffer_section_size);
             c.win_emu.memory.allocate_memory(address, dbwin_buffer_section_size, memory_permission::read_write, false,
-                                             memory_region_kind::section_view);
+                                             memory_region_kind::pagefile_section_view);
             c.proc.dbwin_buffer = address;
             c.proc.dbwin_buffer_size = dbwin_buffer_section_size;
 
@@ -386,7 +386,9 @@ namespace syscalls
         const auto aligned_size = static_cast<size_t>(page_align_up(size));
         const auto reserve_only = section_entry->allocation_attributes == SEC_RESERVE;
         const auto protection = map_nt_to_emulator_protection(section_entry->section_page_protection);
-        const auto address = c.win_emu.memory.allocate_memory(aligned_size, protection, reserve_only, 0, memory_region_kind::section_view);
+        const auto region_kind =
+            section_entry->file_name.empty() ? memory_region_kind::pagefile_section_view : memory_region_kind::file_section_view;
+        const auto address = c.win_emu.memory.allocate_memory(aligned_size, protection, reserve_only, 0, region_kind);
 
         if (!reserve_only && !file_data.empty())
         {


### PR DESCRIPTION
This PR makes several improvements to `QueryVirtualMemory` and `AllocateVirtualMemory`. Some were discovered while trying to run programs with stricter memory requirements under sogen, and others came from the Windows docs.

The changes are basically:

- Parse and validate allocation address requirements in `NtAllocateVirtualMemoryEx`.
    - Use those constraints when finding a free allocation base.
- Add basic `MEM_RESET` validation/stub in `NtAllocateVirtualMemoryEx`.
- Make `NtQueryVirtualMemory` results start at the queried page and end at the next relevant boundary.