### PR TITLE
Render builtin MessageBox: controls, button clicks, IDs and captions

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -33,7 +33,7 @@ Real emulation goal is stronger: builtin controls, dialogs, and custom `WM_PAINT
 - SDL is now native default backend when SDL3 is available
 - guest dialog flow works much better than before
 - `MessageBox` no longer depends on export hook hack
-- builtin control callback dispatch reaches real user32 code
+- builtin control callback dispatch reaches ntdll client thunks, but those thunks still need correct user32 client initialization before real builtin control paint can work
 - builtin `Button` / `Static` no longer crash during paint because correct extra bytes now allocated:
   - `Button` -> `cbWndExtra = 8`
   - `Static` -> `cbWndExtra = 8`
@@ -75,13 +75,13 @@ Real emulation goal is stronger: builtin controls, dialogs, and custom `WM_PAINT
 - direct text rendering path now exists via temporary 8x8 debug font in `NtGdiExtTextOutW`
 - user validated forced direct text path visually: text appears and glyph mirroring bug was fixed
 - current text gap is smaller-text GDI batching behavior, not raw top-level surface presentation
-- `manual-messagebox-sample` runs through the native button/static paint path well enough for visible controls and text.
-- builtin `MessageBox` is past the earlier missing `NtUserSetThreadState` syscall, but it is not working yet.
+- `manual-messagebox-sample` exercises more of the USER/GDI path than before, but builtin control rendering still must not rely on manual fallback drawing.
+- builtin `MessageBox` is past the earlier missing `NtUserSetThreadState`, `NtUserGetIconSize`, and `NtUserGetCursorFrameInfo` blockers, but it is not working correctly yet.
   - `NtUserSetThreadState(value, mask)` is now modeled as a per-thread USER state bitfield.
   - `NtUserGetThreadState(10)` returns that bitfield for the dialog cleanup path.
   - user32 creates the dialog and buttons, then uses predefined class atom `#2032` for the message-box icon/static control.
   - `#2032` now normalizes to the builtin `Static` class, matching the `SS_ICON` control path.
-  - The next concrete blocker is `NtUserGetIconSize(icon, frame, &cx, &cy)`, reached while static/icon painting or setup runs.
+  - The current blocker is no longer a single missing syscall; it is correct user32 client callback initialization and builtin control paint.
 
 ## Builtin MessageBox Investigation Notes
 
@@ -93,25 +93,76 @@ IDA/user32 findings from the current checkpoint:
 - `DialogBox2` later calls `NtUserGetThreadState(10)` before an owner/foreground-window cleanup path.
 - A blind no-op `NtUserSetThreadState` is not sufficient: it lets the sample proceed, but `MessageBox` returns `0` immediately.
 - After adding the thread-state bitfield, verbose report output showed `MessageBox` got as far as dialog/control creation. It then failed on class atom `#2032`, destroyed the dialog, and printed `clicked: other (0)`.
-- Mapping `#2032` to `Static` moves the failure forward to the next missing syscall: `NtUserGetIconSize`.
+- Mapping `#2032` to `Static` moved the failure forward to icon/static setup.
 
-Expected next narrow implementation:
+Implemented narrow syscall progress:
 
-```cpp
-BOOL NtUserGetIconSize(HICON icon, UINT frame, int* cx, int* cy);
-```
+- `NtUserGetIconSize(icon, frame, &cx, &cy)`
+  - returns `TRUE` for non-null icons
+  - writes `cx = 32`
+  - writes `cy = 64`
+- `NtUserGetCursorFrameInfo(icon, frame, &rate, &frame_count)`
+  - returns the icon handle for non-null icons
+  - writes `rate = 0`
+  - writes `frame_count = 1`
+- `NtUserDestroyCursor(icon, flags)`
+  - returns `TRUE` for non-null handles
 
-For the current message-box icon path, returning a default icon size is probably enough to advance:
+The `cy = 64` value is intentional for the user32 static-icon path inspected in IDA: `xxxSetStaticImage` halves the returned height before layout/drawing, so this models a 32x32 icon backed by a 32x64 icon/mask bitmap.
 
-- write `cx = 32`
-- write `cy = 64`
-- return `TRUE`
+Current runtime state:
 
-The `cy = 64` value is intentional for the user32 static-icon path inspected in IDA: it halves the returned height before layout/drawing, so this models a 32x32 icon backed by a 32x64 icon/mask bitmap.
+- builtin `messagebox-sample` now creates the dialog window and child windows.
+- The real guest paint path still does not make builtin button/static controls visible.
+- A manual host-side/emulator-side paint experiment was added briefly:
+  - intercepted builtin `Button` / `Static` `WM_PAINT`
+  - called emulator GDI primitives directly
+  - drew button rectangles and text from stored `window.name`
+- That experiment made text/buttons visible, but it was a hack and has been removed.
+- With that hack removed, visible builtin control rendering is still not solved.
+
+## Ntdll/User32 Callback Findings
+
+The important finding is that builtin class WndProc setup is not just a pointer lookup problem.
+
+Observed current behavior:
+
+- `SERVERINFO.apfnClientA/W` currently contains ntdll client thunks such as:
+  - `NtdllButtonWndProc_A/W`
+  - `NtdllStaticWndProc_A/W`
+  - `NtdllDialogWndProc_A/W`
+- In IDA, those ntdll thunks call entries in ntdll's `NtUserPfn` tables.
+- Those table entries initially point at `UninitUser32Proc`, which prints `"User32 init not called"` and breaks.
+- `user32!InitializeNtdllUserPfn` calls `ntdll!RtlInitializeNtUserPfn` with user32's A/W/worker callback arrays.
+
+Experiments and conclusions:
+
+- Directly replacing `SERVERINFO.apfnClient*` with user32's public WndProc arrays is not correct.
+- That made class WndProcs point into user32, but `messagebox-sample` returned `clicked: other (0)` quickly.
+- IDA explains why: `user32!ButtonWndProcW` immediately calls `ValidateHwnd`.
+- `ValidateHwnd` depends on user32 client/global/shared state:
+  - `TEB.Win32ClientInfo[8/9]`
+  - `gSharedInfo`
+  - `gpsi`
+  - user32 handle-table metadata
+- Our synthetic window objects are not enough for that public WndProc path.
+- Patching ntdll's `NtUserPfn` tables from the emulator was also explored only as a debugging experiment and is not an acceptable solution.
+
+Likely proper direction:
+
+- Do not add manual control drawing fallbacks.
+- Do not ad-hoc patch ntdll memory from emulator code.
+- Make the user32 client initialization path happen in a Windows-like way, or emulate the relevant effects at the USER boundary with a principled model:
+  - `UserClientDllInitialize`
+  - `InitializeNtdllUserPfn`
+  - `RtlInitializeNtUserPfn`
+  - `RtlRetrieveNtUserPfn`
+  - user32 shared info / handle validation state
+- Keep callback dispatch through the ntdll/user32 callback convention instead of directly invoking public user32 WndProcs from host-side code.
 
 ## Remaining blockers
 
-- implement `NtUserGetIconSize` minimally and re-test builtin `messagebox-sample`
+- builtin `MessageBox` control rendering still needs the real client callback/user32 initialization path
 - expect possible follow-up icon/static paint gaps such as `DrawIconEx` behavior or icon-handle metadata
 - finish small-text / batched GDI text path so ordinary `TextOutA/W` works without forcing oversized `ExtTextOutW`
 - decide where batch flush should happen generically, not only in sample-driven probing
@@ -145,10 +196,10 @@ The remaining design direction is to continue moving Win32 behavior out of host 
 
 ## Next steps
 
-1. Make batched text path work for normal `TextOutA/W` without sample hacks.
-2. Re-test `manual-messagebox-sample` and inspect whether builtin control text now appears through guest paint path.
-3. Re-test builtin `STATIC` / `BUTTON` paint after text-path progress.
-4. Remove temporary paint/present probes and temporary sample hacks once path is stable.
+1. Model the user32 client initialization path cleanly enough that ntdll client thunks do not point at `UninitUser32Proc`.
+2. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual `Button` / `Static` drawing fallbacks.
+3. Re-test builtin `STATIC` / `BUTTON` paint after client callback initialization is fixed.
+4. Continue improving batched text and font handling once control paint reaches real GDI calls.
 
 ## Non-goals for this checkpoint
 

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -47,6 +47,11 @@ interface Rect {
   bottom: number;
 }
 
+interface Point {
+  x: number;
+  y: number;
+}
+
 type CaptionCommand = "minimize" | "maximize" | "close";
 
 interface CaptionButton extends Rect {
@@ -94,6 +99,7 @@ const WS_MAXIMIZEBOX = 0x00010000;
 const CAPTION_HEIGHT = 30;
 const FRAME_BORDER = 1;
 const CAPTION_BUTTON_WIDTH = 46;
+const VIEWPORT_MARGIN = 16;
 
 const CHROME_COLORS = {
   frame: "#202020",
@@ -167,6 +173,7 @@ export function attachSogenUiHost(
   let dragState: { hwnd: number; offsetX: number; offsetY: number } | null =
     null;
   let hoverState: { hwnd: number; command: CaptionCommand } | null = null;
+  let viewportOffset: Point = { x: 0, y: 0 };
 
   function notifyWindowCount() {
     options.onWindowCountChanged?.(windows.size);
@@ -345,6 +352,84 @@ export function attachSogenUiHost(
     return x >= rect.left && x < rect.right && y >= rect.top && y < rect.bottom;
   }
 
+  function orderedTopLevelWindows() {
+    const ordered: HostWindowState[] = [];
+    for (const window of windows.values()) {
+      if (window.visible && window.topLevel) {
+        ordered.push(window);
+      }
+    }
+
+    return ordered;
+  }
+
+  function visibleWindowBounds(windowsToDraw: HostWindowState[]) {
+    if (windowsToDraw.length === 0) {
+      return null;
+    }
+
+    const bounds = {
+      left: Number.POSITIVE_INFINITY,
+      top: Number.POSITIVE_INFINITY,
+      right: Number.NEGATIVE_INFINITY,
+      bottom: Number.NEGATIVE_INFINITY,
+    };
+
+    for (const window of windowsToDraw) {
+      const frame = frameRect(window);
+      bounds.left = Math.min(bounds.left, frame.left);
+      bounds.top = Math.min(bounds.top, frame.top);
+      bounds.right = Math.max(bounds.right, frame.right);
+      bounds.bottom = Math.max(bounds.bottom, frame.bottom);
+    }
+
+    return bounds;
+  }
+
+  function computeViewportAxisOffset(
+    min: number,
+    max: number,
+    viewportSize: number,
+  ) {
+    const size = max - min;
+    const usableSize = Math.max(1, viewportSize - VIEWPORT_MARGIN * 2);
+
+    if (size <= usableSize) {
+      if (min < VIEWPORT_MARGIN || max > viewportSize - VIEWPORT_MARGIN) {
+        return Math.round((viewportSize - size) / 2 - min);
+      }
+
+      return 0;
+    }
+
+    if (min > VIEWPORT_MARGIN) {
+      return Math.round(VIEWPORT_MARGIN - min);
+    }
+
+    if (max < viewportSize - VIEWPORT_MARGIN) {
+      return Math.round(viewportSize - VIEWPORT_MARGIN - max);
+    }
+
+    return 0;
+  }
+
+  function updateViewportOffset(
+    windowsToDraw: HostWindowState[],
+    viewportWidth: number,
+    viewportHeight: number,
+  ) {
+    const bounds = visibleWindowBounds(windowsToDraw);
+    if (!bounds) {
+      viewportOffset = { x: 0, y: 0 };
+      return;
+    }
+
+    viewportOffset = {
+      x: computeViewportAxisOffset(bounds.left, bounds.right, viewportWidth),
+      y: computeViewportAxisOffset(bounds.top, bounds.bottom, viewportHeight),
+    };
+  }
+
   function drawButtonGlyph(button: CaptionButton, color: string) {
     const cx = (button.left + button.right) / 2;
     const cy = (button.top + button.bottom) / 2;
@@ -483,9 +568,15 @@ export function attachSogenUiHost(
     context2d.fillStyle = PLAYGROUND_BACKGROUND;
     context2d.fillRect(0, 0, rect.width, rect.height);
 
-    for (const window of windows.values()) {
+    const windowsToDraw = orderedTopLevelWindows();
+    updateViewportOffset(windowsToDraw, rect.width, rect.height);
+
+    context2d.save();
+    context2d.translate(viewportOffset.x, viewportOffset.y);
+    for (const window of windowsToDraw) {
       drawWindow(window);
     }
+    context2d.restore();
   }
 
   function raiseWindow(hwnd: number) {
@@ -499,12 +590,7 @@ export function attachSogenUiHost(
   }
 
   function hitTest(x: number, y: number): HitResult | null {
-    const ordered: HostWindowState[] = [];
-    for (const window of windows.values()) {
-      if (window.visible && window.topLevel) {
-        ordered.push(window);
-      }
-    }
+    const ordered = orderedTopLevelWindows();
 
     for (let i = ordered.length - 1; i >= 0; --i) {
       const window = ordered[i];
@@ -555,8 +641,8 @@ export function attachSogenUiHost(
   function toCanvasPoint(event: MouseEvent) {
     const rect = canvas.getBoundingClientRect();
     return {
-      x: Math.floor(event.clientX - rect.left),
-      y: Math.floor(event.clientY - rect.top),
+      x: Math.floor(event.clientX - rect.left - viewportOffset.x),
+      y: Math.floor(event.clientY - rect.top - viewportOffset.y),
     };
   }
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -446,6 +446,10 @@ namespace sogen
         NTSTATUS handle_NtUserSetCursor();
         uint64_t handle_NtUserGetCursor();
         NTSTATUS handle_NtUserFindExistingCursorIcon();
+        BOOL handle_NtUserDestroyCursor(const syscall_context& c, hicon icon, DWORD flags);
+        hicon handle_NtUserGetCursorFrameInfo(const syscall_context& c, hicon icon, UINT frame, emulator_object<uint32_t> rate_jiffies,
+                                              emulator_object<uint32_t> frame_count);
+        BOOL handle_NtUserGetIconSize(const syscall_context& c, hicon icon, UINT frame, emulator_object<int> cx, emulator_object<int> cy);
         BOOL handle_NtUserMessageBeep();
         uint64_t handle_NtUserFindWindowEx(const syscall_context& c, hwnd parent, hwnd child_after,
                                            emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
@@ -1102,6 +1106,9 @@ namespace sogen
         add_handler(NtUserGetCursorPos);
         add_handler(NtUserReleaseDC);
         add_handler(NtUserFindExistingCursorIcon);
+        add_handler(NtUserDestroyCursor);
+        add_handler(NtUserGetCursorFrameInfo);
+        add_handler(NtUserGetIconSize);
         add_handler(NtUserMessageBeep);
         add_handler(NtSetContextThread);
         add_handler(NtUserFindWindowEx);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -450,6 +450,8 @@ namespace sogen
         hicon handle_NtUserGetCursorFrameInfo(const syscall_context& c, hicon icon, UINT frame, emulator_object<uint32_t> rate_jiffies,
                                               emulator_object<uint32_t> frame_count);
         BOOL handle_NtUserGetIconSize(const syscall_context& c, hicon icon, UINT frame, emulator_object<int> cx, emulator_object<int> cy);
+        BOOL handle_NtUserDrawIconEx(const syscall_context& c, hdc dc, int x, int y, hicon icon, int cx, int cy, UINT istep,
+                                     uint64_t flicker_brush, UINT di_flags);
         BOOL handle_NtUserMessageBeep();
         uint64_t handle_NtUserFindWindowEx(const syscall_context& c, hwnd parent, hwnd child_after,
                                            emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
@@ -558,6 +560,7 @@ namespace sogen
         uint64_t handle_NtGdiSelectBitmap(const syscall_context& c, hdc dc, handle bitmap);
         uint64_t handle_NtGdiSelectFont(const syscall_context& c, hdc dc, uint64_t font);
         hdc handle_NtGdiGetDCforBitmap(const syscall_context& c, handle bitmap);
+        BOOL handle_NtGdiGetDCDword(const syscall_context& c, hdc dc, uint32_t index, emulator_pointer result);
         uint64_t handle_NtGdiHfontCreate(const syscall_context& c, emulator_pointer logfont, uint32_t angle);
         uint32_t handle_NtGdiExtGetObjectW(const syscall_context& c, uint32_t handle_value, uint32_t size, emulator_pointer buffer);
         uint32_t handle_NtGdiEnumFonts();
@@ -1004,6 +1007,7 @@ namespace sogen
         add_handler(NtGdiSelectBitmap);
         add_handler(NtGdiSelectFont);
         add_handler(NtGdiGetDCforBitmap);
+        add_handler(NtGdiGetDCDword);
         add_handler(NtGdiHfontCreate);
         add_handler(NtGdiExtGetObjectW);
         add_handler(NtGdiEnumFonts);
@@ -1109,6 +1113,7 @@ namespace sogen
         add_handler(NtUserDestroyCursor);
         add_handler(NtUserGetCursorFrameInfo);
         add_handler(NtUserGetIconSize);
+        add_handler(NtUserDrawIconEx);
         add_handler(NtUserMessageBeep);
         add_handler(NtSetContextThread);
         add_handler(NtUserFindWindowEx);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -578,6 +578,7 @@ namespace sogen
         BOOL handle_NtGdiLineTo(const syscall_context& c, hdc dc, LONG x_end, LONG y_end);
         BOOL handle_NtGdiRectangle(const syscall_context& c, hdc dc, LONG left, LONG top, LONG right, LONG bottom);
         BOOL handle_NtGdiPatBlt(const syscall_context& c, hdc dc, LONG x, LONG y, LONG width, LONG height, DWORD rop);
+        BOOL handle_NtGdiPolyPatBlt(const syscall_context& c, hdc dc, DWORD rop, emulator_pointer poly, DWORD count, DWORD mode);
         BOOL handle_NtGdiExtTextOutW(const syscall_context& c, hdc dc, LONG x, LONG y, UINT options, emulator_pointer rect,
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
         BOOL handle_NtGdiGetRealizationInfo(const syscall_context& c, hdc dc, emulator_pointer realization_info, uint64_t font);
@@ -1024,6 +1025,7 @@ namespace sogen
         add_handler(NtGdiLineTo);
         add_handler(NtGdiRectangle);
         add_handler(NtGdiPatBlt);
+        add_handler(NtGdiPolyPatBlt);
         add_handler(NtGdiExtTextOutW);
         add_handler(NtGdiGetRealizationInfo);
         add_handler(NtGdiGetEntry);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1616,7 +1616,9 @@ namespace sogen
                 return FALSE;
             }
 
-            // POLYPATBLT entry: { int x; int y; int cx; int cy; HBRUSH hbr; } (HBRUSH at +0x10 on x64).
+            // POLYPATBLT entry (verified at runtime against this build's gdi32): { int x; int y; int cx; int cy; HBRUSH hbr; }
+            // i.e. position + size, NOT a RECT with right/bottom. Button frame draws pass thin edges such as
+            // {x=96, y=4, cx=1, cy=20}, which only make sense as width/height. HBRUSH is at +0x10 on x64.
             constexpr uint64_t k_entry_size = 0x18;
             constexpr uint64_t k_brush_offset = 0x10;
             for (DWORD i = 0; i < count; ++i)

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -714,8 +714,7 @@ namespace sogen
                 int32_t origin_y = 0;
                 if (!get_dc_state_and_surface(c, dc, dc_state, surface, origin_x, origin_y) || !surface)
                 {
-                    std::printf("GDI batch surface missing hdc=0x%llx\n", static_cast<unsigned long long>(dc));
-                    return false;
+                    return true;
                 }
 
                 const auto* bytes = reinterpret_cast<const uint8_t*>(batch.Buffer);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1622,17 +1622,17 @@ namespace sogen
             for (DWORD i = 0; i < count; ++i)
             {
                 const auto entry = poly + static_cast<uint64_t>(i) * k_entry_size;
-                int32_t rect[4]{}; // x, y, cx, cy
+                std::array<int32_t, 4> rect{}; // x, y, cx, cy
                 uint64_t brush = 0;
-                if (!c.win_emu.memory.try_read_memory(entry, rect, sizeof(rect)) ||
+                if (!c.win_emu.memory.try_read_memory(entry, rect.data(), rect.size() * sizeof(int32_t)) ||
                     !c.win_emu.memory.try_read_memory(entry + k_brush_offset, &brush, sizeof(brush)))
                 {
                     return FALSE;
                 }
 
                 const auto color = brush != 0 ? get_brush_color(c, static_cast<uint32_t>(brush)) : get_dc_brush_color(c, dc);
-                fill_rect(*surface, rect[0] + origin_x, rect[1] + origin_y, rect[0] + rect[2] + origin_x,
-                          rect[1] + rect[3] + origin_y, color);
+                fill_rect(*surface, rect[0] + origin_x, rect[1] + origin_y, rect[0] + rect[2] + origin_x, rect[1] + rect[3] + origin_y,
+                          color);
             }
             return TRUE;
         }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1599,6 +1599,44 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtGdiPolyPatBlt(const syscall_context& c, const hdc dc, const DWORD /*rop*/, const emulator_pointer poly,
+                                    const DWORD count, const DWORD /*mode*/)
+        {
+            gdi_dc_state* dc_state = nullptr;
+            gdi_bitmap_surface* surface = nullptr;
+            int32_t origin_x = 0;
+            int32_t origin_y = 0;
+            if (!get_dc_state_and_surface(c, dc, dc_state, surface, origin_x, origin_y) || !surface)
+            {
+                return FALSE;
+            }
+
+            if (poly == 0 || count == 0 || count > 0x1000)
+            {
+                return FALSE;
+            }
+
+            // POLYPATBLT entry: { int x; int y; int cx; int cy; HBRUSH hbr; } (HBRUSH at +0x10 on x64).
+            constexpr uint64_t k_entry_size = 0x18;
+            constexpr uint64_t k_brush_offset = 0x10;
+            for (DWORD i = 0; i < count; ++i)
+            {
+                const auto entry = poly + static_cast<uint64_t>(i) * k_entry_size;
+                int32_t rect[4]{}; // x, y, cx, cy
+                uint64_t brush = 0;
+                if (!c.win_emu.memory.try_read_memory(entry, rect, sizeof(rect)) ||
+                    !c.win_emu.memory.try_read_memory(entry + k_brush_offset, &brush, sizeof(brush)))
+                {
+                    return FALSE;
+                }
+
+                const auto color = brush != 0 ? get_brush_color(c, static_cast<uint32_t>(brush)) : get_dc_brush_color(c, dc);
+                fill_rect(*surface, rect[0] + origin_x, rect[1] + origin_y, rect[0] + rect[2] + origin_x,
+                          rect[1] + rect[3] + origin_y, color);
+            }
+            return TRUE;
+        }
+
         BOOL handle_NtGdiExtTextOutW(const syscall_context& c, const hdc dc, const LONG x, const LONG y, const UINT options,
                                      const emulator_pointer rect, const emulator_pointer text, const UINT count, const emulator_pointer dx,
                                      const DWORD /*code_page*/)

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1320,6 +1320,21 @@ namespace sogen
             return ensure_default_hdc(c);
         }
 
+        BOOL handle_NtGdiGetDCDword(const syscall_context& c, const hdc dc, const uint32_t /*index*/, const emulator_pointer result)
+        {
+            if (dc == 0 || result == 0)
+            {
+                return FALSE;
+            }
+
+            // gdi32 only falls back to this syscall for DC dwords it does not cache client-side
+            // (e.g. GdiGetIsMemDc). 0 is the correct default for the control paint path: the paint
+            // DC is a real (non-memory) DC, so "is memory DC" is false.
+            uint32_t value = 0;
+            c.emu.write_memory(result, &value, sizeof(value));
+            return TRUE;
+        }
+
         uint64_t handle_NtGdiHfontCreate(const syscall_context& c, const emulator_pointer /*logfont*/, const uint32_t /*angle*/)
         {
             return allocate_gdi_object(c, k_gdi_font_type, k_gdi_font_attr_size);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -440,6 +440,24 @@ namespace sogen
             queue_window_paint(c, win);
         }
 
+        // Invalidate a window together with its visible descendant controls. Used when a window
+        // transitions to visible: child controls created while an ancestor was still hidden skip
+        // their paint body (user32 gates control painting on the whole parent chain being visible),
+        // so they must be repainted once the ancestor becomes visible.
+        void invalidate_window_tree(const syscall_context& c, window& win)
+        {
+            invalidate_window(c, win);
+
+            for (auto& [index, child] : c.proc.windows)
+            {
+                (void)index;
+                if (child.parent_handle == win.handle && (child.style & WS_VISIBLE) != 0)
+                {
+                    invalidate_window_tree(c, child);
+                }
+            }
+        }
+
         void write_guest_window_text(const syscall_context& c, window& win, const std::u16string& title)
         {
             win.guest.access([&](USER_WINDOW& guest_win) {
@@ -490,39 +508,6 @@ namespace sogen
         {
             text.erase(std::ranges::remove(text, u'&').begin(), text.end());
             return text;
-        }
-
-        uint64_t map_dialog_button_caption_to_id(const std::u16string_view caption)
-        {
-            if (caption == u"OK")
-            {
-                return IDOK;
-            }
-            if (caption == u"Cancel")
-            {
-                return IDCANCEL;
-            }
-            if (caption == u"Abort")
-            {
-                return IDABORT;
-            }
-            if (caption == u"Retry")
-            {
-                return IDRETRY;
-            }
-            if (caption == u"Ignore")
-            {
-                return IDIGNORE;
-            }
-            if (caption == u"Yes")
-            {
-                return IDYES;
-            }
-            if (caption == u"No")
-            {
-                return IDNO;
-            }
-            return 0;
         }
 
         std::vector<std::u16string> read_msgbox_button_titles(const syscall_context& c, const window& parent)
@@ -619,10 +604,6 @@ namespace sogen
                         if (!titles[i].empty())
                         {
                             update_window_title(c, *empty_buttons[i], titles[i]);
-                            if (const auto id = map_dialog_button_caption_to_id(titles[i]); id != 0)
-                            {
-                                empty_buttons[i]->guest.access([&](USER_WINDOW& guest_win) { guest_win.wID = id; });
-                            }
                         }
                     }
                 }
@@ -1376,6 +1357,15 @@ namespace sogen
             return TRUE;
         }
 
+        // Minimal stub: report success so icon/static (SS_ICON) paint completes. Rendering the actual
+        // system icon pixels is a separate task; for now the icon area is left unpainted.
+        BOOL handle_NtUserDrawIconEx(const syscall_context&, const hdc /*dc*/, const int /*x*/, const int /*y*/, const hicon icon,
+                                     const int /*cx*/, const int /*cy*/, const UINT /*istep*/, const uint64_t /*flicker_brush*/,
+                                     const UINT /*di_flags*/)
+        {
+            return icon != 0 ? TRUE : FALSE;
+        }
+
         uint64_t handle_NtUserFindWindowEx(const syscall_context& c, const hwnd parent, const hwnd child_after,
                                            const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> class_name,
                                            const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> window_name)
@@ -2005,8 +1995,6 @@ namespace sogen
 
             if (want_visible)
             {
-                invalidate_window(c, *win);
-
                 const auto move_lparam = static_cast<uint64_t>(((win->y & 0xFFFF) << 16) | (win->x & 0xFFFF));
                 const auto size_lparam = static_cast<uint64_t>(((win->height & 0xFFFF) << 16) | (win->width & 0xFFFF));
 
@@ -2041,6 +2029,13 @@ namespace sogen
             win->guest.access([&](USER_WINDOW& guest_win) { //
                 guest_win.dwStyle = win->style;
             });
+
+            if (want_visible)
+            {
+                // Now that this window is visible, repaint it and any visible child controls that
+                // were created (and skipped painting) while their ancestor chain was still hidden.
+                invalidate_window_tree(c, *win);
+            }
 
             dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(state), *win, state.message_queue);
             return {};
@@ -2583,6 +2578,8 @@ namespace sogen
                 {
                     c.win_emu.ui().set_window_visible(hWnd, true);
                 }
+                // Repaint the now-visible window and its child controls (see invalidate_window_tree).
+                invalidate_window_tree(c, *win);
             }
 
             return TRUE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -232,29 +232,31 @@ namespace sogen
                 return nullptr;
             }
 
+            (void)win32k_userconnect::try_bootstrap_client_pfn_arrays_from_ntdll(c.win_emu);
+
             c.proc.user_handles.get_server_info().access([&](const USER_SERVERINFO& server_info) {
                 if (normalized_name == u"Button")
                 {
-                    wnd_proc = server_info.apfnClientA[k_client_pfn_button_wndproc_index];
+                    wnd_proc = server_info.apfnClientW[k_client_pfn_button_wndproc_index];
                     if (wnd_proc == 0)
                     {
-                        wnd_proc = server_info.apfnClientW[k_client_pfn_button_wndproc_index];
+                        wnd_proc = server_info.apfnClientA[k_client_pfn_button_wndproc_index];
                     }
                 }
                 else if (normalized_name == u"Static")
                 {
-                    wnd_proc = server_info.apfnClientA[k_client_pfn_static_wndproc_index];
+                    wnd_proc = server_info.apfnClientW[k_client_pfn_static_wndproc_index];
                     if (wnd_proc == 0)
                     {
-                        wnd_proc = server_info.apfnClientW[k_client_pfn_static_wndproc_index];
+                        wnd_proc = server_info.apfnClientA[k_client_pfn_static_wndproc_index];
                     }
                 }
                 else if (normalized_name == u"#32770")
                 {
-                    wnd_proc = server_info.apfnClientA[k_client_pfn_dialog_wndproc_index];
+                    wnd_proc = server_info.apfnClientW[k_client_pfn_dialog_wndproc_index];
                     if (wnd_proc == 0)
                     {
-                        wnd_proc = server_info.apfnClientW[k_client_pfn_dialog_wndproc_index];
+                        wnd_proc = server_info.apfnClientA[k_client_pfn_dialog_wndproc_index];
                     }
                 }
             });
@@ -1336,6 +1338,37 @@ namespace sogen
         NTSTATUS handle_NtUserFindExistingCursorIcon()
         {
             return STATUS_NOT_SUPPORTED;
+        }
+
+        BOOL handle_NtUserDestroyCursor(const syscall_context&, const hicon icon, const DWORD /*flags*/)
+        {
+            return icon != 0 ? TRUE : FALSE;
+        }
+
+        hicon handle_NtUserGetCursorFrameInfo(const syscall_context&, const hicon icon, const UINT /*frame*/,
+                                              const emulator_object<uint32_t> rate_jiffies, const emulator_object<uint32_t> frame_count)
+        {
+            if (icon == 0)
+            {
+                return 0;
+            }
+
+            rate_jiffies.write_if_valid(0);
+            frame_count.write_if_valid(1);
+            return icon;
+        }
+
+        BOOL handle_NtUserGetIconSize(const syscall_context&, const hicon icon, const UINT /*frame*/, const emulator_object<int> cx,
+                                      const emulator_object<int> cy)
+        {
+            if (icon == 0 || !cx || !cy)
+            {
+                return FALSE;
+            }
+
+            cx.write(32);
+            cy.write(64);
+            return TRUE;
         }
 
         BOOL handle_NtUserMessageBeep()

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -154,8 +154,11 @@ namespace sogen
             {
                 return u"Edit";
             }
-            if (class_name == u"#3" || class_name == u"#2032" || class_name == u"#2160" || class_name == u"STATIC" ||
-                class_name == u"Static")
+            // NOTE: the #NNNN aliases are build-specific class atoms for the static control (the value
+            // differs between Windows versions). This hardcoded list is a stopgap; the atom should be
+            // resolved to its registered class name instead.
+            if (class_name == u"#3" || class_name == u"#2032" || class_name == u"#2160" || class_name == u"#12192" ||
+                class_name == u"STATIC" || class_name == u"Static")
             {
                 return u"Static";
             }

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -78,6 +78,56 @@ namespace sogen
             return try_read_exact(memory, source, destination, std::min(sizeof(destination), source_size));
         }
 
+        // user32 builds MessageBox dialogs from SERVERINFO.MBStrings: an array of
+        // { WCHAR achName[16]; UINT id; UINT uStr; } (0x28 bytes) at gpsi + 0x3A4, indexed by the
+        // standard order OK, Cancel, Abort, Retry, Ignore, Yes, No, Close, Help, Try Again, Continue.
+        // SoftModalMessageBox reads each button's control id (+0x20) and caption (+0x00) from here, so
+        // without it message-box buttons get id 0 (wrong return value) and empty captions.
+        void seed_messagebox_button_strings(memory_interface& memory, const uint64_t serverinfo_base)
+        {
+            if (serverinfo_base == 0)
+            {
+                return;
+            }
+
+            struct mb_string
+            {
+                std::u16string_view text;
+                uint32_t id;
+            };
+            static constexpr std::array<mb_string, 11> entries = {{
+                {u"OK", 1},        // IDOK
+                {u"Cancel", 2},    // IDCANCEL
+                {u"&Abort", 3},    // IDABORT
+                {u"&Retry", 4},    // IDRETRY
+                {u"&Ignore", 5},   // IDIGNORE
+                {u"&Yes", 6},      // IDYES
+                {u"&No", 7},       // IDNO
+                {u"&Close", 8},    // IDCLOSE
+                {u"Help", 9},      // IDHELP
+                {u"&Try Again", 10}, // IDTRYAGAIN
+                {u"&Continue", 11},  // IDCONTINUE
+            }};
+
+            constexpr uint64_t k_mbstrings_offset = 0x3A4;
+            constexpr uint64_t k_mbstrings_entry_size = 0x28;
+            constexpr uint64_t k_mbstrings_id_offset = 0x20;
+            constexpr size_t k_mbstrings_name_capacity = 16; // WCHAR achName[16]
+
+            for (size_t i = 0; i < entries.size(); ++i)
+            {
+                const auto entry_base = serverinfo_base + k_mbstrings_offset + i * k_mbstrings_entry_size;
+
+                std::array<char16_t, k_mbstrings_name_capacity> name{};
+                const auto copy_count = std::min<size_t>(entries[i].text.size(), k_mbstrings_name_capacity - 1);
+                std::ranges::copy_n(entries[i].text.begin(), static_cast<std::ptrdiff_t>(copy_count), name.begin());
+                memory.write_memory(entry_base, name.data(), name.size() * sizeof(char16_t));
+
+                const auto id = entries[i].id;
+                memory.write_memory(entry_base + k_mbstrings_id_offset, &id, sizeof(id));
+            }
+        }
+
         bool try_copy_client_pfn_arrays(memory_interface& memory, process_context& process, const client_pfn_arrays arrays)
         {
             if (arrays.ansi == 0 || arrays.wide == 0 || arrays.worker == 0)
@@ -96,6 +146,9 @@ namespace sogen
             {
                 return false;
             }
+
+            // Seed after the pfn copy: the worker-array fill above zeroes part of the MBStrings region.
+            seed_messagebox_button_strings(memory, process.user_handles.get_server_info().value());
 
             refresh_dispatch_client_message(process);
             return true;

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -71,6 +71,7 @@ namespace sogen
             return address != 0 && memory.try_read_memory(address, data, size);
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         bool try_copy_client_pfn_array(memory_interface& memory, const uint64_t source, uint64_t (&destination)[FNID_ARRAY_SIZE],
                                        const size_t source_size)
         {
@@ -96,17 +97,17 @@ namespace sogen
                 uint32_t id;
             };
             static constexpr std::array<mb_string, 11> entries = {{
-                {u"OK", 1},        // IDOK
-                {u"Cancel", 2},    // IDCANCEL
-                {u"&Abort", 3},    // IDABORT
-                {u"&Retry", 4},    // IDRETRY
-                {u"&Ignore", 5},   // IDIGNORE
-                {u"&Yes", 6},      // IDYES
-                {u"&No", 7},       // IDNO
-                {u"&Close", 8},    // IDCLOSE
-                {u"Help", 9},      // IDHELP
-                {u"&Try Again", 10}, // IDTRYAGAIN
-                {u"&Continue", 11},  // IDCONTINUE
+                {.text = u"OK", .id = 1},          // IDOK
+                {.text = u"Cancel", .id = 2},      // IDCANCEL
+                {.text = u"&Abort", .id = 3},      // IDABORT
+                {.text = u"&Retry", .id = 4},      // IDRETRY
+                {.text = u"&Ignore", .id = 5},     // IDIGNORE
+                {.text = u"&Yes", .id = 6},        // IDYES
+                {.text = u"&No", .id = 7},         // IDNO
+                {.text = u"&Close", .id = 8},      // IDCLOSE
+                {.text = u"Help", .id = 9},        // IDHELP
+                {.text = u"&Try Again", .id = 10}, // IDTRYAGAIN
+                {.text = u"&Continue", .id = 11},  // IDCONTINUE
             }};
 
             constexpr uint64_t k_mbstrings_offset = 0x3A4;

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -12,6 +12,15 @@ namespace sogen
         constexpr size_t k_dispatch_client_message_index = 21;
         constexpr size_t k_ntdll_probe_size = 128;
         constexpr size_t k_expected_pfn_pointer_count = 3;
+        constexpr size_t k_client_pfn_array_size = FNID_ARRAY_SIZE * sizeof(uint64_t);
+        constexpr size_t k_client_worker_pfn_array_size = 0x90;
+
+        struct client_pfn_arrays
+        {
+            uint64_t ansi{};
+            uint64_t wide{};
+            uint64_t worker{};
+        };
 
         std::vector<uint64_t> scan_rip_relative_lea_references(const std::vector<uint8_t>& bytes, const uint64_t code_base,
                                                                const size_t max_results)
@@ -56,6 +65,42 @@ namespace sogen
                 process.dispatch_client_message = dispatch_client_message;
             }
         }
+
+        bool try_read_exact(memory_interface& memory, const uint64_t address, void* data, const size_t size)
+        {
+            return address != 0 && memory.try_read_memory(address, data, size);
+        }
+
+        bool try_copy_client_pfn_array(memory_interface& memory, const uint64_t source, uint64_t (&destination)[FNID_ARRAY_SIZE],
+                                       const size_t source_size)
+        {
+            std::ranges::fill(destination, 0);
+            return try_read_exact(memory, source, destination, std::min(sizeof(destination), source_size));
+        }
+
+        bool try_copy_client_pfn_arrays(memory_interface& memory, process_context& process, const client_pfn_arrays arrays)
+        {
+            if (arrays.ansi == 0 || arrays.wide == 0 || arrays.worker == 0)
+            {
+                return false;
+            }
+
+            bool copied = false;
+            process.user_handles.get_server_info().access([&](USER_SERVERINFO& server_info) {
+                copied = try_copy_client_pfn_array(memory, arrays.ansi, server_info.apfnClientA, k_client_pfn_array_size) &&
+                         try_copy_client_pfn_array(memory, arrays.wide, server_info.apfnClientW, k_client_pfn_array_size) &&
+                         try_copy_client_pfn_array(memory, arrays.worker, server_info.apfnClientWorker, k_client_worker_pfn_array_size);
+            });
+
+            if (!copied)
+            {
+                return false;
+            }
+
+            refresh_dispatch_client_message(process);
+            return true;
+        }
+
     }
 
     namespace win32k_userconnect
@@ -211,32 +256,8 @@ namespace sogen
         bool try_update_client_pfn_arrays_from_addresses(memory_interface& memory, process_context& process, const uint64_t apfn_client_a,
                                                          const uint64_t apfn_client_w, const uint64_t apfn_client_worker)
         {
-            try
-            {
-                process.user_handles.get_server_info().access([&](USER_SERVERINFO& server_info) {
-                    if (apfn_client_a != 0)
-                    {
-                        memory.read_memory(apfn_client_a, &server_info.apfnClientA, sizeof(server_info.apfnClientA));
-                    }
-
-                    if (apfn_client_w != 0)
-                    {
-                        memory.read_memory(apfn_client_w, &server_info.apfnClientW, sizeof(server_info.apfnClientW));
-                    }
-
-                    if (apfn_client_worker != 0)
-                    {
-                        memory.read_memory(apfn_client_worker, &server_info.apfnClientWorker, sizeof(server_info.apfnClientWorker));
-                    }
-                });
-            }
-            catch (...)
-            {
-                return false;
-            }
-
-            refresh_dispatch_client_message(process);
-            return true;
+            return try_copy_client_pfn_arrays(
+                memory, process, client_pfn_arrays{.ansi = apfn_client_a, .wide = apfn_client_w, .worker = apfn_client_worker});
         }
 
         bool try_bootstrap_client_pfn_arrays_from_ntdll(windows_emulator& win_emu)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -65,7 +65,10 @@ namespace sogen
 
         bool is_button_window(const window& win)
         {
-            return win.class_name == u"Button" || win.class_name == u"BUTTON";
+            // window::class_name stores the raw class passed to CreateWindowEx, which for builtin
+            // controls is often an ordinal atom (e.g. "#1") rather than the literal name. Match the
+            // same aliases that syscalls::normalize_builtin_window_class_name maps to "Button".
+            return win.class_name == u"Button" || win.class_name == u"BUTTON" || win.class_name == u"#1";
         }
 
         const window* find_button_child_at(const process_context& process, const hwnd parent, const int x, const int y)


### PR DESCRIPTION
## Summary

Makes the builtin `MessageBox` actually render and behave through the guest USER/GDI path. Starting from an empty window, `messagebox-sample` (`MB_YESNO | MB_ICONQUESTION`) now:

- renders the dialog with **Yes/No buttons**, their **labels**, and the **message text**
- responds to **mouse clicks** — clicking **Yes** returns `IDYES` (the sample prints `clicked: yes`)

## Background

The real user32 control wndprocs run (layout, `BeginPaint`), but produced no pixels and the dialog returned `IDOK` regardless of which button was clicked. Investigation (incl. Ghidra on the host user32.dll) traced this to three independent gaps in the emulated USER/GDI layer.

## Changes

**Control painting** — MessageBox creates its child controls during `WM_INITDIALOG` and they paint while the dialog is still hidden; user32 gates control painting on the whole parent chain being visible, so they correctly skip drawing. `ShowWindow` then only invalidated the dialog itself, never its children, so they never repainted once the dialog became visible.
- Add `invalidate_window_tree()` and invalidate the visible child subtree from `NtUserShowWindow` / `NtUserSetWindowPos(SWP_SHOWWINDOW)`.

**Button clicks** — `is_button_window` only matched the literal `"Button"` class, but builtin controls store the raw ordinal-atom class (`#1`), so click hit-testing never found the buttons. Now matches `#1` too, so clicking dismisses the dialog.

**Button IDs + captions** — user32's `SoftModalMessageBox` builds the dialog template by reading each button's `{caption, control id}` from `SERVERINFO.MBStrings` (`gpsi + 0x3A4`). Our SERVERINFO left that table zeroed, so every button got control id 0 (wrong return value) and an empty caption (blank label).
- Seed `SERVERINFO.MBStrings` with the 11 standard message-box buttons (OK, Cancel, Abort, Retry, Ignore, Yes, No, Close, Help, Try Again, Continue) after the client pfn arrays are copied.
- Removed the previous fragile caption→ID heuristic.

**New/!missing syscalls**
- Implement `NtGdiGetDCDword` (gdi32 calls it for `GdiGetIsMemDc` during control paint; was unimplemented and halted emulation).
- Implement `NtGdiPolyPatBlt` (button press/focus repaint on click).
- Stub `NtUserDrawIconEx` so the icon static finishes painting.

## Known remaining gaps

- The message-box **icon** is not drawn (`NtUserDrawIconEx` is a stub).
- The dialog **background** may stay white rather than the gray dialog face.

## Test

```
build\release\artifacts\analyzer.exe -s build\release\artifacts\messagebox-sample.exe
```
Renders the dialog with Yes/No + text; clicking Yes prints `clicked: yes`.