### PR TITLE
Switch debugger scripts to JavaScript

### DIFF
--- a/page/src/components/script-console.tsx
+++ b/page/src/components/script-console.tsx
@@ -8,11 +8,9 @@ import { cn } from "@/lib/utils";
 import { PlayFill, StopFill, PlusLg, Trash } from "react-bootstrap-icons";
 
 import { Emulator } from "@/emulator";
-import { runPythonScript, type ScriptHandle } from "@/debugger/scripting";
+import { runScript, type ScriptHandle } from "@/debugger/scripting";
 
-// Bumped suffix: previously stored scripts were JavaScript and would not run
-// as Python; start the Python console from a clean default set.
-const STORAGE_KEY = "sogen.debugger.scripts.py";
+const STORAGE_KEY = "sogen.debugger.scripts.js";
 
 interface Script {
   id: string;
@@ -20,18 +18,18 @@ interface Script {
   source: string;
 }
 
-const DEFAULT_SOURCE = `# Python scripting — drives the REAL emulator via the debugger backend.
-# 'emu' mirrors the sogen Python bindings (emu.debug.*, emu.memory.*).
-# Emulator calls are coroutines: use 'await'. Top-level await is supported.
+const DEFAULT_SOURCE = `// JS scripting — drives the REAL emulator via debugger backend.
+// emu exposes debugger + memory helpers. Use await.
 
-regs = await emu.debug.registers()
-print("rip =", regs["rip"])
+const regs = await emu.debug.registers();
+console.log("rip =", regs.rip);
 
-for insn in await emu.debug.disassemble(int(regs["rip"], 16), 5):
-    print(insn["address"], " ", insn["mnemonic"], insn["operands"])
+for (const insn of await emu.debug.disassemble(BigInt(regs.rip), 5)) {
+  console.log(insn.address, insn.mnemonic, insn.operands);
+}
 
-# await emu.debug.breakpoint(0x140001000)
-# await emu.debug.step_into()
+// await emu.debug.breakpoint(0x140001000n);
+// await emu.debug.step_into();
 `;
 
 function loadScripts(): Script[] {
@@ -99,7 +97,7 @@ export function ScriptConsole({ emulator }: ScriptConsoleProps) {
     setRunning(true);
     setOutput([`> running ${active.name}…`]);
 
-    const result = await runPythonScript(emulator, source, appendLine, handle);
+    const result = await runScript(emulator, source, appendLine, handle);
     if (!result.ok) {
       appendLine("--- traceback ---");
       appendLine(result.error ?? "unknown error");
@@ -238,7 +236,7 @@ export function ScriptConsole({ emulator }: ScriptConsoleProps) {
       <div className="min-h-0 flex-1">
         <Editor
           height="100%"
-          language="python"
+          language="javascript"
           theme="vs-dark"
           value={active.source}
           onChange={(v) => updateSource(v ?? "")}
@@ -257,8 +255,7 @@ export function ScriptConsole({ emulator }: ScriptConsoleProps) {
       <div className="h-40 shrink-0 overflow-auto border-t bg-black/30 p-2 font-mono text-[11px] whitespace-pre-wrap">
         {output.length === 0 ? (
           <span className="text-muted-foreground">
-            Output. `emu.debug.*` drives the live emulator (Python via Pyodide;
-            mirrors the sogen Python API). Use `await`.
+            Output. `emu.debug.*` drives the live emulator. Use `await`.
           </span>
         ) : (
           output.map((l, i) => <div key={i}>{l}</div>)

--- a/page/src/debugger/scripting.ts
+++ b/page/src/debugger/scripting.ts
@@ -1,11 +1,7 @@
 // Scripting bridge.
 //
-// This is NOT a fake frontend mock: every call drives the real emulator via
-// the same generic debug-command channel / debug_session used by the rest of
-// the debugger. The host language is Python (CPython via Pyodide); the
-// injected `emu` object mirrors the existing nanobind `sogen` model
-// (emu.debug.*, emu.memory.*) so scripts read like the project's Python
-// bindings. The same facade also still backs the JS runner.
+// Real emulator access, no fake mock. JS scripts call same debugger channel
+// used by rest of UI.
 
 import { Emulator } from "@/emulator";
 import * as dbg from "@/debugger/api";
@@ -14,11 +10,7 @@ export interface ScriptHandle {
   cancelled: boolean;
 }
 
-function buildEmuFacade(
-  emulator: Emulator,
-  print: (line: string) => void,
-  handle: ScriptHandle,
-) {
+function buildEmuFacade(emulator: Emulator, handle: ScriptHandle) {
   const guard = () => {
     if (handle.cancelled) {
       throw new Error("Script cancelled");
@@ -58,7 +50,6 @@ function buildEmuFacade(
       guard();
       return dbg.continueExecution(emulator);
     },
-    // `await emu.debug.registers()` -> { rax: "0x..", rip: "0x..", ... }
     async registers() {
       guard();
       const regs = await dbg.getRegisters(emulator);
@@ -91,7 +82,6 @@ function buildEmuFacade(
       guard();
       return emulator.readMemory(BigInt(address), size);
     },
-    // Alias matching the sogen Python bindings (MemoryManager.read_memory).
     async read_memory(address: bigint | number, size: number) {
       guard();
       return emulator.readMemory(BigInt(address), size);
@@ -112,10 +102,13 @@ export interface ScriptResult {
   error?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function bigintReplacer(_key: string, value: any) {
+  return typeof value === "bigint" ? "0x" + value.toString(16) : value;
+}
+
 /**
- * Run `source` as an async JavaScript function with the live `emu` facade and
- * a `print` builtin. Returns a traceback string on failure. Cancellation is
- * cooperative (checked at every emulator call).
+ * Run `source` as async JavaScript with live `emu` facade and `print` builtin.
  */
 export async function runScript(
   emulator: Emulator,
@@ -123,7 +116,7 @@ export async function runScript(
   print: (line: string) => void,
   handle: ScriptHandle,
 ): Promise<ScriptResult> {
-  const emu = buildEmuFacade(emulator, print, handle);
+  const emu = buildEmuFacade(emulator, handle);
 
   const log = (...args: unknown[]) => {
     print(
@@ -150,179 +143,5 @@ export async function runScript(
       ok: false,
       error: `${err.name}: ${err.message}\n${err.stack ?? ""}`,
     };
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function bigintReplacer(_key: string, value: any) {
-  return typeof value === "bigint" ? "0x" + value.toString(16) : value;
-}
-
-/* ------------------------------- Python ------------------------------- */
-
-// Pyodide is loaded lazily from the CDN on first script run and cached for the
-// session. The browser emulator has no native `sogen` wasm module, so the
-// `emu` facade above (which speaks the real debug-command protocol) is what we
-// expose to Python — scripts read like the nanobind bindings.
-
-const PYODIDE_VERSION = "0.26.4";
-
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    loadPyodide?: (config: { indexURL: string }) => Promise<any>;
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let pyodidePromise: Promise<any> | null = null;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function loadPyodideRuntime(): Promise<any> {
-  if (pyodidePromise) {
-    return pyodidePromise;
-  }
-  pyodidePromise = new Promise((resolve, reject) => {
-    const base = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
-    if (window.loadPyodide) {
-      window.loadPyodide({ indexURL: base }).then(resolve, reject);
-      return;
-    }
-    const script = document.createElement("script");
-    script.src = base + "pyodide.js";
-    script.onload = () => {
-      if (!window.loadPyodide) {
-        reject(new Error("Pyodide loaded but loadPyodide is missing"));
-        return;
-      }
-      window.loadPyodide({ indexURL: base }).then(resolve, reject);
-    };
-    script.onerror = () =>
-      reject(new Error("Failed to load the Pyodide runtime from the CDN"));
-    document.head.appendChild(script);
-  });
-  // A failed load must not be cached forever; allow a later retry.
-  pyodidePromise.catch(() => {
-    pyodidePromise = null;
-  });
-  return pyodidePromise;
-}
-
-/**
- * Run `source` as CPython (Pyodide) with the live `emu` facade in scope and
- * Python `print` wired to the console. Emulator calls are coroutines, so
- * scripts use `await emu.debug.…`; top-level await is supported. Cancellation
- * is cooperative (checked at every emulator call).
- */
-export async function runPythonScript(
-  emulator: Emulator,
-  source: string,
-  print: (line: string) => void,
-  handle: ScriptHandle,
-): Promise<ScriptResult> {
-  const emu = buildEmuFacade(emulator, print, handle);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let py: any;
-  try {
-    print("> loading Python runtime (first run downloads Pyodide)…");
-    py = await loadPyodideRuntime();
-  } catch (e) {
-    const err = e as Error;
-    return { ok: false, error: err.message ?? String(e) };
-  }
-
-  if (handle.cancelled) {
-    return { ok: false, error: "Script cancelled" };
-  }
-
-  const emit = (text: string) => {
-    // Pyodide batches stdout without a trailing newline; appendLine splits.
-    print(text.replace(/\n$/, ""));
-  };
-  py.setStdout({ batched: emit });
-  py.setStderr({ batched: emit });
-
-  try {
-    // Keep `emu` as JsProxy, then wrap selected methods into Python-native
-    // objects so scripts can use normal indexing / iteration.
-    py.globals.set("emu", emu);
-    await py.runPythonAsync(`
-from pyodide.ffi import to_py
-
-class _Debug:
-    def __init__(self, js):
-        self._js = js
-
-    async def breakpoint(self, address):
-        return to_py(await self._js.breakpoint(address))
-
-    async def clear_breakpoint(self, address):
-        return to_py(await self._js.clear_breakpoint(address))
-
-    async def breakpoints(self):
-        return to_py(await self._js.breakpoints())
-
-    async def step_into(self):
-        return to_py(await self._js.step_into())
-
-    async def step_over(self):
-        return to_py(await self._js.step_over())
-
-    async def step_out(self):
-        return to_py(await self._js.step_out())
-
-    async def run_to(self, address):
-        return to_py(await self._js.run_to(address))
-
-    async def continue_execution(self):
-        return to_py(await self._js.continue_execution())
-
-    async def registers(self):
-        return to_py(await self._js.registers())
-
-    async def disassemble(self, address, count=16):
-        return to_py(await self._js.disassemble(address, count))
-
-    async def modules(self):
-        return to_py(await self._js.modules())
-
-    async def threads(self):
-        return to_py(await self._js.threads())
-
-    async def call_stack(self):
-        return to_py(await self._js.call_stack())
-
-
-class _Memory:
-    def __init__(self, js):
-        self._js = js
-
-    async def read(self, address, size):
-        return to_py(await self._js.read(address, size))
-
-    async def read_memory(self, address, size):
-        return to_py(await self._js.read_memory(address, size))
-
-
-class _Emu:
-    def __init__(self, js):
-        self.debug = _Debug(js.debug)
-        self.memory = _Memory(js.memory)
-        self.state = js.state
-
-
-emu = _Emu(emu)
-`);
-    await py.runPythonAsync(source);
-    return { ok: true };
-  } catch (e) {
-    const err = e as Error;
-    return {
-      ok: false,
-      error: `${err.name ?? "PythonError"}: ${err.message ?? String(e)}`,
-    };
-  } finally {
-    py.globals.delete("emu");
   }
 }


### PR DESCRIPTION
Replace Pyodide-based debugger scripting with browser-native JavaScript and update the default script accordingly.