### PR TITLE
Keep Python hook handles alive internally

### DIFF
--- a/src/python-bindings/sogen_api_hooks.cpp
+++ b/src/python-bindings/sogen_api_hooks.cpp
@@ -92,7 +92,7 @@ namespace sogen::py
     {
     }
 
-    void hook_handle::remove()
+    void hook_handle::remove() const
     {
         if (this->shared_state)
         {

--- a/src/python-bindings/sogen_api_hooks.cpp
+++ b/src/python-bindings/sogen_api_hooks.cpp
@@ -57,43 +57,18 @@ namespace sogen::py
 
     // ----- hook_handle -----
 
-    hook_handle::hook_handle(windows_emulator& emulator, emulator_hook* hook, nb::object owner)
+    hook_handle::hook_state::hook_state(windows_emulator& emulator, emulator_hook* hook)
         : emu(&emulator),
-          hook(hook),
-          owner(std::move(owner))
+          hook(hook)
     {
     }
 
-    hook_handle::~hook_handle()
+    hook_handle::hook_state::~hook_state()
     {
         remove();
     }
 
-    hook_handle::hook_handle(hook_handle&& other) noexcept
-        : emu(other.emu),
-          hook(other.hook),
-          owner(std::move(other.owner))
-    {
-        other.emu = nullptr;
-        other.hook = nullptr;
-    }
-
-    hook_handle& hook_handle::operator=(hook_handle&& other) noexcept
-    {
-        if (this != &other)
-        {
-            remove();
-            emu = other.emu;
-            hook = other.hook;
-            owner = std::move(other.owner);
-            other.emu = nullptr;
-            other.hook = nullptr;
-        }
-
-        return *this;
-    }
-
-    void hook_handle::remove()
+    void hook_handle::hook_state::remove()
     {
         if (!this->emu || !this->hook)
         {
@@ -109,6 +84,20 @@ namespace sogen::py
         }
 
         this->hook = nullptr;
+    }
+
+    hook_handle::hook_handle(windows_emulator& emulator, emulator_hook* hook, nb::object owner)
+        : shared_state(std::make_shared<hook_state>(emulator, hook)),
+          owner(std::move(owner))
+    {
+    }
+
+    void hook_handle::remove()
+    {
+        if (this->shared_state)
+        {
+            this->shared_state->remove();
+        }
     }
 
     // ----- api_hook_registry -----

--- a/src/python-bindings/sogen_internal.hpp
+++ b/src/python-bindings/sogen_internal.hpp
@@ -8,23 +8,34 @@ namespace sogen::py
     // RAII wrapper for emulator hooks. Removes the hook on destruction.
     struct hook_handle
     {
-        windows_emulator* emu{};
-        emulator_hook* hook{};
+        struct hook_state
+        {
+            windows_emulator* emu{};
+            emulator_hook* hook{};
+
+            hook_state() = default;
+            hook_state(windows_emulator& emulator, emulator_hook* hook);
+            ~hook_state();
+
+            hook_state(const hook_state&) = delete;
+            hook_state& operator=(const hook_state&) = delete;
+
+            void remove();
+            bool active() const
+            {
+                return this->hook != nullptr;
+            }
+        };
+
+        std::shared_ptr<hook_state> shared_state{};
         nb::object owner = nb::none();
 
         hook_handle() = default;
         hook_handle(windows_emulator& emulator, emulator_hook* hook, nb::object owner);
-        ~hook_handle();
-
-        hook_handle(const hook_handle&) = delete;
-        hook_handle& operator=(const hook_handle&) = delete;
-
-        hook_handle(hook_handle&& other) noexcept;
-        hook_handle& operator=(hook_handle&& other) noexcept;
 
         bool active() const
         {
-            return this->hook != nullptr;
+            return this->shared_state && this->shared_state->active();
         }
         void remove();
     };
@@ -119,6 +130,7 @@ namespace sogen::py
     {
         windows_emulator* emu{};
         std::shared_ptr<api_hook_registry> apis{};
+        std::vector<hook_handle> active_hooks{};
 
         explicit hook_registry(windows_emulator& emulator);
 

--- a/src/python-bindings/sogen_internal.hpp
+++ b/src/python-bindings/sogen_internal.hpp
@@ -37,7 +37,7 @@ namespace sogen::py
         {
             return this->shared_state && this->shared_state->active();
         }
-        void remove();
+        void remove() const;
     };
 
     // Information about a single API call passed to the user's Python callback.

--- a/src/python-bindings/sogen_wrappers.cpp
+++ b/src/python-bindings/sogen_wrappers.cpp
@@ -12,7 +12,12 @@ namespace sogen::py
 
     hook_handle hook_registry::make_hook(emulator_hook* hook)
     {
-        return {*this->emu, hook, nb::cast(this, nb::rv_policy::reference_internal)};
+        hook_handle stored{*this->emu, hook, nb::none()};
+        this->active_hooks.emplace_back(stored);
+
+        auto exposed = stored;
+        exposed.owner = nb::cast(this, nb::rv_policy::reference_internal);
+        return exposed;
     }
 
     hook_handle hook_registry::memory_execution(nb::object callback)

--- a/src/python-bindings/test.py
+++ b/src/python-bindings/test.py
@@ -134,6 +134,42 @@ with tempfile.TemporaryDirectory(prefix="sogen-python-") as temp_dir:
     app = None
     gc.collect()
 
+# temporary hook lifetime smoke test: returned Hook object must not be kept in Python
+# for hook to stay active.
+if hook_sample.exists():
+    temp_hook_hits = {"count": 0}
+    temp_app_box = {"app": None}
+
+    def on_temp_module_load(module):
+        if module.name.lower() == "hook-sample.exe":
+            temp_app_box["app"].hooks.memory_execution_at(
+                module.entry_point,
+                lambda address: temp_hook_hits.__setitem__("count", temp_hook_hits["count"] + 1),
+            )
+
+    hook_sample_copy = filesys_root / "hook-sample.exe"
+    hook_sample_copy.write_bytes(hook_sample.read_bytes())
+
+    @win.api_call(cc=mod.CallingConvention.stdcall, params=[])
+    def on_temp_get_current_process_id(call, params):
+        call.return_value = 0xC0FFEE01
+        return mod.ApiContinuation.intercept
+
+    temp_app = win.create_application(
+        r"C:\hook-sample.exe",
+        emulation_root=emulator_root,
+    )
+    temp_app_box["app"] = temp_app
+    temp_app.callbacks.on_stdout = lambda text: print(text, end="", flush=True)
+    temp_app.callbacks.on_module_load = on_temp_module_load
+    temp_app.hooks.apis["GetCurrentProcessId"] = on_temp_get_current_process_id
+    temp_app.start()
+    assert temp_hook_hits["count"] > 0, "temporary memory_execution_at hook died immediately"
+    assert temp_app.process.exit_status == 0, f"non-zero exit: {temp_app.process.exit_status}"
+
+    temp_app = None
+    gc.collect()
+
 # ----- intercept smoke test against a controlled minimal sample -----
 #
 # hook-sample.exe returns 0 only when GetCurrentProcessId() returns the magic


### PR DESCRIPTION
Fixes #1025.

Low-level Python hook APIs now retain hook handles inside hook_registry, so temporary return values no longer get destroyed at end of statement.