### PR TITLE
Fix window message callbacks and WoW64 fixes

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -126,10 +126,10 @@ namespace sogen
         uint8_t rgbReserved[32];
     };
 
+#define EMU_HWND_MESSAGE ((hwnd) - 3)
+
 #ifndef OS_WINDOWS
 #define MAXINTATOM           0xC000
-
-#define HWND_MESSAGE         ((hwnd) - 3)
 
 #define WS_POPUP             0x80000000L
 #define WS_CHILD             0x40000000L

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1490,9 +1490,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_file_locking, "File Locking")
     RUN_TEST(test_dir_io, "Dir I/O")
     RUN_TEST(test_apis, "APIs")
-#ifdef _WIN64
     RUN_TEST(test_working_directory, "Working Directory")
-#endif
     RUN_TEST(test_registry, "Registry")
     RUN_TEST(test_system_info, "System Info")
     RUN_TEST(test_monitor_info, "Monitor Info")
@@ -1507,19 +1505,15 @@ int main(const int argc, const char* argv[])
 #ifndef __MINGW64__
     RUN_TEST(test_native_exceptions, "Native Exceptions")
 #endif
-#ifdef _WIN64
     if (!getenv("EMULATOR_ICICLE"))
     {
         RUN_TEST(test_interrupts, "Interrupts")
     }
-#endif
     RUN_TEST(test_tls, "TLS")
     RUN_TEST(test_socket, "Socket")
     RUN_TEST(test_apc, "APC")
     RUN_TEST(test_user_callback, "User Callback")
-#ifdef _WIN64
     RUN_TEST(test_message_queue, "Message Queue")
-#endif
     RUN_TEST(test_private_namespace, "Private Namespace")
     RUN_TEST(test_actctx, "Activation Context")
     RUN_TEST(test_mmio, "MMIO")

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1490,7 +1490,9 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_file_locking, "File Locking")
     RUN_TEST(test_dir_io, "Dir I/O")
     RUN_TEST(test_apis, "APIs")
+#ifdef _WIN64
     RUN_TEST(test_working_directory, "Working Directory")
+#endif
     RUN_TEST(test_registry, "Registry")
     RUN_TEST(test_system_info, "System Info")
     RUN_TEST(test_monitor_info, "Monitor Info")

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -819,9 +819,17 @@ namespace sogen
         }
 
         this->rip = emu.reg(x86_register::rip);
+        this->rbp = emu.reg(x86_register::rbp);
+        this->rdi = emu.reg(x86_register::rdi);
         this->rsi = emu.reg(x86_register::rsi);
         this->rsp = emu.reg(x86_register::rsp);
         this->r10 = emu.reg(x86_register::r10);
+        this->r11 = emu.reg(x86_register::r11);
+        this->r12 = emu.reg(x86_register::r12);
+        this->r13 = emu.reg(x86_register::r13);
+        this->r14 = emu.reg(x86_register::r14);
+        this->r15 = emu.reg(x86_register::r15);
+        this->rax = emu.reg(x86_register::rax);
         this->rbx = emu.reg(x86_register::rbx);
         this->rcx = emu.reg(x86_register::rcx);
         this->rdx = emu.reg(x86_register::rdx);
@@ -849,9 +857,17 @@ namespace sogen
         emu.reg<uint16_t>(x86_register::fs, this->fs);
         emu.reg<uint16_t>(x86_register::gs, this->gs);
         emu.reg(x86_register::rip, this->rip);
+        emu.reg(x86_register::rbp, this->rbp);
+        emu.reg(x86_register::rdi, this->rdi);
         emu.reg(x86_register::rsi, this->rsi);
         emu.reg(x86_register::rsp, this->rsp);
         emu.reg(x86_register::r10, this->r10);
+        emu.reg(x86_register::r11, this->r11);
+        emu.reg(x86_register::r12, this->r12);
+        emu.reg(x86_register::r13, this->r13);
+        emu.reg(x86_register::r14, this->r14);
+        emu.reg(x86_register::r15, this->r15);
+        emu.reg(x86_register::rax, this->rax);
         emu.reg(x86_register::rbx, this->rbx);
         emu.reg(x86_register::rcx, this->rcx);
         emu.reg(x86_register::rdx, this->rdx);
@@ -863,9 +879,17 @@ namespace sogen
     {
         buffer.write(this->handler_id);
         buffer.write(this->rip);
+        buffer.write(this->rbp);
+        buffer.write(this->rdi);
         buffer.write(this->rsi);
         buffer.write(this->rsp);
         buffer.write(this->r10);
+        buffer.write(this->r11);
+        buffer.write(this->r12);
+        buffer.write(this->r13);
+        buffer.write(this->r14);
+        buffer.write(this->r15);
+        buffer.write(this->rax);
         buffer.write(this->rbx);
         buffer.write(this->rcx);
         buffer.write(this->rdx);
@@ -889,9 +913,17 @@ namespace sogen
     {
         buffer.read(this->handler_id);
         buffer.read(this->rip);
+        buffer.read(this->rbp);
+        buffer.read(this->rdi);
         buffer.read(this->rsi);
         buffer.read(this->rsp);
         buffer.read(this->r10);
+        buffer.read(this->r11);
+        buffer.read(this->r12);
+        buffer.read(this->r13);
+        buffer.read(this->r14);
+        buffer.read(this->r15);
+        buffer.read(this->rax);
         buffer.read(this->rbx);
         buffer.read(this->rcx);
         buffer.read(this->rdx);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -137,9 +137,17 @@ namespace sogen
     {
         callback_id handler_id{};
         uint64_t rip{};
+        uint64_t rbp{};
+        uint64_t rdi{};
         uint64_t rsi{};
         uint64_t rsp{};
         uint64_t r10{};
+        uint64_t r11{};
+        uint64_t r12{};
+        uint64_t r13{};
+        uint64_t r14{};
+        uint64_t r15{};
+        uint64_t rax{};
         uint64_t rbx{};
         uint64_t rcx{};
         uint64_t rdx{};

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -323,7 +323,14 @@ namespace sogen
             for (const auto& arg : app_settings.arguments)
             {
                 command_line.push_back(u' ');
-                command_line.append(arg);
+                if (arg.find(' ') != std::string::npos)
+                {
+                    command_line.append(u"\"" + arg + u"\"");
+                }
+                else
+                {
+                    command_line.append(arg);
+                }
             }
 
             allocator.make_unicode_string(proc_params.CommandLine, command_line);

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -124,6 +124,11 @@ namespace sogen
                                                                 c.PriorityClass = 32; // Normal
                                                             });
 
+            case ProcessWow64Information:
+                return handle_query<EmulatorTraits<Emu64>::ULONG_PTR>(
+                    c.emu, process_information, process_information_length, return_length,
+                    [&](EmulatorTraits<Emu64>::ULONG_PTR& peb32) { peb32 = c.proc.peb32 ? c.proc.peb32->value() : 0; });
+
             case ProcessBasicInformation: {
                 const auto init_basic_info = [&](PROCESS_BASIC_INFORMATION64& basic_info) {
                     basic_info.PebBaseAddress = c.proc.peb64.value();

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -47,7 +47,59 @@ namespace sogen
                 // Update the persistent context for future queries
                 thread->wow64_cpu_reserved->access([&](WOW64_CPURESERVED& ctx) {
                     ctx.Flags |= WOW64_CPURESERVED_FLAG_RESET_STATE;
-                    ctx.Context = new_wow64_context;
+                    auto merged_context = ctx.Context;
+                    merged_context.ContextFlags = new_wow64_context.ContextFlags;
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_DEBUG_REGISTERS_32) == CONTEXT_DEBUG_REGISTERS_32)
+                    {
+                        merged_context.Dr0 = new_wow64_context.Dr0;
+                        merged_context.Dr1 = new_wow64_context.Dr1;
+                        merged_context.Dr2 = new_wow64_context.Dr2;
+                        merged_context.Dr3 = new_wow64_context.Dr3;
+                        merged_context.Dr6 = new_wow64_context.Dr6;
+                        merged_context.Dr7 = new_wow64_context.Dr7;
+                    }
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_FLOATING_POINT_32) == CONTEXT_FLOATING_POINT_32)
+                    {
+                        merged_context.FloatSave = new_wow64_context.FloatSave;
+                    }
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_SEGMENTS_32) == CONTEXT_SEGMENTS_32)
+                    {
+                        merged_context.SegGs = new_wow64_context.SegGs;
+                        merged_context.SegFs = new_wow64_context.SegFs;
+                        merged_context.SegEs = new_wow64_context.SegEs;
+                        merged_context.SegDs = new_wow64_context.SegDs;
+                    }
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_INTEGER_32) == CONTEXT_INTEGER_32)
+                    {
+                        merged_context.Edi = new_wow64_context.Edi;
+                        merged_context.Esi = new_wow64_context.Esi;
+                        merged_context.Ebx = new_wow64_context.Ebx;
+                        merged_context.Edx = new_wow64_context.Edx;
+                        merged_context.Ecx = new_wow64_context.Ecx;
+                        merged_context.Eax = new_wow64_context.Eax;
+                    }
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_CONTROL_32) == CONTEXT_CONTROL_32)
+                    {
+                        merged_context.Ebp = new_wow64_context.Ebp;
+                        merged_context.Eip = new_wow64_context.Eip;
+                        merged_context.SegCs = new_wow64_context.SegCs;
+                        merged_context.EFlags = new_wow64_context.EFlags;
+                        merged_context.Esp = new_wow64_context.Esp;
+                        merged_context.SegSs = new_wow64_context.SegSs;
+                    }
+
+                    if ((new_wow64_context.ContextFlags & CONTEXT_EXTENDED_REGISTERS_32) == CONTEXT_EXTENDED_REGISTERS_32)
+                    {
+                        memcpy(merged_context.ExtendedRegisters, new_wow64_context.ExtendedRegisters,
+                               sizeof(merged_context.ExtendedRegisters));
+                    }
+
+                    ctx.Context = merged_context;
                     // c.win_emu.callbacks.on_suspicious_activity("WOW64 CONTEXT");
                 });
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -563,7 +563,8 @@ namespace sogen
                 args.msg = message;
                 args.wParam = w_param;
                 args.lParam = l_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
                 if (l_param != 0)
                 {
                     c.emu.read_memory(l_param, &args.cs, sizeof(args.cs));
@@ -578,7 +579,8 @@ namespace sogen
                 args.pwnd = win.guest.value();
                 args.msg = message;
                 args.wParam = w_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
                 if (l_param != 0)
                 {
                     c.emu.read_memory(l_param, &args.wp, sizeof(args.wp));
@@ -594,7 +596,8 @@ namespace sogen
                 args.pwnd = win.guest.value();
                 args.msg = message;
                 args.wParam = w_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
                 if (l_param != 0)
                 {
                     if (message == WM_WINDOWPOSCHANGING)
@@ -616,7 +619,8 @@ namespace sogen
                 args.pwnd = win.guest.value();
                 args.msg = message;
                 args.wParam = w_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
                 if (l_param != 0)
                 {
                     if (w_param == FALSE)
@@ -643,7 +647,8 @@ namespace sogen
                 args.msg = message;
                 args.wParam = w_param;
                 args.lParam = l_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
 
                 dispatch_user_callback(c, id, k_fn_nc_destroy_callback_id, std::forward<T>(state), args);
                 return;
@@ -655,7 +660,8 @@ namespace sogen
                 args.msg = message;
                 args.wParam = w_param;
                 args.lParam = l_param;
-                args.xpfnProc = win.wnd_proc;
+                args.xParam = win.wnd_proc;
+                args.xpfnProc = c.proc.dispatch_client_message;
 
                 dispatch_user_callback(c, id, k_fn_dword_callback_id, std::forward<T>(state), args);
                 return;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1327,7 +1327,7 @@ namespace sogen
                 return 0;
             }
 
-            const bool is_message_only = parent == reinterpret_cast<pointer>(HWND_MESSAGE);
+            const bool is_message_only = parent == EMU_HWND_MESSAGE;
             const bool has_child_parent = (style & WS_CHILD) != 0 && (style & WS_POPUP) == 0;
             const bool has_owner = parent != 0 && !is_message_only && !has_child_parent;
 


### PR DESCRIPTION
This PR includes the following changes:

* Fixes the window message callbacks, which were set up slightly incorrectly.
* Fixes some WoW64 crashes by restoring additional registers, improving the implementation of the `ThreadWow64Context` set-information class, and implementing the `ProcessWow64Information` information class.
* Fixes argument building to correctly quote arguments that contain spaces.
* Enables the ~~Working Directory,~~ Interrupts, and Message Queue tests for x86, since they appear to be working in the current repo state.