### PR TITLE
Resolve builtin control-class atoms

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -141,37 +141,36 @@ so always analyze the DLL the emulator actually maps):
 
 - The message-box **icon** is not drawn (`NtUserDrawIconEx` stub).
 - The dialog **background** may stay white instead of the gray dialog face.
-- **System builtin-class atom resolution is not portable** (see next section).
 
-## System builtin-class atom resolution (open, build-specific)
+## System builtin-class atom resolution (resolved, portable)
 
-`normalize_builtin_window_class_name` hardcodes specific class-atom values (`#1`→Button,
-`#2032`/`#2160`/`#12192`→Static, `#32770`→dialog). This breaks across Windows builds: the same
-sample works with one system's user32 (static = `#2032`) but fails with another's (static =
-`#12192`, "missing class"). Investigation findings:
+**Fixed** in `resolve_builtin_class_atom` (`syscalls/user.cpp`). The earlier stopgap had
+`normalize_builtin_window_class_name` hardcoding build-specific class-atom values
+(`#2032`/`#2160`/`#12192`→Static); this broke across Windows builds because the same sample
+resolved static = `#2032` on one system's user32 but `#12192` on another's ("missing class").
 
-- The builtin window classes are **never registered via a syscall** — `NtUserRegisterClassExWOW`
-  appears zero times in the full startup+run trace. So the emulator never observes the class
-  atom → name mapping.
-- The class atoms (Button `0x1`, Static `0x7f0`=#2032 / `0x2fa0`=#12192, Dialog `0x8002`=#32770) are
-  **user32-internal, build-specific integer atoms** (< `MAXINTATOM` 0xC000). user32 already holds
-  them; it calls `NtUserGetAtomName(atom)` (emulator returns the `#NNNN` integer form) and then
-  passes the atom to `NtUserCreateWindowEx`. Dialog templates store controls by **system class
-  ordinal** (`0x80`=Button, `0x82`=Static via `FUN_18006c2f4` writing `0xFFFF,<ord>`); user32 maps
-  the ordinal to its internal atom.
-- The atoms are **not** present in our `gpsi`/`USER_SERVERINFO` (scanned the full `0x1B58` struct as
-  both 16- and 32-bit; the only `0x7f0` hits were the low word of worker-pfn pointers like
-  `0x1801207f0`). So user32 is not reading them from a table the emulator populates.
-- `add_or_find_atom` assigns string atoms from `0xC000` up, so emulator-registered atoms never
-  collide with these low integer atoms anyway.
+How user32 sources the atom (host `user32.dll`, dialog-creation worker `FUN_18002a070`): dialog
+templates store controls by **system class ordinal** (`0x80`=Button, `0x81`=Edit, `0x82`=Static,
+`0x83`=ListBox, `0x84`=ScrollBar, `0x85`=ComboBox, written as `0xFFFF,<ord>`). user32 turns the
+ordinal into a class atom by indexing the WORD table `SERVERINFO.atomSysClass[ICLS]` at **`gpsi +
+0x364`** with `(ordinal & 0x7F)`, then passes that atom to `NtUserCreateWindowEx`:
 
-Because there is no registration hook and the atoms live in user32-internal build-specific state,
-the emulator cannot currently resolve them dynamically — the hardcoded list is the stopgap (each new
-build's atom must be added). **Decisive next step for a real fix:** decompile the `NtUserGetAtomName`
-caller / dialog class-ordinal resolution in user32 to find where the static atom (`0x7f0`) is
-sourced — either `gpsi->atomSysClass` (possibly *beyond* our `0x1B58` SERVERINFO size, in which case
-enlarge the struct and pre-register system classes with emulator-chosen atoms = fully portable) or a
-user32-internal global baked at `DllMain` (then read it at startup or keep the hardcode).
+```c
+class_atom = *(WORD *)(gpsi + (ordinal & 0x7F) * 2 + 0x364);
+```
+
+The atom values are assigned per build (Static = `0x7F0` here, `0x2FA0` elsewhere), which is why a
+hardcoded list cannot be portable.
+
+The fix reverse-maps an incoming integer class atom back to its canonical builtin class name by
+reading that **same** `gpsi + 0x364` table and matching the atom against the ICLS-indexed entries
+(0=Button, 1=Edit, 2=Static, 3=ListBox, 4=ScrollBar, 5=ComboBox). Because the lookup round-trips
+through the exact memory user32 used for the forward mapping, it agrees with user32 regardless of the
+build's atom values — no hardcoded atoms. Verified: the message-box dialog now creates `Button` and
+`Static` controls with no "missing class" errors and no `#NNNN` aliases.
+
+Confirmed empirically with a runtime probe at `NtUserCreateWindowEx`: incoming Button atom `0x1`
+matched `atomSysClass[0]`, incoming Static atom `0x7F0` matched `atomSysClass[2]`.
 
 ## Builtin MessageBox Investigation Notes
 
@@ -253,10 +252,10 @@ Likely proper direction:
 ## Remaining blockers
 
 Resolved by the 2026-06-06 update above: builtin `MessageBox` control rendering on the real
-user32 paint path, button self-draw, click→`WM_COMMAND`→`EndDialog`, correct return code, and
-button captions. Still open:
+user32 paint path, button self-draw, click→`WM_COMMAND`→`EndDialog`, correct return code,
+button captions, and portable system builtin-class atom resolution (see "System builtin-class
+atom resolution"). Still open:
 
-- portable system builtin-class atom resolution (see "System builtin-class atom resolution")
 - message-box **icon** pixels (`NtUserDrawIconEx` is a success stub)
 - dialog **background** fill (may render white instead of the gray dialog face)
 - finish small-text / batched GDI text path so ordinary `TextOutA/W` works without forcing oversized `ExtTextOutW`
@@ -291,12 +290,10 @@ The remaining design direction is to continue moving Win32 behavior out of host 
 
 ## Next steps
 
-1. Make system builtin-class atom resolution portable (see that section) so the hardcoded `#NNNN`
-   list can be dropped.
-2. Draw the message-box icon (`NtUserDrawIconEx`) and the dialog background.
-3. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual
+1. Draw the message-box icon (`NtUserDrawIconEx`) and the dialog background.
+2. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual
    `Button` / `Static` drawing fallbacks.
-4. Continue improving batched text and font handling.
+3. Continue improving batched text and font handling.
 
 ## Non-goals for this checkpoint
 

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -83,6 +83,96 @@ Real emulation goal is stronger: builtin controls, dialogs, and custom `WM_PAINT
   - `#2032` now normalizes to the builtin `Static` class, matching the `SS_ICON` control path.
   - The current blocker is no longer a single missing syscall; it is correct user32 client callback initialization and builtin control paint.
 
+## UPDATE 2026-06-06 — builtin `MessageBox` renders and works end-to-end
+
+`messagebox-sample` (`MessageBoxA(NULL, "Proceed?", "Question", MB_YESNO | MB_ICONQUESTION)`)
+now renders the dialog with **Yes/No buttons, their labels, and the message text**, and
+**clicking Yes returns `IDYES`** (the sample prints `clicked: yes`). The real user32
+control wndprocs run and paint through the guest GDI path — no manual fallback drawing.
+
+The sections below ("Current truth", "Builtin MessageBox Investigation Notes",
+"Ntdll/User32 Callback Findings") predate this and are kept for history; several of their
+"blockers" are resolved. The root causes that were actually blocking visible, interactive
+controls turned out to be four independent issues (all verified with Ghidra on the **host**
+`C:\Windows\System32\user32.dll` — note the emulator loads the *host* live system DLLs when
+run with no `-e root`, not a captured `root` copy; the routing globals differ between builds
+so always analyze the DLL the emulator actually maps):
+
+1. **Controls never repaint after the dialog becomes visible.** user32's control wndprocs gate
+   their paint body on the whole parent chain being visible
+   (`ButtonWndProcW` → worker `FUN_18000a540` → drawability check `FUN_180008030`, which walks
+   the window + every ancestor requiring `WS_VISIBLE`, style byte at WND `+0x1f` bit `0x10` =
+   `0x10000000`; this maps to `USER_WINDOW dwStyle@0x1c`, `fnid@0x2a`, `spwndParent@0x30`).
+   MessageBox creates its children during `WM_INITDIALOG` and they paint while the dialog is
+   still hidden, so they correctly skip drawing. `NtUserShowWindow` then only invalidated the
+   dialog itself. Fix: `invalidate_window_tree()` (in `user.cpp`) recursively re-invalidates the
+   visible child subtree, called from `NtUserShowWindow` and `NtUserSetWindowPos(SWP_SHOWWINDOW)`
+   after `WS_VISIBLE` is set.
+
+2. **Button click hit-testing failed.** `is_button_window` (in `windows_emulator.cpp`) compared
+   the literal `"Button"`, but `window::class_name` stores the raw ordinal-atom class (`#1`).
+   Fix: also match `#1` so `find_button_child_at` works and clicking dismisses the dialog.
+
+3. **Wrong return code + blank button labels — both from `SERVERINFO.MBStrings`.**
+   user32 `SoftModalMessageBox` builds the dialog template by reading each button's
+   `{caption, control id}` from `gpsi->MBStrings`: an array at `gpsi + 0x3A4` of
+   `{ WCHAR achName[16]; UINT id @ +0x20; UINT uStr @ +0x24 }` (0x28-byte entries), fixed order
+   OK, Cancel, Abort, Retry, Ignore, Yes, No, Close, Help, Try Again, Continue (ids 1..11; per-MB-type
+   index tables `DAT_…b3c00/b3c5c/b3c64`). Our SERVERINFO left it zeroed → buttons got control id 0
+   (so the dialog always returned `IDOK`) and empty captions (blank labels). The dialog proc
+   (`MB_DlgProc` @ `0x1800530a0`) stores MSGBOXDATA in the dialog's `GWLP_USERDATA` on
+   `WM_INITDIALOG` and calls `EndDialog(control_id)` on `WM_COMMAND`. Fix:
+   `seed_messagebox_button_strings()` in `win32k_userconnect.cpp` populates `MBStrings`, called from
+   `try_copy_client_pfn_arrays` **after** the client-pfn copy (the `apfnClientWorker` fill zeroes the
+   overlapping tail). Confirmed at runtime that user32's `gpsi` == our `user_handles.get_server_info()`.
+   The fragile caption→ID heuristic (`map_dialog_button_caption_to_id`) was removed.
+
+4. **Missing GDI/USER syscalls surfaced once controls actually painted:**
+   - `NtGdiGetDCDword` — gdi32 calls it for `GdiGetIsMemDc`; was unimplemented and halted. Returns 0
+     (a real paint DC is not a memory DC).
+   - `NtGdiPolyPatBlt` — button frame/press repaint. **Entry layout verified at runtime against this
+     build's gdi32: `{ int x; int y; int cx; int cy; HBRUSH hbr@+0x10 }` (position + size), NOT a RECT
+     with right/bottom** — button frame draws pass thin edges like `{x=96,y=4,cx=1,cy=20}` that only
+     make sense as width/height.
+   - `NtUserDrawIconEx` — stubbed to return success so the `SS_ICON` static finishes painting (icon
+     pixels are not drawn yet).
+
+### Still open after this update
+
+- The message-box **icon** is not drawn (`NtUserDrawIconEx` stub).
+- The dialog **background** may stay white instead of the gray dialog face.
+- **System builtin-class atom resolution is not portable** (see next section).
+
+## System builtin-class atom resolution (open, build-specific)
+
+`normalize_builtin_window_class_name` hardcodes specific class-atom values (`#1`→Button,
+`#2032`/`#2160`/`#12192`→Static, `#32770`→dialog). This breaks across Windows builds: the same
+sample works with one system's user32 (static = `#2032`) but fails with another's (static =
+`#12192`, "missing class"). Investigation findings:
+
+- The builtin window classes are **never registered via a syscall** — `NtUserRegisterClassExWOW`
+  appears zero times in the full startup+run trace. So the emulator never observes the class
+  atom → name mapping.
+- The class atoms (Button `0x1`, Static `0x7f0`=#2032 / `0x2fa0`=#12192, Dialog `0x8002`=#32770) are
+  **user32-internal, build-specific integer atoms** (< `MAXINTATOM` 0xC000). user32 already holds
+  them; it calls `NtUserGetAtomName(atom)` (emulator returns the `#NNNN` integer form) and then
+  passes the atom to `NtUserCreateWindowEx`. Dialog templates store controls by **system class
+  ordinal** (`0x80`=Button, `0x82`=Static via `FUN_18006c2f4` writing `0xFFFF,<ord>`); user32 maps
+  the ordinal to its internal atom.
+- The atoms are **not** present in our `gpsi`/`USER_SERVERINFO` (scanned the full `0x1B58` struct as
+  both 16- and 32-bit; the only `0x7f0` hits were the low word of worker-pfn pointers like
+  `0x1801207f0`). So user32 is not reading them from a table the emulator populates.
+- `add_or_find_atom` assigns string atoms from `0xC000` up, so emulator-registered atoms never
+  collide with these low integer atoms anyway.
+
+Because there is no registration hook and the atoms live in user32-internal build-specific state,
+the emulator cannot currently resolve them dynamically — the hardcoded list is the stopgap (each new
+build's atom must be added). **Decisive next step for a real fix:** decompile the `NtUserGetAtomName`
+caller / dialog class-ordinal resolution in user32 to find where the static atom (`0x7f0`) is
+sourced — either `gpsi->atomSysClass` (possibly *beyond* our `0x1B58` SERVERINFO size, in which case
+enlarge the struct and pre-register system classes with emulator-chosen atoms = fully portable) or a
+user32-internal global baked at `DllMain` (then read it at startup or keep the hardcode).
+
 ## Builtin MessageBox Investigation Notes
 
 IDA/user32 findings from the current checkpoint:
@@ -162,14 +252,19 @@ Likely proper direction:
 
 ## Remaining blockers
 
-- builtin `MessageBox` control rendering still needs the real client callback/user32 initialization path
-- expect possible follow-up icon/static paint gaps such as `DrawIconEx` behavior or icon-handle metadata
+Resolved by the 2026-06-06 update above: builtin `MessageBox` control rendering on the real
+user32 paint path, button self-draw, click→`WM_COMMAND`→`EndDialog`, correct return code, and
+button captions. Still open:
+
+- portable system builtin-class atom resolution (see "System builtin-class atom resolution")
+- message-box **icon** pixels (`NtUserDrawIconEx` is a success stub)
+- dialog **background** fill (may render white instead of the gray dialog face)
 - finish small-text / batched GDI text path so ordinary `TextOutA/W` works without forcing oversized `ExtTextOutW`
-- decide where batch flush should happen generically, not only in sample-driven probing
 - replace temporary debug-font text path with more correct font/text handling over time
-- improve builtin control self-draw (`Button`, `Static`) via real user32 paint path
 - add more correct clip/region handling
 - add more correct ROP / brush / pen / DC semantics where builtin paint needs them
+- `NtGdiGetDCDword` only returns the default (0); other indices (MapMode, GraphicsMode, …) would need
+  real values if a control relies on them
 
 ## Backend parity notes
 
@@ -196,10 +291,12 @@ The remaining design direction is to continue moving Win32 behavior out of host 
 
 ## Next steps
 
-1. Model the user32 client initialization path cleanly enough that ntdll client thunks do not point at `UninitUser32Proc`.
-2. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual `Button` / `Static` drawing fallbacks.
-3. Re-test builtin `STATIC` / `BUTTON` paint after client callback initialization is fixed.
-4. Continue improving batched text and font handling once control paint reaches real GDI calls.
+1. Make system builtin-class atom resolution portable (see that section) so the hardcoded `#NNNN`
+   list can be dropped.
+2. Draw the message-box icon (`NtUserDrawIconEx`) and the dialog background.
+3. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual
+   `Button` / `Static` drawing fallbacks.
+4. Continue improving batched text and font handling.
 
 ## Non-goals for this checkpoint
 
@@ -217,6 +314,12 @@ Manual message box sample:
 
 ```cmd
 build\release\artifacts\analyzer.exe -s build\release\artifacts\manual-messagebox-sample.exe
+```
+
+Builtin message box sample (renders Yes/No + text; clicking Yes prints `clicked: yes`):
+
+```cmd
+build\release\artifacts\analyzer.exe -s build\release\artifacts\messagebox-sample.exe
 ```
 
 MessageBox sample with root mapping:

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -724,8 +724,6 @@ namespace sogen
                     const auto* header = reinterpret_cast<const gdi_batch_header*>(bytes + offset);
                     if (header->size <= 0 || offset + static_cast<size_t>(header->size) > batch_offset)
                     {
-                        std::printf("GDI batch invalid header offset=%zu size=%d cmd=%d batch_offset=%zu\n", offset, header->size,
-                                    header->cmd, static_cast<size_t>(batch_offset));
                         break;
                     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -154,11 +154,10 @@ namespace sogen
             {
                 return u"Edit";
             }
-            // NOTE: the #NNNN aliases are build-specific class atoms for the static control (the value
-            // differs between Windows versions). This hardcoded list is a stopgap; the atom should be
-            // resolved to its registered class name instead.
-            if (class_name == u"#3" || class_name == u"#2032" || class_name == u"#2160" || class_name == u"#12192" ||
-                class_name == u"STATIC" || class_name == u"Static")
+            // Build-specific integer atoms for the control classes are resolved to their canonical names
+            // earlier, via SERVERINFO.atomSysClass (see resolve_builtin_class_atom), so only the literal
+            // class names and the stable ordinal aliases need to be handled here.
+            if (class_name == u"#3" || class_name == u"STATIC" || class_name == u"Static")
             {
                 return u"Static";
             }
@@ -890,6 +889,55 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        // user32's dialog manager turns a control-class ordinal (0x80=Button, 0x81=Edit, 0x82=Static,
+        // 0x83=ListBox, 0x84=ScrollBar, 0x85=ComboBox) into a class atom by indexing the WORD table
+        // SERVERINFO.atomSysClass[ICLS] at gpsi+0x364 with (ordinal & 0x7F), then hands that atom to
+        // NtUserCreateWindowEx. Those atom values are assigned per build, so the same control shows up
+        // as e.g. atom 0x7F0 on one Windows version and a different value on another. Map an incoming
+        // integer atom back to its canonical builtin class name by reverse-looking it up in that table,
+        // which is portable across builds (no hardcoded atom values).
+        std::u16string_view resolve_builtin_class_atom(const syscall_context& c, const uint16_t atom)
+        {
+            if (atom == 0)
+            {
+                return {};
+            }
+
+            static constexpr std::array<std::u16string_view, 6> class_names = {
+                u"Button", u"Edit", u"Static", u"ListBox", u"ScrollBar", u"ComboBox",
+            };
+
+            constexpr uint64_t k_atom_sys_class_offset = 0x364;
+
+            const auto serverinfo_base = c.proc.user_handles.get_server_info().value();
+            if (serverinfo_base == 0)
+            {
+                return {};
+            }
+
+            for (size_t i = 0; i < class_names.size(); ++i)
+            {
+                uint16_t entry = 0;
+                const auto address = serverinfo_base + k_atom_sys_class_offset + i * sizeof(uint16_t);
+                if (c.win_emu.memory.try_read_memory(address, &entry, sizeof(entry)) && entry == atom)
+                {
+                    return class_names[i];
+                }
+            }
+
+            return {};
+        }
+
+        std::u16string resolve_atom_name(const syscall_context& c, const uint16_t atom)
+        {
+            if (const auto builtin = resolve_builtin_class_atom(c, atom); !builtin.empty())
+            {
+                return std::u16string{builtin};
+            }
+
+            return c.proc.get_atom_name(atom).value_or(u"");
+        }
+
         std::u16string read_unicode_string_or_atom(const syscall_context& c,
                                                    const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> uc_string,
                                                    const size_t index = 0)
@@ -901,7 +949,7 @@ namespace sogen
 
             if (uc_string.value() <= std::numeric_limits<uint16_t>::max())
             {
-                return c.proc.get_atom_name(static_cast<uint16_t>(uc_string.value())).value_or(u"");
+                return resolve_atom_name(c, static_cast<uint16_t>(uc_string.value()));
             }
 
             return read_unicode_string(c.emu, uc_string, index);
@@ -917,7 +965,7 @@ namespace sogen
 
             if (str_obj.value() <= std::numeric_limits<uint16_t>::max())
             {
-                return c.proc.get_atom_name(static_cast<uint16_t>(str_obj.value())).value_or(u"");
+                return resolve_atom_name(c, static_cast<uint16_t>(str_obj.value()));
             }
 
             return read_large_string(str_obj, index);


### PR DESCRIPTION
## Summary

Makes builtin control-class atom resolution portable across Windows builds, so dialogs (e.g. `MessageBox`) create their `Button`/`Static`/etc. child controls correctly regardless of which host `user32.dll` the emulator runs against.

## Problem

`normalize_builtin_window_class_name` hardcoded build-specific class-atom values for the static control (`#2032`/`#2160`/`#12192` → `Static`). Those atom values are assigned **per Windows build**, so a sample that resolved the static class as `#2032` on one system failed with `#12192` ("missing class") on another — the hardcoded list could never be complete.

## Root cause

From the host `user32.dll` dialog-creation worker (`FUN_18002a070`): dialog templates store controls by **system class ordinal** (`0x80`=Button, `0x81`=Edit, `0x82`=Static, `0x83`=ListBox, `0x84`=ScrollBar, `0x85`=ComboBox, written as `0xFFFF,<ord>`). user32 turns the ordinal into a class atom by indexing the `SERVERINFO.atomSysClass[ICLS]` WORD table at **`gpsi + 0x364`** with `(ordinal & 0x7F)`, then passes that atom to `NtUserCreateWindowEx`:

```c
class_atom = *(WORD *)(gpsi + (ordinal & 0x7F) * 2 + 0x364);
```

Since the table holds the build's own atom values, no static list of atom numbers can be portable.

## Fix

`resolve_builtin_class_atom` (in `syscalls/user.cpp`) reverse-maps an incoming integer class atom back to its canonical builtin class name by reading that **same** `gpsi + 0x364` table and matching the atom against the ICLS-indexed entries (0=Button, 1=Edit, 2=Static, 3=ListBox, 4=ScrollBar, 5=ComboBox). It is wired into `read_large_string_or_atom` / `read_unicode_string_or_atom` via `resolve_atom_name`. Because the lookup round-trips through the exact memory user32 used for the forward mapping, it always agrees with user32 regardless of the build's atom values — no hardcoded atoms. The build-specific `#NNNN` aliases are dropped from `normalize_builtin_window_class_name`.

Verified with a runtime probe at `NtUserCreateWindowEx`: incoming Button atom `0x1` matched `atomSysClass[0]` and incoming Static atom `0x7F0` matched `atomSysClass[2]`. The message-box dialog now creates `Button`/`Static` controls with no "missing class" errors and no `#NNNN` fallbacks.

## Also in this PR

- Remove a leftover `std::printf` debug trace from the GDI batch-flush validation path (`gdi.cpp`); the error path now bails silently like the other guards in that function.
- Documentation: `docs/windows-ui-emulation.md` updated to record the atom-resolution mechanism/fix and the earlier MessageBox rendering/click findings.
