### PR TITLE
Fix DNS Resolver and LSA Policy Lookup

### DIFF
--- a/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
@@ -22,6 +22,53 @@ const FOREIGN_READ: u8 = 1 << 0;
 const FOREIGN_WRITE: u8 = 1 << 1;
 const FOREIGN_EXEC: u8 = 1 << 2;
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct IcicleStopInfo {
+    pub kind: u32,
+    pub code: u32,
+    pub value: u64,
+}
+
+impl IcicleStopInfo {
+    const NONE: u32 = 0;
+    const INSTRUCTION_LIMIT: u32 = 1;
+    const UNHANDLED_EXCEPTION: u32 = 2;
+    const OTHER: u32 = 3;
+
+    fn none() -> Self {
+        Self {
+            kind: Self::NONE,
+            code: 0,
+            value: 0,
+        }
+    }
+
+    fn instruction_limit() -> Self {
+        Self {
+            kind: Self::INSTRUCTION_LIMIT,
+            code: 0,
+            value: 0,
+        }
+    }
+
+    fn unhandled_exception(code: ExceptionCode, value: u64) -> Self {
+        Self {
+            kind: Self::UNHANDLED_EXCEPTION,
+            code: code as u32,
+            value,
+        }
+    }
+
+    fn other() -> Self {
+        Self {
+            kind: Self::OTHER,
+            code: 0,
+            value: 0,
+        }
+    }
+}
+
 fn map_permissions(foreign_permissions: u8) -> u8 {
     let mut permissions: u8 = 0;
 
@@ -342,6 +389,7 @@ impl ExecutionHooks {
 pub struct IcicleEmulator {
     executing_thread: std::thread::ThreadId,
     vm: icicle_vm::Vm,
+    last_stop: IcicleStopInfo,
     reg: registers::X86RegisterNodes,
     syscall_hooks: HookContainer<dyn Fn()>,
     interrupt_hooks: HookContainer<dyn Fn(i32)>,
@@ -434,6 +482,7 @@ impl IcicleEmulator {
         Self {
             stop: stop_value,
             executing_thread: std::thread::current().id(),
+            last_stop: IcicleStopInfo::none(),
             reg: registers::X86RegisterNodes::new(&virtual_machine.cpu.arch),
             vm: virtual_machine,
             syscall_hooks: HookContainer::new(),
@@ -450,6 +499,7 @@ impl IcicleEmulator {
 
     pub fn start(&mut self, count: u64) {
         self.executing_thread = std::thread::current().id();
+        self.last_stop = IcicleStopInfo::none();
 
         self.vm.icount_limit = match count {
             0 => u64::MAX,
@@ -466,16 +516,27 @@ impl IcicleEmulator {
             let reason = self.vm.run();
 
             match reason {
-                icicle_vm::VmExit::InstructionLimit => break,
+                icicle_vm::VmExit::InstructionLimit => {
+                    self.last_stop = IcicleStopInfo::instruction_limit();
+                    break;
+                }
                 icicle_vm::VmExit::UnhandledException((code, value)) => {
                     let continue_execution = self.handle_exception(code, value);
                     if !continue_execution {
+                        self.last_stop = IcicleStopInfo::unhandled_exception(code, value);
                         break;
                     }
                 }
-                _ => break,
+                _ => {
+                    self.last_stop = IcicleStopInfo::other();
+                    break;
+                }
             };
         }
+    }
+
+    pub fn last_stop_info(&self) -> IcicleStopInfo {
+        return self.last_stop;
     }
 
     fn handle_interrupt(&mut self, code: i32) -> bool {
@@ -493,6 +554,8 @@ impl IcicleEmulator {
             ExceptionCode::WritePerm => self.handle_violation(value, FOREIGN_WRITE, false),
             ExceptionCode::ReadUnmapped => self.handle_violation(value, FOREIGN_READ, true),
             ExceptionCode::WriteUnmapped => self.handle_violation(value, FOREIGN_WRITE, true),
+            ExceptionCode::ExecViolation => self.handle_violation(value, FOREIGN_EXEC, false),
+            ExceptionCode::SelfModifyingCode => self.handle_self_modifying_code(),
             ExceptionCode::SoftwareBreakpoint => self.handle_interrupt(3),
             ExceptionCode::InvalidInstruction => self.handle_interrupt(6),
             ExceptionCode::DivisionException => self.handle_interrupt(0),
@@ -500,6 +563,12 @@ impl IcicleEmulator {
         };
 
         return continue_execution;
+    }
+
+    fn handle_self_modifying_code(&mut self) -> bool {
+        self.vm.code.flush_code();
+        self.vm.cpu.block_id = u64::MAX;
+        return true;
     }
 
     fn handle_violation(&mut self, address: u64, permission: u8, unmapped: bool) -> bool {

--- a/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
@@ -1,7 +1,7 @@
 mod icicle;
 mod registers;
 
-use icicle::IcicleEmulator;
+use icicle::{IcicleEmulator, IcicleStopInfo};
 use registers::X86Register;
 use std::os::raw::c_void;
 
@@ -25,6 +25,20 @@ pub fn icicle_start(ptr: *mut c_void, count: usize) {
         let emulator = &mut *(ptr as *mut IcicleEmulator);
         emulator.start(count as u64);
     }
+}
+
+#[unsafe(no_mangle)]
+pub fn icicle_get_stop_info(ptr: *mut c_void, out: *mut IcicleStopInfo) -> i32 {
+    if out.is_null() {
+        return 0;
+    }
+
+    unsafe {
+        let emulator = &*(ptr as *mut IcicleEmulator);
+        *out = emulator.last_stop_info();
+    }
+
+    return 1;
 }
 
 #[unsafe(no_mangle)]

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -570,20 +570,20 @@ namespace sogen::icicle
                 return;
             }
 
-            char message[160]{};
+            std::array<char, 160> message{};
             if (kind == icicle_stop_kind::unhandled_exception)
             {
-                std::snprintf(message, sizeof(message), "Icicle stopped on unhandled exception: code=0x%X value=0x%llX rip=0x%llX",
+                std::snprintf(message.data(), message.size(), "Icicle stopped on unhandled exception: code=0x%X value=0x%llX rip=0x%llX",
                               info.code, static_cast<unsigned long long>(info.value),
                               static_cast<unsigned long long>(this->read_instruction_pointer()));
             }
             else
             {
-                std::snprintf(message, sizeof(message), "Icicle stopped on unhandled VM exit at rip=0x%llX",
+                std::snprintf(message.data(), message.size(), "Icicle stopped on unhandled VM exit at rip=0x%llX",
                               static_cast<unsigned long long>(this->read_instruction_pointer()));
             }
 
-            throw std::runtime_error(message);
+            throw std::runtime_error(message.data());
         }
 
         emulator_hook* hook_memory_access(memory_access_hook hook, emulator_hook* hook_id)

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -1,6 +1,7 @@
 #define ICICLE_EMULATOR_IMPL
 #include "icicle_x86_64_emulator.hpp"
 
+#include <cstdio>
 #include <unordered_set>
 #include <utils/object.hpp>
 #include <utils/finally.hpp>
@@ -19,6 +20,13 @@ extern "C"
     using violation_func = int32_t(void*, uint64_t address, uint8_t operation, int32_t unmapped);
     using data_accessor_func = void(void* user, const void* data, size_t length);
     using memory_access_func = icicle_mmio_write_func;
+
+    struct icicle_stop_info
+    {
+        uint32_t kind;
+        uint32_t code;
+        uint64_t value;
+    };
 
     icicle_emulator* icicle_create_emulator();
     int32_t icicle_protect_memory(icicle_emulator*, uint64_t address, uint64_t length, uint8_t permissions);
@@ -45,6 +53,7 @@ extern "C"
     size_t icicle_read_register(icicle_emulator*, int reg, void* data, size_t length);
     size_t icicle_write_register(icicle_emulator*, int reg, const void* data, size_t length);
     void icicle_start(icicle_emulator*, size_t count);
+    int32_t icicle_get_stop_info(icicle_emulator*, icicle_stop_info* info);
     void icicle_stop(icicle_emulator*);
     void icicle_destroy_emulator(icicle_emulator*);
     void icicle_run_on_next_instruction(icicle_emulator*, raw_func* callback, void* data);
@@ -110,6 +119,14 @@ namespace sogen::icicle
             memory_access_hook_callback callback{};
             bool is_read{};
         };
+
+        enum class icicle_stop_kind : uint32_t
+        {
+            none = 0,
+            instruction_limit = 1,
+            unhandled_exception = 2,
+            other = 3,
+        };
     }
 
     class icicle_x86_64_emulator : public x86_64_emulator
@@ -140,6 +157,7 @@ namespace sogen::icicle
         void start(const size_t count) override
         {
             icicle_start(this->emu_, count);
+            this->throw_if_unhandled_stop();
             this->perform_pending_actions();
         }
 
@@ -539,6 +557,33 @@ namespace sogen::icicle
             this->id_mapping_[hook] = icicle_id;
 
             return hook;
+        }
+
+        void throw_if_unhandled_stop()
+        {
+            icicle_stop_info info{};
+            ice(icicle_get_stop_info(this->emu_, &info) != 0, "Failed to read icicle stop info");
+
+            const auto kind = static_cast<icicle_stop_kind>(info.kind);
+            if (kind == icicle_stop_kind::none || kind == icicle_stop_kind::instruction_limit)
+            {
+                return;
+            }
+
+            char message[160]{};
+            if (kind == icicle_stop_kind::unhandled_exception)
+            {
+                std::snprintf(message, sizeof(message), "Icicle stopped on unhandled exception: code=0x%X value=0x%llX rip=0x%llX",
+                              info.code, static_cast<unsigned long long>(info.value),
+                              static_cast<unsigned long long>(this->read_instruction_pointer()));
+            }
+            else
+            {
+                std::snprintf(message, sizeof(message), "Icicle stopped on unhandled VM exit at rip=0x%llX",
+                              static_cast<unsigned long long>(this->read_instruction_pointer()));
+            }
+
+            throw std::runtime_error(message);
         }
 
         emulator_hook* hook_memory_access(memory_access_hook hook, emulator_hook* hook_id)

--- a/src/emulator/binary_writer.hpp
+++ b/src/emulator/binary_writer.hpp
@@ -63,15 +63,23 @@ namespace sogen
                 next_referent_id_ += sizeof(typename Traits::PVOID);
             }
 
-            void write_ndr_u16string(const std::u16string& str)
+            void write_ndr_u16string(const std::u16string_view str, const bool include_nul = true)
             {
-                size_t char_count = str.size() + 1;
-                size_t byte_length = char_count * sizeof(char16_t);
+                const auto max_char_count = str.size() + 1;
+                const auto actual_char_count = str.size() + (include_nul ? 1 : 0);
 
-                write<typename Traits::SIZE_T>(char_count);
+                write<typename Traits::SIZE_T>(max_char_count);
                 write<typename Traits::SIZE_T>(0);
-                write<typename Traits::SIZE_T>(char_count);
-                write(str.c_str(), byte_length);
+                write<typename Traits::SIZE_T>(actual_char_count);
+                if (!str.empty())
+                {
+                    write(str.data(), str.size() * sizeof(char16_t));
+                }
+                if (include_nul)
+                {
+                    constexpr char16_t nul{};
+                    write(&nul, sizeof(nul));
+                }
             }
 
             void pad(size_t count)

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -193,6 +193,59 @@ namespace
         return !computername.empty() && blub == "LUL";
     }
 
+    bool test_lookup_account_sid()
+    {
+        HANDLE token{};
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+        {
+            return false;
+        }
+
+        const auto close_token = sogen::utils::finally([&] { CloseHandle(token); });
+
+        DWORD size = 0;
+        GetTokenInformation(token, TokenUser, nullptr, 0, &size);
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || size < sizeof(TOKEN_USER))
+        {
+            return false;
+        }
+
+        std::vector<std::byte> buffer(size);
+        if (!GetTokenInformation(token, TokenUser, buffer.data(), size, &size))
+        {
+            return false;
+        }
+
+        const auto& token_user = *reinterpret_cast<const TOKEN_USER*>(buffer.data());
+        if (token_user.User.Sid == nullptr || IsValidSid(token_user.User.Sid) == FALSE)
+        {
+            return false;
+        }
+
+        DWORD name_size = 0;
+        DWORD domain_size = 0;
+        SID_NAME_USE use = SidTypeUnknown;
+
+        LookupAccountSidW(nullptr, token_user.User.Sid, nullptr, &name_size, nullptr, &domain_size, &use);
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || name_size == 0 || domain_size == 0)
+        {
+            return false;
+        }
+
+        std::wstring name(name_size, L'\0');
+        std::wstring domain(domain_size, L'\0');
+
+        if (!LookupAccountSidW(nullptr, token_user.User.Sid, name.data(), &name_size, domain.data(), &domain_size, &use))
+        {
+            return false;
+        }
+
+        name.resize(name_size);
+        domain.resize(domain_size);
+
+        return !name.empty() && !domain.empty() && use == SidTypeUser;
+    }
+
     bool test_file_path_io(const std::filesystem::path& filename)
     {
         std::error_code ec{};
@@ -1446,6 +1499,9 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_threads, "Threads")
     RUN_TEST(test_threads_winapi, "Threads WinAPI")
     RUN_TEST(test_env, "Environment")
+#ifdef _WIN64
+    RUN_TEST(test_lookup_account_sid, "LSA")
+#endif
     RUN_TEST(test_exceptions, "Exceptions")
 #ifndef __MINGW64__
     RUN_TEST(test_native_exceptions, "Native Exceptions")

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -780,7 +780,7 @@ namespace
         const auto query_status = DnsQuery_A(hostname, DNS_TYPE_A, DNS_QUERY_STANDARD, nullptr, &records, nullptr);
         if (query_status != ERROR_SUCCESS)
         {
-            puts("DnsQuery_A failed");
+            printf("DnsQuery_A failed: %ld\n", query_status);
             return false;
         }
 
@@ -1483,8 +1483,9 @@ int main(const int argc, const char* argv[])
 
     bool valid = true;
 
-    (void)&test_dns;
-    // RUN_TEST(test_dns, "DNS")
+#ifdef _WIN64
+    RUN_TEST(test_dns, "DNS")
+#endif
     RUN_TEST(test_io, "I/O")
     RUN_TEST(test_file_locking, "File Locking")
     RUN_TEST(test_dir_io, "Dir I/O")

--- a/src/windows-emulator/devices/network_store_interface.cpp
+++ b/src/windows-emulator/devices/network_store_interface.cpp
@@ -1,0 +1,184 @@
+#include "../std_include.hpp"
+#include "network_store_interface.hpp"
+
+#include "../windows_emulator.hpp"
+
+namespace sogen
+{
+    namespace
+    {
+        constexpr ULONG k_nsi_get_parameter = 0x120007;
+        constexpr ULONG k_nsi_get_all_parameters = 0x12000F;
+        constexpr ULONG k_nsi_enumerate_objects_all_parameters = 0x12001B;
+        constexpr uint64_t k_adapter_index = 7;
+
+        constexpr std::array<uint8_t, 0xB8> k_adapter_parameter = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 0x30, 0x75, 0x00, 0x00, 0xE8, 0x03, 0x00, 0x00, 0xC0, 0x27,
+            0x09, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0x19, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00,
+            0x00, 0x07, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xDC, 0x05, 0x00, 0x00, 0x40, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x07, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35, 0x97, 0x98, 0x00, 0x00, 0x00, 0x00, 0x00,
+        };
+
+        struct nsi_buffer
+        {
+            uint64_t address{};
+            uint64_t size{};
+        };
+
+        struct nsi_request
+        {
+            nsi_buffer key;
+            nsi_buffer rw;
+            nsi_buffer dynamic;
+        };
+
+        uint64_t read_u64(windows_emulator& win_emu, const io_device_context& c, const ULONG offset)
+        {
+            if (c.input_buffer_length < offset + sizeof(uint64_t))
+            {
+                return 0;
+            }
+
+            return win_emu.emu().read_memory<uint64_t>(c.input_buffer + offset);
+        }
+
+        nsi_buffer read_buffer(windows_emulator& win_emu, const io_device_context& c, const ULONG address_offset, const ULONG size_offset)
+        {
+            return nsi_buffer{.address = read_u64(win_emu, c, address_offset), .size = read_u64(win_emu, c, size_offset)};
+        }
+
+        nsi_request read_request(windows_emulator& win_emu, const io_device_context& c, const ULONG rw_address_offset,
+                                 const ULONG rw_size_offset, const ULONG dynamic_address_offset, const ULONG dynamic_size_offset)
+        {
+            return nsi_request{
+                .key = read_buffer(win_emu, c, 0x28, 0x30),
+                .rw = read_buffer(win_emu, c, rw_address_offset, rw_size_offset),
+                .dynamic = read_buffer(win_emu, c, dynamic_address_offset, dynamic_size_offset),
+            };
+        }
+
+        void write_io_information(const io_device_context& c, const uint64_t information)
+        {
+            if (!c.io_status_block)
+            {
+                return;
+            }
+
+            IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
+            block.Information = information;
+            c.io_status_block.write(block);
+        }
+
+        void write_zeroes(windows_emulator& win_emu, const nsi_buffer buffer)
+        {
+            if (!buffer.address || !buffer.size)
+            {
+                return;
+            }
+
+            std::vector<uint8_t> zeroes(static_cast<size_t>(buffer.size), 0);
+            win_emu.emu().write_memory(buffer.address, zeroes.data(), zeroes.size());
+        }
+
+        void write_adapter_key(windows_emulator& win_emu, const nsi_buffer buffer)
+        {
+            if (!buffer.address || buffer.size < sizeof(uint64_t))
+            {
+                return;
+            }
+
+            win_emu.emu().write_memory<uint64_t>(buffer.address, k_adapter_index);
+        }
+
+        void write_adapter_parameter(windows_emulator& win_emu, const nsi_buffer buffer)
+        {
+            if (!buffer.address || !buffer.size)
+            {
+                return;
+            }
+
+            const auto bytes_to_write = std::min<size_t>(static_cast<size_t>(buffer.size), k_adapter_parameter.size());
+            win_emu.emu().write_memory(buffer.address, k_adapter_parameter.data(), bytes_to_write);
+        }
+
+        struct network_store_interface_device : stateless_device
+        {
+            NTSTATUS io_control(windows_emulator& win_emu, const io_device_context& c) override
+            {
+                switch (c.io_control_code)
+                {
+                case k_nsi_get_parameter:
+                    return get_parameter(win_emu, c, read_request(win_emu, c, 0x40, 0x48, 0x50, 0x58));
+                case k_nsi_get_all_parameters:
+                    return get_all_parameters(win_emu, c, read_request(win_emu, c, 0x40, 0x48, 0x50, 0x58));
+                case k_nsi_enumerate_objects_all_parameters:
+                    return enumerate_objects_all_parameters(win_emu, c, read_request(win_emu, c, 0x48, 0x50, 0x58, 0x60));
+                default:
+                    return STATUS_SUCCESS;
+                }
+            }
+
+            static NTSTATUS get_parameter(windows_emulator& win_emu, const io_device_context& c, const nsi_request& request)
+            {
+                const nsi_buffer output{.address = request.rw.address ? request.rw.address : c.output_buffer,
+                                        .size = c.output_buffer_length};
+
+                if (c.output_buffer_length == sizeof(uint32_t))
+                {
+                    if (output.address)
+                    {
+                        win_emu.emu().write_memory<uint32_t>(output.address, 1);
+                    }
+                }
+                else if (c.output_buffer_length == sizeof(uint64_t))
+                {
+                    if (output.address)
+                    {
+                        win_emu.emu().write_memory<uint64_t>(output.address, k_adapter_index);
+                    }
+                }
+                else
+                {
+                    write_adapter_parameter(win_emu, output);
+                }
+
+                write_io_information(c, 0);
+                return STATUS_SUCCESS;
+            }
+
+            static NTSTATUS get_all_parameters(windows_emulator& win_emu, const io_device_context& c, const nsi_request& request)
+            {
+                write_adapter_key(win_emu, request.key);
+                write_adapter_parameter(win_emu, request.rw);
+                write_zeroes(win_emu, request.dynamic);
+                write_io_information(c, 0);
+                return STATUS_SUCCESS;
+            }
+
+            static NTSTATUS enumerate_objects_all_parameters(windows_emulator& win_emu, const io_device_context& c,
+                                                             const nsi_request& request)
+            {
+                if (c.input_buffer_length >= 0x70)
+                {
+                    win_emu.emu().write_memory<uint64_t>(c.input_buffer + 0x68, 1);
+                }
+
+                write_adapter_key(win_emu, request.key);
+                write_adapter_parameter(win_emu, request.rw);
+                write_zeroes(win_emu, request.dynamic);
+                write_io_information(c, 0);
+                return STATUS_SUCCESS;
+            }
+        };
+    }
+
+    std::unique_ptr<io_device> create_network_store_interface()
+    {
+        return std::make_unique<network_store_interface_device>();
+    }
+}

--- a/src/windows-emulator/devices/network_store_interface.hpp
+++ b/src/windows-emulator/devices/network_store_interface.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../io_device.hpp"
+
+namespace sogen
+{
+    std::unique_ptr<io_device> create_network_store_interface();
+}

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -5,6 +5,7 @@
 #include "devices/mount_point_manager.hpp"
 #include "devices/security_support_provider.hpp"
 #include "devices/named_pipe.hpp"
+#include "devices/network_store_interface.hpp"
 #include <iostream>
 
 namespace sogen
@@ -50,7 +51,6 @@ namespace sogen
     std::unique_ptr<io_device> create_device(const std::u16string_view device, const bool is_32_bit)
     {
         if (device == u"CNG"                    //
-            || device == u"Nsi"                 //
             || device == u"RasAcd"              //
             || device == u"PcwDrv"              //
             || device == u"DeviceApi\\CMApi"    //
@@ -58,6 +58,11 @@ namespace sogen
             || device == u"ConDrv\\Server")
         {
             return std::make_unique<dummy_device>();
+        }
+
+        if (device == u"Nsi")
+        {
+            return create_network_store_interface();
         }
 
         if (device == u"Afd\\Endpoint")

--- a/src/windows-emulator/port.cpp
+++ b/src/windows-emulator/port.cpp
@@ -151,13 +151,16 @@ namespace sogen
             win_emu.emu().write_memory<uint32_t>(c.recv_buffer + rpc_handshake_state_offset, 2);
         }
 
+        c.recv_buffer_length = c.send_buffer_length;
+
         return STATUS_SUCCESS;
     }
 
     NTSTATUS rpc_port::handle_rpc_call(windows_emulator& win_emu, const lpc_request_context& c)
     {
         constexpr ULONG rpc_call_header_size = 0x40;
-        constexpr ULONG rpc_call_proc_id_offset = 12;
+        constexpr ULONG rpc_call_id_offset = 12;
+        constexpr ULONG rpc_call_opnum_offset = 20;
 
         if (c.send_buffer_length < rpc_call_header_size)
         {
@@ -170,10 +173,12 @@ namespace sogen
             return STATUS_BUFFER_TOO_SMALL;
         }
 
-        const auto procedure_id = win_emu.emu().read_memory<uint8_t>(c.send_buffer + rpc_call_proc_id_offset);
+        const auto call_id = win_emu.emu().read_memory<uint32_t>(c.send_buffer + rpc_call_id_offset);
+        const auto procedure_id = win_emu.emu().read_memory<uint32_t>(c.send_buffer + rpc_call_opnum_offset);
 
-        std::array<uint8_t, 24> header = {0x03,         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          procedure_id, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        std::array<uint8_t, 24> header = {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        std::memcpy(header.data() + 12, &call_id, sizeof(call_id));
         win_emu.emu().write_memory(c.recv_buffer, header);
 
         const auto max_payload_length = c.recv_buffer_length - rpc_header_size;

--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -21,14 +21,7 @@ namespace sogen
     namespace
     {
         constexpr DWORD k_dns_record_flags = 0x2009;
-        constexpr DWORD k_dns_record_flags_without_name = 0x0009;
-        constexpr DWORD k_default_ttl = 0x91;
-        constexpr DWORD k_proc2_single_record_a_ttl = 0x5E;
-        constexpr DWORD k_proc2_aaaa_direct_ttl = 0x70;
-        constexpr DWORD k_proc3_default_ttl = 0x12C;
-        constexpr DWORD k_native_record_reserved = 1;
-        constexpr DWORD k_native_record_rank = 1;
-        constexpr uint64_t k_native_pointer_referent = 0x20000;
+        constexpr DWORD k_dns_record_ttl = 0x708;
         constexpr size_t k_dns_record_data_size = 16;
 
         struct resolved_dns_record
@@ -37,8 +30,8 @@ namespace sogen
             WORD type{};
             WORD data_length{};
             DWORD flags{k_dns_record_flags};
-            DWORD ttl{k_default_ttl};
-            DWORD reserved{k_native_record_reserved};
+            DWORD ttl{k_dns_record_ttl};
+            DWORD reserved{};
             std::array<std::byte, k_dns_record_data_size> data{};
         };
 
@@ -47,324 +40,46 @@ namespace sogen
             std::u16string hostname;
             WORD type{};
             DWORD flags{};
-            uint64_t rpc_query_options{};
-        };
-
-        enum class proc2_query_family
-        {
-            record_query,
-            addrinfo_compatible_query,
-            unsupported,
-        };
-
-        proc2_query_family classify_proc2_query_family(const dns_query_request& request)
-        {
-            switch (request.type)
-            {
-            case DNS_TYPE_A:
-                return proc2_query_family::record_query;
-            case DNS_TYPE_AAAA:
-                return proc2_query_family::addrinfo_compatible_query;
-            default:
-                return proc2_query_family::unsupported;
-            }
-        }
-
-        // R_ResolverQuery() returns a marshaled PDNS_RECORD chain. The semantic
-        // structure comes from nt5src/.../resolver/idl/resrpc.h and the modern
-        // dnsapi client later runs FixupNameOwnerPointers() over the decoded list.
-        // We model that explicitly: the first record in a chain carries the owner
-        // name, later records can omit it and rely on fixup semantics.
-        struct rpc_dns_record_header
-        {
-            WORD type{};
-            WORD data_length{};
-            DWORD flags{};
-            DWORD ttl{};
-            DWORD reserved{};
-            uint64_t rank{};
-        };
-
-        struct rpc_proc2_record_wire_layout
-        {
-            static constexpr size_t record_with_owner_name_size = 0x30;
-            static constexpr size_t chained_record_size = 0x20;
-            static constexpr size_t max_marshaled_size = record_with_owner_name_size;
-
-            rpc_dns_record_header header{};
-            std::array<std::byte, k_dns_record_data_size> data{};
-        };
-
-        struct rpc_proc3_record_wire_layout
-        {
-            static constexpr size_t marshaled_size = 0x28;
-
-            rpc_dns_record_header header{};
-            std::array<std::byte, k_dns_record_data_size> data{};
-        };
-
-        struct rpc_proc2_record_semantics
-        {
-            const resolved_dns_record* record{};
-            bool is_owner_name_record{};
-            bool uses_embedded_owner_name{};
-        };
-
-        struct rpc_proc2_response_shape
-        {
-            bool has_result_record_list{};
-            bool has_alias_record_list{};
-            bool has_owner_name_anchor{};
-            size_t payload_size{};
+            std::array<uint8_t, 8> cookie{};
         };
 
         template <typename Traits>
-        void write_rpc_pointer(utils::aligned_binary_writer<Traits>& writer, const bool present)
+        struct dns_query_response
         {
-            writer.template write<typename Traits::PVOID>(present ? k_native_pointer_referent : 0);
-        }
+            std::optional<resolved_dns_record> record;
+            uint64_t error_code{};
 
-        template <typename Traits>
-        void write_proc2_result_record_list_pointer(utils::aligned_binary_writer<Traits>& writer, const bool present)
-        {
-            write_rpc_pointer(writer, present);
-        }
-
-        template <typename Traits>
-        void write_proc2_alias_record_list_pointer(utils::aligned_binary_writer<Traits>& writer, const bool present)
-        {
-            write_rpc_pointer(writer, present);
-        }
-
-        template <typename Traits>
-        void write_proc2_name_owner_pointer(utils::aligned_binary_writer<Traits>& writer, const bool present)
-        {
-            write_rpc_pointer(writer, present);
-        }
-
-        std::vector<rpc_proc2_record_semantics> build_proc2_rpc_record_chain(const std::vector<resolved_dns_record>& records)
-        {
-            std::vector<rpc_proc2_record_semantics> chain;
-            chain.reserve(records.size());
-
-            // Mirrors the producer/client contract in the NT source:
-            // Cache_PrepareRecordList() may null owner names on later records and
-            // dnsapi later restores them with FixupNameOwnerPointers(). Native
-            // dumps additionally show that the single-record proc2 case keeps the
-            // owner name entirely out-of-line, while the multi-record case uses the
-            // larger first-record layout.
-            const bool has_multiple_records = records.size() > 1;
-            for (size_t index = 0; index < records.size(); ++index)
+            void write(utils::aligned_binary_writer<Traits>& writer) const
             {
-                chain.push_back(rpc_proc2_record_semantics{
-                    .record = &records[index],
-                    .is_owner_name_record = index == 0,
-                    .uses_embedded_owner_name = has_multiple_records && index == 0,
-                });
+                writer.write_ndr_pointer(record.has_value());
+                if (record)
+                {
+                    writer.write_ndr_pointer(false);
+                    writer.write_ndr_pointer(true);
+                    writer.write(record->type);
+                    writer.write(record->data_length);
+                    writer.write(record->flags);
+                    writer.write(record->ttl);
+                    writer.write(record->reserved);
+
+                    writer.write(record->type);
+                    writer.write(record->data.data(), record->data_length, sizeof(typename Traits::PVOID));
+
+                    writer.write_ndr_u16string(record->name);
+                }
+
+                writer.align_to(sizeof(typename Traits::PVOID));
+                writer.pad(24);
+                writer.write(error_code);
+                writer.pad(64);
             }
-
-            return chain;
-        }
-
-        rpc_proc2_response_shape describe_proc2_response_shape(const std::vector<rpc_proc2_record_semantics>& record_chain,
-                                                               const DWORD status)
-        {
-            if (status != ERROR_SUCCESS || record_chain.empty())
-            {
-                return rpc_proc2_response_shape{
-                    .has_result_record_list = false,
-                    .has_alias_record_list = false,
-                    .has_owner_name_anchor = false,
-                    .payload_size = static_cast<size_t>(0x18),
-                };
-            }
-
-            const bool has_multiple_records = record_chain.size() > 1;
-            return rpc_proc2_response_shape{
-                .has_result_record_list = true,
-                .has_alias_record_list = has_multiple_records,
-                .has_owner_name_anchor = true,
-                .payload_size = static_cast<size_t>(has_multiple_records ? 0x100 : 0xD0),
-            };
-        }
-
-        rpc_dns_record_header build_rpc_dns_record_header(const resolved_dns_record& record, const DWORD flags, const uint64_t rank,
-                                                          const DWORD reserved)
-        {
-            return rpc_dns_record_header{
-                .type = record.type,
-                .data_length = record.data_length,
-                .flags = flags,
-                .ttl = record.ttl,
-                .reserved = reserved,
-                .rank = rank,
-            };
-        }
-
-        void copy_rpc_record_to_bytes(std::array<std::byte, rpc_proc2_record_wire_layout::max_marshaled_size>& buffer,
-                                      const rpc_proc2_record_wire_layout& wire)
-        {
-            memcpy(buffer.data() + 0x00, &wire.header.type, sizeof(wire.header.type));
-            memcpy(buffer.data() + 0x02, &wire.header.data_length, sizeof(wire.header.data_length));
-            memcpy(buffer.data() + 0x04, &wire.header.flags, sizeof(wire.header.flags));
-            memcpy(buffer.data() + 0x08, &wire.header.ttl, sizeof(wire.header.ttl));
-            memcpy(buffer.data() + 0x0C, &wire.header.reserved, sizeof(wire.header.reserved));
-            memcpy(buffer.data() + 0x10, &wire.header.rank, sizeof(wire.header.rank));
-            memcpy(buffer.data() + 0x18, wire.data.data(), wire.header.data_length);
-        }
-
-        void copy_rpc_record_to_bytes(std::array<std::byte, rpc_proc3_record_wire_layout::marshaled_size>& buffer,
-                                      const rpc_proc3_record_wire_layout& wire)
-        {
-            memcpy(buffer.data() + 0x00, &wire.header.type, sizeof(wire.header.type));
-            memcpy(buffer.data() + 0x02, &wire.header.data_length, sizeof(wire.header.data_length));
-            memcpy(buffer.data() + 0x04, &wire.header.flags, sizeof(wire.header.flags));
-            memcpy(buffer.data() + 0x08, &wire.header.ttl, sizeof(wire.header.ttl));
-            memcpy(buffer.data() + 0x0C, &wire.header.reserved, sizeof(wire.header.reserved));
-            memcpy(buffer.data() + 0x10, &wire.header.rank, sizeof(wire.header.rank));
-            memcpy(buffer.data() + 0x18, wire.data.data(), wire.header.data_length);
-        }
-
-        template <typename Traits>
-        void write_proc2_marshaled_record(utils::aligned_binary_writer<Traits>& writer, const rpc_proc2_record_semantics& semantic_record)
-        {
-            const auto& record = *semantic_record.record;
-
-            rpc_proc2_record_wire_layout wire{};
-            wire.header =
-                build_rpc_dns_record_header(record, semantic_record.is_owner_name_record ? record.flags : k_dns_record_flags_without_name,
-                                            k_native_record_rank, record.reserved);
-            wire.data = record.data;
-
-            std::array<std::byte, rpc_proc2_record_wire_layout::max_marshaled_size> buffer{};
-            copy_rpc_record_to_bytes(buffer, wire);
-
-            const auto wire_size = semantic_record.uses_embedded_owner_name ? rpc_proc2_record_wire_layout::record_with_owner_name_size
-                                                                            : rpc_proc2_record_wire_layout::chained_record_size;
-            writer.write(buffer.data(), wire_size);
-        }
-
-        template <typename Traits>
-        void write_proc2_record_chain(utils::aligned_binary_writer<Traits>& writer,
-                                      const std::vector<rpc_proc2_record_semantics>& record_chain)
-        {
-            for (const auto& semantic_record : record_chain)
-            {
-                write_proc2_marshaled_record(writer, semantic_record);
-            }
-        }
-
-        template <typename Traits>
-        void write_proc2_query_response(utils::aligned_binary_writer<Traits>& writer, const dns_query_request& request,
-                                        const std::vector<resolved_dns_record>& records, const DWORD status)
-        {
-            const auto start = writer.offset();
-            const auto record_chain = build_proc2_rpc_record_chain(records);
-            const auto shape = describe_proc2_response_shape(record_chain, status);
-
-            writer.write(request.rpc_query_options);
-
-            write_proc2_result_record_list_pointer(writer, shape.has_result_record_list);
-            write_proc2_alias_record_list_pointer(writer, shape.has_alias_record_list);
-            write_proc2_name_owner_pointer(writer, shape.has_owner_name_anchor);
-
-            if (shape.has_result_record_list)
-            {
-                write_proc2_record_chain(writer, record_chain);
-                writer.write_ndr_u16string(records.front().name);
-            }
-
-            if (writer.offset() < start + shape.payload_size)
-            {
-                writer.pad(static_cast<size_t>(start + shape.payload_size - writer.offset()));
-            }
-
-            (void)request;
-        }
-
-        template <typename Traits>
-        void write_proc3_record(utils::aligned_binary_writer<Traits>& writer, const resolved_dns_record& record, const DWORD flags,
-                                const DWORD reserved)
-        {
-            rpc_proc3_record_wire_layout wire{};
-            wire.header = build_rpc_dns_record_header(record, flags, static_cast<uint64_t>(record.type), reserved);
-            wire.data = record.data;
-
-            std::array<std::byte, rpc_proc3_record_wire_layout::marshaled_size> buffer{};
-            copy_rpc_record_to_bytes(buffer, wire);
-            writer.write(buffer);
-        }
-
-        template <typename Traits>
-        void write_proc3_response(utils::aligned_binary_writer<Traits>& writer, const dns_query_request& request,
-                                  const std::vector<resolved_dns_record>& direct_records,
-                                  const std::vector<resolved_dns_record>& mapped_records, const DWORD status)
-        {
-            writer.write(request.rpc_query_options);
-
-            if (status != ERROR_SUCCESS || (direct_records.empty() && mapped_records.empty()))
-            {
-                write_rpc_pointer(writer, false);
-                write_rpc_pointer(writer, false);
-                write_rpc_pointer(writer, false);
-                return;
-            }
-
-            write_rpc_pointer(writer, true);
-            write_rpc_pointer(writer, true);
-            write_rpc_pointer(writer, true);
-
-            if (!direct_records.empty())
-            {
-                write_proc3_record(writer, direct_records[0], k_dns_record_flags, 1);
-            }
-
-            if (direct_records.size() > 1)
-            {
-                write_rpc_pointer(writer, true);
-                write_rpc_pointer(writer, false);
-                write_proc3_record(writer, direct_records[1], k_dns_record_flags_without_name, 1);
-            }
-
-            if (!mapped_records.empty())
-            {
-                write_rpc_pointer(writer, true);
-                write_rpc_pointer(writer, true);
-                write_proc3_record(writer, mapped_records[0], k_dns_record_flags, 0);
-            }
-
-            if (mapped_records.size() > 1)
-            {
-                write_rpc_pointer(writer, false);
-                write_rpc_pointer(writer, true);
-                write_proc3_record(writer, mapped_records[1], k_dns_record_flags, 0);
-            }
-
-            const auto& owner_name = direct_records.empty() ? mapped_records.front().name : direct_records.front().name;
-            writer.write_ndr_u16string(owner_name);
-
-            if (!mapped_records.empty())
-            {
-                writer.write_ndr_u16string(mapped_records[0].name);
-            }
-
-            if (mapped_records.size() > 1)
-            {
-                writer.write_ndr_u16string(mapped_records[1].name);
-            }
-
-            constexpr size_t k_native_proc3_reply_payload_size = 0x1E0;
-            if (writer.offset() < k_native_proc3_reply_payload_size)
-            {
-                writer.pad(static_cast<size_t>(k_native_proc3_reply_payload_size - writer.offset()));
-            }
-        }
+        };
 
         bool parse_dns_query_request(windows_emulator& win_emu, const lpc_request_context& c, dns_query_request& request)
         {
             constexpr ULONG hostname_header_offset = 0x08;
             constexpr ULONG hostname_offset = 0x20;
-            constexpr ULONG fixed_trailer_size = 8; // query type + padding + flags
+            constexpr ULONG fixed_trailer_size = 8;
             auto& emu = win_emu.emu();
 
             if (c.send_buffer_length < hostname_offset + sizeof(char16_t) + fixed_trailer_size)
@@ -396,7 +111,7 @@ namespace sogen
             const auto query_type_offset = c.send_buffer + hostname_offset + hostname_bytes;
             request.type = emu.read_memory<uint16_t>(query_type_offset);
             request.flags = emu.read_memory<uint32_t>(query_type_offset + sizeof(uint32_t));
-            request.rpc_query_options = emu.read_memory<uint64_t>(c.send_buffer + c.send_buffer_length - sizeof(uint64_t));
+            emu.read_memory(c.send_buffer + c.send_buffer_length - request.cookie.size(), request.cookie.data(), request.cookie.size());
             return true;
         }
 
@@ -446,32 +161,45 @@ namespace sogen
             return records;
         }
 
-        std::vector<resolved_dns_record> build_proc3_mapped_records(windows_emulator& win_emu, const std::u16string& host)
+        std::optional<resolved_dns_record> resolve_single_host_record(windows_emulator& win_emu, const std::u16string& host,
+                                                                      const WORD dns_type)
         {
-            const auto ipv4_records = resolve_host_addresses(win_emu, host, DNS_TYPE_A);
-            std::vector<resolved_dns_record> mapped_records;
-            mapped_records.reserve(ipv4_records.size());
-
-            for (const auto& ipv4_record : ipv4_records)
+            if (dns_type == DNS_TYPE_A)
             {
-                resolved_dns_record mapped{};
-                mapped.name = host;
-                mapped.type = DNS_TYPE_AAAA;
-                mapped.data_length = 16;
-                mapped.ttl = k_proc3_default_ttl;
-                mapped.reserved = 0;
-                mapped.data.fill(std::byte{0});
-                mapped.data[10] = std::byte{0xFF};
-                mapped.data[11] = std::byte{0xFF};
-                memcpy(mapped.data.data() + 12, ipv4_record.data.data(), 4);
-                mapped_records.push_back(mapped);
+                auto records = resolve_host_addresses(win_emu, host, DNS_TYPE_A);
+                if (records.empty())
+                {
+                    return std::nullopt;
+                }
+
+                return records.front();
             }
 
-            std::ranges::sort(mapped_records, [](const resolved_dns_record& a, const resolved_dns_record& b) {
-                return std::memcmp(a.data.data(), b.data.data(), k_dns_record_data_size) < 0;
-            });
+            if (dns_type == DNS_TYPE_AAAA)
+            {
+                auto ipv6_records = resolve_host_addresses(win_emu, host, DNS_TYPE_AAAA);
+                if (!ipv6_records.empty())
+                {
+                    return ipv6_records.front();
+                }
 
-            return mapped_records;
+                auto ipv4_records = resolve_host_addresses(win_emu, host, DNS_TYPE_A);
+                if (ipv4_records.empty())
+                {
+                    return std::nullopt;
+                }
+
+                auto mapped_record = ipv4_records.front();
+                mapped_record.type = DNS_TYPE_AAAA;
+                mapped_record.data_length = 16;
+                mapped_record.data.fill(std::byte{0});
+                mapped_record.data[10] = std::byte{0xFF};
+                mapped_record.data[11] = std::byte{0xFF};
+                memcpy(mapped_record.data.data() + 12, ipv4_records.front().data.data(), 4);
+                return mapped_record;
+            }
+
+            return std::nullopt;
         }
 
         struct dns_resolver : rpc_port
@@ -480,16 +208,13 @@ namespace sogen
             {
                 utils::aligned_binary_writer<EmulatorTraits<Emu64>> writer(win_emu.emu(), c.recv_buffer);
 
-                switch (procedure_id)
+                if (procedure_id == 4)
                 {
-                case 2:
                     return handle_dns_query(win_emu, c, writer);
-                case 3:
-                    return handle_dns_addrinfo_query(win_emu, c, writer);
-                default:
-                    win_emu.log.print(color::gray, "Unexpected DNSResolver procedure: %u\n", procedure_id);
-                    return STATUS_NOT_SUPPORTED;
                 }
+
+                win_emu.log.print(color::gray, "Unexpected DNSResolver procedure: %u\n", procedure_id);
+                return STATUS_NOT_SUPPORTED;
             }
 
             template <typename Traits>
@@ -502,95 +227,19 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto hostname = u16_to_u8(request.hostname);
-                win_emu.callbacks.on_generic_activity("DNS query: " + hostname);
-
-                switch (classify_proc2_query_family(request))
+                if (request.type != DNS_TYPE_A && request.type != DNS_TYPE_AAAA)
                 {
-                case proc2_query_family::record_query: {
-                    auto records = resolve_host_addresses(win_emu, request.hostname, DNS_TYPE_A);
-                    if (records.size() > 2)
-                    {
-                        records.resize(2);
-                    }
-
-                    if (records.size() == 1)
-                    {
-                        records[0].ttl = k_proc2_single_record_a_ttl;
-                    }
-
-                    const DWORD status = records.empty() ? DNS_ERROR_RCODE_NAME_ERROR : ERROR_SUCCESS;
-                    write_proc2_query_response(writer, request, records, status);
-                    break;
-                }
-                case proc2_query_family::addrinfo_compatible_query: {
-                    auto direct_records = resolve_host_addresses(win_emu, request.hostname, DNS_TYPE_AAAA);
-                    auto mapped_records = build_proc3_mapped_records(win_emu, request.hostname);
-
-                    for (auto& record : direct_records)
-                    {
-                        record.ttl = k_proc2_aaaa_direct_ttl;
-                        record.reserved = 1;
-                    }
-
-                    if (direct_records.size() > 2)
-                    {
-                        direct_records.resize(2);
-                    }
-                    if (mapped_records.size() > 2)
-                    {
-                        mapped_records.resize(2);
-                    }
-
-                    const DWORD status = direct_records.empty() && mapped_records.empty() ? DNS_ERROR_RCODE_NAME_ERROR : ERROR_SUCCESS;
-                    write_proc3_response(writer, request, direct_records, mapped_records, status);
-                    break;
-                }
-                case proc2_query_family::unsupported:
-                    write_proc2_query_response(writer, request, {}, STATUS_INVALID_PARAMETER);
-                    break;
-                }
-                c.recv_buffer_length = static_cast<ULONG>(writer.offset());
-                return STATUS_SUCCESS;
-            }
-
-            template <typename Traits>
-            static NTSTATUS handle_dns_addrinfo_query(windows_emulator& win_emu, const lpc_request_context& c,
-                                                      utils::aligned_binary_writer<Traits>& writer)
-            {
-                dns_query_request request{};
-                if (!parse_dns_query_request(win_emu, c, request))
-                {
-                    return STATUS_INVALID_PARAMETER;
+                    return STATUS_NOT_SUPPORTED;
                 }
 
-                const auto hostname = u16_to_u8(request.hostname);
-                win_emu.callbacks.on_generic_activity("DNS addrinfo query: " + hostname);
+                win_emu.callbacks.on_generic_activity("DNS query: " + u16_to_u8(request.hostname));
+                writer.write(request.cookie);
 
-                auto direct_records = resolve_host_addresses(win_emu, request.hostname, DNS_TYPE_AAAA);
-                auto mapped_records = build_proc3_mapped_records(win_emu, request.hostname);
+                dns_query_response<Traits> response{};
+                response.record = resolve_single_host_record(win_emu, request.hostname, request.type);
+                response.error_code = response.record ? ERROR_SUCCESS : DNS_ERROR_RCODE_NAME_ERROR;
+                writer.write(response);
 
-                std::ranges::sort(direct_records, [](const resolved_dns_record& a, const resolved_dns_record& b) {
-                    return std::memcmp(a.data.data(), b.data.data(), k_dns_record_data_size) < 0;
-                });
-
-                for (auto& record : direct_records)
-                {
-                    record.ttl = k_proc3_default_ttl;
-                    record.reserved = 1;
-                }
-
-                if (direct_records.size() > 2)
-                {
-                    direct_records.resize(2);
-                }
-                if (mapped_records.size() > 2)
-                {
-                    mapped_records.resize(2);
-                }
-
-                const DWORD status = direct_records.empty() && mapped_records.empty() ? DNS_ERROR_RCODE_NAME_ERROR : ERROR_SUCCESS;
-                write_proc3_response(writer, request, direct_records, mapped_records, status);
                 c.recv_buffer_length = static_cast<ULONG>(writer.offset());
                 return STATUS_SUCCESS;
             }

--- a/src/windows-emulator/ports/lsa_policy_lookup.cpp
+++ b/src/windows-emulator/ports/lsa_policy_lookup.cpp
@@ -1,6 +1,8 @@
 #include "../std_include.hpp"
 #include "lsa_policy_lookup.hpp"
 
+#include "binary_writer.hpp"
+#include "../registry/registry_utils.hpp"
 #include "../windows_emulator.hpp"
 
 namespace sogen
@@ -9,32 +11,144 @@ namespace sogen
     namespace
     {
         constexpr NTSTATUS k_status_none_mapped = static_cast<NTSTATUS>(0xC0000073);
-        constexpr ULONG k_request_cookie_size = 8;
-        constexpr ULONG k_open_policy_reply_size = 0x20;
-        constexpr ULONG k_lookup_names_reply_size = 0x18;
-        constexpr ULONG k_close_policy_reply_size = 0x0C;
-        constexpr ULONG k_open_policy_context_attr_offset = 0x08;
-        constexpr ULONG k_open_policy_ntstatus_offset = 0x1C;
-        constexpr ULONG k_lookup_names_status_offset = 0x14;
-        constexpr ULONG k_close_policy_status_offset = 0x08;
+        constexpr ULONG k_open_policy_reply_size = 0x44;
+        constexpr ULONG k_lookup_sids_not_mapped_reply_size = 0x18;
+        constexpr ULONG k_lookup_sids_min_success_reply_size = 0x10C;
+        constexpr ULONG k_close_policy_reply_size = 0x44;
+        constexpr uint32_t k_lsa_max_referenced_domains = 0x20;
+        constexpr uint32_t k_sid_type_user = 1;
+        constexpr std::array<uint8_t, 16> k_policy_context_uuid = {
+            0xBA, 0xA3, 0xDA, 0x01, 0x6E, 0x16, 0x62, 0x49, 0x81, 0x46, 0x13, 0x9B, 0x8A, 0x70, 0x69, 0xE7,
+        };
+
+        void write_bytes(std::vector<uint8_t>& buffer, const size_t offset, const std::span<const uint8_t> bytes)
+        {
+            if (offset + bytes.size() > buffer.size())
+            {
+                buffer.resize(offset + bytes.size(), 0);
+            }
+
+            std::memcpy(buffer.data() + offset, bytes.data(), bytes.size());
+        }
+
+        bool request_contains_sid(windows_emulator& win_emu, const lpc_request_context& c, const std::span<const uint8_t> sid)
+        {
+            if (sid.empty() || c.send_buffer_length < sid.size())
+            {
+                return false;
+            }
+
+            std::vector<uint8_t> request(c.send_buffer_length, 0);
+            win_emu.emu().read_memory(c.send_buffer, request.data(), request.size());
+
+            const auto it = std::ranges::search(request, sid);
+            return it.begin() != request.end();
+        }
+
+        bool is_domain_user_sid(const std::span<const uint8_t> sid)
+        {
+            if (sid.size() < 12)
+            {
+                return false;
+            }
+
+            const auto sub_authority_count = sid[1];
+            if (sub_authority_count < 2 || sid.size() < static_cast<size_t>(8 + (sub_authority_count * sizeof(uint32_t))))
+            {
+                return false;
+            }
+
+            constexpr std::array<uint8_t, 6> nt_authority = {0, 0, 0, 0, 0, 5};
+            if (!std::ranges::equal(nt_authority, sid.subspan(2, nt_authority.size())))
+            {
+                return false;
+            }
+
+            uint32_t first_sub_authority{};
+            std::memcpy(&first_sub_authority, sid.data() + 8, sizeof(first_sub_authority));
+            return first_sub_authority == 21;
+        }
+
+        std::vector<uint8_t> derive_account_domain_sid(const std::span<const uint8_t> sid)
+        {
+            if (!is_domain_user_sid(sid))
+            {
+                return {sid.begin(), sid.end()};
+            }
+
+            std::vector<uint8_t> domain_sid(sid.begin(), sid.end() - sizeof(uint32_t));
+            --domain_sid[1];
+            return domain_sid;
+        }
+
+        template <typename Traits>
+        void write_lsa_unicode_string(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view value)
+        {
+            writer.write(static_cast<uint16_t>(value.size() * sizeof(char16_t)));
+            writer.write(static_cast<uint16_t>((value.size() + 1) * sizeof(char16_t)));
+            writer.write_ndr_pointer(true);
+        }
+
+        template <typename Traits>
+        void write_lsa_translated_name(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view value)
+        {
+            writer.write(k_sid_type_user);
+            writer.align_to(sizeof(typename Traits::PVOID));
+            write_lsa_unicode_string(writer, value);
+            writer.template write<int32_t>(0);
+            writer.align_to(sizeof(typename Traits::PVOID));
+        }
+
+        template <typename Traits>
+        void write_lookup_sids_success_reply(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view domain,
+                                             const std::span<const uint8_t> domain_sid, const std::u16string_view user)
+        {
+            writer.write_ndr_pointer(true);
+
+            writer.template write<uint32_t>(1);
+            writer.write_ndr_pointer(true);
+            writer.write(k_lsa_max_referenced_domains);
+
+            writer.template write<typename Traits::SIZE_T>(1);
+            write_lsa_unicode_string(writer, domain);
+            writer.write_ndr_pointer(true);
+
+            writer.write_ndr_u16string(domain, false);
+            writer.align_to(sizeof(typename Traits::PVOID));
+
+            writer.write(static_cast<uint32_t>(domain_sid.empty() ? 0 : domain_sid[1]));
+            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.write(domain_sid.data(), domain_sid.size(), alignof(uint32_t));
+            writer.align_to(sizeof(typename Traits::PVOID));
+
+            writer.template write<uint32_t>(1);
+            writer.write_ndr_pointer(true);
+            writer.template write<typename Traits::SIZE_T>(1);
+
+            write_lsa_translated_name(writer, user);
+            writer.write_ndr_u16string(user, false);
+
+            writer.template write<uint32_t>(1);
+            writer.write(STATUS_SUCCESS);
+
+            if (writer.offset() < k_lookup_sids_min_success_reply_size)
+            {
+                writer.pad(static_cast<size_t>(k_lookup_sids_min_success_reply_size - writer.offset()));
+            }
+        }
 
         struct lsa_policy_lookup_port : rpc_port
         {
             NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c) override
             {
-                if (!write_request_cookie(win_emu, c))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-
                 switch (procedure_id)
                 {
-                case 4:
+                case 0:
                     return handle_open_policy(win_emu, c);
-                case 2:
-                    return handle_lookup_names(win_emu, c);
-                case 3:
+                case 1:
                     return handle_close_policy(win_emu, c);
+                case 2:
+                    return handle_lookup_sids(win_emu, c);
                 default:
                     // win_emu.log.warn("Unsupported lsapolicylookup procedure: %u\n", procedure_id);
                     return STATUS_NOT_SUPPORTED;
@@ -42,76 +156,50 @@ namespace sogen
             }
 
           private:
-            static bool ensure_recv_capacity(windows_emulator& win_emu, const lpc_request_context& c, const ULONG required,
-                                             const char* operation)
-            {
-                if (c.recv_buffer_length >= required)
-                {
-                    return true;
-                }
-
-                win_emu.log.warn("lsapolicylookup %s reply buffer too small: have 0x%X need 0x%X\n", operation,
-                                 static_cast<uint32_t>(c.recv_buffer_length), static_cast<uint32_t>(required));
-                return false;
-            }
-
-            static bool write_request_cookie(windows_emulator& win_emu, const lpc_request_context& c)
-            {
-                if (!ensure_recv_capacity(win_emu, c, k_request_cookie_size, "cookie"))
-                {
-                    return false;
-                }
-
-                std::array<uint8_t, 8> request_cookie{};
-                if (c.send_buffer_length >= k_request_cookie_size)
-                {
-                    win_emu.emu().read_memory(c.send_buffer + c.send_buffer_length - k_request_cookie_size, request_cookie.data(),
-                                              request_cookie.size());
-                }
-                win_emu.emu().write_memory(c.recv_buffer, request_cookie.data(), request_cookie.size());
-                return true;
-            }
-
             static NTSTATUS handle_open_policy(windows_emulator& win_emu, const lpc_request_context& c)
             {
-                if (!ensure_recv_capacity(win_emu, c, k_open_policy_reply_size, "open_policy"))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
+                std::vector<uint8_t> reply(k_open_policy_reply_size, 0);
+                write_bytes(reply, 0x04, k_policy_context_uuid);
 
-                std::array<std::byte, k_open_policy_reply_size> zeros{};
-                win_emu.emu().write_memory(c.recv_buffer, zeros.data(), zeros.size());
+                win_emu.emu().write_memory(c.recv_buffer, reply.data(), reply.size());
 
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + k_open_policy_context_attr_offset, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + k_open_policy_ntstatus_offset, STATUS_SUCCESS);
-                c.recv_buffer_length = k_open_policy_reply_size;
+                c.recv_buffer_length = static_cast<ULONG>(reply.size());
                 return STATUS_SUCCESS;
             }
 
-            static NTSTATUS handle_lookup_names(windows_emulator& win_emu, const lpc_request_context& c)
+            static NTSTATUS handle_lookup_sids(windows_emulator& win_emu, const lpc_request_context& c)
             {
-                if (!ensure_recv_capacity(win_emu, c, k_lookup_names_reply_size, "lookup_names"))
+                if (request_contains_sid(win_emu, c, win_emu.process.sid))
                 {
-                    return STATUS_BUFFER_TOO_SMALL;
+                    const auto domain = registry_utils::get_account_domain(win_emu.registry);
+                    const auto domain_sid = derive_account_domain_sid(win_emu.process.sid);
+                    const auto user = registry_utils::get_user_name(win_emu.registry);
+
+                    utils::aligned_binary_writer<EmulatorTraits<Emu64>> writer(win_emu.emu(), c.recv_buffer);
+                    write_lookup_sids_success_reply(writer, domain, domain_sid, user);
+
+                    c.recv_buffer_length = static_cast<ULONG>(writer.offset());
+                    return STATUS_SUCCESS;
                 }
 
+                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x00, 0);
+                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x04, 0);
                 win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x08, 0);
                 win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x0C, 0);
                 win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x10, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + k_lookup_names_status_offset, k_status_none_mapped);
-                c.recv_buffer_length = k_lookup_names_reply_size;
+                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x14, k_status_none_mapped);
+
+                c.recv_buffer_length = k_lookup_sids_not_mapped_reply_size;
                 return STATUS_SUCCESS;
             }
 
             static NTSTATUS handle_close_policy(windows_emulator& win_emu, const lpc_request_context& c)
             {
-                if (!ensure_recv_capacity(win_emu, c, k_close_policy_reply_size, "close_policy"))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
+                const std::vector<uint8_t> reply(k_close_policy_reply_size, 0);
 
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + k_close_policy_status_offset, STATUS_SUCCESS);
-                c.recv_buffer_length = k_close_policy_reply_size;
+                win_emu.emu().write_memory(c.recv_buffer, reply.data(), reply.size());
+
+                c.recv_buffer_length = static_cast<ULONG>(reply.size());
                 return STATUS_SUCCESS;
             }
         };

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -66,7 +66,7 @@ namespace sogen
 
         std::vector<uint8_t> get_sid(registry_manager& registry)
         {
-            const auto sid_string = get_user_sid_string(registry);
+            const auto sid_string = registry_utils::get_user_sid_string(registry);
             return sid_string_to_bytes(sid_string);
         }
 
@@ -185,25 +185,13 @@ namespace sogen
                 for (size_t i = 0; const auto value_opt = registry.get_value(*env_key, i); i++)
                 {
                     const auto& value = *value_opt;
-
-                    if (value.type != REG_SZ && value.type != REG_EXPAND_SZ)
+                    const auto decoded = registry_utils::decode_registry_string(value);
+                    if (!decoded)
                     {
                         continue;
                     }
 
-                    if (value.data.empty() || value.data.size() % 2 != 0)
-                    {
-                        continue;
-                    }
-
-                    const auto char_count = value.data.size() / sizeof(char16_t);
-                    const auto* data_ptr = reinterpret_cast<const char16_t*>(value.data.data());
-                    if (data_ptr[char_count - 1] != u'\0')
-                    {
-                        continue;
-                    }
-
-                    const auto [it, inserted] = env_map.emplace(u8_to_u16(value.name), std::u16string(data_ptr, char_count - 1));
+                    const auto [it, inserted] = env_map.emplace(u8_to_u16(value.name), *decoded);
                     if (inserted && value.type == REG_EXPAND_SZ)
                     {
                         keys_to_expand.insert(it->first);
@@ -234,14 +222,15 @@ namespace sogen
             }
             system_temp += u"SystemTemp";
 
-            env_map[u"COMPUTERNAME"] = u"momo";
-            env_map[u"USERNAME"] = u"momo";
+            const auto user_profile = registry_utils::get_user_profile_path(registry);
+            env_map[u"COMPUTERNAME"] = registry_utils::get_account_domain(registry);
+            env_map[u"USERNAME"] = registry_utils::get_user_name(registry);
             env_map[u"SystemDrive"] = system_drive;
             env_map[u"SystemRoot"] = system_root;
             env_map[u"SystemTemp"] = system_temp;
-            env_map[u"TMP"] = u"C:\\Users\\momo\\AppData\\Temp";
-            env_map[u"TEMP"] = u"C:\\Users\\momo\\AppData\\Temp";
-            env_map[u"USERPROFILE"] = u"C:\\Users\\momo";
+            env_map[u"TMP"] = user_profile + u"\\AppData\\Temp";
+            env_map[u"TEMP"] = user_profile + u"\\AppData\\Temp";
+            env_map[u"USERPROFILE"] = user_profile;
 
             for (const auto& [key, value] : app_settings.environment)
             {

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -92,7 +92,7 @@ namespace sogen
 
         register_hive(this->hives_, root / "user", this->hive_path_ / "NTUSER.DAT");
 
-        this->add_path_mapping(user / get_user_sid_string(*this), user);
+        this->add_path_mapping(user / registry_utils::get_user_sid_string(*this), user);
         this->add_path_mapping(user / ".Default", user);
 
         this->add_path_mapping(machine / "system" / "CurrentControlSet", machine / "system" / "ControlSet001");
@@ -443,27 +443,7 @@ namespace sogen
             return {};
         }
 
-        const auto& value = value_opt.value();
-
-        if (value.type != REG_SZ && value.type != REG_EXPAND_SZ)
-        {
-            return {};
-        }
-
-        if (value.data.empty() || value.data.size() % 2 != 0)
-        {
-            return {};
-        }
-
-        const auto char_count = value.data.size() / sizeof(char16_t);
-        const auto* data_ptr = reinterpret_cast<const char16_t*>(value.data.data());
-        if (data_ptr[char_count - 1] != u'\0')
-        {
-            return {};
-        }
-
-        auto s = std::u16string(data_ptr, char_count - 1);
-        return s;
+        return registry_utils::decode_registry_string(*value_opt);
     }
 
 } // namespace sogen

--- a/src/windows-emulator/registry/registry_utils.hpp
+++ b/src/windows-emulator/registry/registry_utils.hpp
@@ -2,8 +2,54 @@
 
 #include "registry_manager.hpp"
 
-namespace sogen
+namespace sogen::registry_utils
 {
+
+    inline std::optional<std::u16string> decode_registry_string(const registry_value& value)
+    {
+        if (value.type != REG_SZ && value.type != REG_EXPAND_SZ)
+        {
+            return std::nullopt;
+        }
+
+        if (value.data.empty() || value.data.size() % sizeof(char16_t) != 0)
+        {
+            return std::nullopt;
+        }
+
+        const auto* data = reinterpret_cast<const char16_t*>(value.data.data());
+        auto char_count = value.data.size() / sizeof(char16_t);
+        while (char_count > 0 && data[char_count - 1] == u'\0')
+        {
+            --char_count;
+        }
+
+        return std::u16string(data, char_count);
+    }
+
+    inline std::optional<std::u16string> read_registry_string(registry_manager& registry, const registry_key& key,
+                                                              const std::string_view value_name)
+    {
+        const auto value = registry.get_value(key, value_name);
+        if (!value)
+        {
+            return std::nullopt;
+        }
+
+        return decode_registry_string(*value);
+    }
+
+    inline std::optional<std::u16string> read_registry_string(registry_manager& registry, const std::filesystem::path& key_path,
+                                                              const std::string_view value_name)
+    {
+        const auto key = registry.get_key(utils::path_key{key_path});
+        if (!key)
+        {
+            return std::nullopt;
+        }
+
+        return read_registry_string(registry, *key, value_name);
+    }
 
     inline std::string get_user_sid_string(registry_manager& registry)
     {
@@ -37,6 +83,69 @@ namespace sogen
         }
 
         return "S-1-5-18";
+    }
+
+    inline std::u16string get_user_profile_path(registry_manager& registry)
+    {
+        const std::filesystem::path profile_list_path = R"(\Registry\Machine\Software\Microsoft\Windows NT\CurrentVersion\ProfileList)";
+
+        try
+        {
+            const auto sid = get_user_sid_string(registry);
+            if (auto profile_path = read_registry_string(registry, profile_list_path / sid, "ProfileImagePath");
+                profile_path && !profile_path->empty())
+            {
+                return *profile_path;
+            }
+        }
+        catch (const std::exception&)
+        {
+        }
+
+        return u"C:\\Users\\momo";
+    }
+
+    inline std::u16string get_user_name(registry_manager& registry)
+    {
+        const auto basename_from_windows_path = [&](std::u16string path) -> std::u16string {
+            while (!path.empty() && (path.back() == u'\\' || path.back() == u'/'))
+            {
+                path.pop_back();
+            }
+
+            const auto slash = path.find_last_of(u"\\/");
+            if (slash == std::u16string::npos)
+            {
+                return path;
+            }
+
+            return path.substr(slash + 1);
+        };
+
+        if (auto name = basename_from_windows_path(get_user_profile_path(registry)); !name.empty())
+        {
+            return name;
+        }
+
+        return u"momo";
+    }
+
+    inline std::u16string get_account_domain(registry_manager& registry)
+    {
+        const std::array<std::filesystem::path, 2> key_paths = {
+            R"(\Registry\Machine\System\CurrentControlSet\Control\ComputerName\ActiveComputerName)",
+            R"(\Registry\Machine\System\CurrentControlSet\Control\ComputerName\ComputerName)",
+        };
+
+        for (const auto& key_path : key_paths)
+        {
+            if (auto computer_name = read_registry_string(registry, key_path, "ComputerName"); computer_name && !computer_name->empty())
+            {
+                return *computer_name;
+            }
+        }
+
+        return u"momo";
     }
 
 } // namespace sogen

--- a/src/windows-emulator/registry/registry_utils.hpp
+++ b/src/windows-emulator/registry/registry_utils.hpp
@@ -102,7 +102,7 @@ namespace sogen::registry_utils
         {
         }
 
-        return u"C:\\Users\\momo";
+        return u"C:\\Users\\sogen";
     }
 
     inline std::u16string get_user_name(registry_manager& registry)


### PR DESCRIPTION
This PR includes the following changes:

* Fixes the DNS resolver port.
* Fixes the LSA policy lookup port.
* Implements a better stub for the NSI device, which is necessary for the DNS resolver to work on Windows Server 2022.
* Fixes an issue in the Icicle backend that was preventing it from working correctly after the DNS resolver change. It is unclear why this started being triggered now.
* Makes the Icicle bridge report a detailed error for problems like the above in the future, instead of suddenly terminating the emulator.
* Fetches the previously hard-coded environment variables from the registry.

Originally, I was only going to touch the LSA port, but I found a mistake in how the procedure ID was extracted from the `send_buffer` in the RPC port abstraction. It turns out that what was being extracted before was just a call counter, and the correct procedure ID was somewhere else 😅 

This made me revisit the DNS resolver as well. After a brief analysis, it didn’t seem to be working after @momo5502’s rewrite because it appeared to model a different output layout than the one actually used in `DNSResolver` for DNS queries. Because of that, I ended up reverting most things to how they were before.

If you have any tests or WinAPI functions that trigger the procedures that expected the previous output layout, please let me know so I can adjust this patch.