### PR TITLE
Fix WaitForMultipleObjects and support abandoned mutants

### DIFF
--- a/src/emulator-platform/platform/status.hpp
+++ b/src/emulator-platform/platform/status.hpp
@@ -9,6 +9,7 @@ namespace sogen
 
 #ifndef OS_WINDOWS
 #define STATUS_WAIT_0                 ((NTSTATUS)0x00000000L)
+#define STATUS_ABANDONED_WAIT_0       ((NTSTATUS)0x00000080L)
 #define STATUS_USER_APC               ((NTSTATUS)0x000000C0L)
 #define STATUS_TIMEOUT                ((NTSTATUS)0x00000102L)
 #define STATUS_PENDING                ((NTSTATUS)0x00000103L)

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -11,6 +11,13 @@ namespace sogen
 
     namespace
     {
+        enum class wait_state
+        {
+            not_signaled,
+            signaled,
+            abandoned,
+        };
+
         void setup_wow64_fs_segment(memory_manager& memory, uint64_t teb32_addr)
         {
             const uint64_t base = teb32_addr;
@@ -62,7 +69,7 @@ namespace sogen
             }
         }
 
-        bool is_object_signaled(process_context& c, const handle h, const uint32_t current_thread_id)
+        wait_state observe_object_signal(process_context& c, const handle h, const uint32_t current_thread_id)
         {
             const auto type = h.value.type;
 
@@ -74,32 +81,37 @@ namespace sogen
             case handle_types::event: {
                 if (h.value.is_pseudo)
                 {
-                    return true;
+                    return wait_state::signaled;
                 }
 
-                auto* e = c.events.get(h);
-                if (e)
+                const auto* e = c.events.get(h);
+                if (e && e->signaled)
                 {
-                    return e->is_signaled();
+                    return wait_state::signaled;
                 }
 
                 break;
             }
 
             case handle_types::mutant: {
-                auto* e = c.mutants.get(h);
-                return !e || e->try_lock(current_thread_id);
+                const auto* e = c.mutants.get(h);
+                if (e && e->is_signaled(current_thread_id))
+                {
+                    return e->abandoned ? wait_state::abandoned : wait_state::signaled;
+                }
+
+                break;
             }
 
             case handle_types::timer: {
-                return true; // TODO
+                return wait_state::signaled; // TODO
             }
 
             case handle_types::semaphore: {
-                auto* s = c.semaphores.get(h);
-                if (s)
+                const auto* s = c.semaphores.get(h);
+                if (s && s->current_count > 0)
                 {
-                    return s->try_lock();
+                    return wait_state::signaled;
                 }
 
                 break;
@@ -107,16 +119,84 @@ namespace sogen
 
             case handle_types::thread: {
                 const auto* t = c.threads.get(h);
-                if (t)
+                if (t && t->is_terminated())
                 {
-                    return t->is_terminated();
+                    return wait_state::signaled;
                 }
 
                 break;
             }
             }
 
-            throw std::runtime_error("Bad object: " + std::to_string(h.value.type));
+            return wait_state::not_signaled;
+        }
+
+        std::optional<wait_state> consume_object_signal(process_context& c, const handle h, const uint32_t current_thread_id)
+        {
+            switch (h.value.type)
+            {
+            case handle_types::event: {
+                if (h.value.is_pseudo)
+                {
+                    return wait_state::signaled;
+                }
+
+                auto* event = c.events.get(h);
+                if (!event || !event->signaled)
+                {
+                    return std::nullopt;
+                }
+
+                if (event->type == SynchronizationEvent)
+                {
+                    event->signaled = false;
+                }
+
+                return wait_state::signaled;
+            }
+
+            case handle_types::mutant: {
+                auto* mutant = c.mutants.get(h);
+                if (!mutant)
+                {
+                    return std::nullopt;
+                }
+
+                const auto acquired = mutant->try_lock(current_thread_id);
+                if (!acquired.has_value())
+                {
+                    return std::nullopt;
+                }
+
+                return *acquired ? wait_state::abandoned : wait_state::signaled;
+            }
+
+            case handle_types::timer:
+                return wait_state::signaled; // TODO
+
+            case handle_types::semaphore: {
+                auto* semaphore = c.semaphores.get(h);
+                if (!semaphore || !semaphore->try_lock())
+                {
+                    return std::nullopt;
+                }
+
+                return wait_state::signaled;
+            }
+
+            case handle_types::thread: {
+                const auto* thread = c.threads.get(h);
+                if (!thread || !thread->is_terminated())
+                {
+                    return std::nullopt;
+                }
+
+                return wait_state::signaled;
+            }
+
+            default:
+                throw std::runtime_error("Bad object: " + std::to_string(h.value.type));
+            }
         }
     }
 
@@ -457,23 +537,46 @@ namespace sogen
         if (!this->await_objects.empty())
         {
             bool all_signaled = true;
+            std::optional<uint32_t> abandoned_index{};
             for (uint32_t i = 0; i < this->await_objects.size(); ++i)
             {
                 const auto& obj = this->await_objects[i];
 
-                const auto signaled = is_object_signaled(process, obj, this->id);
+                const auto state = observe_object_signal(process, obj, this->id);
+                const auto signaled = state != wait_state::not_signaled;
                 all_signaled &= signaled;
+
+                if (state == wait_state::abandoned && !abandoned_index.has_value())
+                {
+                    abandoned_index = i;
+                }
 
                 if (signaled && this->await_any)
                 {
-                    this->mark_as_ready(STATUS_WAIT_0 + i);
+                    const auto consumed_state = consume_object_signal(process, obj, this->id);
+                    if (!consumed_state.has_value())
+                    {
+                        all_signaled = false;
+                        continue;
+                    }
+
+                    this->mark_as_ready(*consumed_state == wait_state::abandoned ? (STATUS_ABANDONED_WAIT_0 + i) : (STATUS_WAIT_0 + i));
                     return true;
                 }
             }
 
             if (!this->await_any && all_signaled)
             {
-                this->mark_as_ready(STATUS_SUCCESS);
+                for (const auto& obj : this->await_objects)
+                {
+                    const auto consumed_state = consume_object_signal(process, obj, this->id);
+                    if (!consumed_state.has_value())
+                    {
+                        return false;
+                    }
+                }
+
+                this->mark_as_ready(abandoned_index.has_value() ? (STATUS_ABANDONED_WAIT_0 + *abandoned_index) : STATUS_SUCCESS);
                 return true;
             }
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -556,8 +556,7 @@ namespace sogen
                     const auto consumed_state = consume_object_signal(process, obj, this->id);
                     if (!consumed_state.has_value())
                     {
-                        all_signaled = false;
-                        continue;
+                        throw std::runtime_error("Failed to consume object signal!");
                     }
 
                     this->mark_as_ready(*consumed_state == wait_state::abandoned ? (STATUS_ABANDONED_WAIT_0 + i) : (STATUS_WAIT_0 + i));
@@ -572,7 +571,7 @@ namespace sogen
                     const auto consumed_state = consume_object_signal(process, obj, this->id);
                     if (!consumed_state.has_value())
                     {
-                        return false;
+                        throw std::runtime_error("Failed to consume object signal!");
                     }
                 }
 

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -748,6 +748,31 @@ namespace sogen
         return h;
     }
 
+    void process_context::terminate_thread(emulator_thread& thread, const NTSTATUS thread_exit_status)
+    {
+        thread.exit_status = thread_exit_status;
+
+        for (auto& mutant : this->mutants | std::views::values)
+        {
+            if (mutant.owning_thread_id == thread.id && mutant.locked_count > 0)
+            {
+                mutant.abandon();
+            }
+        }
+
+        for (auto i = this->windows.begin(); i != this->windows.end();)
+        {
+            if (i->second.thread_id != thread.id)
+            {
+                ++i;
+                continue;
+            }
+
+            i->second.ref_count = 1;
+            i = this->windows.erase(i).first;
+        }
+    }
+
     std::optional<uint16_t> process_context::find_atom(const std::u16string_view name)
     {
         for (auto& entry : this->atoms)

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -145,6 +145,7 @@ namespace sogen
 
         handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size, uint32_t create_flags,
                              bool initial_thread = false);
+        void terminate_thread(emulator_thread& thread, NTSTATUS thread_exit_status);
 
         std::optional<uint16_t> find_atom(std::u16string_view name);
         uint16_t add_or_find_atom(std::u16string name);

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -461,7 +461,7 @@ namespace sogen
                 {
                     if (&thread != c.proc.active_thread)
                     {
-                        thread.exit_status = exit_status;
+                        c.proc.terminate_thread(thread, exit_status);
                     }
                 }
 

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -434,21 +434,6 @@ namespace sogen
             return handle_NtOpenThreadToken(c, thread_handle, desired_access, open_as_self, token_handle);
         }
 
-        static void delete_thread_windows(const syscall_context& c, const uint32_t thread_id)
-        {
-            for (auto i = c.proc.windows.begin(); i != c.proc.windows.end();)
-            {
-                if (i->second.thread_id != thread_id)
-                {
-                    ++i;
-                    continue;
-                }
-
-                i->second.ref_count = 1;
-                i = c.proc.windows.erase(i).first;
-            }
-        }
-
         NTSTATUS handle_NtTerminateThread(const syscall_context& c, const handle thread_handle, const NTSTATUS exit_status)
         {
             auto* thread = !thread_handle.bits ? c.proc.active_thread : c.proc.threads.get(thread_handle);
@@ -458,10 +443,8 @@ namespace sogen
                 return STATUS_INVALID_HANDLE;
             }
 
-            thread->exit_status = exit_status;
+            c.proc.terminate_thread(*thread, exit_status);
             c.win_emu.callbacks.on_thread_terminated(thread_handle, *thread);
-
-            delete_thread_windows(c, thread->id);
 
             if (thread == c.proc.active_thread)
             {

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -32,18 +32,6 @@ namespace sogen
         EVENT_TYPE type{};
         std::u16string name{};
 
-        bool is_signaled()
-        {
-            const auto res = this->signaled;
-
-            if (this->type == SynchronizationEvent)
-            {
-                this->signaled = false;
-            }
-
-            return res;
-        }
-
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write(this->signaled);
@@ -164,24 +152,32 @@ namespace sogen
     {
         uint32_t locked_count{0};
         uint32_t owning_thread_id{};
+        bool abandoned{false};
         std::u16string name{};
 
-        bool try_lock(const uint32_t thread_id)
+        bool is_signaled(const uint32_t thread_id) const
+        {
+            return this->abandoned || this->locked_count == 0 || this->owning_thread_id == thread_id;
+        }
+
+        std::optional<bool> try_lock(const uint32_t thread_id)
         {
             if (this->locked_count == 0)
             {
                 ++this->locked_count;
                 this->owning_thread_id = thread_id;
-                return true;
+                const auto was_abandoned = this->abandoned;
+                this->abandoned = false;
+                return was_abandoned;
             }
 
             if (this->owning_thread_id != thread_id)
             {
-                return false;
+                return std::nullopt;
             }
 
             ++this->locked_count;
-            return true;
+            return false;
         }
 
         std::pair<uint32_t, bool> release(const uint32_t thread_id)
@@ -194,13 +190,30 @@ namespace sogen
             }
 
             --this->locked_count;
+            if (this->locked_count == 0)
+            {
+                this->owning_thread_id = 0;
+            }
             return {old_count, true};
+        }
+
+        void abandon()
+        {
+            if (this->locked_count == 0)
+            {
+                return;
+            }
+
+            this->locked_count = 0;
+            this->owning_thread_id = 0;
+            this->abandoned = true;
         }
 
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write(this->locked_count);
             buffer.write(this->owning_thread_id);
+            buffer.write(this->abandoned);
             buffer.write(this->name);
         }
 
@@ -208,6 +221,7 @@ namespace sogen
         {
             buffer.read(this->locked_count);
             buffer.read(this->owning_thread_id);
+            buffer.read(this->abandoned);
             buffer.read(this->name);
         }
     };


### PR DESCRIPTION
This PR fixes an issue where WaitForMultipleObjects could consume signaled objects before a wait had actually completed, causing incorrect behavior for multi-object waits, and adds support for reporting abandoned mutexes during waits.

