### PR TITLE
Fix atom handling and window ancestry state

### DIFF
--- a/src/common/platform/user.hpp
+++ b/src/common/platform/user.hpp
@@ -167,29 +167,41 @@ struct USER_WINDOW
     uint32_t dwExStyle;
     uint32_t dwStyle;
     uint64_t hInstance;
-    uint8_t pad_028[8];
+    uint8_t pad_028[2];
+    uint16_t fnid;
+    uint8_t pad_02C[4];
     uint64_t spwndParent;
-    uint8_t pad_038[64];
+    uint8_t pad_038[8];
+    uint64_t spwndOwner;
+    uint8_t pad_048[48];
     uint64_t lpfnWndProc;
     uint64_t pcls;
     uint8_t pad_088[16];
     uint64_t spmenu;
-    uint8_t pad_0A0[40];
+    uint8_t pad_0A0[24];
+    uint32_t dwTextLengthBytes;
+    uint8_t pad_0BC[4];
+    uint64_t strText;
     uint32_t cbWndExtra;
     uint8_t pad_0CC[12];
     uint64_t userData;
     uint64_t pActCtx;
-    uint8_t pad_0E8[16];
+    uint8_t pad_0E8[4];
+    uint32_t windowBand;
+    uint8_t pad_0F0[8];
     uint32_t wndExtraOffset;
     uint8_t pad_0FC[44];
     uint64_t pExtraBytes;
     uint8_t pad_130[16];
     uint64_t wID;
 };
+static_assert(sizeof(USER_WINDOW) == 328);
 
 struct USER_DESKTOPINFO
 {
-    uint8_t unknown[0xFF];
+    uint8_t unknown0[0x8];
+    uint64_t spwndDesktop;
+    uint8_t unknown10[0xEF];
 };
 
 // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)

--- a/src/common/platform/window.hpp
+++ b/src/common/platform/window.hpp
@@ -108,7 +108,15 @@ struct EMU_CREATESTRUCT
 };
 
 #ifndef OS_WINDOWS
+#define MAXINTATOM           0xC000
+
+#define HWND_MESSAGE         ((hwnd) - 3)
+
+#define WS_POPUP             0x80000000L
+#define WS_CHILD             0x40000000L
 #define WS_VISIBLE           0x10000000L
+#define WS_CLIPSIBLINGS      0x04000000L
+#define WS_CLIPCHILDREN      0x02000000L
 
 #define SWP_SHOWWINDOW       0x0040
 #define SWP_HIDEWINDOW       0x0080

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -164,6 +164,12 @@ emulator_thread::emulator_thread(memory_manager& memory, const process_context& 
             teb_obj.SameTebFlags.SkipLoaderInit = (create_flags & THREAD_CREATE_FLAGS_SKIP_LOADER_INIT) ? 1 : 0;
 
             const auto desktop_info_obj = this->gs_segment->reserve<USER_DESKTOPINFO>();
+            desktop_info_obj.access([&](USER_DESKTOPINFO& info) {
+                if (const auto* wnd = context.windows.get(context.default_desktop_window_handle))
+                {
+                    info.spwndDesktop = wnd->guest.value();
+                }
+            });
             teb_obj.Win32ClientInfo.arr[4] = desktop_info_obj.value();
         });
 

--- a/src/windows-emulator/emulator_utils.hpp
+++ b/src/windows-emulator/emulator_utils.hpp
@@ -409,6 +409,23 @@ inline std::u16string read_unicode_string(emulator& emu, const uint64_t uc_strin
     return read_unicode_string(emu, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>>{emu, uc_string}, index);
 }
 
+inline std::u16string read_large_string(const emulator_object<LARGE_STRING> str_obj, const size_t index = 0)
+{
+    if (!str_obj)
+    {
+        return {};
+    }
+
+    const auto str = str_obj.read(index);
+    if (!str.bAnsi)
+    {
+        return read_string<char16_t>(*str_obj.get_memory_interface(), str.Buffer, str.Length / 2);
+    }
+
+    const auto ansi_string = read_string<char>(*str_obj.get_memory_interface(), str.Buffer, str.Length);
+    return u8_to_u16(ansi_string);
+}
+
 /// Retrieves function arguments from registers or stack memory. This function assumes the stack pointer currently points to the
 /// return address.
 inline uint64_t get_function_argument(x86_64_emulator& emu, const size_t index, const bool is_syscall = false)

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -815,6 +815,11 @@ uint16_t process_context::add_or_find_atom(std::u16string name)
 
 bool process_context::delete_atom(const std::u16string& name)
 {
+    if (name.empty())
+    {
+        return false;
+    }
+
     for (auto it = atoms.begin(); it != atoms.end(); ++it)
     {
         if (utils::string::equals_ignore_case(it->second.name, name))

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -512,10 +512,10 @@ void process_context::setup(x86_64_emulator& emu, memory_manager& memory, regist
 
     this->user_handles.setup(is_wow64_process);
 
-    auto [h, monitor_obj] = this->user_handles.allocate_object<USER_MONITOR>(handle_types::monitor);
-    this->default_monitor_handle = h;
+    auto [mh, monitor_obj] = this->user_handles.allocate_object<USER_MONITOR>(handle_types::monitor);
+    this->default_monitor_handle = mh;
     monitor_obj.access([&](USER_MONITOR& monitor) {
-        monitor.hmon = h.bits;
+        monitor.hmon = mh.bits;
         monitor.rcMonitor = {.left = 0, .top = 0, .right = 1920, .bottom = 1080};
         monitor.rcWork = monitor.rcMonitor;
         if (version.is_build_before(26040))
@@ -530,6 +530,18 @@ void process_context::setup(x86_64_emulator& emu, memory_manager& memory, regist
             monitor.b26.monitorDpi = 96;
             monitor.b26.nativeDpi = monitor.b26.monitorDpi;
         }
+    });
+
+    auto [wh, desktop_win] = this->windows.create(memory);
+    this->default_desktop_window_handle = wh;
+    desktop_win.handle = wh.bits;
+    desktop_win.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+    desktop_win.guest.access([&](USER_WINDOW& window) {
+        window.hWnd = wh.bits;
+        window.ptrBase = desktop_win.guest.value();
+        window.dwStyle = desktop_win.style;
+        window.fnid = 0x29D;   // FNID_DESKTOP
+        window.windowBand = 1; // ZBID_DESKTOP
     });
 
     const auto user_display_info = this->user_handles.get_display_info();
@@ -570,6 +582,7 @@ void process_context::serialize(utils::buffer_serializer& buffer) const
 
     buffer.write(this->user_handles);
     buffer.write(this->default_monitor_handle);
+    buffer.write(this->default_desktop_window_handle);
     buffer.write(this->events);
     buffer.write(this->files);
     buffer.write_map(this->file_locks);
@@ -636,6 +649,7 @@ void process_context::deserialize(utils::buffer_deserializer& buffer)
 
     buffer.read(this->user_handles);
     buffer.read(this->default_monitor_handle);
+    buffer.read(this->default_desktop_window_handle);
     buffer.read(this->events);
     buffer.read(this->files);
     buffer.read_map(this->file_locks);
@@ -746,15 +760,18 @@ std::optional<uint16_t> process_context::find_atom(const std::u16string_view nam
 
 uint16_t process_context::add_or_find_atom(std::u16string name)
 {
-    uint16_t index = 1;
-    if (!this->atoms.empty())
+    constexpr uint32_t max_atom = std::numeric_limits<uint16_t>::max();
+
+    uint32_t index = MAXINTATOM;
+    if (this->atoms.lower_bound(MAXINTATOM) != this->atoms.end())
     {
         auto i = this->atoms.end();
         --i;
-        index = i->first + 1;
+        index = static_cast<uint32_t>(i->first) + 1;
     }
 
     std::optional<uint16_t> last_entry{};
+
     for (auto& entry : this->atoms)
     {
         if (utils::string::equals_ignore_case(entry.second.name, name))
@@ -763,28 +780,37 @@ uint16_t process_context::add_or_find_atom(std::u16string name)
             return entry.first;
         }
 
-        if (entry.first > 0)
+        if (entry.first >= MAXINTATOM)
         {
             if (!last_entry)
             {
-                index = 1;
+                if (entry.first > MAXINTATOM)
+                {
+                    index = MAXINTATOM;
+                }
             }
             else
             {
                 const auto diff = entry.first - *last_entry;
                 if (diff > 1)
                 {
-                    index = *last_entry + 1;
+                    index = static_cast<uint32_t>(*last_entry) + 1;
                 }
             }
-        }
 
-        last_entry = entry.first;
+            last_entry = entry.first;
+        }
     }
 
-    atoms[index] = {.name = std::move(name), .ref_count = 1};
+    if (index > max_atom)
+    {
+        throw std::runtime_error("No slots are available for adding new atoms");
+    }
 
-    return index;
+    const auto atom = static_cast<uint16_t>(index);
+    atoms[atom] = {.name = std::move(name), .ref_count = 1};
+
+    return atom;
 }
 
 bool process_context::delete_atom(const std::u16string& name)
@@ -820,15 +846,27 @@ bool process_context::delete_atom(const uint16_t atom_id)
     return true;
 }
 
-const std::u16string* process_context::get_atom_name(const uint16_t atom_id) const
+std::optional<std::u16string> process_context::get_atom_name(const uint16_t atom_id) const
 {
+    if (atom_id && atom_id < MAXINTATOM)
+    {
+        std::u16string name = u"#";
+
+        for (const char ch : std::to_string(atom_id))
+        {
+            name.push_back(static_cast<char16_t>(ch));
+        }
+
+        return name;
+    }
+
     const auto it = atoms.find(atom_id);
     if (it == atoms.end())
     {
-        return nullptr;
+        return std::nullopt;
     }
 
-    return &it->second.name;
+    return it->second.name;
 }
 
 template <typename T>

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -146,7 +146,7 @@ struct process_context
     uint16_t add_or_find_atom(std::u16string name);
     bool delete_atom(const std::u16string& name);
     bool delete_atom(uint16_t atom_id);
-    const std::u16string* get_atom_name(uint16_t atom_id) const;
+    std::optional<std::u16string> get_atom_name(uint16_t atom_id) const;
 
     template <typename T>
     void build_knowndlls_section_table(registry_manager& registry, const file_system& file_system, const apiset_map& apiset,
@@ -202,6 +202,7 @@ struct process_context
 
     user_handle_table user_handles;
     handle default_monitor_handle{};
+    handle default_desktop_window_handle{};
     handle_store<handle_types::event, event> events{};
     handle_store<handle_types::file, file> files{};
     utils::insensitive_u16string_map<file_lock_ranges> file_locks{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -425,8 +425,8 @@ namespace syscalls
                                              emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_version,
                                              emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name, DWORD function_id,
                                              DWORD flags, emulator_pointer wow);
-    NTSTATUS handle_NtUserUnregisterClass(const syscall_context& c, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
-                                          emulator_pointer instance, emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name);
+    BOOL handle_NtUserUnregisterClass(const syscall_context& c, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
+                                      emulator_pointer instance, emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name);
     BOOL handle_NtUserGetClassInfoEx(const syscall_context& c, hinstance /*instance*/,
                                      emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
                                      emulator_object<EMU_WNDCLASSEX> wnd_class_ex, emulator_pointer menu_name, BOOL /*ansi*/);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -474,11 +474,14 @@ namespace syscalls
     emulator_pointer handle_NtUserSetWindowLongPtr(const syscall_context& c, handle hWnd, int nIndex, emulator_pointer dwNewLong,
                                                    BOOL Ansi);
     uint32_t handle_NtUserSetWindowLong(const syscall_context& c, handle hWnd, int nIndex, uint32_t dwNewLong, BOOL Ansi);
+    uint64_t handle_NtUserGetAncestor(const syscall_context& c, hwnd child_hwnd, UINT flags);
     NTSTATUS handle_NtUserRedrawWindow();
     NTSTATUS handle_NtUserGetCPD();
     NTSTATUS handle_NtUserSetWindowFNID();
     NTSTATUS handle_NtUserEnableWindow();
     NTSTATUS handle_NtUserGetSystemMenu();
+    ULONG handle_NtUserGetAtomName(const syscall_context& c, RTL_ATOM atom,
+                                   emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> atom_name);
     NTSTATUS handle_NtQueryLicenseValue(const syscall_context& c, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> value_name,
                                         emulator_object<uint32_t> type, uint64_t data, uint64_t data_size,
                                         emulator_object<uint32_t> result_data_size);
@@ -721,33 +724,6 @@ namespace syscalls
         return STATUS_SUCCESS;
     }
 
-    NTSTATUS handle_NtUserGetAtomName(const syscall_context& c, const RTL_ATOM atom,
-                                      const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> atom_name)
-    {
-        const auto* name = c.proc.get_atom_name(atom);
-        if (!name)
-        {
-            return STATUS_INVALID_PARAMETER;
-        }
-
-        const size_t name_length = name->size() * 2;
-        const size_t max_length = name_length + 2;
-
-        bool too_small = false;
-        atom_name.access([&](UNICODE_STRING<EmulatorTraits<Emu64>>& str) {
-            if (str.MaximumLength < max_length)
-            {
-                too_small = true;
-                return;
-            }
-
-            str.Length = static_cast<USHORT>(name_length);
-            c.emu.write_memory(str.Buffer, name->data(), max_length);
-        });
-
-        return too_small ? STATUS_BUFFER_TOO_SMALL : STATUS_SUCCESS;
-    }
-
     NTSTATUS handle_NtQueryDebugFilterState()
     {
         return FALSE;
@@ -839,6 +815,7 @@ namespace syscalls
     }
 }
 
+// NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
 void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& handler_mapping)
 {
 #define add_handler(syscall)                                                            \
@@ -1103,6 +1080,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtUserGetForegroundWindow);
     add_handler(NtUserSetWindowLongPtr);
     add_handler(NtUserSetWindowLong);
+    add_handler(NtUserGetAncestor);
     add_handler(NtUserPostMessage);
     add_handler(NtUserRedrawWindow);
     add_handler(NtUserGetCPD);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -583,9 +583,9 @@ namespace syscalls
         return index;
     }
 
-    NTSTATUS handle_NtUserUnregisterClass(const syscall_context& c, const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
-                                          const emulator_pointer /*instance*/,
-                                          const emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name)
+    BOOL handle_NtUserUnregisterClass(const syscall_context& c, const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
+                                      const emulator_pointer /*instance*/,
+                                      const emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name)
     {
         const auto cls_name = read_unicode_string_or_atom(c, class_name);
 
@@ -902,6 +902,11 @@ namespace syscalls
         }
 
         auto prop = read_unicode_string_or_atom(c, str);
+        if (prop.empty())
+        {
+            return FALSE;
+        }
+
         win->props[std::move(prop)] = data;
 
         return TRUE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -289,6 +289,37 @@ namespace
         return schedule_wow64_callback(c, thread, k_wow64_client_setup_callback_id, 0, 0);
     }
 
+    std::u16string read_unicode_string_or_atom(const syscall_context& c,
+                                               const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> uc_string,
+                                               const size_t index = 0)
+    {
+        if (!uc_string)
+        {
+            return {};
+        }
+
+        if (uc_string.value() <= std::numeric_limits<uint16_t>::max())
+        {
+            return c.proc.get_atom_name(static_cast<uint16_t>(uc_string.value())).value_or(u"");
+        }
+
+        return read_unicode_string(c.emu, uc_string, index);
+    }
+
+    std::u16string read_large_string_or_atom(const syscall_context& c, const emulator_object<LARGE_STRING> str_obj, const size_t index = 0)
+    {
+        if (!str_obj)
+        {
+            return {};
+        }
+
+        if (str_obj.value() <= std::numeric_limits<uint16_t>::max())
+        {
+            return c.proc.get_atom_name(static_cast<uint16_t>(str_obj.value())).value_or(u"");
+        }
+
+        return read_large_string(str_obj, index);
+    }
 }
 
 namespace syscalls
@@ -504,7 +535,7 @@ namespace syscalls
 
             if (class_name)
             {
-                class_name_str = u16_to_u8(read_unicode_string(c.emu, class_name));
+                class_name_str = u16_to_u8(read_unicode_string_or_atom(c, class_name));
             }
 
             if (window_name)
@@ -556,7 +587,7 @@ namespace syscalls
                                           const emulator_pointer /*instance*/,
                                           const emulator_object<CLSMENUNAME<EmulatorTraits<Emu64>>> class_menu_name)
     {
-        const auto cls_name = read_unicode_string(c.emu, class_name);
+        const auto cls_name = read_unicode_string_or_atom(c, class_name);
 
         if (const auto it = c.proc.classes.find(cls_name); it != c.proc.classes.end())
         {
@@ -577,7 +608,7 @@ namespace syscalls
                                      const emulator_object<EMU_WNDCLASSEX> wnd_class_ex, const emulator_pointer /*menu_name*/,
                                      const BOOL /*ansi*/)
     {
-        std::u16string name_str = read_unicode_string(c.emu, class_name);
+        std::u16string name_str = read_unicode_string_or_atom(c, class_name);
 
         auto it = c.proc.classes.find(name_str);
         if (it == c.proc.classes.end())
@@ -603,36 +634,40 @@ namespace syscalls
         return STATUS_NOT_SUPPORTED;
     }
 
-    std::u16string read_large_string(const emulator_object<LARGE_STRING> str_obj)
-    {
-        if (!str_obj)
-        {
-            return {};
-        }
-
-        const auto str = str_obj.read();
-        if (!str.bAnsi)
-        {
-            return read_string<char16_t>(*str_obj.get_memory_interface(), str.Buffer, str.Length / 2);
-        }
-
-        const auto ansi_string = read_string<char>(*str_obj.get_memory_interface(), str.Buffer, str.Length);
-        return u8_to_u16(ansi_string);
-    }
-
     hwnd handle_NtUserCreateWindowEx(const syscall_context& c, const DWORD ex_style, const emulator_object<LARGE_STRING> class_name,
                                      const emulator_object<LARGE_STRING> /*cls_version*/, const emulator_object<LARGE_STRING> window_name,
-                                     const DWORD style, const int x, const int y, const int width, const int height, const hwnd /*parent*/,
+                                     const DWORD style, const int x, const int y, const int width, const int height, const hwnd parent,
                                      const hmenu /*menu*/, const hinstance /*instance*/, const pointer l_param, const DWORD /*flags*/,
                                      const pointer /*acbi_buffer*/)
     {
-        const auto cls_name = read_large_string(class_name);
+        const auto cls_name = read_large_string_or_atom(c, class_name);
         const auto cls_it = c.proc.classes.find(cls_name);
 
         if (cls_it == c.proc.classes.end())
         {
             set_guest_last_error(c, 1407); // ERROR_CANNOT_FIND_WND_CLASS
             return 0;
+        }
+
+        const bool is_message_only = parent == reinterpret_cast<pointer>(HWND_MESSAGE);
+        const bool has_child_parent = (style & WS_CHILD) != 0 && (style & WS_POPUP) == 0;
+        const bool has_owner = parent != 0 && !is_message_only && !has_child_parent;
+
+        if (has_child_parent && !parent)
+        {
+            set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+            return 0;
+        }
+
+        window* parent_win = nullptr;
+        if (parent && !is_message_only)
+        {
+            parent_win = c.proc.windows.get(parent);
+            if (!parent_win)
+            {
+                set_guest_last_error(c, 6); // ERROR_INVALID_HANDLE
+                return 0;
+            }
         }
 
         const auto class_obj_addr = cls_it->second.guest_obj_addr;
@@ -647,6 +682,11 @@ namespace syscalls
         win.height = height;
         win.thread_id = c.win_emu.current_thread().id;
         win.handle = handle.bits;
+        if (!is_message_only)
+        {
+            win.parent_handle = has_child_parent ? parent : c.proc.default_desktop_window_handle.bits;
+            win.owner_handle = has_owner ? parent : 0;
+        }
         win.class_name = cls_name;
         win.name = read_large_string(window_name);
         win.wnd_proc = wnd_class->lpfnWndProc;
@@ -656,9 +696,23 @@ namespace syscalls
             guest_win.ptrBase = win.guest.value();
             guest_win.dwExStyle = ex_style;
             guest_win.dwStyle = style;
+            if (parent_win && has_child_parent)
+            {
+                guest_win.spwndParent = parent_win->guest.value();
+            }
+            else if (is_message_only)
+            {
+                guest_win.spwndParent = 0;
+            }
+            else if (const auto* wnd = c.proc.windows.get(c.proc.default_desktop_window_handle))
+            {
+                guest_win.spwndParent = wnd->guest.value();
+            }
+            guest_win.spwndOwner = parent_win && has_owner ? parent_win->guest.value() : 0;
             guest_win.lpfnWndProc = win.wnd_proc;
             guest_win.pcls = class_obj_addr;
             guest_win.cbWndExtra = wnd_class->cbWndExtra;
+            guest_win.windowBand = 1; // ZBID_DESKTOP
 
             if (wnd_class->cbWndExtra > 0)
             {
@@ -826,7 +880,7 @@ namespace syscalls
     BOOL handle_NtUserSetProp(const syscall_context& c, const hwnd window, const uint16_t atom, const uint64_t data)
     {
         auto* win = c.proc.windows.get(window);
-        const auto* prop = c.proc.get_atom_name(atom);
+        const auto prop = c.proc.get_atom_name(atom);
 
         if (!win || !prop)
         {
@@ -847,7 +901,7 @@ namespace syscalls
             return FALSE;
         }
 
-        auto prop = read_unicode_string(c.emu, str);
+        auto prop = read_unicode_string_or_atom(c, str);
         win->props[std::move(prop)] = data;
 
         return TRUE;
@@ -1322,6 +1376,88 @@ namespace syscalls
         return static_cast<uint32_t>(oldValue);
     }
 
+    uint64_t handle_NtUserGetAncestor(const syscall_context& c, const hwnd child_hwnd, const UINT flags)
+    {
+        const auto* win = c.proc.windows.get(child_hwnd);
+        if (!win)
+        {
+            return 0;
+        }
+
+        const hwnd desktop = c.proc.default_desktop_window_handle.bits;
+
+        const auto get_root = [&](const hwnd start) -> hwnd {
+            if (!start || start == desktop)
+            {
+                return 0;
+            }
+
+            hwnd current = start;
+
+            for (;;)
+            {
+                const auto* current_win = c.proc.windows.get(current);
+                if (!current_win)
+                {
+                    return 0;
+                }
+
+                const hwnd parent = current_win->parent_handle;
+                if (!parent || parent == desktop)
+                {
+                    return current;
+                }
+
+                current = parent;
+            }
+        };
+
+        switch (flags)
+        {
+        case 1: // GA_PARENT
+            if (child_hwnd == desktop)
+            {
+                return 0;
+            }
+
+            return win->parent_handle;
+
+        case 2: // GA_ROOT
+            return get_root(child_hwnd);
+
+        case 3: { // GA_ROOTOWNER
+            hwnd current = get_root(child_hwnd);
+
+            while (current)
+            {
+                const auto* current_win = c.proc.windows.get(current);
+                if (!current_win || !current_win->owner_handle)
+                {
+                    return current;
+                }
+
+                if ((current_win->style & WS_POPUP) == 0)
+                {
+                    return current;
+                }
+
+                const hwnd owner_root = get_root(current_win->owner_handle);
+                if (!owner_root || owner_root == current)
+                {
+                    return current;
+                }
+
+                current = owner_root;
+            }
+
+            return 0;
+        }
+
+        default:
+            return 0;
+        }
+    }
+
     NTSTATUS handle_NtUserRedrawWindow()
     {
         return STATUS_SUCCESS;
@@ -1345,5 +1481,51 @@ namespace syscalls
     NTSTATUS handle_NtUserGetSystemMenu()
     {
         return STATUS_SUCCESS;
+    }
+
+    ULONG handle_NtUserGetAtomName(const syscall_context& c, const RTL_ATOM atom,
+                                   const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> atom_name)
+    {
+        const auto name = c.proc.get_atom_name(atom);
+        if (!name || !atom_name)
+        {
+            return 0;
+        }
+
+        const size_t name_length_bytes = name->size() * sizeof(char16_t);
+
+        bool too_small = false;
+        ULONG result = 0;
+
+        atom_name.access([&](UNICODE_STRING<EmulatorTraits<Emu64>>& str) {
+            if (str.MaximumLength < sizeof(char16_t) || !str.Buffer)
+            {
+                str.Length = 0;
+                too_small = true;
+                return;
+            }
+
+            const auto max_copy_bytes = static_cast<size_t>(str.MaximumLength - sizeof(char16_t)) & ~size_t{1};
+            const auto copy_bytes = std::min(name_length_bytes, max_copy_bytes);
+
+            if (copy_bytes)
+            {
+                c.emu.write_memory(str.Buffer, name->data(), copy_bytes);
+            }
+
+            constexpr char16_t terminator = 0;
+            c.emu.write_memory(str.Buffer + copy_bytes, &terminator, sizeof(terminator));
+
+            str.Length = static_cast<USHORT>(copy_bytes);
+            result = static_cast<ULONG>(copy_bytes / sizeof(char16_t));
+        });
+
+        if (too_small)
+        {
+            set_guest_last_error(c, 122); // ERROR_INSUFFICIENT_BUFFER
+            return 0;
+        }
+
+        return result;
     }
 }

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -205,7 +205,27 @@ class user_handle_store : public generic_handle_store
         return &it->second;
     }
 
+    const T* get_by_index(const uint32_t index) const
+    {
+        const auto it = this->store_.find(index);
+        if (it == this->store_.end())
+        {
+            return nullptr;
+        }
+        return &it->second;
+    }
+
     T* get(const handle_value h)
+    {
+        if (h.type != Type || h.is_pseudo)
+        {
+            return nullptr;
+        }
+
+        return this->get_by_index(static_cast<uint32_t>(h.id));
+    }
+
+    const T* get(const handle_value h) const
     {
         if (h.type != Type || h.is_pseudo)
         {
@@ -220,7 +240,19 @@ class user_handle_store : public generic_handle_store
         return this->get(h.value);
     }
 
+    const T* get(const handle h) const
+    {
+        return this->get(h.value);
+    }
+
     T* get(const uint64_t h)
+    {
+        handle hh{};
+        hh.bits = h;
+        return this->get(hh);
+    }
+
+    const T* get(const uint64_t h) const
     {
         handle hh{};
         hh.bits = h;

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -82,6 +82,8 @@ struct window : user_object<USER_WINDOW>
 {
     uint32_t thread_id{};
     hwnd handle{};
+    hwnd parent_handle{};
+    hwnd owner_handle{};
     std::u16string name{};
     std::u16string class_name{};
     int32_t width{};
@@ -103,6 +105,8 @@ struct window : user_object<USER_WINDOW>
         user_object::serialize_object(buffer);
         buffer.write(this->thread_id);
         buffer.write(this->handle);
+        buffer.write(this->parent_handle);
+        buffer.write(this->owner_handle);
         buffer.write(this->name);
         buffer.write(this->class_name);
         buffer.write(this->width);
@@ -120,6 +124,8 @@ struct window : user_object<USER_WINDOW>
         user_object::deserialize_object(buffer);
         buffer.read(this->thread_id);
         buffer.read(this->handle);
+        buffer.read(this->parent_handle);
+        buffer.read(this->owner_handle);
         buffer.read(this->name);
         buffer.read(this->class_name);
         buffer.read(this->width);


### PR DESCRIPTION
This PR fixes some atom-handling edge cases, like the distinction between INT atoms and STRING atoms. It also ensures that Atom is respected as the class name in window APIs, and fixes the ancestry state of windows.