### PR TITLE
Deliver pending user APCs before an alertable wait times out

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -596,7 +596,7 @@ namespace sogen
                 return true;
             }
 
-            if (this->is_await_time_over(clock))
+            if (this->is_await_time_over(clock) && !this->has_pending_alertable_apc())
             {
                 this->mark_as_ready(STATUS_TIMEOUT);
                 return true;
@@ -607,7 +607,7 @@ namespace sogen
 
         if (this->await_time.has_value())
         {
-            if (this->is_await_time_over(clock))
+            if (this->is_await_time_over(clock) && !this->has_pending_alertable_apc())
             {
                 this->mark_as_ready(STATUS_SUCCESS);
                 return true;

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -644,7 +644,7 @@ namespace sogen
                     return true;
                 }
 
-                if (timeout_expired(wait))
+                if (timeout_expired(wait) && !this->has_pending_alertable_apc())
                 {
                     this->mark_as_ready(STATUS_TIMEOUT);
                     return true;
@@ -667,7 +667,7 @@ namespace sogen
                     return true;
                 }
 
-                if (timeout_expired(wait))
+                if (timeout_expired(wait) && !this->has_pending_alertable_apc())
                 {
                     emulator_object<ULONG>{*this->memory_ptr, wait.entries_removed_ptr}.write_if_valid(0);
                     this->mark_as_ready(STATUS_TIMEOUT);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -282,10 +282,6 @@ namespace sogen
             return this->await_time.has_value() && this->await_time.value() != infinite && this->await_time.value() < clock.steady_now();
         }
 
-        // A user APC queued for an alertable wait must be delivered (WAIT_IO_COMPLETION)
-        // before the wait completes by timeout. While such an APC is pending, the wait
-        // must not latch a timeout status, otherwise it suppresses APC dispatch in
-        // switch_to_thread (which skips dispatch when a status is already pending).
         bool has_pending_alertable_apc() const
         {
             return this->apc_alertable && !this->pending_apcs.empty();

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -282,6 +282,15 @@ namespace sogen
             return this->await_time.has_value() && this->await_time.value() != infinite && this->await_time.value() < clock.steady_now();
         }
 
+        // A user APC queued for an alertable wait must be delivered (WAIT_IO_COMPLETION)
+        // before the wait completes by timeout. While such an APC is pending, the wait
+        // must not latch a timeout status, otherwise it suppresses APC dispatch in
+        // switch_to_thread (which skips dispatch when a status is already pending).
+        bool has_pending_alertable_apc() const
+        {
+            return this->apc_alertable && !this->pending_apcs.empty();
+        }
+
         std::optional<msg> peek_pending_message(hwnd hwnd_filter, UINT filter_min, UINT filter_max, bool remove = false);
         void post_message(const msg& msg);
 


### PR DESCRIPTION
## Problem

An alertable wait that has user APCs queued (e.g. `SleepEx(_, TRUE)` or `WaitForSingleObjectEx`) must run those APCs (returning `WAIT_IO_COMPLETION`) **before** the wait completes by timeout.

`is_thread_ready` latched `STATUS_SUCCESS`/`STATUS_TIMEOUT` into `pending_status` as soon as the await time elapsed. `switch_to_thread` only dispatches APCs when no status is already pending, so the queued APCs were silently dropped and the wait returned without running them.

This is timing/clock dependent:

- Under the **relative-time clock** (`tick_clock(1000)` ⇒ 1 instruction = 1 ms), the 1 ms wait expires while the *first* APC's dispatcher is still executing, so the **second** APC is deterministically skipped. The `test-sample` "APC" self-test then fails (`executions != 2`) and the process exits non-zero — this is the failure seen in the Emscripten build and the Linux Python-wheel test.
- On a real wall clock it is a race the host can lose under load.

## Fix

Don't latch the timeout completion while an alertable user APC is still pending, so `switch_to_thread`'s APC-dispatch path drains the queue first.

- `emulator_thread.hpp`: add `has_pending_alertable_apc()` (`apc_alertable && !pending_apcs.empty()`).
- `emulator_thread.cpp`: guard the two timeout-completion branches in `is_thread_ready` with `&& !this->has_pending_alertable_apc()`.

## Verification

Compiles clean on Windows. The deterministic relative-time path is exercised by the gtest `EmulationTest.BasicEmulationWorks` and the Python-wheel/Emscripten CI jobs — those should confirm the APC self-test now passes.