### PR TITLE
Implement --call-count and --break-call arguments

### DIFF
--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -18,6 +18,7 @@ namespace sogen
     namespace
     {
         constexpr size_t MAX_INSTRUCTION_BYTES = 15;
+        constexpr uint64_t SYSCALL_INSTRUCTION_SIZE = 2;
 
         template <typename Return, typename... Args>
         std::function<Return(Args...)> make_callback(analysis_context& c, Return (*callback)(analysis_context&, Args...))
@@ -441,6 +442,35 @@ namespace sogen
             ++c.instructions[instructions[0].id];
         }
 
+        uint64_t next_traced_call_count(analysis_context& c)
+        {
+            return ++c.traced_call_count;
+        }
+
+        bool break_before_traced_call(analysis_context& c, const uint64_t call_count)
+        {
+            if (!c.auto_break_before_call || *c.auto_break_before_call != call_count)
+            {
+                return false;
+            }
+
+            c.auto_break_before_call.reset();
+            c.win_emu->stop();
+            return true;
+        }
+
+        bool break_before_traced_syscall(analysis_context& c, const uint64_t call_count, const uint64_t address)
+        {
+            if (!break_before_traced_call(c, call_count))
+            {
+                return false;
+            }
+
+            c.syscall_to_resume_after_break = address;
+            c.win_emu->emu().reg<uint64_t>(x86_register::rip, address - SYSCALL_INSTRUCTION_SIZE);
+            return true;
+        }
+
         void handle_section_first_execution(analysis_context& c, const mapped_module& binary, const mapped_section& section,
                                             const uint64_t address)
         {
@@ -533,11 +563,14 @@ namespace sogen
                 if (!c.settings->ignored_functions.contains(export_entry->second))
                 {
                     auto details = collect_function_details(c, export_entry->second);
+                    const auto call_count = next_traced_call_count(c);
                     c.emit_observation<function_execution_event>([&](auto& event) {
+                        event.call_count = call_count;
                         event.function_name = export_entry->second;
                         event.interesting = is_interesting_call;
                         event.details = std::move(details);
                     });
+                    (void)break_before_traced_call(c, call_count);
                 }
             }
             else if (address == binary->entry_point)
@@ -593,13 +626,21 @@ namespace sogen
             c.emit_observation<rdtscp_event>();
         }
 
-        emulator_callbacks::continuation handle_syscall(const analysis_context& c, const uint32_t syscall_id,
-                                                        const std::string_view syscall_name)
+        emulator_callbacks::continuation handle_syscall(analysis_context& c, const uint32_t syscall_id, const std::string_view syscall_name)
         {
             auto& win_emu = *c.win_emu;
             auto& emu = win_emu.emu();
 
             const auto address = emu.read_instruction_pointer();
+            if (c.syscall_to_resume_after_break)
+            {
+                const auto syscall_to_resume = std::exchange(c.syscall_to_resume_after_break, std::nullopt);
+                if (*syscall_to_resume == address)
+                {
+                    return instruction_hook_continuation::run_instruction;
+                }
+            }
+
             const auto* mod = win_emu.mod_manager.find_by_address(address);
             const auto is_sus_module = mod != win_emu.mod_manager.ntdll && mod != win_emu.mod_manager.win32u;
             const auto previous_ip = win_emu.current_thread().previous_ip;
@@ -611,11 +652,18 @@ namespace sogen
 
             if (is_sus_module && !is_valid_32_bit_module)
             {
+                const auto call_count = next_traced_call_count(c);
                 c.emit_observation<syscall_event>([&](auto& event) {
+                    event.call_count = call_count;
                     event.classification = syscall_classification::inline_syscall;
                     event.syscall_id = syscall_id;
                     event.syscall_name = std::string(syscall_name);
                 });
+
+                if (break_before_traced_syscall(c, call_count, address))
+                {
+                    return instruction_hook_continuation::skip_instruction;
+                }
             }
             else if (!previous_ip || mod->contains(previous_ip))
             {
@@ -627,27 +675,41 @@ namespace sogen
                     emu.try_read_memory(rsp, &return_address, sizeof(return_address));
 
                     const auto* caller_mod_name = win_emu.mod_manager.find_name(return_address);
+                    const auto call_count = next_traced_call_count(c);
 
                     c.emit_observation<syscall_event>([&](auto& event) {
+                        event.call_count = call_count;
                         event.classification = syscall_classification::regular;
                         event.syscall_id = syscall_id;
                         event.syscall_name = std::string(syscall_name);
                         event.caller_rip = return_address;
                         event.caller_module = caller_mod_name ? std::optional<std::string>{caller_mod_name} : std::nullopt;
                     });
+
+                    if (break_before_traced_syscall(c, call_count, address))
+                    {
+                        return instruction_hook_continuation::skip_instruction;
+                    }
                 }
             }
             else
             {
                 const auto* previous_mod = win_emu.mod_manager.find_by_address(previous_ip);
+                const auto call_count = next_traced_call_count(c);
 
                 c.emit_observation<syscall_event>([&](auto& event) {
+                    event.call_count = call_count;
                     event.classification = syscall_classification::crafted_out_of_line;
                     event.syscall_id = syscall_id;
                     event.syscall_name = std::string(syscall_name);
                     event.caller_rip = previous_ip;
                     event.caller_module = previous_mod ? std::optional<std::string>{previous_mod->name} : std::nullopt;
                 });
+
+                if (break_before_traced_syscall(c, call_count, address))
+                {
+                    return instruction_hook_continuation::skip_instruction;
+                }
             }
 
             return instruction_hook_continuation::run_instruction;

--- a/src/windows-analyzer/analysis.hpp
+++ b/src/windows-analyzer/analysis.hpp
@@ -59,6 +59,9 @@ namespace sogen
         std::set<uint64_t> rdtsc_cache{};
         std::set<uint64_t> rdtscp_cache{};
         std::set<std::pair<uint64_t, uint32_t>> cpuid_cache{};
+        uint64_t traced_call_count{};
+        std::optional<uint64_t> auto_break_before_call{};
+        std::optional<uint64_t> syscall_to_resume_after_break{};
 
         mutable std::pair<uint64_t, uint64_t> mapping_violation{0, 0};
         mutable uint64_t next_event_sequence{1};

--- a/src/windows-analyzer/analysis_event.hpp
+++ b/src/windows-analyzer/analysis_event.hpp
@@ -211,6 +211,7 @@ namespace sogen
 
     struct function_execution_event : observation_event
     {
+        uint64_t call_count{};
         std::string function_name{};
         bool interesting{};
         std::vector<function_execution_detail> details{};
@@ -250,6 +251,7 @@ namespace sogen
 
     struct syscall_event : observation_event
     {
+        uint64_t call_count{};
         syscall_classification classification{syscall_classification::regular};
         uint32_t syscall_id{};
         std::string syscall_name{};

--- a/src/windows-analyzer/analysis_reporter.cpp
+++ b/src/windows-analyzer/analysis_reporter.cpp
@@ -511,6 +511,7 @@ namespace sogen
 
             static void write_fields(json_object_builder& object, const function_execution_event& event)
             {
+                object.field("callCount", event.call_count);
                 object.field("fn", event.function_name);
                 object.field("interesting", event.interesting);
                 object.array_field("details", [&](const auto& emit) {
@@ -559,6 +560,7 @@ namespace sogen
 
             static void write_fields(json_object_builder& object, const syscall_event& event)
             {
+                object.field("callCount", event.call_count);
                 object.field("class", syscall_classification_name(event.classification));
                 object.field("id", event.syscall_id);
                 object.field("name", event.syscall_name);

--- a/src/windows-analyzer/analysis_reporter.hpp
+++ b/src/windows-analyzer/analysis_reporter.hpp
@@ -14,6 +14,7 @@ namespace sogen
     {
         bool silent{};
         bool buffer_stdout{};
+        bool prepend_call_count{};
     };
 
     class analysis_reporter

--- a/src/windows-analyzer/console_reporter.cpp
+++ b/src/windows-analyzer/console_reporter.cpp
@@ -49,6 +49,16 @@ namespace sogen
                            event);
             }
 
+            std::string make_call_prefix(const uint64_t call_count) const
+            {
+                if (!this->settings_.prepend_call_count)
+                {
+                    return {};
+                }
+
+                return "[" + std::to_string(call_count) + "] ";
+            }
+
             void report_regular(const analysis_event& event)
             {
                 std::visit(
@@ -162,8 +172,9 @@ namespace sogen
                                              static_cast<size_t>(e.size), e.execution.rip, e.execution.rip_module.c_str());
                         },
                         [&](const function_execution_event& e) {
+                            const auto prefix = this->make_call_prefix(e.call_count);
                             this->log_.print(e.interesting ? color::yellow : color::dark_gray,
-                                             "Executing function: %s (%s) (0x%" PRIx64 ") via 0x%" PRIx64 " (%s)\n",
+                                             "%sExecuting function: %s (%s) (0x%" PRIx64 ") via 0x%" PRIx64 " (%s)\n", prefix.c_str(),
                                              e.function_name.c_str(), e.execution.rip_module.c_str(), e.execution.rip,
                                              e.execution.previous_ip.value_or(0), e.execution.previous_ip_module.value_or("<N/A>").c_str());
                             for (const auto& detail : e.details)
@@ -206,21 +217,24 @@ namespace sogen
                                              e.execution.rip, e.execution.rip_module.c_str());
                         },
                         [&](const syscall_event& e) {
+                            const auto prefix = this->make_call_prefix(e.call_count);
                             switch (e.classification)
                             {
                             case syscall_classification::inline_syscall:
-                                this->log_.print(color::blue, "Executing inline syscall: %s (0x%X) at 0x%" PRIx64 " (%s)\n",
-                                                 e.syscall_name.c_str(), e.syscall_id, e.execution.rip, e.execution.rip_module.c_str());
+                                this->log_.print(color::blue, "%sExecuting inline syscall: %s (0x%X) at 0x%" PRIx64 " (%s)\n",
+                                                 prefix.c_str(), e.syscall_name.c_str(), e.syscall_id, e.execution.rip,
+                                                 e.execution.rip_module.c_str());
                                 break;
                             case syscall_classification::crafted_out_of_line:
                                 this->log_.print(
-                                    color::blue, "Crafted out-of-line syscall: %s (0x%X) at 0x%" PRIx64 " (%s) via 0x%" PRIx64 " (%s)\n",
-                                    e.syscall_name.c_str(), e.syscall_id, e.execution.rip, e.execution.rip_module.c_str(),
+                                    color::blue, "%sCrafted out-of-line syscall: %s (0x%X) at 0x%" PRIx64 " (%s) via 0x%" PRIx64 " (%s)\n",
+                                    prefix.c_str(), e.syscall_name.c_str(), e.syscall_id, e.execution.rip, e.execution.rip_module.c_str(),
                                     e.execution.previous_ip.value_or(0), e.execution.previous_ip_module.value_or("<N/A>").c_str());
                                 break;
                             case syscall_classification::regular:
                             default:
-                                this->log_.print(color::dark_gray, "Executing syscall: %s (0x%X) at 0x%" PRIx64 " via 0x%" PRIx64 " (%s)\n",
+                                this->log_.print(color::dark_gray,
+                                                 "%sExecuting syscall: %s (0x%X) at 0x%" PRIx64 " via 0x%" PRIx64 " (%s)\n", prefix.c_str(),
                                                  e.syscall_name.c_str(), e.syscall_id, e.execution.rip, e.caller_rip.value_or(0),
                                                  e.caller_module.value_or("<N/A>").c_str());
                                 break;

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -53,6 +53,8 @@ namespace sogen
             bool log_executable_access{false};
             bool log_foreign_module_access{false};
             bool tenet_trace{false};
+            bool prepend_call_count{false};
+            std::optional<uint64_t> break_call{};
             std::filesystem::path dump{};
             std::filesystem::path minidump_path{};
             std::filesystem::path report_path{};
@@ -474,6 +476,24 @@ namespace sogen
             throw std::runtime_error("WHP memory execution hook mode must be auto or int3");
         }
 
+        uint64_t parse_positive_u64_argument(const std::string_view value, const std::string_view option_name)
+        {
+            char* end_ptr = nullptr;
+            const auto parsed = strtoull(std::string(value).c_str(), &end_ptr, 10);
+
+            if (*end_ptr)
+            {
+                throw std::runtime_error("Bad value for " + std::string(option_name));
+            }
+
+            if (parsed == 0)
+            {
+                throw std::runtime_error(std::string(option_name) + " expects a value greater than 0");
+            }
+
+            return parsed;
+        }
+
         std::unique_ptr<x86_64_emulator> create_configured_backend(const analysis_options& options)
         {
             auto emu = create_x86_64_emulator_from_environment();
@@ -557,6 +577,7 @@ namespace sogen
         {
             analysis_context context{
                 .settings = &options,
+                .auto_break_before_call = options.break_call,
             };
 
             const auto concise_logging = options.concise_logging;
@@ -567,6 +588,7 @@ namespace sogen
             reporters.emplace_back(create_console_reporter(win_emu->log, console_reporter_settings{
                                                                              .silent = options.silent,
                                                                              .buffer_stdout = options.buffer_stdout,
+                                                                             .prepend_call_count = options.prepend_call_count,
                                                                          }));
 
             if (!options.report_path.empty())
@@ -795,33 +817,35 @@ namespace sogen
         {
             printf("Usage: analyzer [options] [application] [args...]\n\n");
             printf("Options:\n");
-            printf("  -h, --help                Show this help message\n");
-            printf("  -d, --debug               Enable GDB debugging mode\n");
-            printf("  --bind <ip>               IP or hostname to bind to in GDB mode (default: 127.0.0.1)\n");
-            printf("  --port <port>             Port to listen to in GDB mode (default: 28960)\n");
-            printf("  -s, --silent              Silent mode\n");
-            printf("  -v, --verbose             Verbose logging\n");
-            printf("  -b, --buffer              Buffer stdout\n");
-            printf("  -f, --foreign             Log read access to foreign modules\n");
-            printf("  -c, --concise             Concise logging\n");
-            printf("  -vc, --very-concise       Very concise logging\n");
-            printf("  -x, --exec                Log r/w access to executable memory\n");
-            printf("  -m, --module <module>     Specify module to track\n");
-            printf("  -e, --emulation <path>    Set emulation root path\n");
-            printf("  -a, --snapshot <path>     Load snapshot dump from path\n");
-            printf("  --minidump <path>         Load minidump from path\n");
-            printf("  --report <path>           Write machine-readable analysis events to a file\n");
-            printf("  --report-format <format>  Report format (supported: jsonl)\n");
-            printf("  --whp-exec-hook <mode>    WHP memory execution hook mode: auto or int3 (default: auto)\n");
-            printf("  -t, --tenet-trace         Enable Tenet tracer\n");
-            printf("  -i, --ignore <funcs>      Comma-separated list of functions to ignore\n");
-            printf("  -p, --path <src> <dst>    Map Windows path to host path\n");
-            printf("  -r, --registry <path>     Set registry path (default: ./registry)\n\n");
-            printf("  -fx, --first-exec         Print first executions of sections\n");
-            printf("  -is, --inst-summary       Print a summary of executed instructions of the analyzed modules\n");
-            printf("  -ss, --skip-syscalls      Skip the logging of regular syscalls\n");
-            printf("  -rep, --reproducible      Stub clocks and other mechanisms to make executions reproducible\n");
-            printf("  --env <var> <value>       Set environment variable\n");
+            printf("  -h, --help                 Show this help message\n");
+            printf("  -d, --debug                Enable GDB debugging mode\n");
+            printf("  --bind <ip>                IP or hostname to bind to in GDB mode (default: 127.0.0.1)\n");
+            printf("  --port <port>              Port to listen to in GDB mode (default: 28960)\n");
+            printf("  -s, --silent               Silent mode\n");
+            printf("  -v, --verbose              Verbose logging\n");
+            printf("  -b, --buffer               Buffer stdout\n");
+            printf("  -f, --foreign              Log read access to foreign modules\n");
+            printf("  -c, --concise              Concise logging\n");
+            printf("  -vc, --very-concise        Very concise logging\n");
+            printf("  -x, --exec                 Log r/w access to executable memory\n");
+            printf("  -m, --module <module>      Specify module to track\n");
+            printf("  -e, --emulation <path>     Set emulation root path\n");
+            printf("  -a, --snapshot <path>      Load snapshot dump from path\n");
+            printf("  --minidump <path>          Load minidump from path\n");
+            printf("  --report <path>            Write machine-readable analysis events to a file\n");
+            printf("  --report-format <format>   Report format (supported: jsonl)\n");
+            printf("  --whp-exec-hook <mode>     WHP memory execution hook mode: auto or int3 (default: auto)\n");
+            printf("  --call-count               Prefix function and syscall lines with a traced-call count\n");
+            printf("  -t, --tenet-trace          Enable Tenet tracer\n");
+            printf("  -i, --ignore <funcs>       Comma-separated list of functions to ignore\n");
+            printf("  -p, --path <src> <dst>     Map Windows path to host path\n");
+            printf("  -r, --registry <path>      Set registry path (default: ./registry)\n\n");
+            printf("  -fx, --first-exec          Print first executions of sections\n");
+            printf("  -is, --inst-summary        Print a summary of executed instructions of the analyzed modules\n");
+            printf("  -ss, --skip-syscalls       Skip the logging of regular syscalls\n");
+            printf("  -rep, --reproducible       Stub clocks and other mechanisms to make executions reproducible\n");
+            printf("  --env <var> <value>        Set environment variable\n");
+            printf("  -bc, --break-call <count>  In GDB mode, stop before the specified traced function/syscall call\n");
             printf("Examples:\n");
             printf("  analyzer -v -e path/to/root myapp.exe\n");
             printf("  analyzer --report run.jsonl test-sample.exe\n");
@@ -831,7 +855,7 @@ namespace sogen
         analysis_options parse_options(std::vector<std::string_view>& args)
         {
             analysis_options options{};
-            bool require_debug_option = false;
+            std::optional<std::string_view> require_debug_option{};
 
             while (!args.empty())
             {
@@ -857,7 +881,7 @@ namespace sogen
 
                     arg_it = args.erase(arg_it);
                     options.gdb_host = args[0];
-                    require_debug_option = true;
+                    require_debug_option = arg;
                 }
                 else if (arg == "--port")
                 {
@@ -882,7 +906,7 @@ namespace sogen
                     }
 
                     options.gdb_port = static_cast<uint16_t>(port);
-                    require_debug_option = true;
+                    require_debug_option = arg;
                 }
                 else if (arg == "-s" || arg == "--silent")
                 {
@@ -1047,6 +1071,21 @@ namespace sogen
 
                     options.environment[std::move(env_var)] = std::move(env_value);
                 }
+                else if (arg == "--call-count")
+                {
+                    options.prepend_call_count = true;
+                }
+                else if (arg == "-bc" || arg == "--break-call")
+                {
+                    if (args.size() < 2)
+                    {
+                        throw std::runtime_error("No call count provided after -bc/--break-call");
+                    }
+
+                    arg_it = args.erase(arg_it);
+                    options.break_call = parse_positive_u64_argument(args[0], "--break-call");
+                    require_debug_option = arg;
+                }
                 else
                 {
                     break;
@@ -1057,7 +1096,7 @@ namespace sogen
 
             if (require_debug_option && !options.use_gdb)
             {
-                throw std::runtime_error("--bind or --port options used without -d");
+                throw std::runtime_error(std::string(*require_debug_option) + " option used without -d");
             }
 
             return options;

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -476,19 +476,21 @@ namespace sogen
             throw std::runtime_error("WHP memory execution hook mode must be auto or int3");
         }
 
-        uint64_t parse_positive_u64_argument(const std::string_view value, const std::string_view option_name)
+        uint64_t parse_u64_argument(const std::string_view value, const std::string_view option_name)
         {
-            char* end_ptr = nullptr;
-            const auto parsed = strtoull(std::string(value).c_str(), &end_ptr, 10);
-
-            if (*end_ptr)
+            if (value.empty())
             {
                 throw std::runtime_error("Bad value for " + std::string(option_name));
             }
 
-            if (parsed == 0)
+            uint64_t parsed{};
+            const auto* const begin = value.data();
+            const auto* const end = begin + value.size();
+            const auto result = std::from_chars(begin, end, parsed, 10);
+
+            if (result.ec != std::errc{} || result.ptr != end)
             {
-                throw std::runtime_error(std::string(option_name) + " expects a value greater than 0");
+                throw std::runtime_error("Bad value for " + std::string(option_name));
             }
 
             return parsed;
@@ -892,13 +894,7 @@ namespace sogen
 
                     arg_it = args.erase(arg_it);
 
-                    char* end_ptr = nullptr;
-                    const auto port = strtoull(std::string(args[0]).c_str(), &end_ptr, 10);
-
-                    if (*end_ptr)
-                    {
-                        throw std::runtime_error("Bad port number");
-                    }
+                    const auto port = parse_u64_argument(args[0], arg);
 
                     if (port > 65535)
                     {
@@ -1083,7 +1079,7 @@ namespace sogen
                     }
 
                     arg_it = args.erase(arg_it);
-                    options.break_call = parse_positive_u64_argument(args[0], "--break-call");
+                    options.break_call = parse_u64_argument(args[0], arg);
                     require_debug_option = arg;
                 }
                 else

--- a/src/windows-analyzer/std_include.hpp
+++ b/src/windows-analyzer/std_include.hpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <list>
 #include <array>
+#include <charconv>
 #include <deque>
 #include <queue>
 #include <mutex>


### PR DESCRIPTION
This PR adds two new arguments to the analyzer CLI: `--call-count` and `--break-call`.

When debugging with sogen, I often want to break at a precise point of execution.
My previous workaround was to manually pause at the right moment and then pause in
GDB, which works fine most of the time but gets annoying when a function or syscall
is called more than once. These two arguments make that easier:

- `--call-count`: Prefixes each function/syscall execution with an incrementing counter.
- `--break-call <n>`: Breaks in GDB when the specified call count is reached.