### PR TITLE
Rework section_first_execute trigger for WHP support

### DIFF
--- a/src/analyzer/analysis.cpp
+++ b/src/analyzer/analysis.cpp
@@ -441,32 +441,26 @@ namespace sogen
             ++c.instructions[instructions[0].id];
         }
 
-        void log_first_section_execution(analysis_context& c, mapped_module* binary, const uint64_t address)
+        void handle_section_first_execution(analysis_context& c, const mapped_module& binary, const mapped_section& section,
+                                            const uint64_t address)
         {
-            if (!binary)
+            const auto is_main_exe = &binary == c.win_emu->mod_manager.executable;
+            if (!c.has_reached_main && c.settings->concise_logging && !c.settings->silent && is_main_exe)
+            {
+                c.has_reached_main = true;
+                c.win_emu->log.disable_output(false);
+            }
+
+            if (!c.settings->log_first_section_execution)
             {
                 return;
             }
 
-            for (auto& section : binary->sections)
-            {
-                if (!is_within_start_and_length(address, section.region.start, section.region.length))
-                {
-                    continue;
-                }
-
-                if (!section.first_execute.has_value())
-                {
-                    section.first_execute = address;
-                    c.emit_observation<section_first_execute_event>([&](auto& event) {
-                        event.module_name = binary->name;
-                        event.section_name = section.name;
-                        event.file_address = *section.first_execute - binary->image_base + binary->image_base_file;
-                    });
-                }
-
-                break;
-            }
+            c.emit_observation<section_first_execute_event>([&](auto& event) {
+                event.module_name = binary.name;
+                event.section_name = section.name;
+                event.file_address = address - binary.image_base + binary.image_base_file;
+            });
         }
 
         void handle_instruction(analysis_context& c, const uint64_t address)
@@ -496,11 +490,6 @@ namespace sogen
 
                 return win_emu.mod_manager.find_by_address(address); //
             });
-
-            if (c.settings->log_first_section_execution)
-            {
-                log_first_section_execution(c, binary, address);
-            }
 
             const auto previous_binary = utils::make_lazy([&] {
                 if (is_previous_main_exe)
@@ -532,12 +521,6 @@ namespace sogen
             const auto is_interesting_call = is_previous_main_exe                                              //
                                              || (!previous_binary && current_thread.executed_instructions > 1) //
                                              || is_in_interesting_module();
-
-            if (!c.has_reached_main && c.settings->concise_logging && !c.settings->silent && is_main_exe)
-            {
-                c.has_reached_main = true;
-                win_emu.log.disable_output(false);
-            }
 
             if ((!c.settings->verbose_logging && !is_interesting_call) || !binary)
             {
@@ -813,6 +796,7 @@ namespace sogen
 
         (void)cb.on_module_load.add(make_callback(c, handle_module_load));
         (void)cb.on_module_unload.add(make_callback(c, handle_module_unload));
+        (void)cb.on_section_first_execution.add(make_callback(c, handle_section_first_execution));
 
         cb.on_thread_create = make_callback(c, handle_thread_create);
         cb.on_thread_terminated = make_callback(c, handle_thread_terminated);

--- a/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
@@ -49,6 +49,7 @@ enum HookType {
     Write,
     ExecuteGeneric,
     ExecuteSpecific,
+    ExecuteRange,
     Violation,
     Interrupt,
     Block,
@@ -70,6 +71,10 @@ fn qualify_hook_id(hook_id: u32, hook_type: HookType) -> u32 {
     let hook_type: u32 = (hook_type as u8).into();
     let hook_type_mask: u32 = hook_type << 24;
     return (hook_id | hook_type_mask).into();
+}
+
+fn is_within_start_and_length(value: u64, start: u64, length: u64) -> bool {
+    return value >= start && value < start.wrapping_add(length);
 }
 
 pub struct HookContainer<Func: ?Sized> {
@@ -220,6 +225,7 @@ impl icicle_vm::CodeInjector for InstructionHookInjector {
 struct ExecutionHooks {
     stop: Rc<RefCell<bool>>,
     generic_hooks: HookContainer<dyn Fn(u64)>,
+    ranged_hooks: HookContainer<dyn Fn(u64)>,
     specific_hooks: HookContainer<dyn Fn(u64)>,
     block_hooks: HookContainer<dyn Fn(u64, u64)>,
     address_mapping: HashMap<u64, Vec<u32>>,
@@ -231,6 +237,7 @@ impl ExecutionHooks {
         Self {
             stop: stop_value,
             generic_hooks: HookContainer::new(),
+            ranged_hooks: HookContainer::new(),
             specific_hooks: HookContainer::new(),
             block_hooks: HookContainer::new(),
             address_mapping: HashMap::new(),
@@ -247,6 +254,10 @@ impl ExecutionHooks {
         }
 
         self.generic_hooks.for_each_hook(|func| {
+            func(address);
+        });
+
+        self.ranged_hooks.for_each_hook(|func| {
             func(address);
         });
 
@@ -289,9 +300,17 @@ impl ExecutionHooks {
         self.generic_hooks.add_hook(callback)
     }
 
+    pub fn add_range_hook(&mut self, start: u64, size: u64, callback: Box<dyn Fn(u64)>) -> u32 {
+        self.ranged_hooks
+            .add_hook(Box::new(move |address: u64| {
+                if size != 0 && is_within_start_and_length(address, start, size) {
+                    callback(address);
+                }
+            }))
+    }
+
     pub fn add_specific_hook(&mut self, address: u64, callback: Box<dyn Fn(u64)>) -> u32 {
         let id = self.specific_hooks.add_hook(callback);
-
         let mapping = self.address_mapping.entry(address).or_insert_with(Vec::new);
         mapping.push(id);
 
@@ -304,6 +323,10 @@ impl ExecutionHooks {
 
     pub fn remove_generic_hook(&mut self, id: u32) {
         self.generic_hooks.remove_hook(id);
+    }
+
+    pub fn remove_range_hook(&mut self, id: u32) {
+        self.ranged_hooks.remove_hook(id);
     }
 
     pub fn remove_specific_hook(&mut self, id: u32) {
@@ -537,6 +560,19 @@ impl IcicleEmulator {
         return qualify_hook_id(hook_id, HookType::ExecuteGeneric);
     }
 
+    pub fn add_ranged_execution_hook(
+        &mut self,
+        start: u64,
+        size: u64,
+        callback: Box<dyn Fn(u64)>,
+    ) -> u32 {
+        let hook_id = self
+            .execution_hooks
+            .borrow_mut()
+            .add_range_hook(start, size, callback);
+        return qualify_hook_id(hook_id, HookType::ExecuteRange);
+    }
+
     pub fn add_syscall_hook(&mut self, callback: Box<dyn Fn()>) -> u32 {
         let hook_id = self.syscall_hooks.add_hook(callback);
         return qualify_hook_id(hook_id, HookType::Syscall);
@@ -594,6 +630,7 @@ impl IcicleEmulator {
                 .execution_hooks
                 .borrow_mut()
                 .remove_specific_hook(hook_id),
+            HookType::ExecuteRange => self.execution_hooks.borrow_mut().remove_range_hook(hook_id),
             HookType::Block => self.execution_hooks.borrow_mut().remove_block_hook(hook_id),
             HookType::Read => {
                 self.get_mem().remove_read_after_hook(hook_id);

--- a/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
@@ -300,6 +300,24 @@ pub fn icicle_add_execution_hook(
 }
 
 #[unsafe(no_mangle)]
+pub fn icicle_add_ranged_execution_hook(
+    ptr: *mut c_void,
+    address: u64,
+    size: u64,
+    callback: PtrFunction,
+    data: *mut c_void,
+) -> u32 {
+    unsafe {
+        let emulator = &mut *(ptr as *mut IcicleEmulator);
+        return emulator.add_ranged_execution_hook(
+            address,
+            size,
+            Box::new(move |ptr: u64| callback(data, ptr)),
+        );
+    }
+}
+
+#[unsafe(no_mangle)]
 pub fn icicle_remove_hook(ptr: *mut c_void, id: u32) {
     unsafe {
         let emulator = &mut *(ptr as *mut IcicleEmulator);

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -36,6 +36,7 @@ extern "C"
     uint32_t icicle_add_interrupt_hook(icicle_emulator*, interrupt_func* callback, void* data);
     uint32_t icicle_add_block_hook(icicle_emulator*, block_func* callback, void* data);
     uint32_t icicle_add_execution_hook(icicle_emulator*, uint64_t address, ptr_func* callback, void* data);
+    uint32_t icicle_add_ranged_execution_hook(icicle_emulator*, uint64_t address, uint64_t size, ptr_func* callback, void* data);
     uint32_t icicle_add_generic_execution_hook(icicle_emulator*, ptr_func* callback, void* data);
     uint32_t icicle_add_violation_hook(icicle_emulator*, violation_func* callback, void* data);
     uint32_t icicle_add_read_hook(icicle_emulator*, uint64_t start, uint64_t end, memory_access_func* cb, void* data);
@@ -139,6 +140,7 @@ namespace sogen::icicle
         void start(const size_t count) override
         {
             icicle_start(this->emu_, count);
+            this->perform_pending_actions();
         }
 
         void stop() override
@@ -389,6 +391,27 @@ namespace sogen::icicle
             return wrap_hook(id);
         }
 
+        emulator_hook* hook_memory_range_execution(const uint64_t address, const uint64_t size,
+                                                   memory_execution_hook_callback callback) override
+        {
+            if (size == 1)
+            {
+                return this->hook_memory_execution(address, std::move(callback));
+            }
+
+            auto object = make_function_object(std::move(callback), this->is_in_hook_);
+            auto* ptr = object.get();
+            auto* wrapper = +[](void* user, const uint64_t addr) {
+                const auto& func = *static_cast<decltype(ptr)>(user);
+                (func)(addr);
+            };
+
+            const auto id = icicle_add_ranged_execution_hook(this->emu_, address, size, wrapper, ptr);
+            this->hooks_[id] = std::move(object);
+
+            return wrap_hook(id);
+        }
+
         emulator_hook* hook_memory_execution(memory_execution_hook_callback callback) override
         {
             auto object = make_function_object(std::move(callback), this->is_in_hook_);
@@ -429,7 +452,6 @@ namespace sogen::icicle
             if (this->is_in_hook_)
             {
                 this->hooks_to_delete_.insert(hook);
-                this->schedule_action_execution();
             }
             else
             {
@@ -572,20 +594,25 @@ namespace sogen::icicle
 
         void perform_pending_actions()
         {
-            auto hooks_to_install = std::move(this->hooks_to_install_);
             const auto hooks_to_delete = std::move(this->hooks_to_delete_);
 
             this->hooks_to_delete_ = {};
+            this->perform_pending_hook_installs();
+
+            for (auto* hook : hooks_to_delete)
+            {
+                this->delete_hook_internal(hook);
+            }
+        }
+
+        void perform_pending_hook_installs()
+        {
+            auto hooks_to_install = std::move(this->hooks_to_install_);
             this->hooks_to_install_ = {};
 
             for (auto& hook : hooks_to_install)
             {
                 this->hook_memory_access(std::move(hook.second), hook.first);
-            }
-
-            for (auto* hook : hooks_to_delete)
-            {
-                this->delete_hook_internal(hook);
             }
         }
 
@@ -607,7 +634,7 @@ namespace sogen::icicle
         void schedule_action_execution()
         {
             this->run_on_next_instruction([this] {
-                this->perform_pending_actions(); //
+                this->perform_pending_hook_installs(); //
             });
         }
 

--- a/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
+++ b/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
@@ -559,7 +559,8 @@ namespace sogen::unicorn
                 return result;
             }
 
-            emulator_hook* hook_memory_execution(const uint64_t address, const uint64_t size, memory_execution_hook_callback callback)
+            emulator_hook* hook_memory_range_execution(const uint64_t address, const uint64_t size,
+                                                       memory_execution_hook_callback callback) override
             {
                 auto exec_wrapper = [c = std::move(callback)](uc_engine*, const uint64_t address, const uint32_t /*size*/) {
                     c(address); //
@@ -579,12 +580,12 @@ namespace sogen::unicorn
 
             emulator_hook* hook_memory_execution(memory_execution_hook_callback callback) override
             {
-                return this->hook_memory_execution(0, std::numeric_limits<uint64_t>::max(), std::move(callback));
+                return this->hook_memory_range_execution(0, std::numeric_limits<uint64_t>::max(), std::move(callback));
             }
 
             emulator_hook* hook_memory_execution(const uint64_t address, memory_execution_hook_callback callback) override
             {
-                return this->hook_memory_execution(address, 1, std::move(callback));
+                return this->hook_memory_range_execution(address, 1, std::move(callback));
             }
 
             emulator_hook* hook_memory_read(const uint64_t address, const uint64_t size, memory_access_hook_callback callback) override

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include <address_utils.hpp>
 #include <utils/object.hpp>
 #include <utils/cpu_features.hpp>
 
@@ -863,10 +864,6 @@ namespace sogen::whp
 
             void set_memory_execution_hook_mode(const memory_execution_hook_mode mode) override
             {
-                if (!this->memory_execution_hooks_.empty())
-                {
-                    throw std::runtime_error("Can't change execution hook mode while hooks are applied");
-                }
                 this->memory_execution_hook_mode_ = mode;
             }
 
@@ -1545,6 +1542,22 @@ namespace sogen::whp
                 return hook;
             }
 
+            emulator_hook* hook_memory_range_execution(const uint64_t address, const uint64_t size,
+                                                       memory_execution_hook_callback callback) override
+            {
+                if (size == 1)
+                {
+                    return this->hook_memory_execution(address, std::move(callback));
+                }
+
+                auto* hook = this->make_hook();
+                this->memory_execution_hooks_[hook] =
+                    execution_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
+                this->increment_execution_hook_count(address, size);
+                this->remap_hook_pages(address, size);
+                return hook;
+            }
+
             emulator_hook* hook_memory_execution(const uint64_t address, memory_execution_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
@@ -1564,7 +1577,8 @@ namespace sogen::whp
 
                 case memory_execution_hook_mode::int3:
                     this->install_patched_execution_breakpoint(address);
-                    this->memory_execution_hooks_[hook] = execution_hook_entry{.address = address, .callback = std::move(callback)};
+                    this->memory_execution_hooks_[hook] =
+                        execution_hook_entry{.address = address, .patched_breakpoint = true, .callback = std::move(callback)};
                     return hook;
                 }
 
@@ -1602,28 +1616,8 @@ namespace sogen::whp
 
                 if (const auto execution_it = this->memory_execution_hooks_.find(hook); execution_it != this->memory_execution_hooks_.end())
                 {
-                    const auto execution_address = execution_it->second.address;
+                    this->deactivate_execution_hook(hook);
                     this->memory_execution_hooks_.erase(execution_it);
-
-                    if (execution_address)
-                    {
-                        switch (this->memory_execution_hook_mode_)
-                        {
-                        case memory_execution_hook_mode::automatic: {
-                            if (const auto entry = this->mapped_pages_.find(align_down_to_page(*execution_address));
-                                entry != this->mapped_pages_.end() && entry->second && entry->second->page_execution_hook_count != 0)
-                            {
-                                --entry->second->page_execution_hook_count;
-                            }
-
-                            this->remap_hook_page(*execution_address);
-                            break;
-                        }
-                        case memory_execution_hook_mode::int3:
-                            this->uninstall_patched_execution_breakpoint(*execution_address);
-                            break;
-                        }
-                    }
                 }
 
                 this->memory_read_hooks_.erase(hook);
@@ -1683,6 +1677,11 @@ namespace sogen::whp
                 return false;
             }
 
+            bool supports_global_memory_execution_hooks() const override
+            {
+                return false;
+            }
+
           private:
             struct instruction_hook_entry
             {
@@ -1693,6 +1692,8 @@ namespace sogen::whp
             struct execution_hook_entry
             {
                 std::optional<uint64_t> address{};
+                uint64_t size{1};
+                bool patched_breakpoint{false};
                 memory_execution_hook_callback callback{};
             };
 
@@ -2015,8 +2016,9 @@ namespace sogen::whp
                 page.guest_page_base = align_down_to_page(guest_address);
                 page.guest_physical_address = this->allocate_guest_physical_page();
                 page.page_execution_hook_count = std::ranges::count_if(this->memory_execution_hooks_, [&](const auto& entry) {
-                    return entry.second.address && !this->patched_execution_breakpoints_.contains(*entry.second.address) &&
-                           align_down_to_page(*entry.second.address) == page.guest_page_base;
+                    const auto& hook = entry.second;
+                    return hook.address && !hook.patched_breakpoint && hook.size != 0 &&
+                           regions_with_length_intersect(*hook.address, hook.size, page.guest_page_base, page_size);
                 });
                 this->guest_pages_by_gpa_[this->guest_physical_page_index(page.guest_physical_address)] = page.guest_page_base;
             }
@@ -2194,6 +2196,91 @@ namespace sogen::whp
                 if (entry != this->mapped_pages_.end() && entry->second && entry->second->host_page != nullptr)
                 {
                     this->remap_page(*entry->second);
+                }
+            }
+
+            void remap_hook_pages(const uint64_t address, const uint64_t size)
+            {
+                if (size == 0)
+                {
+                    return;
+                }
+
+                const auto start = align_down_to_page(address);
+                const auto end = align_up(address + size, page_size);
+                for (auto page = start; page < end; page += page_size)
+                {
+                    this->remap_hook_page(page);
+                }
+            }
+
+            void increment_execution_hook_count(const uint64_t address, const uint64_t size)
+            {
+                if (size == 0)
+                {
+                    return;
+                }
+
+                const auto start = align_down_to_page(address);
+                const auto end = align_up(address + size, page_size);
+                for (auto page = start; page < end; page += page_size)
+                {
+                    const auto entry = this->mapped_pages_.find(page);
+                    if (entry == this->mapped_pages_.end() || !entry->second)
+                    {
+                        continue;
+                    }
+
+                    ++entry->second->page_execution_hook_count;
+                }
+            }
+
+            void decrement_execution_hook_count(const uint64_t address, const uint64_t size)
+            {
+                if (size == 0)
+                {
+                    return;
+                }
+
+                const auto start = align_down_to_page(address);
+                const auto end = align_up(address + size, page_size);
+                for (auto page = start; page < end; page += page_size)
+                {
+                    const auto entry = this->mapped_pages_.find(page);
+                    if (entry == this->mapped_pages_.end() || !entry->second)
+                    {
+                        continue;
+                    }
+
+                    if (entry->second->page_execution_hook_count != 0)
+                    {
+                        --entry->second->page_execution_hook_count;
+                    }
+                }
+            }
+
+            void deactivate_execution_hook(emulator_hook* hook)
+            {
+                const auto execution_it = this->memory_execution_hooks_.find(hook);
+                if (execution_it == this->memory_execution_hooks_.end())
+                {
+                    return;
+                }
+
+                auto& execution = execution_it->second;
+                if (!execution.address)
+                {
+                    return;
+                }
+
+                if (execution.patched_breakpoint)
+                {
+                    this->uninstall_patched_execution_breakpoint(*execution.address);
+                }
+                else
+                {
+                    this->decrement_execution_hook_count(*execution.address, execution.size);
+                    this->remap_hook_pages(*execution.address, execution.size);
                 }
             }
 
@@ -2977,7 +3064,8 @@ namespace sogen::whp
                 std::vector<memory_execution_hook_callback> callbacks{};
                 for (const auto& [_, hook] : this->memory_execution_hooks_)
                 {
-                    if (hook.address && *hook.address == address)
+                    if (hook.address && !hook.patched_breakpoint && hook.size != 0 &&
+                        is_within_start_and_length(address, *hook.address, hook.size))
                     {
                         callbacks.push_back(hook.callback);
                     }
@@ -3098,7 +3186,7 @@ namespace sogen::whp
                 std::vector<memory_execution_hook_callback> callbacks{};
                 for (const auto& [_, hook] : this->memory_execution_hooks_)
                 {
-                    if (hook.address && *hook.address == address)
+                    if (hook.address && hook.patched_breakpoint && *hook.address == address)
                     {
                         callbacks.push_back(hook.callback);
                     }

--- a/src/emulator/hook_interface.hpp
+++ b/src/emulator/hook_interface.hpp
@@ -72,8 +72,14 @@ namespace sogen
             }
         }
 
+        virtual bool supports_global_memory_execution_hooks() const
+        {
+            return true;
+        }
+
         virtual emulator_hook* hook_memory_execution(memory_execution_hook_callback callback) = 0;
         virtual emulator_hook* hook_memory_execution(uint64_t address, memory_execution_hook_callback callback) = 0;
+        virtual emulator_hook* hook_memory_range_execution(uint64_t address, uint64_t size, memory_execution_hook_callback callback) = 0;
         virtual emulator_hook* hook_memory_read(uint64_t address, uint64_t size, memory_access_hook_callback callback) = 0;
         virtual emulator_hook* hook_memory_write(uint64_t address, uint64_t size, memory_access_hook_callback callback) = 0;
 

--- a/src/emulator/serialization.hpp
+++ b/src/emulator/serialization.hpp
@@ -36,6 +36,16 @@ namespace sogen
         {
         };
 
+        template <typename T>
+        struct is_vector : std::false_type
+        {
+        };
+
+        template <typename... Args>
+        struct is_vector<std::vector<Args...>> : std::true_type
+        {
+        };
+
         namespace detail
         {
             template <typename, typename = void>
@@ -110,6 +120,10 @@ namespace sogen
                 else if constexpr (detail::has_serialize_function<T>::value)
                 {
                     serialize(*this, object);
+                }
+                else if constexpr (is_vector<T>::value)
+                {
+                    write_vector(object);
                 }
                 else if constexpr (is_trivially_copyable)
                 {
@@ -344,6 +358,10 @@ namespace sogen
                 else if constexpr (detail::has_deserialize_function<T>::value)
                 {
                     deserialize(*this, object);
+                }
+                else if constexpr (is_vector<T>::value)
+                {
+                    read_vector(object);
                 }
                 else if constexpr (is_trivially_copyable)
                 {

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -553,8 +553,8 @@ namespace sogen
             return;
         }
 
-        hooks[section_index] = this->emu().hook_memory_range_execution(
-            section.region.start, section.region.length, [this](const uint64_t address) {
+        hooks[section_index] =
+            this->emu().hook_memory_range_execution(section.region.start, section.region.length, [this](const uint64_t address) {
                 this->track_section_first_execution(address); //
             });
     }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -469,11 +469,6 @@ namespace sogen
 
     void windows_emulator::track_section_first_execution(const uint64_t address)
     {
-        if (!this->callbacks.on_section_first_execution)
-        {
-            return;
-        }
-
         auto* mod = this->mod_manager.find_by_address(address);
         if (!mod)
         {
@@ -499,7 +494,6 @@ namespace sogen
             }
 
             section.first_execute = address;
-            this->callbacks.on_section_first_execution(*mod, section, address);
 
             if (hook_states && i < hook_states->size() && (*hook_states)[i])
             {
@@ -507,6 +501,8 @@ namespace sogen
                 (*hook_states)[i] = nullptr;
                 this->emu().delete_hook(hook);
             }
+
+            this->callbacks.on_section_first_execution(*mod, section, address);
 
             return;
         }
@@ -530,8 +526,7 @@ namespace sogen
 
     void windows_emulator::install_section_first_execution_hook(const mapped_module& mod, const size_t section_index)
     {
-        if (!this->uses_section_first_execution_hooks() || !this->callbacks.on_section_first_execution ||
-            section_index >= mod.sections.size())
+        if (!this->uses_section_first_execution_hooks() || section_index >= mod.sections.size())
         {
             return;
         }
@@ -561,7 +556,7 @@ namespace sogen
 
     void windows_emulator::install_section_first_execution_hooks()
     {
-        if (!this->uses_section_first_execution_hooks() || !this->callbacks.on_section_first_execution)
+        if (!this->uses_section_first_execution_hooks())
         {
             return;
         }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -16,7 +16,6 @@
 
 namespace sogen
 {
-
     constexpr auto MAX_INSTRUCTIONS_PER_TIME_SLICE = 0x20000;
 
     namespace
@@ -370,6 +369,7 @@ namespace sogen
         this->version.load_from_registry(this->registry, this->log);
 
         this->mod_manager.map_main_modules(this->application_settings_.application, this->version, context, this->log);
+        this->install_section_first_execution_hooks();
 
         const auto* executable = this->mod_manager.executable;
         const auto* ntdll = this->mod_manager.ntdll;
@@ -454,11 +454,152 @@ namespace sogen
         thread.previous_ip = thread.current_ip;
         thread.current_ip = this->emu().read_instruction_pointer();
 
+        if (!this->uses_section_first_execution_hooks())
+        {
+            this->track_section_first_execution(address);
+        }
+
         this->callbacks.on_instruction(address);
+    }
+
+    bool windows_emulator::uses_section_first_execution_hooks() const
+    {
+        return !this->emu().supports_global_memory_execution_hooks();
+    }
+
+    void windows_emulator::track_section_first_execution(const uint64_t address)
+    {
+        if (!this->callbacks.on_section_first_execution)
+        {
+            return;
+        }
+
+        auto* mod = this->mod_manager.find_by_address(address);
+        if (!mod)
+        {
+            return;
+        }
+
+        auto* hook_states = [&]() -> std::vector<emulator_hook*>* {
+            const auto entry = this->section_first_execution_hooks_.find(mod->image_base);
+            return entry == this->section_first_execution_hooks_.end() ? nullptr : &entry->second;
+        }();
+
+        for (size_t i = 0; i < mod->sections.size(); ++i)
+        {
+            auto& section = mod->sections[i];
+            if (!is_within_start_and_length(address, section.region.start, section.region.length))
+            {
+                continue;
+            }
+
+            if (section.first_execute.has_value())
+            {
+                return;
+            }
+
+            section.first_execute = address;
+            this->callbacks.on_section_first_execution(*mod, section, address);
+
+            if (hook_states && i < hook_states->size() && (*hook_states)[i])
+            {
+                auto* hook = (*hook_states)[i];
+                (*hook_states)[i] = nullptr;
+                this->emu().delete_hook(hook);
+            }
+
+            return;
+        }
+    }
+
+    void windows_emulator::clear_section_first_execution_hooks()
+    {
+        for (const auto& hooks : this->section_first_execution_hooks_ | std::views::values)
+        {
+            for (auto* hook : hooks)
+            {
+                if (hook)
+                {
+                    this->emu().delete_hook(hook);
+                }
+            }
+        }
+
+        this->section_first_execution_hooks_.clear();
+    }
+
+    void windows_emulator::install_section_first_execution_hook(const mapped_module& mod, const size_t section_index)
+    {
+        if (!this->uses_section_first_execution_hooks() || !this->callbacks.on_section_first_execution ||
+            section_index >= mod.sections.size())
+        {
+            return;
+        }
+
+        const auto& section = mod.sections[section_index];
+        if (section.first_execute.has_value() || section.region.length == 0)
+        {
+            return;
+        }
+
+        auto& hooks = this->section_first_execution_hooks_[mod.image_base];
+        if (hooks.size() < mod.sections.size())
+        {
+            hooks.resize(mod.sections.size());
+        }
+
+        if (hooks[section_index])
+        {
+            return;
+        }
+
+        hooks[section_index] = this->emu().hook_memory_range_execution(
+            section.region.start, section.region.length, [this](const uint64_t address) {
+                this->track_section_first_execution(address); //
+            });
+    }
+
+    void windows_emulator::install_section_first_execution_hooks()
+    {
+        if (!this->uses_section_first_execution_hooks() || !this->callbacks.on_section_first_execution)
+        {
+            return;
+        }
+
+        for (const auto& mod : this->mod_manager.modules() | std::views::values)
+        {
+            for (size_t i = 0; i < mod.sections.size(); ++i)
+            {
+                this->install_section_first_execution_hook(mod, i);
+            }
+        }
     }
 
     void windows_emulator::setup_hooks()
     {
+        this->callbacks.on_module_load.add([this](mapped_module& mod) {
+            for (size_t i = 0; i < mod.sections.size(); ++i)
+            {
+                this->install_section_first_execution_hook(mod, i);
+            }
+        });
+
+        this->callbacks.on_module_unload.add([this](mapped_module& mod) {
+            const auto hooks = this->section_first_execution_hooks_.extract(mod.image_base);
+            if (!hooks)
+            {
+                return;
+            }
+
+            for (auto* hook : hooks.mapped())
+            {
+                if (hook)
+                {
+                    this->emu().delete_hook(hook);
+                }
+            }
+        });
+
         this->emu().hook_instruction(x86_hookable_instructions::syscall, [&] {
             this->dispatcher.dispatch(*this);
             return instruction_hook_continuation::skip_instruction;
@@ -731,11 +872,13 @@ namespace sogen
         this->registry.deserialize_runtime_state(buffer);
 
         this->memory.unmap_all_memory();
+        this->clear_section_first_execution_hooks();
 
         // Match raw serialize() above; do not use backend snapshot mode here.
         this->emu().deserialize_state(buffer, false);
         this->memory.deserialize_memory_state(buffer, false);
         this->mod_manager.deserialize(buffer);
+        this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
         this->process.deserialize(buffer);
     }
@@ -781,10 +924,12 @@ namespace sogen
         this->registry.deserialize_runtime_state(buffer);
 
         this->memory.unmap_all_memory();
+        this->clear_section_first_execution_hooks();
 
         this->emu().deserialize_state(buffer, false);
         this->memory.deserialize_memory_state(buffer, false);
         this->mod_manager.deserialize(buffer);
+        this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
         this->process.deserialize(buffer);
     }

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -41,6 +41,7 @@ namespace sogen
         opt_func<void(std::string_view description)> on_generic_activity{};
         opt_func<void(std::string_view description)> on_suspicious_activity{};
         utils::callback_list<void(std::string_view message)> on_debug_string{};
+        utils::callback_list<void(const mapped_module& mod, const mapped_section& section, uint64_t address)> on_section_first_execution{};
         opt_func<void(uint64_t address)> on_instruction{};
         opt_func<void(io_device& device, std::u16string_view device_name, ULONG code)> on_ioctrl{};
         opt_func<void(uint32_t fail_code)> on_fast_fail{};
@@ -295,9 +296,17 @@ namespace sogen
         stop_reason last_stop_reason_{stop_reason::none};
         std::string last_stop_detail_{};
 
+        std::map<uint64_t, std::vector<emulator_hook*>> section_first_execution_hooks_{};
+
         void setup_hooks();
         void setup_process();
         void on_instruction_execution(uint64_t address);
+
+        bool uses_section_first_execution_hooks() const;
+        void clear_section_first_execution_hooks();
+        void install_section_first_execution_hook(const mapped_module& mod, size_t section_index);
+        void install_section_first_execution_hooks();
+        void track_section_first_execution(uint64_t address);
 
         void register_factories(utils::buffer_deserializer& buffer);
     };


### PR DESCRIPTION
This PR moves the trigger for the `section_first_execute` event to a new callback called `on_section_first_execution`, which can be triggered by the `on_instruction` callback or by a memory range hook (in WHP). This makes the `section_first_execute` event work on the WHP backend, along with concise logging mode.

This PR also includes the following changes:
- Fixes a crash when removing hooks inside a hook callback in Icicle.
- Adds support for hooking execution of a memory range in Icicle and WHP, and exposes the existing Unicorn implementation.