### PR TITLE
Drop Python bindings to 3.9

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.9"
 
       - name: Download wheel artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -843,7 +843,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.9"
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build setuptools-scm
@@ -887,7 +887,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.9"
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v4
@@ -934,7 +934,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.9"
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build setuptools-scm
@@ -957,7 +957,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.9"
 
       - name: Download sdist artifact
         uses: actions/download-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sogen"
 dynamic = ["version"]
 description = "Sogen Windows user-space emulator bindings"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 license = { text = "GPL-2.0-only" }
 authors = [{ name = "momo5502" }]
 classifiers = [


### PR DESCRIPTION
Downgrade Python floor for bindings/CI to 3.9:
- pyproject requires-python -> >=3.9
- GitHub Actions setup-python -> 3.9 for wheel/sdist tests and publish job

Verified locally:
- cmake --build --preset=tidy -j 30
- python src/python-bindings/test.py