### PR TITLE
Tighten landing page stats and python sample

### DIFF
--- a/page/src/landing-page.tsx
+++ b/page/src/landing-page.tsx
@@ -59,8 +59,8 @@ function generateButtons(additionalClasses: string = "") {
 const pythonBindingsSample = `import ctypes
 import sogen
 
-app = sogen.windows.create_application("c:/test-sample.exe",
-                                       emulation_root="./root")
+app = sogen.windows.create_application(
+    "c:/test-sample.exe", emulation_root="./root")
 
 @sogen.windows.api_call(cc=sogen.CallingConvention.stdcall,
                         params=[ctypes.c_uint32])

--- a/page/src/landing-page.tsx
+++ b/page/src/landing-page.tsx
@@ -162,7 +162,6 @@ export function LandingPage() {
 
   const stats = [
     { value: "100%", label: "Open Source" },
-    { value: "14", label: "Platforms" },
     { value: "2", label: "OS Targets" },
     { value: "3", label: "Backends" },
     { value: "100%", label: "Deterministic" },


### PR DESCRIPTION
Remove redundant landing page stat and tighten python sample formatting to avoid overflow.

Checks:
- npm install
- npx prettier --write src/landing-page.tsx
- npm run build