### PR TITLE
Fix WoW64 interrupts and add WHP support

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1809,8 +1809,9 @@ namespace sogen::whp
                 if (enabled_exits.ExceptionExit)
                 {
                     WHV_PARTITION_PROPERTY exception_exit_bitmap{};
-                    exception_exit_bitmap.ExceptionExitBitmap =
-                        (1ull << WHvX64ExceptionTypeDebugTrapOrFault) | (1ull << WHvX64ExceptionTypeBreakpointTrap);
+                    exception_exit_bitmap.ExceptionExitBitmap = (1ull << WHvX64ExceptionTypeDebugTrapOrFault) |
+                                                                (1ull << WHvX64ExceptionTypeBreakpointTrap) |
+                                                                (1ull << WHvX64ExceptionTypeInvalidOpcodeFault);
 
                     WHP_CHECK_HR(WHvSetPartitionProperty(this->partition_, WHvPartitionPropertyCodeExceptionExitBitmap,
                                                          &exception_exit_bitmap, sizeof(exception_exit_bitmap)));
@@ -2970,8 +2971,22 @@ namespace sogen::whp
             {
                 const auto rip = this->read_instruction_pointer();
                 std::array<std::byte, 2> opcode{};
-                if (this->access_memory(rip, opcode.data(), opcode.size(), false) && opcode[0] == std::byte{0x0F} &&
-                    opcode[1] == std::byte{0x0B})
+                if (this->access_memory(rip, opcode.data(), opcode.size(), false) && opcode[0] == std::byte{0xCD})
+                {
+                    for (auto& [_, hook] : this->interrupt_hooks_)
+                    {
+                        hook(std::to_integer<uint8_t>(opcode[1]));
+
+                        if (this->read_instruction_pointer() == rip)
+                        {
+                            this->advance_rip(2);
+                        }
+
+                        return true;
+                    }
+                }
+                else if (this->access_memory(rip, opcode.data(), opcode.size(), false) && opcode[0] == std::byte{0x0F} &&
+                         opcode[1] == std::byte{0x0B})
                 {
                     bool skip = false;
                     bool consumed = false;
@@ -3249,6 +3264,7 @@ namespace sogen::whp
 
                 if (exception.ExceptionType == WHvX64ExceptionTypeInvalidOpcodeFault)
                 {
+                    const auto rip = this->read_instruction_pointer();
                     bool consumed = false;
 
                     for (auto& [_, hook] : this->instruction_hooks_)
@@ -3260,7 +3276,10 @@ namespace sogen::whp
 
                         if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
                         {
-                            this->advance_rip(exception.InstructionByteCount);
+                            if (this->read_instruction_pointer() == rip)
+                            {
+                                this->advance_rip(exception.InstructionByteCount);
+                            }
                             consumed = true;
                         }
                     }

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -157,6 +157,67 @@ namespace sogen
             emu.reg(x86_register::rsp, wow64::heaven_gate::kStackTop);
             emu.reg(x86_register::rip, wow64::heaven_gate::kCodeBase);
         }
+
+        WOW64_CONTEXT make_wow64_context(const CONTEXT64& ctx)
+        {
+            WOW64_CONTEXT result{};
+            result.ContextFlags = CONTEXT32_ALL;
+            result.Dr0 = static_cast<DWORD>(ctx.Dr0);
+            result.Dr1 = static_cast<DWORD>(ctx.Dr1);
+            result.Dr2 = static_cast<DWORD>(ctx.Dr2);
+            result.Dr3 = static_cast<DWORD>(ctx.Dr3);
+            result.Dr6 = static_cast<DWORD>(ctx.Dr6);
+            result.Dr7 = static_cast<DWORD>(ctx.Dr7);
+            result.SegGs = ctx.SegGs;
+            result.SegFs = ctx.SegFs;
+            result.SegEs = ctx.SegEs;
+            result.SegDs = ctx.SegDs;
+            result.Edi = static_cast<DWORD>(ctx.Rdi);
+            result.Esi = static_cast<DWORD>(ctx.Rsi);
+            result.Ebx = static_cast<DWORD>(ctx.Rbx);
+            result.Edx = static_cast<DWORD>(ctx.Rdx);
+            result.Ecx = static_cast<DWORD>(ctx.Rcx);
+            result.Eax = static_cast<DWORD>(ctx.Rax);
+            result.Ebp = static_cast<DWORD>(ctx.Rbp);
+            result.Eip = static_cast<DWORD>(ctx.Rip);
+            result.SegCs = ctx.SegCs;
+            result.EFlags = ctx.EFlags;
+            result.Esp = static_cast<DWORD>(ctx.Rsp);
+            result.SegSs = ctx.SegSs;
+            result.FloatSave.ControlWord = 0x037F;
+            result.FloatSave.TagWord = 0xFFFF;
+
+            XMM_SAVE_AREA32 xmm_state{};
+            xmm_state.ControlWord = 0x037F;
+            xmm_state.TagWord = 0xFF;
+            xmm_state.MxCsr = 0x1F80;
+            xmm_state.MxCsr_Mask = 0xFFFFFFFF;
+            static_assert(sizeof(xmm_state) <= sizeof(result.ExtendedRegisters));
+            memcpy(result.ExtendedRegisters, &xmm_state, sizeof(xmm_state));
+            return result;
+        }
+
+        void sync_wow64_cpu_reserved_context(windows_emulator& win_emu, const CONTEXT64& ctx)
+        {
+            if (!win_emu.process.is_wow64_process)
+            {
+                return;
+            }
+
+            const auto bitness = segment_utils::get_segment_bitness(win_emu.emu(), ctx.SegCs);
+            if (!bitness || *bitness != segment_utils::segment_bitness::bit32)
+            {
+                return;
+            }
+
+            // Wow64PassExceptionToGuest rebuilds the 32-bit context from WOW64_CPURESERVED
+            // (TEB64 TLS slot 1), not from the native exception ContextRecord below.
+            win_emu.current_thread().wow64_cpu_reserved->access([&](WOW64_CPURESERVED& cpu) {
+                cpu.Flags |= WOW64_CPURESERVED_FLAG_RESET_STATE;
+                cpu.Context = make_wow64_context(ctx);
+            });
+        }
+
     }
 
     bool dispatch_debug_exception(windows_emulator& win_emu, CONTEXT64& ctx, EMU_EXCEPTION_RECORD<EmulatorTraits<Emu64>>& record)
@@ -168,45 +229,12 @@ namespace sogen
         {
             // skip 2 bytes int 2dh
             ctx.Rip += 2;
+            record.ExceptionAddress = ctx.Rip + 1;
 
             record.NumberParameters = 3;
-
             record.ExceptionInformation[0] = ctx.Rax;
             record.ExceptionInformation[1] = ctx.Rcx;
             record.ExceptionInformation[2] = ctx.Rdx;
-
-            // https://github.com/ayoubfaouzi/al-khaser/issues/223
-
-            // inc qword ptr [rbp + KTRAP_FRAME_Rip]
-            ctx.Rip++;
-
-            switch (ctx.Rax)
-            {
-            case BREAKPOINT_BREAK:
-                // just drops straight into the debugger trap handler. Doesn't increment the instruction pointer.
-                break;
-            case BREAKPOINT_PRINT:
-                // calls BREAKPOINT_PRINT service, which is implemented by KdpPrint, increments the instruction pointer.
-                ctx.Rip += 3;
-                break;
-            case BREAKPOINT_PROMPT:
-                // calls BREAKPOINT_PROMPT service, which is implemented by KdpPrompt, doesn't increment the instruction pointer.
-                break;
-            case BREAKPOINT_LOAD_SYMBOLS:
-                // calls BREAKPOINT_LOAD_SYMBOLS, which is implemented by KdpSymbol, increments the instruction pointer.
-                ctx.Rip += 3;
-                break;
-            case BREAKPOINT_UNLOAD_SYMBOLS:
-                // calls BREAKPOINT_UNLOAD_SYMBOLS, which is also implemented by KdpSymbol, increments the instruction pointer.
-                ctx.Rip += 3;
-                break;
-            case BREAKPOINT_COMMAND_STRING:
-                // calls BREAKPOINT_COMMAND_STRING, which is implemented in KdpCommandString, increments the instruction pointer.
-                ctx.Rip += 3;
-                break;
-            default:
-                break;
-            }
 
             return true;
         }
@@ -253,10 +281,11 @@ namespace sogen
 
         record.ExceptionAddress = ctx.Rip;
 
+        sync_wow64_cpu_reserved_context(win_emu, ctx);
+
         EMU_EXCEPTION_POINTERS<EmulatorTraits<Emu64>> pointers{};
         pointers.ContextRecord = reinterpret_cast<EmulatorTraits<Emu64>::PVOID>(&ctx);
         pointers.ExceptionRecord = reinterpret_cast<EmulatorTraits<Emu64>::PVOID>(&record);
-
         dispatch_exception_pointers(win_emu.emu(), win_emu.process.ki_user_exception_dispatcher, pointers);
     }
 

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -229,9 +229,9 @@ namespace sogen
         {
             // skip 2 bytes int 2dh
             ctx.Rip += 2;
-            record.ExceptionAddress = ctx.Rip + 1;
 
             record.NumberParameters = 3;
+
             record.ExceptionInformation[0] = ctx.Rax;
             record.ExceptionInformation[1] = ctx.Rcx;
             record.ExceptionInformation[2] = ctx.Rdx;

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -664,7 +664,25 @@ namespace sogen
                 return;
             case 45:
                 this->callbacks.on_suspicious_activity("DbgPrint");
-                dispatch_breakpoint(*this);
+                {
+                    const auto cs_selector = this->emu().reg<uint16_t>(x86_register::cs);
+                    const auto bitness = segment_utils::get_segment_bitness(this->emu(), cs_selector);
+                    const auto service = this->emu().reg<uint32_t>(x86_register::eax);
+
+                    if (bitness && *bitness == segment_utils::segment_bitness::bit64 &&
+                        (service == BREAKPOINT_PRINT || service == BREAKPOINT_LOAD_SYMBOLS || service == BREAKPOINT_UNLOAD_SYMBOLS ||
+                         service == BREAKPOINT_COMMAND_STRING))
+                    {
+                        const auto ip = this->emu().supports_instruction_counting() //
+                                            ? this->current_thread().current_ip
+                                            : this->emu().read_instruction_pointer();
+                        this->emu().reg(x86_register::rip, ip + 3);
+                    }
+                    else
+                    {
+                        dispatch_breakpoint(*this);
+                    }
+                }
                 return;
             default:
                 if (this->callbacks.on_generic_activity)


### PR DESCRIPTION
This PR adds support for interrupts and fixes invalid instruction exceptions in WHP, both of which were previously being reported as memory violations. It also resolves issues encountered while emulating interrupt `0x2D` on both x86 and x64, including a significant omission in `dispatch_exception` affecting WoW64.