### PR TITLE
Use KiUserCallbackDispatcher for user callbacks

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -662,8 +662,10 @@ namespace sogen
         }
 
         this->rip = emu.reg(x86_register::rip);
+        this->rsi = emu.reg(x86_register::rsi);
         this->rsp = emu.reg(x86_register::rsp);
         this->r10 = emu.reg(x86_register::r10);
+        this->rbx = emu.reg(x86_register::rbx);
         this->rcx = emu.reg(x86_register::rcx);
         this->rdx = emu.reg(x86_register::rdx);
         this->r8 = emu.reg(x86_register::r8);
@@ -690,8 +692,10 @@ namespace sogen
         emu.reg<uint16_t>(x86_register::fs, this->fs);
         emu.reg<uint16_t>(x86_register::gs, this->gs);
         emu.reg(x86_register::rip, this->rip);
+        emu.reg(x86_register::rsi, this->rsi);
         emu.reg(x86_register::rsp, this->rsp);
         emu.reg(x86_register::r10, this->r10);
+        emu.reg(x86_register::rbx, this->rbx);
         emu.reg(x86_register::rcx, this->rcx);
         emu.reg(x86_register::rdx, this->rdx);
         emu.reg(x86_register::r8, this->r8);
@@ -702,8 +706,10 @@ namespace sogen
     {
         buffer.write(this->handler_id);
         buffer.write(this->rip);
+        buffer.write(this->rsi);
         buffer.write(this->rsp);
         buffer.write(this->r10);
+        buffer.write(this->rbx);
         buffer.write(this->rcx);
         buffer.write(this->rdx);
         buffer.write(this->r8);
@@ -726,8 +732,10 @@ namespace sogen
     {
         buffer.read(this->handler_id);
         buffer.read(this->rip);
+        buffer.read(this->rsi);
         buffer.read(this->rsp);
         buffer.read(this->r10);
+        buffer.read(this->rbx);
         buffer.read(this->rcx);
         buffer.read(this->rdx);
         buffer.read(this->r8);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -125,6 +125,7 @@ namespace sogen
     enum class callback_id : uint32_t
     {
         Invalid = 0,
+        NtUserGetThreadState,
         NtUserCreateWindowEx,
         NtUserDestroyWindow,
         NtUserShowWindow,
@@ -132,36 +133,14 @@ namespace sogen
         NtUserEnumDisplayMonitors,
     };
 
-    enum class wow64_callback_postprocess : uint8_t
-    {
-        none = 0,
-        bool_result_to_status = 1,
-    };
-
-    struct pending_wow64_callback
-    {
-        uint32_t callback_id{};
-        wow64_callback_postprocess postprocess{wow64_callback_postprocess::none};
-
-        void serialize(utils::buffer_serializer& buffer) const
-        {
-            buffer.write(this->callback_id);
-            buffer.write(static_cast<uint8_t>(this->postprocess));
-        }
-
-        void deserialize(utils::buffer_deserializer& buffer)
-        {
-            buffer.read(this->callback_id);
-            this->postprocess = static_cast<wow64_callback_postprocess>(buffer.read<uint8_t>());
-        }
-    };
-
     struct callback_frame
     {
         callback_id handler_id{};
         uint64_t rip{};
+        uint64_t rsi{};
         uint64_t rsp{};
         uint64_t r10{};
+        uint64_t rbx{};
         uint64_t rcx{};
         uint64_t rdx{};
         uint64_t r8{};
@@ -257,8 +236,6 @@ namespace sogen
 
         uint64_t win32k_thread_info{0};
         handle win32k_desktop{};
-        uint64_t win32k_callback_buffer{0};
-        std::optional<pending_wow64_callback> win32k_pending_wow64_callback{};
         bool win32k_thread_setup_pending{false};
         bool win32k_thread_setup_done{false};
 
@@ -359,8 +336,6 @@ namespace sogen
             buffer.write_optional(this->pending_status);
             buffer.write(this->win32k_thread_info);
             buffer.write(this->win32k_desktop);
-            buffer.write(this->win32k_callback_buffer);
-            buffer.write_optional(this->win32k_pending_wow64_callback);
             buffer.write(this->win32k_thread_setup_pending);
             buffer.write(this->win32k_thread_setup_done);
             buffer.write_optional(this->gs_segment);
@@ -421,8 +396,6 @@ namespace sogen
             buffer.read_optional(this->pending_status);
             buffer.read(this->win32k_thread_info);
             buffer.read(this->win32k_desktop);
-            buffer.read(this->win32k_callback_buffer);
-            buffer.read_optional(this->win32k_pending_wow64_callback, [] { return pending_wow64_callback{}; });
             buffer.read(this->win32k_thread_setup_pending);
             buffer.read(this->win32k_thread_setup_done);
             buffer.read_optional(this->gs_segment, [this] { return emulator_allocator(*this->memory_ptr); });

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -484,8 +484,8 @@ namespace sogen
         this->rtl_user_thread_start = ntdll.find_export("RtlUserThreadStart");
         this->ki_user_apc_dispatcher = ntdll.find_export("KiUserApcDispatcher");
         this->ki_user_exception_dispatcher = ntdll.find_export("KiUserExceptionDispatcher");
+        this->ki_user_callback_dispatcher = ntdll.find_export("KiUserCallbackDispatcher");
         this->instrumentation_callback = 0;
-        this->wow64_ki_user_callback_dispatcher = 0;
         this->zw_callback_return = ntdll.find_export("ZwCallbackReturn");
         this->gdi_default_dc_handle = 0;
         this->etw_notification_event.reset();
@@ -577,8 +577,8 @@ namespace sogen
         buffer.write_optional(this->rtl_user_thread_start32);
         buffer.write(this->ki_user_apc_dispatcher);
         buffer.write(this->ki_user_exception_dispatcher);
+        buffer.write(this->ki_user_callback_dispatcher);
         buffer.write(this->instrumentation_callback);
-        buffer.write(this->wow64_ki_user_callback_dispatcher);
         buffer.write(this->zw_callback_return);
         buffer.write(this->dispatch_client_message);
         buffer.write(this->gdi_default_dc_handle);
@@ -644,8 +644,8 @@ namespace sogen
         buffer.read_optional(this->rtl_user_thread_start32);
         buffer.read(this->ki_user_apc_dispatcher);
         buffer.read(this->ki_user_exception_dispatcher);
+        buffer.read(this->ki_user_callback_dispatcher);
         buffer.read(this->instrumentation_callback);
-        buffer.read(this->wow64_ki_user_callback_dispatcher);
         buffer.read(this->zw_callback_return);
         buffer.read(this->dispatch_client_message);
         buffer.read(this->gdi_default_dc_handle);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -192,8 +192,8 @@ namespace sogen
         uint64_t rtl_user_thread_start{};
         uint64_t ki_user_apc_dispatcher{};
         uint64_t ki_user_exception_dispatcher{};
+        uint64_t ki_user_callback_dispatcher{};
         uint64_t instrumentation_callback{};
-        uint64_t wow64_ki_user_callback_dispatcher{};
         uint64_t zw_callback_return{};
         uint64_t dispatch_client_message{};
         uint32_t gdi_default_dc_handle{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -426,6 +426,7 @@ namespace sogen
         NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo();
         NTSTATUS handle_NtUserRegisterWindowMessage();
         NTSTATUS handle_NtUserGetThreadState(const syscall_context& c, ULONG routine);
+        NTSTATUS completion_NtUserGetThreadState(const syscall_context& c, ULONG routine);
         NTSTATUS handle_NtUserProcessConnect(const syscall_context& c, handle process_handle, ULONG length, emulator_pointer user_connect);
         NTSTATUS handle_NtUserInitializeClientPfnArrays(const syscall_context& c, emulator_pointer apfn_client_a,
                                                         emulator_pointer apfn_client_w, emulator_pointer apfn_client_worker,
@@ -1146,6 +1147,7 @@ namespace sogen
         this->completion_handlers_[callback_id::syscall] = make_syscall_handler<syscalls::completion_##syscall>(); \
     } while (0)
 
+        add_stateless_callback(NtUserGetThreadState);
         add_callback(NtUserCreateWindowEx, window_create_state);
         add_callback(NtUserDestroyWindow, window_destroy_state);
         add_callback(NtUserShowWindow, window_show_state);

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -9,66 +9,6 @@
 namespace sogen
 {
 
-    namespace
-    {
-        struct wow64_callback_context
-        {
-            std::array<std::byte, 0x108> reserved0{};
-            uint64_t output_pointer{};
-            uint32_t output_length{};
-            uint32_t status{};
-            std::array<std::byte, 0x28> reserved1{};
-        };
-        static_assert(offsetof(wow64_callback_context, output_pointer) == 0x108);
-        static_assert(offsetof(wow64_callback_context, output_length) == 0x110);
-        static_assert(offsetof(wow64_callback_context, status) == 0x114);
-        static_assert(sizeof(wow64_callback_context) == 0x140);
-
-        void apply_pending_wow64_callback_postprocess(const syscall_context& c)
-        {
-            auto* thread = c.proc.active_thread;
-            if (!thread || !thread->win32k_pending_wow64_callback.has_value())
-            {
-                return;
-            }
-
-            const auto postprocess = thread->win32k_pending_wow64_callback->postprocess;
-            thread->win32k_pending_wow64_callback.reset();
-
-            if (postprocess != wow64_callback_postprocess::bool_result_to_status)
-            {
-                return;
-            }
-
-            if (thread->win32k_callback_buffer == 0)
-            {
-                return;
-            }
-
-            wow64_callback_context callback_context{};
-            if (!c.win_emu.memory.try_read_memory(thread->win32k_callback_buffer, &callback_context, sizeof(callback_context)))
-            {
-                return;
-            }
-
-            if (!NT_SUCCESS(static_cast<NTSTATUS>(callback_context.status)) || callback_context.output_pointer == 0 ||
-                callback_context.output_length < sizeof(uint32_t))
-            {
-                return;
-            }
-
-            uint32_t callback_result{};
-            if (!c.win_emu.memory.try_read_memory(callback_context.output_pointer, &callback_result, sizeof(callback_result)))
-            {
-                return;
-            }
-
-            callback_context.status = callback_result;
-            c.win_emu.memory.try_write_memory(thread->win32k_callback_buffer + offsetof(wow64_callback_context, status),
-                                              &callback_context.status, sizeof(callback_context.status));
-        }
-    }
-
     namespace syscalls
     {
         NTSTATUS handle_NtSetInformationThread(const syscall_context& c, const handle thread_handle, const THREADINFOCLASS info_class,
@@ -665,7 +605,6 @@ namespace sogen
                 argument = c.emu.read_memory<KCONTINUE_ARGUMENT>(continue_argument);
             }
 
-            apply_pending_wow64_callback_postprocess(c);
             const auto context = thread_context.read();
             cpu_context::restore(c.emu, context);
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2,10 +2,8 @@
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../win32k_userconnect.hpp"
-#include "segment_utils.hpp"
 #include "windows-emulator/user_callback_dispatch.hpp"
 #include <limits>
-#include <utils/string.hpp>
 
 #ifdef msg
 #undef msg
@@ -19,26 +17,85 @@ namespace sogen
         constexpr ULONG k_thread_state_win32_thread_info = 0xE;
         constexpr size_t k_win32_thread_info_slab_size = 0x2000;
         constexpr uint64_t k_win32_thread_info_bias = 0x800;
-        // callback id used by wow64.dll!Wow64KiUserCallbackDispatcher
-        constexpr uint32_t k_wow64_client_setup_callback_id = 0x54;
-        // user32 callback id for ___ClientMonitorEnumProc@4
-        constexpr uint32_t k_wow64_enum_display_monitors_callback_id = 0x57;
-        constexpr size_t k_wow64_callback_context_buffer_size = 0x140;
+        constexpr uint32_t k_client_setup_callback_id = 0x54;
+        constexpr uint32_t k_enum_display_monitors_callback_id = 0x57;
+        constexpr uint32_t k_fn_dword_callback_id = 0x02;
+        constexpr uint32_t k_fn_nc_destroy_callback_id = 0x03;
+        constexpr uint32_t k_fn_in_lp_create_struct_callback_id = 0x0A;
+        constexpr uint32_t k_fn_in_lp_window_pos_callback_id = 0x11;
+        constexpr uint32_t k_fn_inout_lp_point5_callback_id = 0x12;
+        constexpr uint32_t k_fn_inout_nc_calc_size_callback_id = 0x15;
 
-        struct wow64_enum_display_monitors_callback_args
+        struct user_callback_capture_buffer
         {
-            uint32_t monitor{};
-            uint32_t dc{};
-            RECT rect{};
-            uint32_t param{};
-            uint32_t callback{};
+            DWORD cbCallback{};
+            DWORD cbCapture{};
+            DWORD cCapturedPointers{};
+            pointer pbFree{};
+            DWORD offPointers{};
+            pointer pvVirtualAddress{};
         };
-        static_assert(offsetof(wow64_enum_display_monitors_callback_args, monitor) == 0x0);
-        static_assert(offsetof(wow64_enum_display_monitors_callback_args, dc) == 0x4);
-        static_assert(offsetof(wow64_enum_display_monitors_callback_args, rect) == 0x8);
-        static_assert(offsetof(wow64_enum_display_monitors_callback_args, param) == 0x18);
-        static_assert(offsetof(wow64_enum_display_monitors_callback_args, callback) == 0x1C);
-        static_assert(sizeof(wow64_enum_display_monitors_callback_args) == 0x20);
+
+        struct fn_dword_message
+        {
+            pointer pwnd{};
+            UINT msg{};
+            wparam wParam{};
+            lparam lParam{};
+            pointer xParam{};
+            pointer xpfnProc{};
+        };
+
+        struct fn_in_lp_create_struct_message
+        {
+            user_callback_capture_buffer captureBuffer{};
+            pointer pwnd{};
+            UINT msg{};
+            wparam wParam{};
+            lparam lParam{};
+            EMU_CREATESTRUCT cs{};
+            pointer xParam{};
+            pointer xpfnProc{};
+        };
+
+        struct fn_in_lp_window_pos_message
+        {
+            pointer pwnd{};
+            UINT msg{};
+            wparam wParam{};
+            EMU_WINDOWPOS wp{};
+            pointer xParam{};
+            pointer xpfnProc{};
+        };
+
+        struct fn_inout_lp_point5_message
+        {
+            pointer pwnd{};
+            UINT msg{};
+            wparam wParam{};
+            EMU_MINMAXINFO point5{};
+            pointer xParam{};
+            pointer xpfnProc{};
+        };
+
+        struct fn_inout_nc_calc_size_message
+        {
+            pointer pwnd{};
+            UINT msg{};
+            wparam wParam{};
+            pointer xParam{};
+            pointer xpfnProc{};
+            RECT rect{};
+        };
+
+        struct enum_display_monitors_callback_args
+        {
+            hdc monitor{};
+            hdc dc{};
+            RECT rect{};
+            pointer data{};
+            pointer callback{};
+        };
 
         void set_guest_last_error(const syscall_context& c, uint32_t last_error)
         {
@@ -117,8 +174,95 @@ namespace sogen
         {
             set_thread_window_context(c, win.handle, win.guest.value());
 
-            dispatch_user_callback(c, id, std::forward<T>(state), c.proc.dispatch_client_message, win.guest.value(),
-                                   static_cast<uint64_t>(message), w_param, l_param, win.wnd_proc);
+            switch (message)
+            {
+            case WM_CREATE:
+            case WM_NCCREATE: {
+                fn_in_lp_create_struct_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.lParam = l_param;
+                args.xpfnProc = win.wnd_proc;
+                if (l_param != 0)
+                {
+                    c.emu.read_memory(l_param, &args.cs, sizeof(args.cs));
+                }
+
+                dispatch_user_callback(c, id, k_fn_in_lp_create_struct_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            case WM_WINDOWPOSCHANGING:
+            case WM_WINDOWPOSCHANGED: {
+                fn_in_lp_window_pos_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.xpfnProc = win.wnd_proc;
+                if (l_param != 0)
+                {
+                    c.emu.read_memory(l_param, &args.wp, sizeof(args.wp));
+                }
+
+                dispatch_user_callback(c, id, k_fn_in_lp_window_pos_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            case WM_NCCALCSIZE: {
+                fn_inout_nc_calc_size_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.xpfnProc = win.wnd_proc;
+                if (l_param != 0)
+                {
+                    c.emu.read_memory(l_param, &args.rect, sizeof(args.rect));
+                }
+
+                dispatch_user_callback(c, id, k_fn_inout_nc_calc_size_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            case WM_GETMINMAXINFO: {
+                fn_inout_lp_point5_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.xpfnProc = win.wnd_proc;
+                if (l_param != 0)
+                {
+                    c.emu.read_memory(l_param, &args.point5, sizeof(args.point5));
+                }
+
+                dispatch_user_callback(c, id, k_fn_inout_lp_point5_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            case WM_NCDESTROY: {
+                fn_dword_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.lParam = l_param;
+                args.xpfnProc = win.wnd_proc;
+
+                dispatch_user_callback(c, id, k_fn_nc_destroy_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            default: {
+                fn_dword_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.lParam = l_param;
+                args.xpfnProc = win.wnd_proc;
+
+                dispatch_user_callback(c, id, k_fn_dword_callback_id, std::forward<T>(state), args);
+                return;
+            }
+            }
         }
 
         template <typename T>
@@ -217,86 +361,6 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        uint64_t resolve_wow64_callback_dispatcher(const syscall_context& c)
-        {
-            if (c.proc.wow64_ki_user_callback_dispatcher != 0)
-            {
-                return c.proc.wow64_ki_user_callback_dispatcher;
-            }
-
-            for (const auto& [_, mod] : c.win_emu.mod_manager.modules())
-            {
-                if (!utils::string::equals_ignore_case(std::string_view{mod.name}, std::string_view{"wow64.dll"}))
-                {
-                    continue;
-                }
-
-                const auto dispatcher = mod.find_export("Wow64KiUserCallbackDispatcher");
-                if (dispatcher != 0)
-                {
-                    c.proc.wow64_ki_user_callback_dispatcher = dispatcher;
-                    return dispatcher;
-                }
-            }
-
-            return 0;
-        }
-
-        uint64_t ensure_wow64_callback_buffer(const syscall_context& c, emulator_thread& thread)
-        {
-            if (thread.win32k_callback_buffer != 0)
-            {
-                return thread.win32k_callback_buffer;
-            }
-
-            thread.win32k_callback_buffer = c.proc.base_allocator.reserve(k_wow64_callback_context_buffer_size, 0x10);
-            std::array<std::byte, k_wow64_callback_context_buffer_size> zeros{};
-            c.emu.write_memory(thread.win32k_callback_buffer, zeros.data(), zeros.size());
-            return thread.win32k_callback_buffer;
-        }
-
-        bool schedule_wow64_callback(const syscall_context& c, emulator_thread& thread, const uint32_t callback_id,
-                                     const uint64_t arg_buffer, const uint32_t arg_length,
-                                     const std::optional<pending_wow64_callback>& pending_callback = std::nullopt)
-        {
-            if (!c.proc.is_wow64_process)
-            {
-                return false;
-            }
-
-            thread.win32k_pending_wow64_callback.reset();
-
-            const auto dispatcher = resolve_wow64_callback_dispatcher(c);
-            if (dispatcher == 0)
-            {
-                return false;
-            }
-
-            const auto cs_selector = c.emu.reg<uint16_t>(x86_register::cs);
-            const auto bitness = segment_utils::get_segment_bitness(c.emu, cs_selector);
-            if (!bitness || *bitness != segment_utils::segment_bitness::bit64)
-            {
-                return false;
-            }
-
-            const auto callback_buffer = ensure_wow64_callback_buffer(c, thread);
-            std::array<std::byte, k_wow64_callback_context_buffer_size> zeros{};
-            c.emu.write_memory(callback_buffer, zeros.data(), zeros.size());
-
-            c.emu.reg(x86_register::rcx, callback_buffer);
-            c.emu.reg(x86_register::rdx, static_cast<uint64_t>(callback_id));
-            c.emu.reg(x86_register::r8, arg_buffer);
-            c.emu.reg(x86_register::r9, static_cast<uint64_t>(arg_length));
-            c.emu.reg(x86_register::rip, dispatcher);
-            thread.win32k_pending_wow64_callback = pending_callback;
-            return true;
-        }
-
-        bool schedule_wow64_client_callback(const syscall_context& c, emulator_thread& thread)
-        {
-            return schedule_wow64_callback(c, thread, k_wow64_client_setup_callback_id, 0, 0);
-        }
-
         std::u16string read_unicode_string_or_atom(const syscall_context& c,
                                                    const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> uc_string,
                                                    const size_t index = 0)
@@ -368,14 +432,16 @@ namespace sogen
             if (c.proc.is_wow64_process && c.proc.active_thread && !c.proc.active_thread->win32k_thread_setup_done &&
                 !c.proc.active_thread->win32k_thread_setup_pending)
             {
-                if (!schedule_wow64_client_callback(c, *c.proc.active_thread))
-                {
-                    return STATUS_UNSUCCESSFUL;
-                }
-
                 c.proc.active_thread->win32k_thread_setup_pending = true;
+                dispatch_user_callback(c, callback_id::NtUserGetThreadState, k_client_setup_callback_id);
+                return {};
             }
 
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS completion_NtUserGetThreadState(const syscall_context&, const ULONG /*routine*/)
+        {
             return STATUS_SUCCESS;
         }
 
@@ -1233,44 +1299,15 @@ namespace sogen
                 }
             }
 
-            if (c.proc.is_wow64_process)
-            {
-                if (!c.proc.active_thread)
-                {
-                    return FALSE;
-                }
+            const enum_display_monitors_callback_args args{
+                .monitor = hmon,
+                .dc = hdc_in,
+                .rect = effective_rc,
+                .data = param,
+                .callback = callback,
+            };
 
-                if (hmon > std::numeric_limits<uint32_t>::max() || hdc_in > std::numeric_limits<uint32_t>::max() ||
-                    callback > std::numeric_limits<uint32_t>::max() || param > std::numeric_limits<uint32_t>::max())
-                {
-                    return FALSE;
-                }
-
-                wow64_enum_display_monitors_callback_args args{};
-                args.monitor = static_cast<uint32_t>(hmon);
-                args.dc = static_cast<uint32_t>(hdc_in);
-                args.param = static_cast<uint32_t>(param);
-                args.callback = static_cast<uint32_t>(callback);
-                args.rect = effective_rc;
-
-                const auto arg_buffer = c.proc.base_allocator.reserve(sizeof(args), alignof(uint32_t));
-                emulator_object<wow64_enum_display_monitors_callback_args>{c.emu, arg_buffer}.write(args);
-
-                pending_wow64_callback pending_callback{};
-                pending_callback.callback_id = k_wow64_enum_display_monitors_callback_id;
-                pending_callback.postprocess = wow64_callback_postprocess::bool_result_to_status;
-
-                if (!schedule_wow64_callback(c, *c.proc.active_thread, k_wow64_enum_display_monitors_callback_id, arg_buffer,
-                                             static_cast<uint32_t>(sizeof(args)), pending_callback))
-                {
-                    return FALSE;
-                }
-
-                return TRUE;
-            }
-
-            const uint64_t rect_ptr = display_info.pPrimaryMonitor + offsetof(USER_MONITOR, rcMonitor);
-            dispatch_user_callback(c, callback_id::NtUserEnumDisplayMonitors, callback, hmon, hdc_in, rect_ptr, param);
+            dispatch_user_callback(c, callback_id::NtUserEnumDisplayMonitors, k_enum_display_monitors_callback_id, args);
             return {};
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -73,9 +73,19 @@ namespace sogen
             pointer pwnd{};
             UINT msg{};
             wparam wParam{};
-            EMU_MINMAXINFO point5{};
+            union
+            {
+                EMU_MINMAXINFO point5;
+                EMU_WINDOWPOS window_pos;
+            } data{};
             pointer xParam{};
             pointer xpfnProc{};
+        };
+
+        struct EMU_NCCALCSIZE_PARAMS
+        {
+            std::array<RECT, 3> rgrc{};
+            pointer lppos{};
         };
 
         struct fn_inout_nc_calc_size_message
@@ -85,7 +95,15 @@ namespace sogen
             wparam wParam{};
             pointer xParam{};
             pointer xpfnProc{};
-            RECT rect{};
+            union
+            {
+                RECT rect;
+                struct
+                {
+                    EMU_NCCALCSIZE_PARAMS params;
+                    EMU_WINDOWPOS pos;
+                } data;
+            } u{};
         };
 
         struct enum_display_monitors_callback_args
@@ -193,7 +211,6 @@ namespace sogen
                 return;
             }
 
-            case WM_WINDOWPOSCHANGING:
             case WM_WINDOWPOSCHANGED: {
                 fn_in_lp_window_pos_message args{};
                 args.pwnd = win.guest.value();
@@ -209,21 +226,7 @@ namespace sogen
                 return;
             }
 
-            case WM_NCCALCSIZE: {
-                fn_inout_nc_calc_size_message args{};
-                args.pwnd = win.guest.value();
-                args.msg = message;
-                args.wParam = w_param;
-                args.xpfnProc = win.wnd_proc;
-                if (l_param != 0)
-                {
-                    c.emu.read_memory(l_param, &args.rect, sizeof(args.rect));
-                }
-
-                dispatch_user_callback(c, id, k_fn_inout_nc_calc_size_callback_id, std::forward<T>(state), args);
-                return;
-            }
-
+            case WM_WINDOWPOSCHANGING:
             case WM_GETMINMAXINFO: {
                 fn_inout_lp_point5_message args{};
                 args.pwnd = win.guest.value();
@@ -232,10 +235,43 @@ namespace sogen
                 args.xpfnProc = win.wnd_proc;
                 if (l_param != 0)
                 {
-                    c.emu.read_memory(l_param, &args.point5, sizeof(args.point5));
+                    if (message == WM_WINDOWPOSCHANGING)
+                    {
+                        c.emu.read_memory(l_param, &args.data.window_pos, sizeof(args.data.window_pos));
+                    }
+                    else
+                    {
+                        c.emu.read_memory(l_param, &args.data.point5, sizeof(args.data.point5));
+                    }
                 }
 
                 dispatch_user_callback(c, id, k_fn_inout_lp_point5_callback_id, std::forward<T>(state), args);
+                return;
+            }
+
+            case WM_NCCALCSIZE: {
+                fn_inout_nc_calc_size_message args{};
+                args.pwnd = win.guest.value();
+                args.msg = message;
+                args.wParam = w_param;
+                args.xpfnProc = win.wnd_proc;
+                if (l_param != 0)
+                {
+                    if (w_param == FALSE)
+                    {
+                        c.emu.read_memory(l_param, &args.u.rect, sizeof(args.u.rect));
+                    }
+                    else
+                    {
+                        c.emu.read_memory(l_param, &args.u.data.params, sizeof(args.u.data.params));
+                        if (args.u.data.params.lppos != 0)
+                        {
+                            c.emu.read_memory(args.u.data.params.lppos, &args.u.data.pos, sizeof(args.u.data.pos));
+                        }
+                    }
+                }
+
+                dispatch_user_callback(c, id, k_fn_inout_nc_calc_size_callback_id, std::forward<T>(state), args);
                 return;
             }
 

--- a/src/windows-emulator/user_callback_dispatch.hpp
+++ b/src/windows-emulator/user_callback_dispatch.hpp
@@ -2,39 +2,29 @@
 
 #include "syscall_utils.hpp"
 
-// TODO: Here we are calling guest functions directly, but this is not how it works in the real Windows kernel.
-//       In the real implementation, the kernel invokes ntdll!KiUserCallbackDispatcher and passes a callback
-//       index that refers to an entry in PEB->KernelCallbackTable. The dispatcher then looks up the function
-//       pointer in that table and invokes the corresponding user-mode callback.
-//       See Also: https://web.archive.org/web/20080717175308/http://www.nynaeve.net/?p=204
-
 namespace sogen
 {
 
     template <typename... Args>
-    void prepare_call_stack(x86_64_emulator& emu, uint64_t return_address, Args... args)
+    constexpr uint32_t user_callback_args_size()
     {
-        constexpr size_t arg_count = sizeof...(Args);
-        const size_t stack_args_size = aligned_stack_space(arg_count);
-
-        const uint64_t current_rsp = emu.read_stack_pointer();
-        const uint64_t aligned_rsp = align_down(current_rsp, 16);
-
-        // We subtract the args size (including the shadow space) AND the size of the return address
-        const uint64_t new_rsp = aligned_rsp - stack_args_size - sizeof(emulator_pointer);
-        emu.reg(x86_register::rsp, new_rsp);
-
-        emu.write_memory(new_rsp, &return_address, sizeof(return_address));
-
-        size_t index = 0;
-        (set_function_argument(emu, index++, static_cast<uint64_t>(args)), ...);
+        size_t offset = 0;
+        ((offset = static_cast<size_t>(align_up(offset, alignof(Args))), offset += sizeof(Args)), ...);
+        return static_cast<uint32_t>(offset);
     }
 
-    template <typename StateT, typename... Args>
+    template <typename T>
+    void write_user_callback_arg(x86_64_emulator& emu, const uint64_t arg_buffer, size_t& offset, const T& arg)
+    {
+        offset = static_cast<size_t>(align_up(offset, alignof(T)));
+        emu.write_memory(arg_buffer + offset, &arg, sizeof(arg));
+        offset += sizeof(arg);
+    }
+
+    template <typename StateT>
         requires(std::derived_from<std::remove_reference_t<StateT>, completion_state> ||
                  std::same_as<std::remove_reference_t<StateT>, std::nullptr_t>)
-    void dispatch_user_callback(const syscall_context& c, callback_id completion_id, StateT&& state_obj, uint64_t func_address,
-                                Args... args)
+    void push_callback_frame(const syscall_context& c, callback_id completion_id, StateT&& state_obj)
     {
         if (c.run_callback)
         {
@@ -56,17 +46,53 @@ namespace sogen
         frame.save_registers(c.emu);
         c.proc.active_thread->callback_return_rax.reset();
         c.proc.active_thread->callback_stack.emplace_back(std::move(frame));
+    }
 
-        prepare_call_stack(c.emu, c.proc.zw_callback_return, args...);
+    template <typename... Args>
+    void prepare_call_stack(x86_64_emulator& emu, const uint32_t callback_index, const Args&... args)
+    {
+        const uint32_t arg_length = user_callback_args_size<Args...>();
+        const size_t stack_args_size = align_up(static_cast<size_t>(arg_length), 0x10);
+        const uint64_t current_rsp = emu.read_stack_pointer();
+        const uint64_t aligned_rsp = align_down(current_rsp, 16);
 
-        c.emu.reg(x86_register::rip, func_address);
+        // KiUserCallbackDispatcher expects 0x20 bytes of shadow space plus the arg buffer pointer,
+        // arg length, and callback index stored in the 0x10 bytes above it.
+        const uint64_t new_rsp = aligned_rsp - 0x30 - stack_args_size;
+        const uint64_t arg_buffer = new_rsp + 0x30;
+
+        emu.reg(x86_register::rsp, new_rsp);
+
+        if constexpr (sizeof...(Args) > 0)
+        {
+            size_t offset = 0;
+            (write_user_callback_arg(emu, arg_buffer, offset, args), ...);
+        }
+
+        emu.write_memory(new_rsp + 0x20, &arg_buffer, sizeof(arg_buffer));
+        emu.write_memory(new_rsp + 0x28, &arg_length, sizeof(arg_length));
+        emu.write_memory(new_rsp + 0x2C, &callback_index, sizeof(callback_index));
+    }
+
+    template <typename StateT, typename... Args>
+        requires(std::derived_from<std::remove_reference_t<StateT>, completion_state> ||
+                 std::same_as<std::remove_reference_t<StateT>, std::nullptr_t>)
+    void dispatch_user_callback(const syscall_context& c, const callback_id completion_id, const uint32_t callback_index,
+                                StateT&& state_obj, const Args&... args)
+    {
+        push_callback_frame(c, completion_id, std::forward<StateT>(state_obj));
+
+        prepare_call_stack(c.emu, callback_index, args...);
+
+        c.emu.reg(x86_register::rip, c.proc.ki_user_callback_dispatcher);
         c.run_callback = true;
     }
 
     template <typename... Args>
-    void dispatch_user_callback(const syscall_context& c, callback_id completion_id, uint64_t func_address, Args... args)
+    void dispatch_user_callback(const syscall_context& c, const callback_id completion_id, const uint32_t callback_index,
+                                const Args&... args)
     {
-        dispatch_user_callback(c, completion_id, nullptr, func_address, args...);
+        dispatch_user_callback(c, completion_id, callback_index, nullptr, args...);
     }
 
 } // namespace sogen

--- a/src/windows-emulator/user_callback_dispatch.hpp
+++ b/src/windows-emulator/user_callback_dispatch.hpp
@@ -52,7 +52,7 @@ namespace sogen
     void prepare_call_stack(x86_64_emulator& emu, const uint32_t callback_index, const Args&... args)
     {
         const uint32_t arg_length = user_callback_args_size<Args...>();
-        const size_t stack_args_size = align_up(static_cast<size_t>(arg_length), 0x10);
+        const uint64_t stack_args_size = align_up(arg_length, 0x10);
         const uint64_t current_rsp = emu.read_stack_pointer();
         const uint64_t aligned_rsp = align_down(current_rsp, 16);
 


### PR DESCRIPTION
This PR makes user32 callback dispatch considerably less cursed. Because of how I initially implemented it, WoW64 was just dying on it. @redthing1 fixed that for the `NtUserEnumDisplayMonitors` syscall by writing a completely different path for WoW64, but that was still wrong because, as it turns out, if we just use `KiUserCallbackDispatcher`, everything just works™. So this PR does precisely that.

One downside is that we are now hardcoding callback indexes, but I don't think this is as big of a problem as I initially thought, since callback indexes apparently haven't changed in a long time.