### PR TITLE
Properly add child/sibling links and window destruction

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -198,9 +198,10 @@ namespace sogen
         uint16_t fnid;
         uint8_t pad_02C[4];
         uint64_t spwndParent;
-        uint8_t pad_038[8];
+        uint64_t spwndChild;
         uint64_t spwndOwner;
-        RECT rcUnknown_048;
+        uint64_t spwndNext;
+        uint64_t spwndPrev;
         RECT rcWindow;
         RECT rcClient;
         uint64_t lpfnWndProc;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -542,8 +542,7 @@ namespace sogen
             window.hWnd = wh.bits;
             window.ptrBase = desktop_win.guest.value();
             window.dwStyle = desktop_win.style;
-            window.rcUnknown_048 = {.left = 0, .top = 0, .right = desktop_win.width, .bottom = desktop_win.height};
-            window.rcWindow = window.rcUnknown_048;
+            window.rcWindow = {.left = 0, .top = 0, .right = desktop_win.width, .bottom = desktop_win.height};
             window.rcClient = window.rcWindow;
             window.fnid = 0x29D;   // FNID_DESKTOP
             window.windowBand = 1; // ZBID_DESKTOP

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -78,22 +78,51 @@ namespace sogen
         }
     };
 
-    struct window_destroy_state : completion_state
+    enum class window_destroy_phase : uint8_t
     {
+        messages,
+        children,
+        nc_destroy,
+        finalize
+    };
+
+    struct window_destroy_frame
+    {
+        hwnd handle{};
         emulator_stack_allocation window_pos_alloc{};
         std::vector<qmsg> message_queue{};
+        window_destroy_phase phase{window_destroy_phase::messages};
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(this->handle);
+            buffer.write(this->window_pos_alloc);
+            buffer.write_vector(this->message_queue);
+            buffer.write(this->phase);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(this->handle);
+            buffer.read(this->window_pos_alloc);
+            buffer.read_vector(this->message_queue);
+            buffer.read(this->phase);
+        }
+    };
+
+    struct window_destroy_state : completion_state
+    {
+        std::vector<window_destroy_frame> frames{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
-            buffer.write(this->window_pos_alloc);
-            buffer.write_vector(this->message_queue);
+            buffer.write_vector(this->frames);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
-            buffer.read(this->window_pos_alloc);
-            buffer.read_vector(this->message_queue);
+            buffer.read_vector(this->frames);
         }
     };
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2,6 +2,7 @@
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../win32k_userconnect.hpp"
+#include "../window_destroy_orchestrator.hpp"
 #include "windows-emulator/user_callback_dispatch.hpp"
 #include <limits>
 
@@ -311,7 +312,6 @@ namespace sogen
             const auto window_rect = get_window_rect(win);
 
             win.guest.access([&](USER_WINDOW& guest_win) {
-                guest_win.rcUnknown_048 = window_rect;
                 guest_win.rcWindow = window_rect;
                 guest_win.rcClient = window_rect;
             });
@@ -676,6 +676,26 @@ namespace sogen
             message_queue.pop_back();
 
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
+        }
+
+        BOOL advance_window_destroy(const syscall_context& c, window_destroy_state& state)
+        {
+            window_destroy_orchestrator orchestrator{state};
+            const auto step = orchestrator.advance(c);
+            if (!step)
+            {
+                return TRUE;
+            }
+
+            auto* win = c.proc.windows.get(step->handle);
+            if (!win)
+            {
+                return advance_window_destroy(c, state);
+            }
+
+            dispatch_window_message(c, callback_id::NtUserDestroyWindow, std::move(state), *win, step->message.message,
+                                    step->message.wParam, step->message.lParam);
+            return {};
         }
 
         uint64_t ensure_win32_thread_info(const syscall_context& c)
@@ -1404,8 +1424,7 @@ namespace sogen
                 guest_win.ptrBase = win.guest.value();
                 guest_win.dwExStyle = ex_style;
                 guest_win.dwStyle = style;
-                guest_win.rcUnknown_048 = {.left = x, .top = y, .right = x + width, .bottom = y + height};
-                guest_win.rcWindow = guest_win.rcUnknown_048;
+                guest_win.rcWindow = {.left = x, .top = y, .right = x + width, .bottom = y + height};
                 guest_win.rcClient = guest_win.rcWindow;
                 if (parent_win && has_child_parent)
                 {
@@ -1437,32 +1456,49 @@ namespace sogen
 
             if (has_child_parent && parent_win && parent_win->guest.value() != 0)
             {
-                constexpr uint64_t k_spwnd_child_offset = 0x38;
-                constexpr uint64_t k_spwnd_next_offset = 0x48;
-                constexpr uint64_t k_null_ptr = 0;
-
-                c.win_emu.memory.write_memory(win.guest.value() + k_spwnd_next_offset, &k_null_ptr, sizeof(k_null_ptr));
-
+                const auto child_ptr = win.guest.value();
                 uint64_t first_child = 0;
-                c.win_emu.memory.try_read_memory(parent_win->guest.value() + k_spwnd_child_offset, &first_child, sizeof(first_child));
-                if (first_child == 0)
-                {
-                    const auto child_ptr = win.guest.value();
-                    c.win_emu.memory.write_memory(parent_win->guest.value() + k_spwnd_child_offset, &child_ptr, sizeof(child_ptr));
-                }
-                else
+
+                parent_win->guest.access([&](USER_WINDOW& parent_guest) {
+                    first_child = parent_guest.spwndChild;
+
+                    if (first_child == 0)
+                    {
+                        parent_guest.spwndChild = child_ptr;
+                    }
+                });
+
+                if (first_child != 0)
                 {
                     uint64_t current = first_child;
-                    uint64_t next = 0;
-                    while (current != 0)
+
+                    // Guard against corrupted/cyclic child chains.
+                    for (size_t guard = 0; current != 0 && guard < c.proc.windows.size(); ++guard)
                     {
-                        c.win_emu.memory.try_read_memory(current + k_spwnd_next_offset, &next, sizeof(next));
-                        if (next == 0)
+                        uint64_t next = 0;
+                        bool appended = false;
+
+                        emulator_object<USER_WINDOW> current_win_obj{c.emu, current};
+                        current_win_obj.access([&](USER_WINDOW& current_guest) {
+                            next = current_guest.spwndNext;
+
+                            if (next == 0)
+                            {
+                                current_guest.spwndNext = child_ptr;
+                                appended = true;
+                            }
+                        });
+
+                        if (appended)
                         {
-                            const auto child_ptr = win.guest.value();
-                            c.win_emu.memory.write_memory(current + k_spwnd_next_offset, &child_ptr, sizeof(child_ptr));
+                            win.guest.access([&](USER_WINDOW& guest_win) {
+                                guest_win.spwndPrev = current;
+                                guest_win.spwndNext = 0;
+                            });
+
                             break;
                         }
+
                         current = next;
                     }
                 }
@@ -1623,61 +1659,14 @@ namespace sogen
             }
 
             window_destroy_state state{};
-
-            if ((win->style & WS_VISIBLE) != 0)
-            {
-                EMU_WINDOWPOS wp{};
-                wp.hwnd = window;
-                wp.hwndInsertAfter = 0;
-                wp.x = win->x;
-                wp.y = win->y;
-                wp.cx = win->width;
-                wp.cy = win->height;
-                wp.flags = SWP_HIDEWINDOW;
-                state.window_pos_alloc = c.emu.push_stack(wp);
-
-                state.message_queue = {
-                    {.message = WM_NCDESTROY, .wParam = 0, .lParam = 0},
-                    {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
-                    {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
-                    {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
-                    {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
-                    {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
-                };
-            }
-            else
-            {
-                state.message_queue = {
-                    {.message = WM_NCDESTROY, .wParam = 0, .lParam = 0},
-                    {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
-                    {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
-                };
-            }
-
-            dispatch_next_message(c, callback_id::NtUserDestroyWindow, std::move(state), *win, state.message_queue);
-            return {};
+            window_destroy_orchestrator{state}.start(c, *win);
+            return advance_window_destroy(c, state);
         }
 
-        BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd window)
+        BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd /*window*/)
         {
             auto& s = c.get_completion_state<window_destroy_state>();
-            auto* win = c.proc.windows.get(window);
-
-            if (!s.message_queue.empty())
-            {
-                dispatch_next_message(c, callback_id::NtUserDestroyWindow, std::move(s), *win, s.message_queue);
-                return {};
-            }
-
-            if (s.window_pos_alloc.address != 0)
-            {
-                c.emu.pop_stack(std::move(s.window_pos_alloc));
-            }
-
-            c.win_emu.ui().destroy_window(window);
-            return c.proc.windows.erase(window);
+            return advance_window_destroy(c, s);
         }
 
         BOOL handle_NtUserSetProp(const syscall_context& c, const hwnd window, const uint16_t atom, const uint64_t data)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -680,8 +680,8 @@ namespace sogen
 
         BOOL advance_window_destroy(const syscall_context& c, window_destroy_state& state)
         {
-            window_destroy_orchestrator orchestrator{state};
-            const auto step = orchestrator.advance(c);
+            window_destroy_orchestrator orchestrator{state, c};
+            const auto step = orchestrator.advance();
             if (!step)
             {
                 return TRUE;
@@ -1659,7 +1659,7 @@ namespace sogen
             }
 
             window_destroy_state state{};
-            window_destroy_orchestrator{state}.start(c, *win);
+            window_destroy_orchestrator{state, c}.start(*win);
             return advance_window_destroy(c, state);
         }
 

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -91,7 +91,7 @@ namespace sogen
         return 0;
     }
 
-    void window_destroy_orchestrator::unlink_window_from_parent_and_siblings(window& win) const
+    void window_destroy_orchestrator::unlink_window_from_parent_and_siblings(const window& win) const
     {
         uint64_t parent = 0;
         uint64_t prev = 0;
@@ -176,7 +176,7 @@ namespace sogen
         return frame;
     }
 
-    void window_destroy_orchestrator::push_frame(window& win) const
+    void window_destroy_orchestrator::push_frame(const window& win) const
     {
         this->unlink_window_from_parent_and_siblings(win);
         this->state_.frames.push_back(this->make_frame(win));
@@ -231,7 +231,7 @@ namespace sogen
         return dependents;
     }
 
-    void window_destroy_orchestrator::finalize_frame(window_destroy_frame& frame, window& win) const
+    void window_destroy_orchestrator::finalize_frame(window_destroy_frame& frame, const window& win) const
     {
         this->pop_frame_allocation(frame);
 

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -1,0 +1,248 @@
+#include "std_include.hpp"
+#include "window_destroy_orchestrator.hpp"
+
+#include "syscall_utils.hpp"
+
+namespace sogen
+{
+
+    window_destroy_orchestrator::window_destroy_orchestrator(window_destroy_state& state)
+        : state_(state)
+    {
+    }
+
+    void window_destroy_orchestrator::start(const syscall_context& c, window& root)
+    {
+        this->push_frame(c, root);
+    }
+
+    std::optional<window_destroy_step> window_destroy_orchestrator::advance(const syscall_context& c)
+    {
+        while (!this->state_.frames.empty())
+        {
+            auto& frame = this->state_.frames.back();
+            auto* win = c.proc.windows.get(frame.handle);
+            if (!win || win->thread_id != c.proc.active_thread->id)
+            {
+                this->pop_frame_allocation(c, frame);
+                this->state_.frames.pop_back();
+                continue;
+            }
+
+            if (!frame.message_queue.empty())
+            {
+                const auto m = frame.message_queue.back();
+                frame.message_queue.pop_back();
+                return window_destroy_step{.handle = frame.handle, .message = m};
+            }
+
+            switch (frame.phase)
+            {
+            case window_destroy_phase::messages:
+                frame.phase = window_destroy_phase::children;
+                continue;
+
+            case window_destroy_phase::children: {
+                const auto dependents = this->collect_dependents(c, *win);
+                frame.phase = window_destroy_phase::nc_destroy;
+
+                for (const auto dependent : std::ranges::reverse_view(dependents))
+                {
+                    if (auto* dependent_win = c.proc.windows.get(dependent))
+                    {
+                        this->push_frame(c, *dependent_win);
+                    }
+                }
+                continue;
+            }
+
+            case window_destroy_phase::nc_destroy:
+                frame.phase = window_destroy_phase::finalize;
+                frame.message_queue = {{.message = WM_NCDESTROY, .wParam = 0, .lParam = 0}};
+                continue;
+
+            case window_destroy_phase::finalize:
+                this->finalize_frame(c, frame, *win);
+                this->state_.frames.pop_back();
+                continue;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    hwnd window_destroy_orchestrator::find_window_by_guest_pointer(const process_context& proc, const uint64_t window_ptr) const
+    {
+        if (window_ptr == 0)
+        {
+            return 0;
+        }
+
+        for (const auto& [_, win] : proc.windows)
+        {
+            if (win.guest.value() == window_ptr)
+            {
+                return win.handle;
+            }
+        }
+
+        return 0;
+    }
+
+    void window_destroy_orchestrator::unlink_window_from_parent_and_siblings(const syscall_context& c, window& win) const
+    {
+        uint64_t parent = 0;
+        uint64_t prev = 0;
+        uint64_t next = 0;
+        win.guest.access([&](USER_WINDOW& guest_win) {
+            parent = guest_win.spwndParent;
+            prev = guest_win.spwndPrev;
+            next = guest_win.spwndNext;
+        });
+
+        const auto win_ptr = win.guest.value();
+
+        if (parent != 0)
+        {
+            emulator_object<USER_WINDOW> parent_obj{c.emu, parent};
+            parent_obj.access([&](USER_WINDOW& parent_guest) {
+                if (parent_guest.spwndChild == win_ptr)
+                {
+                    parent_guest.spwndChild = next;
+                }
+            });
+        }
+
+        if (prev != 0)
+        {
+            emulator_object<USER_WINDOW> prev_obj{c.emu, prev};
+            prev_obj.access([&](USER_WINDOW& prev_guest) {
+                if (prev_guest.spwndNext == win_ptr)
+                {
+                    prev_guest.spwndNext = next;
+                }
+            });
+        }
+
+        if (next != 0)
+        {
+            emulator_object<USER_WINDOW> next_obj{c.emu, next};
+            next_obj.access([&](USER_WINDOW& next_guest) {
+                if (next_guest.spwndPrev == win_ptr)
+                {
+                    next_guest.spwndPrev = prev;
+                }
+            });
+        }
+    }
+
+    window_destroy_frame window_destroy_orchestrator::make_frame(const syscall_context& c, const window& win) const
+    {
+        window_destroy_frame frame{};
+        frame.handle = win.handle;
+
+        if ((win.style & WS_VISIBLE) != 0)
+        {
+            EMU_WINDOWPOS wp{};
+            wp.hwnd = win.handle;
+            wp.hwndInsertAfter = 0;
+            wp.x = win.x;
+            wp.y = win.y;
+            wp.cx = win.width;
+            wp.cy = win.height;
+            wp.flags = SWP_HIDEWINDOW;
+            frame.window_pos_alloc = c.emu.push_stack(wp);
+
+            frame.message_queue = {
+                {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
+                {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
+                {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
+                {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
+                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.window_pos_alloc.address},
+                {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = frame.window_pos_alloc.address},
+                {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
+            };
+        }
+        else
+        {
+            frame.message_queue = {
+                {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
+                {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
+            };
+        }
+
+        return frame;
+    }
+
+    void window_destroy_orchestrator::push_frame(const syscall_context& c, window& win)
+    {
+        this->unlink_window_from_parent_and_siblings(c, win);
+        this->state_.frames.push_back(this->make_frame(c, win));
+    }
+
+    void window_destroy_orchestrator::pop_frame_allocation(const syscall_context& c, window_destroy_frame& frame) const
+    {
+        if (frame.window_pos_alloc.address != 0)
+        {
+            c.emu.pop_stack(std::move(frame.window_pos_alloc));
+        }
+    }
+
+    std::vector<hwnd> window_destroy_orchestrator::collect_dependents(const syscall_context& c, const window& win) const
+    {
+        std::vector<hwnd> dependents{};
+
+        auto add_dependent = [&](const hwnd dependent) {
+            if (dependent == 0 || dependent == win.handle || std::ranges::find(dependents, dependent) != dependents.end())
+            {
+                return;
+            }
+
+            const auto* dependent_win = c.proc.windows.get(dependent);
+            if (!dependent_win || dependent_win->thread_id != win.thread_id)
+            {
+                return;
+            }
+
+            dependents.push_back(dependent);
+        };
+
+        uint64_t child = 0;
+        win.guest.access([&](const USER_WINDOW& guest_win) { child = guest_win.spwndChild; });
+
+        for (size_t guard = 0; child != 0 && guard < c.proc.windows.size(); ++guard)
+        {
+            add_dependent(this->find_window_by_guest_pointer(c.proc, child));
+
+            emulator_object<USER_WINDOW> child_obj{c.emu, child};
+            child_obj.access([&](const USER_WINDOW& child_guest) { child = child_guest.spwndNext; });
+        }
+
+        for (const auto& [_, candidate] : c.proc.windows)
+        {
+            if (candidate.owner_handle == win.handle)
+            {
+                add_dependent(candidate.handle);
+            }
+        }
+
+        return dependents;
+    }
+
+    void window_destroy_orchestrator::finalize_frame(const syscall_context& c, window_destroy_frame& frame, window& win) const
+    {
+        this->pop_frame_allocation(c, frame);
+
+        win.guest.access([&](USER_WINDOW& guest_win) {
+            guest_win.spwndParent = 0;
+            guest_win.spwndChild = 0;
+            guest_win.spwndOwner = 0;
+            guest_win.spwndNext = 0;
+            guest_win.spwndPrev = 0;
+        });
+
+        c.win_emu.ui().destroy_window(frame.handle);
+        (void)c.proc.windows.erase(frame.handle);
+    }
+
+} // namespace sogen

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -1,4 +1,3 @@
-#include "std_include.hpp"
 #include "window_destroy_orchestrator.hpp"
 
 #include "syscall_utils.hpp"
@@ -6,25 +5,28 @@
 namespace sogen
 {
 
-    window_destroy_orchestrator::window_destroy_orchestrator(window_destroy_state& state)
-        : state_(state)
+    window_destroy_orchestrator::window_destroy_orchestrator(window_destroy_state& state, const syscall_context& c)
+        : state_(state),
+          emu_(c.emu),
+          proc_(c.proc),
+          ui_(c.win_emu.ui())
     {
     }
 
-    void window_destroy_orchestrator::start(const syscall_context& c, window& root)
+    void window_destroy_orchestrator::start(window& root) const
     {
-        this->push_frame(c, root);
+        this->push_frame(root);
     }
 
-    std::optional<window_destroy_step> window_destroy_orchestrator::advance(const syscall_context& c)
+    std::optional<window_destroy_step> window_destroy_orchestrator::advance() const
     {
         while (!this->state_.frames.empty())
         {
             auto& frame = this->state_.frames.back();
-            auto* win = c.proc.windows.get(frame.handle);
-            if (!win || win->thread_id != c.proc.active_thread->id)
+            auto* win = this->proc_.windows.get(frame.handle);
+            if (!win || win->thread_id != this->proc_.active_thread->id)
             {
-                this->pop_frame_allocation(c, frame);
+                this->pop_frame_allocation(frame);
                 this->state_.frames.pop_back();
                 continue;
             }
@@ -43,14 +45,14 @@ namespace sogen
                 continue;
 
             case window_destroy_phase::children: {
-                const auto dependents = this->collect_dependents(c, *win);
+                const auto dependents = this->collect_dependents(*win);
                 frame.phase = window_destroy_phase::nc_destroy;
 
                 for (const auto dependent : std::ranges::reverse_view(dependents))
                 {
-                    if (auto* dependent_win = c.proc.windows.get(dependent))
+                    if (auto* dependent_win = this->proc_.windows.get(dependent))
                     {
-                        this->push_frame(c, *dependent_win);
+                        this->push_frame(*dependent_win);
                     }
                 }
                 continue;
@@ -62,7 +64,7 @@ namespace sogen
                 continue;
 
             case window_destroy_phase::finalize:
-                this->finalize_frame(c, frame, *win);
+                this->finalize_frame(frame, *win);
                 this->state_.frames.pop_back();
                 continue;
             }
@@ -71,14 +73,14 @@ namespace sogen
         return std::nullopt;
     }
 
-    hwnd window_destroy_orchestrator::find_window_by_guest_pointer(const process_context& proc, const uint64_t window_ptr) const
+    hwnd window_destroy_orchestrator::find_window_by_guest_pointer(const uint64_t window_ptr) const
     {
         if (window_ptr == 0)
         {
             return 0;
         }
 
-        for (const auto& [_, win] : proc.windows)
+        for (const auto& [_, win] : this->proc_.windows)
         {
             if (win.guest.value() == window_ptr)
             {
@@ -89,7 +91,7 @@ namespace sogen
         return 0;
     }
 
-    void window_destroy_orchestrator::unlink_window_from_parent_and_siblings(const syscall_context& c, window& win) const
+    void window_destroy_orchestrator::unlink_window_from_parent_and_siblings(window& win) const
     {
         uint64_t parent = 0;
         uint64_t prev = 0;
@@ -104,7 +106,7 @@ namespace sogen
 
         if (parent != 0)
         {
-            emulator_object<USER_WINDOW> parent_obj{c.emu, parent};
+            emulator_object<USER_WINDOW> parent_obj{this->emu_, parent};
             parent_obj.access([&](USER_WINDOW& parent_guest) {
                 if (parent_guest.spwndChild == win_ptr)
                 {
@@ -115,7 +117,7 @@ namespace sogen
 
         if (prev != 0)
         {
-            emulator_object<USER_WINDOW> prev_obj{c.emu, prev};
+            emulator_object<USER_WINDOW> prev_obj{this->emu_, prev};
             prev_obj.access([&](USER_WINDOW& prev_guest) {
                 if (prev_guest.spwndNext == win_ptr)
                 {
@@ -126,7 +128,7 @@ namespace sogen
 
         if (next != 0)
         {
-            emulator_object<USER_WINDOW> next_obj{c.emu, next};
+            emulator_object<USER_WINDOW> next_obj{this->emu_, next};
             next_obj.access([&](USER_WINDOW& next_guest) {
                 if (next_guest.spwndPrev == win_ptr)
                 {
@@ -136,7 +138,7 @@ namespace sogen
         }
     }
 
-    window_destroy_frame window_destroy_orchestrator::make_frame(const syscall_context& c, const window& win) const
+    window_destroy_frame window_destroy_orchestrator::make_frame(const window& win) const
     {
         window_destroy_frame frame{};
         frame.handle = win.handle;
@@ -151,7 +153,7 @@ namespace sogen
             wp.cx = win.width;
             wp.cy = win.height;
             wp.flags = SWP_HIDEWINDOW;
-            frame.window_pos_alloc = c.emu.push_stack(wp);
+            frame.window_pos_alloc = this->emu_.push_stack(wp);
 
             frame.message_queue = {
                 {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
@@ -174,21 +176,21 @@ namespace sogen
         return frame;
     }
 
-    void window_destroy_orchestrator::push_frame(const syscall_context& c, window& win)
+    void window_destroy_orchestrator::push_frame(window& win) const
     {
-        this->unlink_window_from_parent_and_siblings(c, win);
-        this->state_.frames.push_back(this->make_frame(c, win));
+        this->unlink_window_from_parent_and_siblings(win);
+        this->state_.frames.push_back(this->make_frame(win));
     }
 
-    void window_destroy_orchestrator::pop_frame_allocation(const syscall_context& c, window_destroy_frame& frame) const
+    void window_destroy_orchestrator::pop_frame_allocation(window_destroy_frame& frame) const
     {
         if (frame.window_pos_alloc.address != 0)
         {
-            c.emu.pop_stack(std::move(frame.window_pos_alloc));
+            this->emu_.pop_stack(std::move(frame.window_pos_alloc));
         }
     }
 
-    std::vector<hwnd> window_destroy_orchestrator::collect_dependents(const syscall_context& c, const window& win) const
+    std::vector<hwnd> window_destroy_orchestrator::collect_dependents(const window& win) const
     {
         std::vector<hwnd> dependents{};
 
@@ -198,7 +200,7 @@ namespace sogen
                 return;
             }
 
-            const auto* dependent_win = c.proc.windows.get(dependent);
+            const auto* dependent_win = this->proc_.windows.get(dependent);
             if (!dependent_win || dependent_win->thread_id != win.thread_id)
             {
                 return;
@@ -210,15 +212,15 @@ namespace sogen
         uint64_t child = 0;
         win.guest.access([&](const USER_WINDOW& guest_win) { child = guest_win.spwndChild; });
 
-        for (size_t guard = 0; child != 0 && guard < c.proc.windows.size(); ++guard)
+        for (size_t guard = 0; child != 0 && guard < this->proc_.windows.size(); ++guard)
         {
-            add_dependent(this->find_window_by_guest_pointer(c.proc, child));
+            add_dependent(this->find_window_by_guest_pointer(child));
 
-            emulator_object<USER_WINDOW> child_obj{c.emu, child};
+            emulator_object<USER_WINDOW> child_obj{this->emu_, child};
             child_obj.access([&](const USER_WINDOW& child_guest) { child = child_guest.spwndNext; });
         }
 
-        for (const auto& [_, candidate] : c.proc.windows)
+        for (const auto& [_, candidate] : this->proc_.windows)
         {
             if (candidate.owner_handle == win.handle)
             {
@@ -229,9 +231,9 @@ namespace sogen
         return dependents;
     }
 
-    void window_destroy_orchestrator::finalize_frame(const syscall_context& c, window_destroy_frame& frame, window& win) const
+    void window_destroy_orchestrator::finalize_frame(window_destroy_frame& frame, window& win) const
     {
-        this->pop_frame_allocation(c, frame);
+        this->pop_frame_allocation(frame);
 
         win.guest.access([&](USER_WINDOW& guest_win) {
             guest_win.spwndParent = 0;
@@ -241,8 +243,8 @@ namespace sogen
             guest_win.spwndPrev = 0;
         });
 
-        c.win_emu.ui().destroy_window(frame.handle);
-        (void)c.proc.windows.erase(frame.handle);
+        this->ui_.destroy_window(frame.handle);
+        (void)this->proc_.windows.erase(frame.handle);
     }
 
 } // namespace sogen

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <arch_emulator.hpp>
+
 #include "syscall_dispatcher.hpp"
 
 namespace sogen
 {
 
     struct syscall_context;
+    class ui_backend;
+    struct process_context;
 
     struct window_destroy_step
     {
@@ -16,21 +20,24 @@ namespace sogen
     class window_destroy_orchestrator
     {
       public:
-        explicit window_destroy_orchestrator(window_destroy_state& state);
+        window_destroy_orchestrator(window_destroy_state& state, const syscall_context& c);
 
-        void start(const syscall_context& c, window& root);
-        std::optional<window_destroy_step> advance(const syscall_context& c);
+        void start(window& root) const;
+        std::optional<window_destroy_step> advance() const;
 
       private:
-        hwnd find_window_by_guest_pointer(const process_context& proc, uint64_t window_ptr) const;
-        void unlink_window_from_parent_and_siblings(const syscall_context& c, window& win) const;
-        window_destroy_frame make_frame(const syscall_context& c, const window& win) const;
-        void push_frame(const syscall_context& c, window& win);
-        void pop_frame_allocation(const syscall_context& c, window_destroy_frame& frame) const;
-        std::vector<hwnd> collect_dependents(const syscall_context& c, const window& win) const;
-        void finalize_frame(const syscall_context& c, window_destroy_frame& frame, window& win) const;
+        hwnd find_window_by_guest_pointer(uint64_t window_ptr) const;
+        void unlink_window_from_parent_and_siblings(window& win) const;
+        window_destroy_frame make_frame(const window& win) const;
+        void push_frame(window& win) const;
+        void pop_frame_allocation(window_destroy_frame& frame) const;
+        std::vector<hwnd> collect_dependents(const window& win) const;
+        void finalize_frame(window_destroy_frame& frame, window& win) const;
 
         window_destroy_state& state_;
+        x86_64_emulator& emu_;
+        process_context& proc_;
+        ui_backend& ui_;
     };
 
 } // namespace sogen

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -4,6 +4,8 @@
 
 #include "syscall_dispatcher.hpp"
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+
 namespace sogen
 {
 
@@ -27,12 +29,12 @@ namespace sogen
 
       private:
         hwnd find_window_by_guest_pointer(uint64_t window_ptr) const;
-        void unlink_window_from_parent_and_siblings(window& win) const;
+        void unlink_window_from_parent_and_siblings(const window& win) const;
         window_destroy_frame make_frame(const window& win) const;
-        void push_frame(window& win) const;
+        void push_frame(const window& win) const;
         void pop_frame_allocation(window_destroy_frame& frame) const;
         std::vector<hwnd> collect_dependents(const window& win) const;
-        void finalize_frame(window_destroy_frame& frame, window& win) const;
+        void finalize_frame(window_destroy_frame& frame, const window& win) const;
 
         window_destroy_state& state_;
         x86_64_emulator& emu_;
@@ -41,3 +43,5 @@ namespace sogen
     };
 
 } // namespace sogen
+
+// NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "syscall_dispatcher.hpp"
+
+namespace sogen
+{
+
+    struct syscall_context;
+
+    struct window_destroy_step
+    {
+        hwnd handle{};
+        qmsg message{};
+    };
+
+    class window_destroy_orchestrator
+    {
+      public:
+        explicit window_destroy_orchestrator(window_destroy_state& state);
+
+        void start(const syscall_context& c, window& root);
+        std::optional<window_destroy_step> advance(const syscall_context& c);
+
+      private:
+        hwnd find_window_by_guest_pointer(const process_context& proc, uint64_t window_ptr) const;
+        void unlink_window_from_parent_and_siblings(const syscall_context& c, window& win) const;
+        window_destroy_frame make_frame(const syscall_context& c, const window& win) const;
+        void push_frame(const syscall_context& c, window& win);
+        void pop_frame_allocation(const syscall_context& c, window_destroy_frame& frame) const;
+        std::vector<hwnd> collect_dependents(const syscall_context& c, const window& win) const;
+        void finalize_frame(const syscall_context& c, window_destroy_frame& frame, window& win) const;
+
+        window_destroy_state& state_;
+    };
+
+} // namespace sogen


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/momo5502/sogen/pull/1002, where incorrect offsets were apparently used and an attempt to set up child/sibling links could cause infinite recursion. It also improves the window destruction flow so windows are unlinked properly and child windows are destroyed.