### PR TITLE
Refactor (A)LPC ports

### DIFF
--- a/src/emulator/binary_writer.hpp
+++ b/src/emulator/binary_writer.hpp
@@ -4,30 +4,61 @@ namespace sogen
 {
     namespace utils
     {
-        template <typename Traits>
         class aligned_binary_writer;
 
-        template <typename T, typename Traits>
-        concept Writable = requires(const T ac, aligned_binary_writer<Traits>& writer) {
+        template <typename T>
+        concept Writable = requires(const T ac, aligned_binary_writer& writer) {
             { ac.write(writer) } -> std::same_as<void>;
         };
 
-        template <typename Traits>
         class aligned_binary_writer
         {
           public:
-            aligned_binary_writer(memory_interface& mem, uint64_t address)
-                : memory(mem),
+            static constexpr size_t pointer_size_32 = 4;
+            static constexpr size_t pointer_size_64 = 8;
+
+            aligned_binary_writer(memory_interface& mem, uint64_t address, const size_t pointer_size = pointer_size_64)
+                : memory(&mem),
                   base_address(address),
-                  current_position(address)
+                  current_position(address),
+                  pointer_size_(validate_pointer_size(pointer_size))
+            {
+            }
+
+            explicit aligned_binary_writer(std::vector<uint8_t>& buffer, const size_t pointer_size = pointer_size_64)
+                : buffer(&buffer),
+                  pointer_size_(validate_pointer_size(pointer_size))
             {
             }
 
             void write(const void* data, size_t size, size_t alignment = 1)
             {
                 align_to(alignment);
-                memory.write_memory(current_position, data, size);
+                write_at(static_cast<size_t>(current_position - base_address), data, size);
                 current_position += size;
+            }
+
+            void write_at(uint64_t offset, const void* data, size_t size)
+            {
+                if (buffer)
+                {
+                    if (offset + size > buffer->size())
+                    {
+                        buffer->resize(static_cast<size_t>(offset + size), 0);
+                    }
+
+                    std::memcpy(buffer->data() + offset, data, size);
+                }
+                else
+                {
+                    memory->write_memory(base_address + offset, data, size);
+                }
+            }
+
+            template <typename T>
+            void write_at(uint64_t offset, const T& value)
+            {
+                write_at(offset, &value, sizeof(value));
             }
 
             template <typename T>
@@ -36,7 +67,7 @@ namespace sogen
             {
                 constexpr auto is_trivially_copyable = std::is_trivially_copyable_v<T>;
 
-                if constexpr (Writable<T, Traits>)
+                if constexpr (Writable<T>)
                 {
                     value.write(*this);
                 }
@@ -55,12 +86,12 @@ namespace sogen
             {
                 if (!not_null)
                 {
-                    write<typename Traits::PVOID>(0);
+                    write_pointer_sized(0);
                     return;
                 }
 
-                write<typename Traits::PVOID>(next_referent_id_);
-                next_referent_id_ += sizeof(typename Traits::PVOID);
+                write_pointer_sized(next_referent_id_);
+                next_referent_id_ += pointer_size_;
             }
 
             void write_ndr_u16string(const std::u16string_view str, const bool include_nul = true)
@@ -68,9 +99,9 @@ namespace sogen
                 const auto max_char_count = str.size() + 1;
                 const auto actual_char_count = str.size() + (include_nul ? 1 : 0);
 
-                write<typename Traits::SIZE_T>(max_char_count);
-                write<typename Traits::SIZE_T>(0);
-                write<typename Traits::SIZE_T>(actual_char_count);
+                write_pointer_sized(max_char_count);
+                write_pointer_sized(0);
+                write_pointer_sized(actual_char_count);
                 if (!str.empty())
                 {
                     write(str.data(), str.size() * sizeof(char16_t));
@@ -80,6 +111,17 @@ namespace sogen
                     constexpr char16_t nul{};
                     write(&nul, sizeof(nul));
                 }
+            }
+
+            void write_pointer_sized(const uint64_t value)
+            {
+                if (pointer_size_ == pointer_size_32)
+                {
+                    write(static_cast<uint32_t>(value));
+                    return;
+                }
+
+                write(value);
             }
 
             void pad(size_t count)
@@ -107,11 +149,28 @@ namespace sogen
                 return current_position - base_address;
             }
 
+            size_t pointer_size() const
+            {
+                return pointer_size_;
+            }
+
           private:
-            memory_interface& memory; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-            uint64_t base_address;
-            uint64_t current_position;
-            typename Traits::PVOID next_referent_id_{0x20000};
+            static size_t validate_pointer_size(const size_t pointer_size)
+            {
+                if (pointer_size != pointer_size_32 && pointer_size != pointer_size_64)
+                {
+                    throw std::invalid_argument("Pointer size must be 4 or 8");
+                }
+
+                return pointer_size;
+            }
+
+            memory_interface* memory{};
+            std::vector<uint8_t>* buffer{};
+            uint64_t base_address{};
+            uint64_t current_position{};
+            size_t pointer_size_{pointer_size_64};
+            uint64_t next_referent_id_{0x20000};
         };
     }
 

--- a/src/windows-emulator/port.cpp
+++ b/src/windows-emulator/port.cpp
@@ -5,6 +5,7 @@
 #include "ports/api_port.hpp"
 #include "ports/dns_resolver.hpp"
 #include "ports/lsa_policy_lookup.hpp"
+#include "binary_writer.hpp"
 
 namespace sogen
 {
@@ -13,7 +14,7 @@ namespace sogen
     {
         struct dummy_port : port
         {
-            NTSTATUS handle_request(windows_emulator& win_emu, const lpc_request_context&) override
+            lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context&) override
             {
                 win_emu.log.error("!!! BAD PORT\n");
                 return STATUS_NOT_SUPPORTED;
@@ -22,18 +23,17 @@ namespace sogen
 
         struct noop_port : port
         {
-            NTSTATUS handle_request(windows_emulator& /*win_emu*/, const lpc_request_context& c) override
+            lpc_request_result handle_request(windows_emulator& /*win_emu*/, const lpc_request_context&) override
             {
-                c.recv_buffer_length = 0;
                 return STATUS_SUCCESS;
             }
         };
 
         struct noop_rpc_port : rpc_port
         {
-            NTSTATUS handle_rpc(windows_emulator& /*win_emu*/, const uint32_t /*procedure_id*/, const lpc_request_context& c) override
+            NTSTATUS handle_rpc(windows_emulator& /*win_emu*/, const uint32_t /*procedure_id*/, const lpc_request_context&,
+                                utils::aligned_binary_writer& /*writer*/) override
             {
-                c.recv_buffer_length = 0;
                 return STATUS_SUCCESS;
             }
         };
@@ -72,8 +72,54 @@ namespace sogen
         return std::make_unique<dummy_port>();
     }
 
-    NTSTATUS port::handle_message(windows_emulator& win_emu, const lpc_message_context& c)
+    lpc_message_result port_container::handle_message(windows_emulator& win_emu, const lpc_message_context& c)
     {
+        this->assert_validity();
+
+        if (!c.receive_message)
+        {
+            return {.status = STATUS_INVALID_PARAMETER};
+        }
+
+        if (!c.send_message)
+        {
+            if (reply_queue_.empty())
+            {
+                return {.status = STATUS_UNSUCCESSFUL};
+            }
+
+            auto& pending_reply = reply_queue_.front();
+            const auto required_length = pending_reply.total_length();
+            if (c.receive_buffer_length < required_length)
+            {
+                return {.status = STATUS_BUFFER_TOO_SMALL, .message = pending_reply.message};
+            }
+
+            lpc_message_result result = std::move(pending_reply);
+            result.status = STATUS_SUCCESS;
+            reply_queue_.erase(reply_queue_.begin());
+            return result;
+        }
+
+        auto result = this->port_->handle_message(win_emu, c);
+
+        if (NT_SUCCESS(result.status) && c.receive_buffer_length < result.total_length())
+        {
+            const auto message = result.message;
+            reply_queue_.push_back(std::move(result));
+            return {.status = STATUS_BUFFER_TOO_SMALL, .message = message};
+        }
+
+        return result;
+    }
+
+    lpc_message_result port::handle_message(windows_emulator& win_emu, const lpc_message_context& c)
+    {
+        if (!c.send_message)
+        {
+            return {.status = STATUS_INVALID_PARAMETER};
+        }
+
         const auto send_header = c.send_message.read();
 
         auto recv_header = send_header;
@@ -87,21 +133,31 @@ namespace sogen
         lpc_request_context context{};
         context.send_buffer = c.send_message.value() + sizeof(PORT_MESSAGE64);
         context.send_buffer_length = send_header.u1.s1.DataLength;
-        context.recv_buffer = c.receive_message.value() + sizeof(PORT_MESSAGE64);
+        context.recv_buffer = c.receive_message ? c.receive_message.value() + sizeof(PORT_MESSAGE64) : 0;
         context.recv_buffer_length = c.receive_buffer_length >= sizeof(PORT_MESSAGE64)
                                          ? static_cast<ULONG>(c.receive_buffer_length - sizeof(PORT_MESSAGE64))
                                          : recv_header.u1.s1.DataLength;
 
-        NTSTATUS status = this->handle_request(win_emu, context);
+        auto request_result = this->handle_request(win_emu, context);
+        const auto payload_size = request_result.payload ? static_cast<ULONG>(request_result.payload->size()) : context.recv_buffer_length;
 
-        recv_header.u1.s1.DataLength = static_cast<CSHORT>(context.recv_buffer_length);
-        recv_header.u1.s1.TotalLength = static_cast<CSHORT>(sizeof(PORT_MESSAGE64) + context.recv_buffer_length);
-        c.receive_message.write(recv_header);
+        if (sizeof(PORT_MESSAGE64) + payload_size > static_cast<uint16_t>(std::numeric_limits<CSHORT>::max()))
+        {
+            throw std::runtime_error("Response payload too big");
+        }
 
-        return status;
+        recv_header.u1.s1.DataLength = static_cast<CSHORT>(payload_size);
+        recv_header.u1.s1.TotalLength = static_cast<CSHORT>(sizeof(PORT_MESSAGE64) + payload_size);
+
+        lpc_message_result result{.status = request_result.status, .message = recv_header};
+        if (request_result.payload)
+        {
+            result.payload = std::move(*request_result.payload);
+        }
+        return result;
     }
 
-    NTSTATUS rpc_port::handle_request(windows_emulator& win_emu, const lpc_request_context& c)
+    lpc_request_result rpc_port::handle_request(windows_emulator& win_emu, const lpc_request_context& c)
     {
         constexpr ULONG rpc_op_size = sizeof(uint32_t);
         if (c.send_buffer_length < rpc_op_size)
@@ -123,54 +179,39 @@ namespace sogen
         }
     }
 
-    NTSTATUS rpc_port::handle_handshake(windows_emulator& win_emu, const lpc_request_context& c)
+    lpc_request_result rpc_port::handle_handshake(windows_emulator& win_emu, const lpc_request_context& c)
     {
         constexpr ULONG rpc_handshake_state_offset = 32;
         constexpr ULONG required_handshake_read_bytes = rpc_handshake_state_offset + sizeof(uint32_t);
-        constexpr ULONG required_handshake_reply_status_bytes = 8 + sizeof(uint32_t);
 
-        if (c.send_buffer_length < required_handshake_read_bytes)
+        if (c.send_buffer_length < required_handshake_read_bytes || c.recv_buffer_length < c.send_buffer_length)
         {
             return STATUS_INVALID_PARAMETER;
         }
 
-        if (c.recv_buffer_length < required_handshake_reply_status_bytes)
-        {
-            return STATUS_BUFFER_TOO_SMALL;
-        }
+        std::vector<uint8_t> payload(c.send_buffer_length, 0);
+        win_emu.emu().read_memory(c.recv_buffer, payload.data(), payload.size());
 
-        win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 8, 0);
+        utils::aligned_binary_writer writer(payload);
+        writer.write_at<uint32_t>(8, 0);
 
         if (win_emu.emu().read_memory<uint32_t>(c.send_buffer + rpc_handshake_state_offset) == 3)
         {
-            if (c.recv_buffer_length < required_handshake_read_bytes)
-            {
-                return STATUS_BUFFER_TOO_SMALL;
-            }
-
-            win_emu.emu().write_memory<uint32_t>(c.recv_buffer + rpc_handshake_state_offset, 2);
+            writer.write_at<uint32_t>(rpc_handshake_state_offset, 2);
         }
 
-        c.recv_buffer_length = c.send_buffer_length;
-
-        return STATUS_SUCCESS;
+        return {STATUS_SUCCESS, std::move(payload)};
     }
 
-    NTSTATUS rpc_port::handle_rpc_call(windows_emulator& win_emu, const lpc_request_context& c)
+    lpc_request_result rpc_port::handle_rpc_call(windows_emulator& win_emu, const lpc_request_context& c)
     {
-        constexpr ULONG rpc_call_header_size = 0x40;
+        constexpr ULONG rpc_call_send_header_size = 0x40;
         constexpr ULONG rpc_call_id_offset = 12;
         constexpr ULONG rpc_call_opnum_offset = 20;
 
-        if (c.send_buffer_length < rpc_call_header_size)
+        if (c.send_buffer_length < rpc_call_send_header_size)
         {
             return STATUS_INVALID_PARAMETER;
-        }
-
-        constexpr auto rpc_header_size = static_cast<ULONG>(sizeof(std::array<uint8_t, 24>));
-        if (c.recv_buffer_length < rpc_header_size)
-        {
-            return STATUS_BUFFER_TOO_SMALL;
         }
 
         const auto call_id = win_emu.emu().read_memory<uint32_t>(c.send_buffer + rpc_call_id_offset);
@@ -179,27 +220,23 @@ namespace sogen
         std::array<uint8_t, 24> header = {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
         std::memcpy(header.data() + 12, &call_id, sizeof(call_id));
-        win_emu.emu().write_memory(c.recv_buffer, header);
 
-        const auto max_payload_length = c.recv_buffer_length - rpc_header_size;
+        std::vector<uint8_t> payload;
+        utils::aligned_binary_writer writer(payload);
+        writer.write(header.data(), header.size());
 
         lpc_request_context rpc_context{};
-        rpc_context.send_buffer = c.send_buffer + rpc_call_header_size;
-        rpc_context.send_buffer_length = c.send_buffer_length - rpc_call_header_size;
+        rpc_context.send_buffer = c.send_buffer + rpc_call_send_header_size;
+        rpc_context.send_buffer_length = c.send_buffer_length - rpc_call_send_header_size;
         rpc_context.recv_buffer = c.recv_buffer + sizeof(header);
-        rpc_context.recv_buffer_length = max_payload_length;
-
-        NTSTATUS status = this->handle_rpc(win_emu, procedure_id, rpc_context);
-        if (rpc_context.recv_buffer_length > max_payload_length)
+        if (c.recv_buffer_length >= header.size())
         {
-            win_emu.log.warn("RPC reply payload too large: %u > %u\n", static_cast<uint32_t>(rpc_context.recv_buffer_length),
-                             static_cast<uint32_t>(max_payload_length));
-            return STATUS_BUFFER_TOO_SMALL;
+            rpc_context.recv_buffer_length = c.recv_buffer_length - static_cast<DWORD>(header.size());
         }
 
-        c.recv_buffer_length = rpc_header_size + rpc_context.recv_buffer_length;
+        const auto status = this->handle_rpc(win_emu, procedure_id, rpc_context, writer);
 
-        return status;
+        return {status, std::move(payload)};
     }
 
 } // namespace sogen

--- a/src/windows-emulator/port.hpp
+++ b/src/windows-emulator/port.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
 #include <arch_emulator.hpp>
 #include <serialization.hpp>
 
@@ -12,6 +16,10 @@ namespace sogen
 
     class windows_emulator;
     struct process_context;
+    namespace utils
+    {
+        class aligned_binary_writer;
+    }
 
     struct lpc_message_context
     {
@@ -50,7 +58,7 @@ namespace sogen
         emulator_pointer send_buffer{};
         ULONG send_buffer_length{};
         emulator_pointer recv_buffer{};
-        mutable ULONG recv_buffer_length{};
+        ULONG recv_buffer_length{};
 
         void serialize(utils::buffer_serializer& buffer) const
         {
@@ -66,6 +74,68 @@ namespace sogen
             buffer.read(send_buffer_length);
             buffer.read(recv_buffer);
             buffer.read(recv_buffer_length);
+        }
+    };
+
+    struct lpc_request_result
+    {
+        struct reply_in_place_t
+        {
+        };
+
+        static constexpr reply_in_place_t reply_in_place{};
+
+        NTSTATUS status{};
+        std::optional<std::vector<uint8_t>> payload{};
+
+        lpc_request_result() = default;
+
+        lpc_request_result(NTSTATUS s)
+            : status{s},
+              payload{std::vector<uint8_t>{}}
+        {
+        }
+
+        lpc_request_result(NTSTATUS s, std::vector<uint8_t>&& p)
+            : status{s},
+              payload{std::move(p)}
+        {
+        }
+
+        lpc_request_result(NTSTATUS s, reply_in_place_t)
+            : status{s}
+        {
+        }
+    };
+
+    struct lpc_message_result
+    {
+        NTSTATUS status{};
+        PORT_MESSAGE64 message{};
+        std::vector<uint8_t> payload{};
+
+        [[nodiscard]] ULONG total_length() const
+        {
+            if (message.u1.s1.TotalLength != 0)
+            {
+                return static_cast<ULONG>(message.u1.s1.TotalLength);
+            }
+
+            return static_cast<ULONG>(sizeof(message) + payload.size());
+        }
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(status);
+            buffer.write(message);
+            buffer.write_vector(payload);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(status);
+            buffer.read(message);
+            buffer.read_vector(payload);
         }
     };
 
@@ -108,20 +178,21 @@ namespace sogen
             view_size = data.view_size;
         }
 
-        NTSTATUS handle_message(windows_emulator& win_emu, const lpc_message_context& c);
+        virtual lpc_message_result handle_message(windows_emulator& win_emu, const lpc_message_context& c);
 
-        virtual NTSTATUS handle_request(windows_emulator& win_emu, const lpc_request_context& c) = 0;
+        virtual lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) = 0;
     };
 
     struct rpc_port : port
     {
-        NTSTATUS handle_request(windows_emulator& win_emu, const lpc_request_context& c) override;
+        lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) override;
 
-        virtual NTSTATUS handle_rpc(windows_emulator& win_emu, uint32_t procedure_id, const lpc_request_context& c) = 0;
+        virtual NTSTATUS handle_rpc(windows_emulator& win_emu, uint32_t procedure_id, const lpc_request_context& c,
+                                    utils::aligned_binary_writer& writer) = 0;
 
       private:
-        static NTSTATUS handle_handshake(windows_emulator& win_emu, const lpc_request_context& c);
-        NTSTATUS handle_rpc_call(windows_emulator& win_emu, const lpc_request_context& c);
+        static lpc_request_result handle_handshake(windows_emulator& win_emu, const lpc_request_context& c);
+        lpc_request_result handle_rpc_call(windows_emulator& win_emu, const lpc_request_context& c);
     };
 
     std::unique_ptr<port> create_port(std::u16string_view port);
@@ -138,23 +209,27 @@ namespace sogen
             this->port_->create(win_emu, data);
         }
 
-        NTSTATUS handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
+        lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
         {
             this->assert_validity();
             return this->port_->handle_request(win_emu, c);
         }
+
+        lpc_message_result handle_message(windows_emulator& win_emu, const lpc_message_context& c) override;
 
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             this->assert_validity();
 
             buffer.write_string(this->port_name_);
+            buffer.write_vector(this->reply_queue_);
             this->port_->serialize(buffer);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read_string(this->port_name_);
+            buffer.read_vector(this->reply_queue_);
             this->setup();
             this->port_->deserialize(buffer);
         }
@@ -177,6 +252,7 @@ namespace sogen
       private:
         std::u16string port_name_{};
         std::unique_ptr<port> port_{};
+        std::vector<lpc_message_result> reply_queue_;
 
         void setup()
         {

--- a/src/windows-emulator/ports/api_port.cpp
+++ b/src/windows-emulator/ports/api_port.cpp
@@ -120,7 +120,7 @@ namespace sogen
                 return true;
             }
 
-            NTSTATUS handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
+            lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
             {
                 wow64_userconnect_payload payload{};
                 if (try_read_wow64_payload(win_emu, c, payload))
@@ -131,7 +131,7 @@ namespace sogen
                         win_emu.log.warn("ApiPort WOW64 userconnect write failed: status=0x%X, ptr=0x%llX, len=0x%llX\n", status,
                                          static_cast<unsigned long long>(payload.user_connect_ptr),
                                          static_cast<unsigned long long>(payload.user_connect_length));
-                        return status;
+                        return {status, lpc_request_result::reply_in_place};
                     }
 
                     if (!win32k_userconnect::try_bootstrap_client_pfn_arrays_from_ntdll(win_emu))
@@ -139,27 +139,27 @@ namespace sogen
                         win_emu.log.warn("ApiPort userconnect callback-table bootstrap failed\n");
                     }
 
-                    return STATUS_SUCCESS;
+                    return {STATUS_SUCCESS, lpc_request_result::reply_in_place};
                 }
 
                 uint32_t server_dll_index{};
                 if (!try_read_reply_server_dll_index(win_emu, c, server_dll_index) ||
                     server_dll_index != win32k_userconnect::k_user_server_dll_index)
                 {
-                    return STATUS_SUCCESS;
+                    return {STATUS_SUCCESS, lpc_request_result::reply_in_place};
                 }
 
                 uint64_t base{};
                 if (!resolve_reply_base(win_emu, c, base))
                 {
                     win_emu.log.warn("ApiPort userconnect reply base resolution failed\n");
-                    return STATUS_INVALID_PARAMETER;
+                    return {STATUS_INVALID_PARAMETER, lpc_request_result::reply_in_place};
                 }
 
                 if (!win32k_userconnect::try_write_api_port_userconnect_reply(win_emu.memory, base, win_emu.process))
                 {
                     win_emu.log.warn("ApiPort userconnect shared info write failed\n");
-                    return STATUS_INVALID_PARAMETER;
+                    return {STATUS_INVALID_PARAMETER, lpc_request_result::reply_in_place};
                 }
 
                 if (!win32k_userconnect::try_bootstrap_client_pfn_arrays_from_ntdll(win_emu))
@@ -167,7 +167,7 @@ namespace sogen
                     win_emu.log.warn("ApiPort userconnect callback-table bootstrap failed\n");
                 }
 
-                return STATUS_SUCCESS;
+                return {STATUS_SUCCESS, lpc_request_result::reply_in_place};
             }
         };
     }

--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -43,13 +43,12 @@ namespace sogen
             std::array<uint8_t, 8> cookie{};
         };
 
-        template <typename Traits>
         struct dns_query_response
         {
             std::optional<resolved_dns_record> record;
             uint64_t error_code{};
 
-            void write(utils::aligned_binary_writer<Traits>& writer) const
+            void write(utils::aligned_binary_writer& writer) const
             {
                 writer.write_ndr_pointer(record.has_value());
                 if (record)
@@ -63,12 +62,12 @@ namespace sogen
                     writer.write(record->reserved);
 
                     writer.write(record->type);
-                    writer.write(record->data.data(), record->data_length, sizeof(typename Traits::PVOID));
+                    writer.write(record->data.data(), record->data_length, writer.pointer_size());
 
                     writer.write_ndr_u16string(record->name);
                 }
 
-                writer.align_to(sizeof(typename Traits::PVOID));
+                writer.align_to(writer.pointer_size());
                 writer.pad(24);
                 writer.write(error_code);
                 writer.pad(64);
@@ -204,10 +203,9 @@ namespace sogen
 
         struct dns_resolver : rpc_port
         {
-            NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c) override
+            NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c,
+                                utils::aligned_binary_writer& writer) override
             {
-                utils::aligned_binary_writer<EmulatorTraits<Emu64>> writer(win_emu.emu(), c.recv_buffer);
-
                 if (procedure_id == 4)
                 {
                     return handle_dns_query(win_emu, c, writer);
@@ -217,9 +215,7 @@ namespace sogen
                 return STATUS_NOT_SUPPORTED;
             }
 
-            template <typename Traits>
-            static NTSTATUS handle_dns_query(windows_emulator& win_emu, const lpc_request_context& c,
-                                             utils::aligned_binary_writer<Traits>& writer)
+            static NTSTATUS handle_dns_query(windows_emulator& win_emu, const lpc_request_context& c, utils::aligned_binary_writer& writer)
             {
                 dns_query_request request{};
                 if (!parse_dns_query_request(win_emu, c, request))
@@ -235,12 +231,11 @@ namespace sogen
                 win_emu.callbacks.on_generic_activity("DNS query: " + u16_to_u8(request.hostname));
                 writer.write(request.cookie);
 
-                dns_query_response<Traits> response{};
+                dns_query_response response{};
                 response.record = resolve_single_host_record(win_emu, request.hostname, request.type);
                 response.error_code = response.record ? ERROR_SUCCESS : DNS_ERROR_RCODE_NAME_ERROR;
                 writer.write(response);
 
-                c.recv_buffer_length = static_cast<ULONG>(writer.offset());
                 return STATUS_SUCCESS;
             }
         };

--- a/src/windows-emulator/ports/lsa_policy_lookup.cpp
+++ b/src/windows-emulator/ports/lsa_policy_lookup.cpp
@@ -21,16 +21,6 @@ namespace sogen
             0xBA, 0xA3, 0xDA, 0x01, 0x6E, 0x16, 0x62, 0x49, 0x81, 0x46, 0x13, 0x9B, 0x8A, 0x70, 0x69, 0xE7,
         };
 
-        void write_bytes(std::vector<uint8_t>& buffer, const size_t offset, const std::span<const uint8_t> bytes)
-        {
-            if (offset + bytes.size() > buffer.size())
-            {
-                buffer.resize(offset + bytes.size(), 0);
-            }
-
-            std::memcpy(buffer.data() + offset, bytes.data(), bytes.size());
-        }
-
         bool request_contains_sid(windows_emulator& win_emu, const lpc_request_context& c, const std::span<const uint8_t> sid)
         {
             if (sid.empty() || c.send_buffer_length < sid.size())
@@ -81,54 +71,51 @@ namespace sogen
             return domain_sid;
         }
 
-        template <typename Traits>
-        void write_lsa_unicode_string(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view value)
+        void write_lsa_unicode_string(utils::aligned_binary_writer& writer, const std::u16string_view value)
         {
             writer.write(static_cast<uint16_t>(value.size() * sizeof(char16_t)));
             writer.write(static_cast<uint16_t>((value.size() + 1) * sizeof(char16_t)));
             writer.write_ndr_pointer(true);
         }
 
-        template <typename Traits>
-        void write_lsa_translated_name(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view value)
+        void write_lsa_translated_name(utils::aligned_binary_writer& writer, const std::u16string_view value)
         {
             writer.write(k_sid_type_user);
-            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.align_to(writer.pointer_size());
             write_lsa_unicode_string(writer, value);
-            writer.template write<int32_t>(0);
-            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.write<int32_t>(0);
+            writer.align_to(writer.pointer_size());
         }
 
-        template <typename Traits>
-        void write_lookup_sids_success_reply(utils::aligned_binary_writer<Traits>& writer, const std::u16string_view domain,
+        void write_lookup_sids_success_reply(utils::aligned_binary_writer& writer, const std::u16string_view domain,
                                              const std::span<const uint8_t> domain_sid, const std::u16string_view user)
         {
             writer.write_ndr_pointer(true);
 
-            writer.template write<uint32_t>(1);
+            writer.write<uint32_t>(1);
             writer.write_ndr_pointer(true);
             writer.write(k_lsa_max_referenced_domains);
 
-            writer.template write<typename Traits::SIZE_T>(1);
+            writer.write_pointer_sized(1);
             write_lsa_unicode_string(writer, domain);
             writer.write_ndr_pointer(true);
 
             writer.write_ndr_u16string(domain, false);
-            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.align_to(writer.pointer_size());
 
             writer.write(static_cast<uint32_t>(domain_sid.empty() ? 0 : domain_sid[1]));
-            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.align_to(writer.pointer_size());
             writer.write(domain_sid.data(), domain_sid.size(), alignof(uint32_t));
-            writer.align_to(sizeof(typename Traits::PVOID));
+            writer.align_to(writer.pointer_size());
 
-            writer.template write<uint32_t>(1);
+            writer.write<uint32_t>(1);
             writer.write_ndr_pointer(true);
-            writer.template write<typename Traits::SIZE_T>(1);
+            writer.write_pointer_sized(1);
 
             write_lsa_translated_name(writer, user);
             writer.write_ndr_u16string(user, false);
 
-            writer.template write<uint32_t>(1);
+            writer.write<uint32_t>(1);
             writer.write(STATUS_SUCCESS);
 
             if (writer.offset() < k_lookup_sids_min_success_reply_size)
@@ -139,16 +126,17 @@ namespace sogen
 
         struct lsa_policy_lookup_port : rpc_port
         {
-            NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c) override
+            NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c,
+                                utils::aligned_binary_writer& writer) override
             {
                 switch (procedure_id)
                 {
                 case 0:
-                    return handle_open_policy(win_emu, c);
+                    return handle_open_policy(win_emu, writer);
                 case 1:
-                    return handle_close_policy(win_emu, c);
+                    return handle_close_policy(win_emu, writer);
                 case 2:
-                    return handle_lookup_sids(win_emu, c);
+                    return handle_lookup_sids(win_emu, c, writer);
                 default:
                     // win_emu.log.warn("Unsupported lsapolicylookup procedure: %u\n", procedure_id);
                     return STATUS_NOT_SUPPORTED;
@@ -156,18 +144,18 @@ namespace sogen
             }
 
           private:
-            static NTSTATUS handle_open_policy(windows_emulator& win_emu, const lpc_request_context& c)
+            static NTSTATUS handle_open_policy(windows_emulator& win_emu, utils::aligned_binary_writer& writer)
             {
-                std::vector<uint8_t> reply(k_open_policy_reply_size, 0);
-                write_bytes(reply, 0x04, k_policy_context_uuid);
+                (void)win_emu;
+                const auto reply_offset = writer.offset();
+                writer.pad(k_open_policy_reply_size);
+                writer.write_at(reply_offset + 0x04, k_policy_context_uuid.data(), k_policy_context_uuid.size());
 
-                win_emu.emu().write_memory(c.recv_buffer, reply.data(), reply.size());
-
-                c.recv_buffer_length = static_cast<ULONG>(reply.size());
                 return STATUS_SUCCESS;
             }
 
-            static NTSTATUS handle_lookup_sids(windows_emulator& win_emu, const lpc_request_context& c)
+            static NTSTATUS handle_lookup_sids(windows_emulator& win_emu, const lpc_request_context& c,
+                                               utils::aligned_binary_writer& writer)
             {
                 if (request_contains_sid(win_emu, c, win_emu.process.sid))
                 {
@@ -175,31 +163,21 @@ namespace sogen
                     const auto domain_sid = derive_account_domain_sid(win_emu.process.sid);
                     const auto user = registry_utils::get_user_name(win_emu.registry);
 
-                    utils::aligned_binary_writer<EmulatorTraits<Emu64>> writer(win_emu.emu(), c.recv_buffer);
                     write_lookup_sids_success_reply(writer, domain, domain_sid, user);
 
-                    c.recv_buffer_length = static_cast<ULONG>(writer.offset());
                     return STATUS_SUCCESS;
                 }
 
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x00, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x04, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x08, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x0C, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x10, 0);
-                win_emu.emu().write_memory<uint32_t>(c.recv_buffer + 0x14, k_status_none_mapped);
-
-                c.recv_buffer_length = k_lookup_sids_not_mapped_reply_size;
+                const auto reply_offset = writer.offset();
+                writer.pad(k_lookup_sids_not_mapped_reply_size);
+                writer.write_at(reply_offset + 0x14, k_status_none_mapped);
                 return STATUS_SUCCESS;
             }
 
-            static NTSTATUS handle_close_policy(windows_emulator& win_emu, const lpc_request_context& c)
+            static NTSTATUS handle_close_policy(windows_emulator& win_emu, utils::aligned_binary_writer& writer)
             {
-                const std::vector<uint8_t> reply(k_close_policy_reply_size, 0);
-
-                win_emu.emu().write_memory(c.recv_buffer, reply.data(), reply.size());
-
-                c.recv_buffer_length = static_cast<ULONG>(reply.size());
+                (void)win_emu;
+                writer.pad(k_close_policy_reply_size);
                 return STATUS_SUCCESS;
             }
         };

--- a/src/windows-emulator/syscalls/port.cpp
+++ b/src/windows-emulator/syscalls/port.cpp
@@ -121,14 +121,31 @@ namespace sogen
             context.receive_message = receive_message;
             context.receive_buffer_length = buffer_length ? buffer_length.read() : 0;
 
-            const auto status = port->handle_message(c.win_emu, context);
+            const auto result = port->handle_message(c.win_emu, context);
+
+            if (receive_message && NT_SUCCESS(result.status))
+            {
+                if (context.receive_buffer_length < result.total_length())
+                {
+                    // The port handler should always queue messages that are too large to be written,
+                    // so if we still got a message that doesn't fit in the receive buffer, something
+                    // has gone wrong.
+                    throw std::runtime_error("Unexpected success result returned by port handler");
+                }
+
+                receive_message.write(result.message);
+                if (!result.payload.empty())
+                {
+                    c.emu.write_memory(receive_message.value() + sizeof(PORT_MESSAGE64), result.payload.data(), result.payload.size());
+                }
+            }
 
             if (receive_message && buffer_length)
             {
-                buffer_length.write(static_cast<typename EmulatorTraits<Emu64>::SIZE_T>(receive_message.read().u1.s1.TotalLength));
+                buffer_length.write(static_cast<typename EmulatorTraits<Emu64>::SIZE_T>(result.total_length()));
             }
 
-            return status;
+            return result.status;
         }
 
         NTSTATUS handle_NtAlpcQueryInformation()


### PR DESCRIPTION
This PR improves the (A)LPC ports by refactoring `aligned_binary_writer` into a regular class that can write either to a vector or to guest memory, and by making all ports either use the receive buffer in place or return a payload that can be queued when the supplied receive buffer is too small, allowing the client to retrieve the reply later.