### PR TITLE
Improve Windows UI control emulation

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -268,6 +268,49 @@ with the class background brush — gray dialog face instead of white). Still op
 - `NtGdiGetDCDword` only returns the default (0); other indices (MapMode, GraphicsMode, …) would need
   real values if a control relies on them
 
+## UPDATE 2026-06-07 — input routing consolidated into the emulated win32k layer
+
+Pointer hit-testing is win32k's (kernel) job, not the host backend's and not the guest's
+user32: in real Windows the raw-input thread hit-tests the window tree, sends `WM_NCHITTEST`,
+and posts the mouse message **already targeted at the specific child HWND**. `DefWindowProc`
+never forwards a click to children, so the emulator (which plays the kernel role) must do the
+hit-test. The earlier web/SDL backends each re-derived this themselves, which was the actual
+hack.
+
+Now consolidated:
+
+- `windows_emulator::route_pointer` is the single authority for mouse capture, child
+  hit-testing, and window-local coordinate translation. Both backends only forward
+  `(top-level window, top-level-local x/y, button-state)`.
+- The duplicated `findChildTarget` / `resolveClientTarget` / `windowOrigin` tree-walks were
+  deleted from both web hosts (`page/src/web-ui-host.ts` and `ui_backends/web_ui_host.js`).
+- **`GetMessage`/`PeekMessage` `IsChild` filter fixed**: `peek_pending_message` now matches a
+  message whose target is the filter HWND *or any descendant of it*, so `GetMessage(&msg, hWnd,
+  …)` with a non-NULL top-level no longer silently drops child-control messages. Previously the
+  filter was exact-equality only and the hwnd-filtered form lost all child input.
+
+### Host-side USER logic still to move into the emulated USER/win32k path (TODO)
+
+These are simplifications/cheats that currently live in host C++ and should grow into a more
+principled USER/win32k model over time:
+
+- **`route_pointer` is a simplified hit-test.** It does not send `WM_NCHITTEST` to the wndproc
+  (so `HTTRANSPARENT`, draggable client areas, and custom hit-testing don't work), emits no
+  `WM_SETCURSOR` / `WM_MOUSEACTIVATE`, and approximates z-order by "last matching child wins".
+- **Only `WM_LBUTTONDOWN/UP` are child-routed** (`is_pointer_message`). `WM_MOUSEMOVE` and
+  `WM_RBUTTON*` still go to the top-level window only; they should be routed through the same
+  hit-test for hover/right-click on child controls to work.
+- **Dialog manager shortcut.** `handle_dialog_message` + `complete_dialog` (`syscalls/user.cpp`)
+  intercept `WM_COMMAND(BN_CLICKED)` / `WM_KEYDOWN(VK_RETURN/ESCAPE)` / `WM_CLOSE` in host code
+  and write the dialog's `DLGINFO` end-flag + result directly — i.e. the emulator performs
+  `EndDialog` itself instead of letting the guest's `DefDlgProcWorker` / `MB_DlgProc` drive
+  completion. Invoked from `NtUserMessageCall`, `NtUserDispatchMessage`, and `PeekMessage`.
+  Evaluate whether it can be removed now that real control wndprocs run.
+- **`WM_COMMAND` control-id fixup** in `handle_ui_event` (`windows_emulator.cpp`) rewrites
+  `wParam` with the child's control id from host code.
+- **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
+  compensating for the lack of real win32k visibility/repaint propagation.
+
 ## Backend parity notes
 
 SDL and web still need separate host backends because their platform integration is genuinely different:

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -297,15 +297,17 @@ principled USER/win32k model over time:
 - **`route_pointer` is a simplified hit-test.** It does not send `WM_NCHITTEST` to the wndproc
   (so `HTTRANSPARENT`, draggable client areas, and custom hit-testing don't work), emits no
   `WM_SETCURSOR` / `WM_MOUSEACTIVATE`, and approximates z-order by "last matching child wins".
-- **Only `WM_LBUTTONDOWN/UP` are child-routed** (`is_pointer_message`). `WM_MOUSEMOVE` and
-  `WM_RBUTTON*` still go to the top-level window only; they should be routed through the same
-  hit-test for hover/right-click on child controls to work.
-- **Dialog manager shortcut.** `handle_dialog_message` + `complete_dialog` (`syscalls/user.cpp`)
-  intercept `WM_COMMAND(BN_CLICKED)` / `WM_KEYDOWN(VK_RETURN/ESCAPE)` / `WM_CLOSE` in host code
-  and write the dialog's `DLGINFO` end-flag + result directly — i.e. the emulator performs
-  `EndDialog` itself instead of letting the guest's `DefDlgProcWorker` / `MB_DlgProc` drive
-  completion. Invoked from `NtUserMessageCall`, `NtUserDispatchMessage`, and `PeekMessage`.
-  Evaluate whether it can be removed now that real control wndprocs run.
+- **All mouse messages are now child-routed** through `route_pointer` (`is_pointer_message`
+  covers `WM_MOUSEMOVE` / `WM_LBUTTON*` / `WM_RBUTTON*`, honoring `SetCapture`). It is still a
+  simplified hit-test (see above bullet).
+- **Dialog manager shortcut (now partly redundant).** `handle_dialog_message` + `complete_dialog`
+  (`syscalls/user.cpp`) intercept `WM_COMMAND(BN_CLICKED)` / `WM_KEYDOWN(VK_RETURN/ESCAPE)` /
+  `WM_CLOSE` in host code and write the dialog's `DLGINFO` end-flag + result directly. As of the
+  2026-06-07 (2) cross-build fix, **button-click completion no longer relies on this**: the real
+  `DefDlgProc` → `EndDialog` → modal loop now drives it (a button's `WM_COMMAND` is a synchronous
+  `SendMessage` that never reaches `handle_dialog_message` anyway). The shortcut still backs
+  keyboard (`VK_RETURN`/`VK_ESCAPE`) and `WM_CLOSE` dismissal, which go through the message queue.
+  Follow-up: route those through the real `DefDlgProc` path too, then remove the shortcut.
 - **`WM_COMMAND` control-id fixup** in `handle_ui_event` (`windows_emulator.cpp`) rewrites
   `wParam` with the child's control id from host code.
 - **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
@@ -340,6 +342,15 @@ each build's `user32.dll`:
    reached the loop. Fix: `NtUserSetDialogPointer` now sets/clears `WND+0x12` bit 0 with the pointer,
    matching the kernel. The dialog now completes through the real `DefDlgProc` → `EndDialog` → modal
    loop path (no synthesis); `messagebox-sample` returns `IDYES` on click again.
+
+Both fixes mirror real Windows semantics rather than working around it: a child's id genuinely
+lives in `spmenu`, and the kernel genuinely sets the `WND+0x12` DLGINFO bit. Writing the id to both
+`spmenu` and `wID` is a deliberate build-agnostic choice (the emulator can't know at create time
+which `user32` build is mapped, and each build reads only its own offset). Verified end-to-end on
+both the host (Win11) and Server 2022 roots with `manual-controls-sample` and `messagebox-sample`.
+
+The temporary `[ui-event]` / `[capture]` / `[sogen-ui]` input-routing diagnostics used to chase
+this down were removed in the same change; the branch carries no leftover debug logging.
 
 ## Backend parity notes
 

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -311,6 +311,36 @@ principled USER/win32k model over time:
 - **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
   compensating for the lack of real win32k visibility/repaint propagation.
 
+## UPDATE 2026-06-07 (2) — cross-build support: control id + dialog completion
+
+Clicks worked with the host's live system DLLs (Windows 11, build 26x00) but failed with a
+captured **Windows Server 2022 (20348)** emulation root. The earlier "web backend" click bug was
+really this build difference (web used the Server 2022 root, SDL used the host DLLs); SDL with the
+Server 2022 root reproduces it. Two build-specific gaps were fixed, both verified by decompiling
+each build's `user32.dll`:
+
+1. **Child control id field differs between builds.** A button's `ButtonWndProc` builds its
+   `WM_COMMAND` from the child's control id, which it reads from a build-specific WND offset:
+   Windows 11 reads `wID` at **`WND+0x140`**, Windows Server 2022 reads `spmenu` at **`WND+0x98`**
+   (`(short)pwnd[0x13]` in the notify helper; `spmenu` is where real Windows stores a child's id).
+   The emulator only wrote `wID@0x140`, so on Server 2022 every `WM_COMMAND` carried id `0` and the
+   app's handler fell through to `DefWindowProc`. Fix (`NtUserCreateWindowEx` /
+   `NtUserSetWindowLongPtr(GWLP_ID)`): child windows now mirror the id into **both** `spmenu` and
+   `wID`, so the builtin wndprocs notify correctly regardless of the loaded build. This removed the
+   need for the old `handle_ui_event` `find_button_child_at` `WM_COMMAND` synthesis — the **real**
+   `ButtonWndProc` now drives `WM_COMMAND` on both builds.
+
+2. **Builtin `MessageBox`/dialog never ended (real `EndDialog` path).** Once real button
+   `WM_COMMAND` replaced the synthesis, the builtin message box stopped closing on click. Root
+   cause: `NtUserSetDialogPointer` stored the DLGINFO pointer but never set the WND "has-DLGINFO"
+   flag at **`WND+0x12` bit 0**. user32's ensure-dialog-info helper gates on that bit, so it
+   re-allocated a fresh DLGINFO on *every* dialog message (observed: hundreds of
+   `NtUserSetDialogPointer` calls). The modal loop and `EndDialog` then read/wrote different DLGINFO
+   blocks, so `EndDialog` (which sets `DLGINFO+0x18 |= 1`, hides the dialog, posts `WM_NULL`) never
+   reached the loop. Fix: `NtUserSetDialogPointer` now sets/clears `WND+0x12` bit 0 with the pointer,
+   matching the kernel. The dialog now completes through the real `DefDlgProc` → `EndDialog` → modal
+   loop path (no synthesis); `messagebox-sample` returns `IDYES` on click again.
+
 ## Backend parity notes
 
 SDL and web still need separate host backends because their platform integration is genuinely different:

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -140,7 +140,8 @@ so always analyze the DLL the emulator actually maps):
 ### Still open after this update
 
 - The message-box **icon** is not drawn (`NtUserDrawIconEx` stub).
-- The dialog **background** may stay white instead of the gray dialog face.
+- The classic checkbox/radio **check glyph** is not drawn (`NtUserBitBltSysBmp` stub); the control
+  box, label, and click/state handling work.
 
 ## System builtin-class atom resolution (resolved, portable)
 
@@ -253,11 +254,13 @@ Likely proper direction:
 
 Resolved by the 2026-06-06 update above: builtin `MessageBox` control rendering on the real
 user32 paint path, button self-draw, click→`WM_COMMAND`→`EndDialog`, correct return code,
-button captions, and portable system builtin-class atom resolution (see "System builtin-class
-atom resolution"). Still open:
+button captions, portable system builtin-class atom resolution (see "System builtin-class
+atom resolution"), and the window/dialog **background** fill (top-level surfaces are now filled
+with the class background brush — gray dialog face instead of white). Still open:
 
 - message-box **icon** pixels (`NtUserDrawIconEx` is a success stub)
-- dialog **background** fill (may render white instead of the gray dialog face)
+- classic checkbox/radio **check glyph** pixels (`NtUserBitBltSysBmp` is a success stub; box, label,
+  and click/state handling work)
 - finish small-text / batched GDI text path so ordinary `TextOutA/W` works without forcing oversized `ExtTextOutW`
 - replace temporary debug-font text path with more correct font/text handling over time
 - add more correct clip/region handling

--- a/page/public/emulator-worker.js
+++ b/page/public/emulator-worker.js
@@ -27,7 +27,15 @@ function getUiEventBridge() {
   return null;
 }
 
-function dispatchUiEvent(data) {
+function dispatchUiEvent(data, fromMessage = false) {
+  if (
+    fromMessage &&
+    globalThis.__sogenUiBridgeInitialized &&
+    globalThis.__sogenUiBridgeAvailable
+  ) {
+    return true;
+  }
+
   const bridge = getUiEventBridge();
   if (!bridge) {
     pendingUiEvents.push(data);
@@ -61,7 +69,7 @@ onmessage = async (event) => {
   const data = event.data;
 
   if (data?.type === "sogen_ui_event") {
-    dispatchUiEvent(data);
+    dispatchUiEvent(data, true);
     return;
   }
 

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -635,6 +635,7 @@ export function attachSogenUiHost(
     wParam: number,
     lParam: number,
   ) {
+    console.log("[sogen-ui][send]", "msg=0x" + (message >>> 0).toString(16), "hwnd=" + (hwnd >>> 0), "lParam=" + (lParam >>> 0)); // TEMP diagnostic
     worker.postMessage({
       type: "sogen_ui_event",
       window: hwnd >>> 0,
@@ -663,7 +664,7 @@ export function attachSogenUiHost(
     }
 
     const hwnd = message.hwnd ?? 0;
-    console.debug("[sogen-ui][recv]", message.command, "hwnd=" + hwnd); // TEMP diagnostic
+    console.log("[sogen-ui][recv]", message.command, "hwnd=" + hwnd); // TEMP diagnostic
     if (!hwnd) {
       return;
     }

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -175,6 +175,7 @@ export function attachSogenUiHost(
   let dragState: { hwnd: number; offsetX: number; offsetY: number } | null =
     null;
   let hoverState: { hwnd: number; command: CaptionCommand } | null = null;
+  let mouseDownWindow = 0;
   let viewportOffset: Point = { x: 0, y: 0 };
   let viewportPinnedByUser = false;
 
@@ -766,6 +767,7 @@ export function attachSogenUiHost(
 
     const localX = point.x - window.rect.left;
     const localY = point.y - window.rect.top;
+    mouseDownWindow = window.hwnd;
     sendUiEvent(
       window.hwnd,
       event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN,
@@ -790,11 +792,13 @@ export function attachSogenUiHost(
     }
 
     const target =
-      hit && hit.region === "client"
+      (mouseDownWindow ? windows.get(mouseDownWindow) : null) ??
+      (hit && hit.region === "client"
         ? hit.window
         : focusedWindow
           ? (windows.get(focusedWindow) ?? null)
-          : null;
+          : null);
+    mouseDownWindow = 0;
     if (!target) {
       return;
     }

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -83,6 +83,8 @@ const WM_LBUTTONUP = 0x0202;
 const WM_RBUTTONDOWN = 0x0204;
 const WM_RBUTTONUP = 0x0205;
 
+const MK_LBUTTON = 0x0001;
+
 const SC_MINIMIZE = 0xf020;
 const SC_MAXIMIZE = 0xf030;
 
@@ -767,7 +769,7 @@ export function attachSogenUiHost(
     sendUiEvent(
       window.hwnd,
       event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN,
-      0,
+      event.button === 0 ? MK_LBUTTON : 0,
       packPoint(localX, localY),
     );
     composite();

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -628,14 +628,12 @@ export function attachSogenUiHost(
     return null;
   }
 
-
   function sendUiEvent(
     hwnd: number,
     message: number,
     wParam: number,
     lParam: number,
   ) {
-    console.log("[sogen-ui][send]", "msg=0x" + (message >>> 0).toString(16), "hwnd=" + (hwnd >>> 0), "lParam=" + (lParam >>> 0)); // TEMP diagnostic
     worker.postMessage({
       type: "sogen_ui_event",
       window: hwnd >>> 0,
@@ -664,7 +662,6 @@ export function attachSogenUiHost(
     }
 
     const hwnd = message.hwnd ?? 0;
-    console.log("[sogen-ui][recv]", message.command, "hwnd=" + hwnd); // TEMP diagnostic
     if (!hwnd) {
       return;
     }

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -663,6 +663,7 @@ export function attachSogenUiHost(
     }
 
     const hwnd = message.hwnd ?? 0;
+    console.debug("[sogen-ui][recv]", message.command, "hwnd=" + hwnd); // TEMP diagnostic
     if (!hwnd) {
       return;
     }

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -66,6 +66,11 @@ interface HitResult {
   button?: CaptionButton;
 }
 
+interface ClientTarget {
+  window: HostWindowState;
+  point: Point;
+}
+
 const PLAYGROUND_BACKGROUND = "#18181b";
 
 interface AttachSogenUiHostOptions {
@@ -629,6 +634,63 @@ export function attachSogenUiHost(
     return null;
   }
 
+  function findChildTarget(
+    parent: HostWindowState,
+    x: number,
+    y: number,
+  ): ClientTarget | null {
+    let result: ClientTarget | null = null;
+
+    for (const child of windows.values()) {
+      if (
+        child.parent !== parent.hwnd ||
+        !child.visible ||
+        !child.enabled ||
+        !pointInRect(child.rect, x, y)
+      ) {
+        continue;
+      }
+
+      const childPoint = {
+        x: x - child.rect.left,
+        y: y - child.rect.top,
+      };
+      result =
+        findChildTarget(child, childPoint.x, childPoint.y) ?? {
+          window: child,
+          point: childPoint,
+        };
+    }
+
+    return result;
+  }
+
+  function resolveClientTarget(
+    window: HostWindowState,
+    x: number,
+    y: number,
+  ): ClientTarget {
+    return (
+      findChildTarget(window, x, y) ?? {
+        window,
+        point: { x, y },
+      }
+    );
+  }
+
+  function windowOrigin(window: HostWindowState): Point {
+    const parent = window.parent ? windows.get(window.parent) : null;
+    if (!parent) {
+      return { x: window.rect.left, y: window.rect.top };
+    }
+
+    const parentOrigin = windowOrigin(parent);
+    return {
+      x: parentOrigin.x + window.rect.left,
+      y: parentOrigin.y + window.rect.top,
+    };
+  }
+
   function sendUiEvent(
     hwnd: number,
     message: number,
@@ -765,14 +827,17 @@ export function attachSogenUiHost(
       return;
     }
 
-    const localX = point.x - window.rect.left;
-    const localY = point.y - window.rect.top;
-    mouseDownWindow = window.hwnd;
+    const target = resolveClientTarget(
+      window,
+      point.x - window.rect.left,
+      point.y - window.rect.top,
+    );
+    mouseDownWindow = target.window.hwnd;
     sendUiEvent(
-      window.hwnd,
+      target.window.hwnd,
       event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN,
       event.button === 0 ? MK_LBUTTON : 0,
-      packPoint(localX, localY),
+      packPoint(target.point.x, target.point.y),
     );
     composite();
   }
@@ -803,8 +868,9 @@ export function attachSogenUiHost(
       return;
     }
 
-    const localX = point.x - target.rect.left;
-    const localY = point.y - target.rect.top;
+    const origin = windowOrigin(target);
+    const localX = point.x - origin.x;
+    const localY = point.y - origin.y;
     sendUiEvent(
       target.hwnd,
       event.button === 2 ? WM_RBUTTONUP : WM_LBUTTONUP,
@@ -847,9 +913,17 @@ export function attachSogenUiHost(
     }
 
     if (hit && hit.region === "client") {
-      const localX = point.x - hit.window.rect.left;
-      const localY = point.y - hit.window.rect.top;
-      sendUiEvent(hit.window.hwnd, WM_MOUSEMOVE, 0, packPoint(localX, localY));
+      const target = resolveClientTarget(
+        hit.window,
+        point.x - hit.window.rect.left,
+        point.y - hit.window.rect.top,
+      );
+      sendUiEvent(
+        target.window.hwnd,
+        WM_MOUSEMOVE,
+        0,
+        packPoint(target.point.x, target.point.y),
+      );
     }
   }
 

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -66,11 +66,6 @@ interface HitResult {
   button?: CaptionButton;
 }
 
-interface ClientTarget {
-  window: HostWindowState;
-  point: Point;
-}
-
 const PLAYGROUND_BACKGROUND = "#18181b";
 
 interface AttachSogenUiHostOptions {
@@ -180,7 +175,6 @@ export function attachSogenUiHost(
   let dragState: { hwnd: number; offsetX: number; offsetY: number } | null =
     null;
   let hoverState: { hwnd: number; command: CaptionCommand } | null = null;
-  let mouseDownWindow = 0;
   let viewportOffset: Point = { x: 0, y: 0 };
   let viewportPinnedByUser = false;
 
@@ -634,62 +628,6 @@ export function attachSogenUiHost(
     return null;
   }
 
-  function findChildTarget(
-    parent: HostWindowState,
-    x: number,
-    y: number,
-  ): ClientTarget | null {
-    let result: ClientTarget | null = null;
-
-    for (const child of windows.values()) {
-      if (
-        child.parent !== parent.hwnd ||
-        !child.visible ||
-        !child.enabled ||
-        !pointInRect(child.rect, x, y)
-      ) {
-        continue;
-      }
-
-      const childPoint = {
-        x: x - child.rect.left,
-        y: y - child.rect.top,
-      };
-      result =
-        findChildTarget(child, childPoint.x, childPoint.y) ?? {
-          window: child,
-          point: childPoint,
-        };
-    }
-
-    return result;
-  }
-
-  function resolveClientTarget(
-    window: HostWindowState,
-    x: number,
-    y: number,
-  ): ClientTarget {
-    return (
-      findChildTarget(window, x, y) ?? {
-        window,
-        point: { x, y },
-      }
-    );
-  }
-
-  function windowOrigin(window: HostWindowState): Point {
-    const parent = window.parent ? windows.get(window.parent) : null;
-    if (!parent) {
-      return { x: window.rect.left, y: window.rect.top };
-    }
-
-    const parentOrigin = windowOrigin(parent);
-    return {
-      x: parentOrigin.x + window.rect.left,
-      y: parentOrigin.y + window.rect.top,
-    };
-  }
 
   function sendUiEvent(
     hwnd: number,
@@ -827,17 +765,13 @@ export function attachSogenUiHost(
       return;
     }
 
-    const target = resolveClientTarget(
-      window,
-      point.x - window.rect.left,
-      point.y - window.rect.top,
-    );
-    mouseDownWindow = target.window.hwnd;
+    const localX = point.x - window.rect.left;
+    const localY = point.y - window.rect.top;
     sendUiEvent(
-      target.window.hwnd,
+      window.hwnd,
       event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN,
       event.button === 0 ? MK_LBUTTON : 0,
-      packPoint(target.point.x, target.point.y),
+      packPoint(localX, localY),
     );
     composite();
   }
@@ -857,20 +791,17 @@ export function attachSogenUiHost(
     }
 
     const target =
-      (mouseDownWindow ? windows.get(mouseDownWindow) : null) ??
-      (hit && hit.region === "client"
+      hit && hit.region === "client"
         ? hit.window
         : focusedWindow
           ? (windows.get(focusedWindow) ?? null)
-          : null);
-    mouseDownWindow = 0;
+          : null;
     if (!target) {
       return;
     }
 
-    const origin = windowOrigin(target);
-    const localX = point.x - origin.x;
-    const localY = point.y - origin.y;
+    const localX = point.x - target.rect.left;
+    const localY = point.y - target.rect.top;
     sendUiEvent(
       target.hwnd,
       event.button === 2 ? WM_RBUTTONUP : WM_LBUTTONUP,
@@ -913,17 +844,9 @@ export function attachSogenUiHost(
     }
 
     if (hit && hit.region === "client") {
-      const target = resolveClientTarget(
-        hit.window,
-        point.x - hit.window.rect.left,
-        point.y - hit.window.rect.top,
-      );
-      sendUiEvent(
-        target.window.hwnd,
-        WM_MOUSEMOVE,
-        0,
-        packPoint(target.point.x, target.point.y),
-      );
+      const localX = point.x - hit.window.rect.left;
+      const localY = point.y - hit.window.rect.top;
+      sendUiEvent(hit.window.hwnd, WM_MOUSEMOVE, 0, packPoint(localX, localY));
     }
   }
 

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -185,6 +185,8 @@ namespace sogen
 
 #define BN_CLICKED           0
 
+#define MK_LBUTTON           0x0001
+
 #define VK_ESCAPE            0x1B
 #define VK_RETURN            0x0D
 

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(bad-sample)
 add_subdirectory(hook-sample)
 add_subdirectory(messagebox-sample)
 add_subdirectory(manual-messagebox-sample)
+add_subdirectory(manual-controls-sample)
 add_subdirectory(custom-paint-sample)
 add_subdirectory(test-sample)
 

--- a/src/samples/manual-controls-sample/CMakeLists.txt
+++ b/src/samples/manual-controls-sample/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
+  *.cpp
+  *.hpp
+  *.rc
+)
+
+list(SORT SRC_FILES)
+
+add_executable(manual-controls-sample ${SRC_FILES})
+
+sogen_assign_source_group(${SRC_FILES})

--- a/src/samples/manual-controls-sample/manual-controls-sample.cpp
+++ b/src/samples/manual-controls-sample/manual-controls-sample.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
 
+#include <array>
 #include <cstdio>
 
 // A slightly richer manual UI sample (no dialog template) used to exercise the emulated
@@ -13,18 +14,23 @@ namespace
     constexpr auto* kWindowClassName = "ManualControlsSampleClass";
     constexpr auto* kWindowTitle = "Controls";
 
-    enum control_id : int
+    enum class control_id : int
     {
-        kTitleId = 100,
-        kGroupId = 101,
-        kCheckId = 102,
-        kModeLabelId = 103,
-        kRadioFastId = 104,
-        kRadioAccurateId = 105,
-        kStatusId = 106,
-        kOkId = 107,
-        kCancelId = 108,
+        title = 100,
+        group = 101,
+        check = 102,
+        mode_label = 103,
+        radio_fast = 104,
+        radio_accurate = 105,
+        status = 106,
+        ok = 107,
+        cancel = 108,
     };
+
+    constexpr int id(control_id value)
+    {
+        return static_cast<int>(value);
+    }
 
     int g_exit_code = 2;
     HWND g_check = nullptr;
@@ -49,27 +55,27 @@ namespace
         const bool checked = SendMessageA(g_check, BM_GETCHECK, 0, 0) == BST_CHECKED;
         const bool fast = SendMessageA(g_radio_fast, BM_GETCHECK, 0, 0) == BST_CHECKED;
 
-        char buffer[128];
-        std::snprintf(buffer, sizeof(buffer), "Status: feature %s, mode %s", checked ? "on" : "off", fast ? "fast" : "accurate");
-        SetWindowTextA(g_status, buffer);
+        std::array<char, 128> buffer{};
+        std::snprintf(buffer.data(), buffer.size(), "Status: feature %s, mode %s", checked ? "on" : "off", fast ? "fast" : "accurate");
+        SetWindowTextA(g_status, buffer.data());
         (void)hwnd;
     }
 
     void on_create(HWND hwnd)
     {
-        create_control(hwnd, "STATIC", "Configure the sample:", 0, 16, 12, 320, 20, kTitleId);
+        create_control(hwnd, "STATIC", "Configure the sample:", 0, 16, 12, 320, 20, id(control_id::title));
 
-        create_control(hwnd, "BUTTON", "Options", BS_GROUPBOX, 16, 40, 320, 116, kGroupId);
-        g_check = create_control(hwnd, "BUTTON", "Enable feature", BS_AUTOCHECKBOX, 32, 64, 200, 22, kCheckId);
+        create_control(hwnd, "BUTTON", "Options", BS_GROUPBOX, 16, 40, 320, 116, id(control_id::group));
+        g_check = create_control(hwnd, "BUTTON", "Enable feature", BS_AUTOCHECKBOX, 32, 64, 200, 22, id(control_id::check));
 
-        create_control(hwnd, "STATIC", "Mode:", 0, 32, 96, 48, 20, kModeLabelId);
-        g_radio_fast = create_control(hwnd, "BUTTON", "Fast", BS_AUTORADIOBUTTON | WS_GROUP, 88, 94, 90, 22, kRadioFastId);
-        g_radio_accurate = create_control(hwnd, "BUTTON", "Accurate", BS_AUTORADIOBUTTON, 184, 94, 120, 22, kRadioAccurateId);
+        create_control(hwnd, "STATIC", "Mode:", 0, 32, 96, 48, 20, id(control_id::mode_label));
+        g_radio_fast = create_control(hwnd, "BUTTON", "Fast", BS_AUTORADIOBUTTON | WS_GROUP, 88, 94, 90, 22, id(control_id::radio_fast));
+        g_radio_accurate = create_control(hwnd, "BUTTON", "Accurate", BS_AUTORADIOBUTTON, 184, 94, 120, 22, id(control_id::radio_accurate));
 
-        g_status = create_control(hwnd, "STATIC", "Status: feature off, mode fast", WS_GROUP, 16, 168, 320, 20, kStatusId);
+        g_status = create_control(hwnd, "STATIC", "Status: feature off, mode fast", WS_GROUP, 16, 168, 320, 20, id(control_id::status));
 
-        create_control(hwnd, "BUTTON", "OK", BS_DEFPUSHBUTTON, 160, 208, 80, 28, kOkId);
-        create_control(hwnd, "BUTTON", "Cancel", BS_PUSHBUTTON, 252, 208, 80, 28, kCancelId);
+        create_control(hwnd, "BUTTON", "OK", BS_DEFPUSHBUTTON, 160, 208, 80, 28, id(control_id::ok));
+        create_control(hwnd, "BUTTON", "Cancel", BS_PUSHBUTTON, 252, 208, 80, 28, id(control_id::cancel));
 
         // Default the radio group to "Fast".
         SendMessageA(g_radio_fast, BM_SETCHECK, BST_CHECKED, 0);
@@ -86,13 +92,13 @@ namespace
         case WM_COMMAND:
             switch (LOWORD(wp))
             {
-            case kCheckId:
-            case kRadioFastId:
-            case kRadioAccurateId:
+            case id(control_id::check):
+            case id(control_id::radio_fast):
+            case id(control_id::radio_accurate):
                 update_status(hwnd);
                 return 0;
 
-            case kOkId: {
+            case id(control_id::ok): {
                 const bool checked = SendMessageA(g_check, BM_GETCHECK, 0, 0) == BST_CHECKED;
                 const bool fast = SendMessageA(g_radio_fast, BM_GETCHECK, 0, 0) == BST_CHECKED;
                 std::printf("clicked: ok (feature=%s, mode=%s)\n", checked ? "on" : "off", fast ? "fast" : "accurate");
@@ -101,7 +107,7 @@ namespace
                 return 0;
             }
 
-            case kCancelId:
+            case id(control_id::cancel):
                 std::puts("clicked: cancel");
                 g_exit_code = 1;
                 DestroyWindow(hwnd);

--- a/src/samples/manual-controls-sample/manual-controls-sample.cpp
+++ b/src/samples/manual-controls-sample/manual-controls-sample.cpp
@@ -1,0 +1,166 @@
+#include <windows.h>
+
+#include <cstdio>
+
+// A slightly richer manual UI sample (no dialog template) used to exercise the emulated
+// USER/GDI paint path with several builtin control variations: a group box, an auto-checkbox,
+// an auto-radio-button group, multiple static labels (one updated at runtime), and default vs.
+// normal push buttons. All controls are created by hand in WM_CREATE so the create/paint/click
+// flow stays easy to trace.
+
+namespace
+{
+    constexpr auto* kWindowClassName = "ManualControlsSampleClass";
+    constexpr auto* kWindowTitle = "Controls";
+
+    enum control_id : int
+    {
+        kTitleId = 100,
+        kGroupId = 101,
+        kCheckId = 102,
+        kModeLabelId = 103,
+        kRadioFastId = 104,
+        kRadioAccurateId = 105,
+        kStatusId = 106,
+        kOkId = 107,
+        kCancelId = 108,
+    };
+
+    int g_exit_code = 2;
+    HWND g_check = nullptr;
+    HWND g_radio_fast = nullptr;
+    HWND g_radio_accurate = nullptr;
+    HWND g_status = nullptr;
+
+    HWND create_control(HWND parent, const char* cls, const char* text, DWORD style, int x, int y, int w, int h, int id)
+    {
+        auto* const control = CreateWindowExA(0, cls, text, WS_CHILD | WS_VISIBLE | style, x, y, w, h, parent,
+                                              reinterpret_cast<HMENU>(static_cast<INT_PTR>(id)), GetModuleHandleA(nullptr), nullptr);
+        if (!control)
+        {
+            std::printf("create '%s' (id=%d) failed: %lu\n", text, id, GetLastError());
+        }
+
+        return control;
+    }
+
+    void update_status(HWND hwnd)
+    {
+        const bool checked = SendMessageA(g_check, BM_GETCHECK, 0, 0) == BST_CHECKED;
+        const bool fast = SendMessageA(g_radio_fast, BM_GETCHECK, 0, 0) == BST_CHECKED;
+
+        char buffer[128];
+        std::snprintf(buffer, sizeof(buffer), "Status: feature %s, mode %s", checked ? "on" : "off", fast ? "fast" : "accurate");
+        SetWindowTextA(g_status, buffer);
+        (void)hwnd;
+    }
+
+    void on_create(HWND hwnd)
+    {
+        create_control(hwnd, "STATIC", "Configure the sample:", 0, 16, 12, 320, 20, kTitleId);
+
+        create_control(hwnd, "BUTTON", "Options", BS_GROUPBOX, 16, 40, 320, 116, kGroupId);
+        g_check = create_control(hwnd, "BUTTON", "Enable feature", BS_AUTOCHECKBOX, 32, 64, 200, 22, kCheckId);
+
+        create_control(hwnd, "STATIC", "Mode:", 0, 32, 96, 48, 20, kModeLabelId);
+        g_radio_fast = create_control(hwnd, "BUTTON", "Fast", BS_AUTORADIOBUTTON | WS_GROUP, 88, 94, 90, 22, kRadioFastId);
+        g_radio_accurate = create_control(hwnd, "BUTTON", "Accurate", BS_AUTORADIOBUTTON, 184, 94, 120, 22, kRadioAccurateId);
+
+        g_status = create_control(hwnd, "STATIC", "Status: feature off, mode fast", WS_GROUP, 16, 168, 320, 20, kStatusId);
+
+        create_control(hwnd, "BUTTON", "OK", BS_DEFPUSHBUTTON, 160, 208, 80, 28, kOkId);
+        create_control(hwnd, "BUTTON", "Cancel", BS_PUSHBUTTON, 252, 208, 80, 28, kCancelId);
+
+        // Default the radio group to "Fast".
+        SendMessageA(g_radio_fast, BM_SETCHECK, BST_CHECKED, 0);
+    }
+
+    LRESULT CALLBACK window_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
+    {
+        switch (msg)
+        {
+        case WM_CREATE:
+            on_create(hwnd);
+            return 0;
+
+        case WM_COMMAND:
+            switch (LOWORD(wp))
+            {
+            case kCheckId:
+            case kRadioFastId:
+            case kRadioAccurateId:
+                update_status(hwnd);
+                return 0;
+
+            case kOkId: {
+                const bool checked = SendMessageA(g_check, BM_GETCHECK, 0, 0) == BST_CHECKED;
+                const bool fast = SendMessageA(g_radio_fast, BM_GETCHECK, 0, 0) == BST_CHECKED;
+                std::printf("clicked: ok (feature=%s, mode=%s)\n", checked ? "on" : "off", fast ? "fast" : "accurate");
+                g_exit_code = 0;
+                DestroyWindow(hwnd);
+                return 0;
+            }
+
+            case kCancelId:
+                std::puts("clicked: cancel");
+                g_exit_code = 1;
+                DestroyWindow(hwnd);
+                return 0;
+
+            default:
+                break;
+            }
+            break;
+
+        case WM_CLOSE:
+            std::puts("wm_close");
+            DestroyWindow(hwnd);
+            return 0;
+
+        case WM_DESTROY:
+            std::puts("wm_destroy");
+            PostQuitMessage(g_exit_code);
+            return 0;
+
+        default:
+            break;
+        }
+
+        return DefWindowProcA(hwnd, msg, wp, lp);
+    }
+}
+
+int main()
+{
+    WNDCLASSEXA wc{};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = &window_proc;
+    wc.hInstance = GetModuleHandleA(nullptr);
+    wc.lpszClassName = kWindowClassName;
+    wc.hCursor = LoadCursorA(nullptr, IDC_ARROW);
+    wc.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
+
+    if (!RegisterClassExA(&wc))
+    {
+        return 10;
+    }
+
+    auto* const hwnd = CreateWindowExA(0, kWindowClassName, kWindowTitle, WS_OVERLAPPEDWINDOW | WS_VISIBLE, 200, 200, 368, 296, nullptr,
+                                       nullptr, wc.hInstance, nullptr);
+    if (!hwnd)
+    {
+        return 11;
+    }
+
+    ShowWindow(hwnd, SW_SHOW);
+    UpdateWindow(hwnd);
+
+    MSG msg{};
+    while (GetMessageA(&msg, nullptr, 0, 0) > 0)
+    {
+        TranslateMessage(&msg);
+        DispatchMessageA(&msg);
+    }
+
+    return static_cast<int>(msg.wParam);
+}

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -489,16 +489,46 @@ namespace sogen
         this->waiting_for_alert = false;
     }
 
-    std::optional<msg> emulator_thread::peek_pending_message(hwnd hwnd_filter, UINT filter_min, UINT filter_max, bool remove)
+    namespace
+    {
+        // GetMessage(hWnd) retrieves messages for hWnd and all of its children (IsChild semantics),
+        // so a message targeted at a child control must match a filter naming any of its ancestors.
+        bool window_matches_filter(const process_context& process, const hwnd target, const hwnd filter)
+        {
+            auto current = target;
+            while (current != 0)
+            {
+                if (current == filter)
+                {
+                    return true;
+                }
+
+                const auto* win = process.windows.get(current);
+                if (!win)
+                {
+                    break;
+                }
+
+                current = win->parent_handle;
+            }
+
+            return false;
+        }
+    }
+
+    std::optional<msg> emulator_thread::peek_pending_message(const process_context& process, hwnd hwnd_filter, UINT filter_min,
+                                                             UINT filter_max, bool remove)
     {
         for (auto it = message_queue.begin(); it != message_queue.end(); ++it)
         {
-            if (hwnd_filter != 0 && hwnd_filter != static_cast<hwnd>(-1) && it->window != hwnd_filter)
+            if (hwnd_filter == static_cast<hwnd>(-1))
             {
-                continue;
+                if (it->window != 0)
+                {
+                    continue;
+                }
             }
-
-            if (hwnd_filter == static_cast<hwnd>(-1) && it->window != 0)
+            else if (hwnd_filter != 0 && !window_matches_filter(process, it->window, hwnd_filter))
             {
                 continue;
             }
@@ -683,7 +713,7 @@ namespace sogen
 
         if (this->await_msg.has_value())
         {
-            if (const auto m = this->peek_pending_message(this->await_msg->hwnd_filter, this->await_msg->filter_min,
+            if (const auto m = this->peek_pending_message(process, this->await_msg->hwnd_filter, this->await_msg->filter_min,
                                                           this->await_msg->filter_max, true))
             {
                 this->await_msg->message.write(*m);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -288,7 +288,8 @@ namespace sogen
             return this->apc_alertable && !this->pending_apcs.empty();
         }
 
-        std::optional<msg> peek_pending_message(hwnd hwnd_filter, UINT filter_min, UINT filter_max, bool remove = false);
+        std::optional<msg> peek_pending_message(const process_context& process, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
+                                                bool remove = false);
         void post_message(const msg& msg);
 
         bool is_terminated() const;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -589,6 +589,7 @@ namespace sogen
         buffer.write_map(this->gdi_bitmap_surfaces);
         buffer.write_map(this->gdi_window_surfaces);
         buffer.write_optional(this->etw_notification_event);
+        buffer.write(this->mouse_capture_window);
 
         buffer.write(this->user_handles);
         buffer.write(this->default_monitor_handle);
@@ -659,6 +660,7 @@ namespace sogen
         buffer.read_map(this->gdi_bitmap_surfaces);
         buffer.read_map(this->gdi_window_surfaces);
         buffer.read_optional(this->etw_notification_event);
+        buffer.read(this->mouse_capture_window);
 
         buffer.read(this->user_handles);
         buffer.read(this->default_monitor_handle);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -252,6 +252,7 @@ namespace sogen
         // Persistent per-top-level-window paint surface; child controls composite into it at their offset.
         std::map<uint32_t, gdi_bitmap_surface> gdi_window_surfaces{};
         std::optional<handle> etw_notification_event{};
+        hwnd mouse_capture_window{};
 
         // For WOW64 processes
         std::optional<emulator_object<PEB32>> peb32;

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -439,6 +439,10 @@ namespace sogen
         hdc handle_NtUserGetWindowDC(const syscall_context& c, hwnd window);
         uint64_t handle_NtUserGetControlBrush(const syscall_context& c, hwnd window, hdc dc, uint32_t control_type);
         BOOL handle_NtUserReleaseDC();
+        BOOL handle_NtUserGetOemBitmapSize(const syscall_context& c, uint32_t bitmap_id, emulator_pointer size_ptr);
+        BOOL handle_NtUserSetWindowState(const syscall_context& c, hwnd window, uint32_t flags);
+        BOOL handle_NtUserClearWindowState(const syscall_context& c, hwnd window, uint32_t flags);
+        BOOL handle_NtUserBitBltSysBmp(const syscall_context& c, hdc dc, int x, int y, uint32_t bitmap_index);
         BOOL handle_NtUserGetClientRect(const syscall_context& c, hwnd window, emulator_pointer rect_ptr);
         hdc handle_NtUserBeginPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
         BOOL handle_NtUserEndPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
@@ -1097,6 +1101,10 @@ namespace sogen
         add_handler(NtUserGetDC);
         add_handler(NtUserGetWindowDC);
         add_handler(NtUserGetControlBrush);
+        add_handler(NtUserGetOemBitmapSize);
+        add_handler(NtUserSetWindowState);
+        add_handler(NtUserClearWindowState);
+        add_handler(NtUserBitBltSysBmp);
         add_handler(NtUserGetClientRect);
         add_handler(NtUserBeginPaint);
         add_handler(NtUserEndPaint);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -439,6 +439,9 @@ namespace sogen
         hdc handle_NtUserGetWindowDC(const syscall_context& c, hwnd window);
         uint64_t handle_NtUserGetControlBrush(const syscall_context& c, hwnd window, hdc dc, uint32_t control_type);
         BOOL handle_NtUserReleaseDC();
+        hwnd handle_NtUserSetCapture(const syscall_context& c, hwnd window);
+        BOOL handle_NtUserReleaseCapture(const syscall_context& c);
+        BOOL handle_NtUserDefSetText(const syscall_context& c, hwnd window, emulator_object<LARGE_STRING> text);
         BOOL handle_NtUserGetOemBitmapSize(const syscall_context& c, uint32_t bitmap_id, emulator_pointer size_ptr);
         BOOL handle_NtUserSetWindowState(const syscall_context& c, hwnd window, uint32_t flags);
         BOOL handle_NtUserClearWindowState(const syscall_context& c, hwnd window, uint32_t flags);
@@ -565,6 +568,7 @@ namespace sogen
         uint64_t handle_NtGdiSelectFont(const syscall_context& c, hdc dc, uint64_t font);
         hdc handle_NtGdiGetDCforBitmap(const syscall_context& c, handle bitmap);
         BOOL handle_NtGdiGetDCDword(const syscall_context& c, hdc dc, uint32_t index, emulator_pointer result);
+        BOOL handle_NtGdiSetBrushOrg(const syscall_context& c, hdc dc, int x, int y, emulator_pointer prev);
         uint64_t handle_NtGdiHfontCreate(const syscall_context& c, emulator_pointer logfont, uint32_t angle);
         uint32_t handle_NtGdiExtGetObjectW(const syscall_context& c, uint32_t handle_value, uint32_t size, emulator_pointer buffer);
         uint32_t handle_NtGdiEnumFonts();
@@ -1013,6 +1017,7 @@ namespace sogen
         add_handler(NtGdiSelectFont);
         add_handler(NtGdiGetDCforBitmap);
         add_handler(NtGdiGetDCDword);
+        add_handler(NtGdiSetBrushOrg);
         add_handler(NtGdiHfontCreate);
         add_handler(NtGdiExtGetObjectW);
         add_handler(NtGdiEnumFonts);
@@ -1102,6 +1107,9 @@ namespace sogen
         add_handler(NtUserGetWindowDC);
         add_handler(NtUserGetControlBrush);
         add_handler(NtUserGetOemBitmapSize);
+        add_handler(NtUserSetCapture);
+        add_handler(NtUserReleaseCapture);
+        add_handler(NtUserDefSetText);
         add_handler(NtUserSetWindowState);
         add_handler(NtUserClearWindowState);
         add_handler(NtUserBitBltSysBmp);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -416,6 +416,8 @@ namespace sogen
                 return addr != 0;
             }
 
+            uint32_t window_surface_fill_color(const syscall_context& c, const window& win);
+
             // Resolves the bitmap surface a DC draws into, plus the offset from DC-local coordinates to surface
             // coordinates, and the host window handle the surface should be presented to. For a window DC this is
             // the top-level host window's persistent surface; child controls draw into it at their client offset.
@@ -480,7 +482,7 @@ namespace sogen
                 {
                     surface.width = width;
                     surface.height = height;
-                    surface.pixels.assign(static_cast<size_t>(width) * height, 0xFFFFFFFFu);
+                    surface.pixels.assign(static_cast<size_t>(width) * height, window_surface_fill_color(c, *win));
                 }
 
                 origin_x = off_x;
@@ -608,6 +610,40 @@ namespace sogen
                 }
 
                 return get_brush_color(c, brush_handle);
+            }
+
+            // The base fill for a freshly (re)created top-level window surface, matching what WM_ERASEBKGND
+            // would paint: the window class's background brush. hbrBackground is either a (COLOR_* + 1)
+            // system-color encoding (small integer) or a real GDI brush handle. A class brush of 0 means
+            // "no background", which we keep white, except for dialogs (#32770) whose face is the gray 3D
+            // face (COLOR_BTNFACE) painted by DefDlgProc.
+            uint32_t window_surface_fill_color(const syscall_context& c, const window& win)
+            {
+                constexpr uint32_t white_fill = 0xFFFFFFFFu;
+                constexpr uint32_t color_btnface_index = 15; // COLOR_BTNFACE in k_default_system_colors
+
+                uint64_t background = 0;
+                if (const auto it = c.proc.classes.find(win.class_name); it != c.proc.classes.end())
+                {
+                    background = it->second.wnd_class.hbrBackground;
+                }
+
+                if (background == 0)
+                {
+                    if (win.class_name == u"#32770")
+                    {
+                        return colorref_to_bgra(k_default_system_colors[color_btnface_index]);
+                    }
+
+                    return white_fill;
+                }
+
+                if (background <= USER_NUM_SYSCOLORS)
+                {
+                    return colorref_to_bgra(k_default_system_colors[background - 1]);
+                }
+
+                return get_brush_color(c, static_cast<uint32_t>(background));
             }
 
             void draw_line(gdi_bitmap_surface& surface, int x0, int y0, const int x1, const int y1, const uint32_t color)

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -640,7 +640,7 @@ namespace sogen
 
                 if (background <= USER_NUM_SYSCOLORS)
                 {
-                    return colorref_to_bgra(k_default_system_colors[background - 1]);
+                    return colorref_to_bgra(k_default_system_colors[static_cast<size_t>(background - 1)]);
                 }
 
                 return get_brush_color(c, static_cast<uint32_t>(background));

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1190,6 +1190,136 @@ namespace sogen
             return dc ? 1 : 0;
         }
 
+        void draw_system_button_glyph(const syscall_context& c, const hdc dc, const int x, const int y, const uint32_t index)
+        {
+            constexpr uint32_t k_obi_radio_mask = 0x47;
+            constexpr uint32_t k_obi_check_base = 0x48;
+            constexpr uint32_t k_obi_radio_base = 0x4D;
+            constexpr uint32_t k_obi_3state_base = 0x52;
+            constexpr uint32_t k_state_count = 5;
+
+            if (index == k_obi_radio_mask)
+            {
+                return;
+            }
+
+            bool radio = false;
+            bool indeterminate = false;
+            uint32_t offset = 0;
+            if (index >= k_obi_radio_base && index < k_obi_radio_base + k_state_count)
+            {
+                radio = true;
+                offset = index - k_obi_radio_base;
+            }
+            else if (index >= k_obi_3state_base && index < k_obi_3state_base + k_state_count)
+            {
+                indeterminate = true;
+                offset = index - k_obi_3state_base;
+            }
+            else if (index >= k_obi_check_base && index < k_obi_check_base + k_state_count)
+            {
+                offset = index - k_obi_check_base;
+            }
+            else
+            {
+                return; // not a checkbox/radio glyph we model
+            }
+
+            const bool checked = indeterminate || offset == 1 || offset == 3 || offset == 4;
+            const bool pressed = offset == 2 || offset == 3;
+            const bool disabled_mark = indeterminate || offset == 4;
+
+            gdi_dc_state* dc_state = nullptr;
+            gdi_bitmap_surface* surface = nullptr;
+            int32_t origin_x = 0;
+            int32_t origin_y = 0;
+            if (!get_dc_state_and_surface(c, dc, dc_state, surface, origin_x, origin_y) || !surface)
+            {
+                return;
+            }
+
+            const int ox = x + origin_x;
+            const int oy = y + origin_y;
+
+            constexpr int k_glyph = 13;
+            constexpr uint32_t k_white = 0xFFFFFFFFu;
+            constexpr uint32_t k_face = 0xFFF0F0F0u;
+            constexpr uint32_t k_shadow = 0xFF808080u;
+            constexpr uint32_t k_frame = 0xFF404040u;
+            constexpr uint32_t k_ink = 0xFF000000u;
+            constexpr uint32_t k_ink_disabled = 0xFF808080u;
+
+            const uint32_t interior = pressed ? k_face : k_white;
+            const uint32_t mark = disabled_mark ? k_ink_disabled : k_ink;
+
+            if (radio)
+            {
+                // 13x13 disc: thin ring around the edge, filled interior, centre dot when checked.
+                constexpr int center = 6;
+                for (int dy = -center; dy <= center; ++dy)
+                {
+                    for (int dx = -center; dx <= center; ++dx)
+                    {
+                        const int d2 = dx * dx + dy * dy;
+                        if (d2 > 37)
+                        {
+                            continue;
+                        }
+                        uint32_t color = (d2 >= 25) ? k_frame : interior;
+                        if (checked && d2 <= 5)
+                        {
+                            color = mark;
+                        }
+                        set_surface_pixel(*surface, ox + center + dx, oy + center + dy, color);
+                    }
+                }
+                return;
+            }
+
+            fill_rect(*surface, ox, oy, ox + k_glyph, oy + k_glyph, interior);
+            for (int i = 0; i < k_glyph; ++i)
+            {
+                set_surface_pixel(*surface, ox + i, oy, k_shadow);              // top edge
+                set_surface_pixel(*surface, ox, oy + i, k_shadow);              // left edge
+                set_surface_pixel(*surface, ox + i, oy + k_glyph - 1, k_white); // bottom edge
+                set_surface_pixel(*surface, ox + k_glyph - 1, oy + i, k_white); // right edge
+            }
+            for (int i = 1; i < k_glyph - 1; ++i)
+            {
+                set_surface_pixel(*surface, ox + i, oy + 1, k_frame); // inner top
+                set_surface_pixel(*surface, ox + 1, oy + i, k_frame); // inner left
+            }
+
+            if (checked)
+            {
+                static constexpr std::array<const char*, k_glyph> k_check = {
+                    "             ", //
+                    "             ", //
+                    "             ", //
+                    "          XX ", //
+                    "         XX  ", //
+                    "        XX   ", //
+                    "  X    XX    ", //
+                    "  XX  XX     ", //
+                    "   XXXX      ", //
+                    "    XX       ", //
+                    "             ", //
+                    "             ", //
+                    "             ", //
+                };
+                for (int row = 0; row < k_glyph; ++row)
+                {
+                    for (int col = 0; col < k_glyph; ++col)
+                    {
+                        if (k_check[row][col] != ' ')
+                        {
+                            set_surface_pixel(*surface, ox + col, oy + row, mark);
+                        }
+                    }
+                }
+            }
+        }
+
         BOOL handle_NtGdiFlush(const syscall_context& c)
         {
             auto& thread = c.win_emu.current_thread();
@@ -1366,6 +1496,22 @@ namespace sogen
             // DC is a real (non-memory) DC, so "is memory DC" is false.
             uint32_t value = 0;
             c.emu.write_memory(result, &value, sizeof(value));
+            return TRUE;
+        }
+
+        BOOL handle_NtGdiSetBrushOrg(const syscall_context& c, const hdc dc, const int /*x*/, const int /*y*/, const emulator_pointer prev)
+        {
+            if (dc == 0)
+            {
+                return FALSE;
+            }
+
+            if (prev != 0)
+            {
+                constexpr POINT previous{};
+                c.emu.write_memory(prev, &previous, sizeof(previous));
+            }
+
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -971,6 +971,60 @@ namespace sogen
             return read_large_string(str_obj, index);
         }
 
+        std::u16string read_def_set_text_string(const syscall_context& c, const emulator_object<LARGE_STRING> text)
+        {
+            if (!text)
+            {
+                return {};
+            }
+
+            if (const auto str = text.try_read())
+            {
+                constexpr ULONG k_max_reasonable_text_bytes = 0x10000;
+                const auto length = str->Length;
+                const auto max_length = str->MaximumLength;
+                const auto has_valid_empty_string = length == 0;
+                std::byte last_byte{};
+                const auto has_valid_buffer = str->Buffer != 0 && length <= k_max_reasonable_text_bytes && length <= max_length &&
+                                              length > 0 &&
+                                              c.win_emu.memory.try_read_memory(str->Buffer + length - 1, &last_byte, sizeof(last_byte));
+                if (has_valid_empty_string)
+                {
+                    return {};
+                }
+
+                if (has_valid_buffer)
+                {
+                    std::array<uint8_t, 2> buffer_bytes{};
+                    c.win_emu.memory.try_read_memory(str->Buffer, buffer_bytes.data(), buffer_bytes.size());
+                    if (str->bAnsi || (buffer_bytes[0] >= 0x20 && buffer_bytes[0] < 0x7F && buffer_bytes[1] != 0))
+                    {
+                        return u8_to_u16(read_string<char>(c.win_emu.memory, str->Buffer, length));
+                    }
+
+                    return read_string<char16_t>(c.win_emu.memory, str->Buffer, length / sizeof(char16_t));
+                }
+            }
+
+            std::array<uint8_t, 2> first_bytes{};
+            if (!c.win_emu.memory.try_read_memory(text.value(), first_bytes.data(), first_bytes.size()))
+            {
+                return {};
+            }
+
+            if (first_bytes[0] >= 0x20 && first_bytes[0] < 0x7F && first_bytes[1] == 0)
+            {
+                return read_string<char16_t>(c.win_emu.memory, text.value());
+            }
+
+            if (first_bytes[0] >= 0x20 && first_bytes[0] < 0x7F)
+            {
+                return u8_to_u16(read_string<char>(c.win_emu.memory, text.value()));
+            }
+
+            return read_string<char16_t>(c.win_emu.memory, text.value());
+        }
+
         std::u16string standard_dialog_button_caption(const uint64_t id)
         {
             switch (id)
@@ -1040,6 +1094,7 @@ namespace sogen
         uint32_t handle_NtGdiDeleteObjectApp(const syscall_context& c, uint32_t handle_value);
         BOOL handle_NtGdiFlush(const syscall_context& c);
         gdi_bitmap_surface* get_dc_present_surface(const syscall_context& c, hdc dc, uint32_t& present_handle);
+        void draw_system_button_glyph(const syscall_context& c, hdc dc, int x, int y, uint32_t index);
 
         NTSTATUS handle_NtUserTraceLoggingSendMixedModeTelemetry()
         {
@@ -1272,6 +1327,34 @@ namespace sogen
             return TRUE;
         }
 
+        hwnd handle_NtUserSetCapture(const syscall_context& c, const hwnd window)
+        {
+            const auto previous = c.proc.mouse_capture_window;
+            if (window == 0 || c.proc.windows.get(window))
+            {
+                c.proc.mouse_capture_window = window;
+            }
+            return previous;
+        }
+
+        BOOL handle_NtUserReleaseCapture(const syscall_context& c)
+        {
+            c.proc.mouse_capture_window = 0;
+            return TRUE;
+        }
+
+        BOOL handle_NtUserDefSetText(const syscall_context& c, const hwnd window, const emulator_object<LARGE_STRING> text)
+        {
+            auto* win = c.proc.windows.get(window);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            update_window_title(c, *win, read_def_set_text_string(c, text));
+            return TRUE;
+        }
+
         // user32 builds the classic checkbox/radio glyph bitmaps (FUN_18000b440 in user32) by asking
         // win32k for each OEM control bitmap's dimensions via NtUserGetOemBitmapSize(id, SIZE*), filling
         // { LONG cx; LONG cy; }. We don't host the real system bitmaps, but the size is still needed so
@@ -1322,13 +1405,10 @@ namespace sogen
             return apply_window_state(c, window, flags, false);
         }
 
-        // user32 blits the classic checkbox/radio/scrollbar glyphs from a kernel-owned system bitmap onto
-        // a DC via NtUserBitBltSysBmp(hdc, x, y, index). We don't host those system bitmaps, so this is a
-        // success stub (no glyph pixels) — like NtUserDrawIconEx — so control paint completes without the
-        // emulator aborting on an unimplemented syscall. The glyph itself is simply not drawn yet.
-        BOOL handle_NtUserBitBltSysBmp(const syscall_context& /*c*/, const hdc /*dc*/, const int /*x*/, const int /*y*/,
-                                       const uint32_t /*bitmap_index*/)
+        BOOL handle_NtUserBitBltSysBmp(const syscall_context& c, const hdc dc, const int x, const int y, const uint32_t bitmap_index)
         {
+            (void)handle_NtGdiFlush(c);
+            draw_system_button_glyph(c, dc, x, y, bitmap_index);
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1334,11 +1334,15 @@ namespace sogen
             {
                 c.proc.mouse_capture_window = window;
             }
+            c.win_emu.log.info("[capture] SetCapture(0x%X) prev=0x%X\n", static_cast<uint32_t>(window),
+                               static_cast<uint32_t>(previous)); // TEMP diagnostic
             return previous;
         }
 
         BOOL handle_NtUserReleaseCapture(const syscall_context& c)
         {
+            c.win_emu.log.info("[capture] ReleaseCapture prev=0x%X\n",
+                               static_cast<uint32_t>(c.proc.mouse_capture_window)); // TEMP diagnostic
             c.proc.mouse_capture_window = 0;
             return TRUE;
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1272,6 +1272,66 @@ namespace sogen
             return TRUE;
         }
 
+        // user32 builds the classic checkbox/radio glyph bitmaps (FUN_18000b440 in user32) by asking
+        // win32k for each OEM control bitmap's dimensions via NtUserGetOemBitmapSize(id, SIZE*), filling
+        // { LONG cx; LONG cy; }. We don't host the real system bitmaps, but the size is still needed so
+        // button layout/paint can proceed instead of aborting on an unimplemented syscall. The classic
+        // check/radio glyph is 13x13 at 96 DPI; report that for every id.
+        BOOL handle_NtUserGetOemBitmapSize(const syscall_context& c, const uint32_t /*bitmap_id*/, const emulator_pointer size_ptr)
+        {
+            if (size_ptr == 0)
+            {
+                return FALSE;
+            }
+
+            constexpr std::array<int32_t, 2> size = {13, 13}; // { cx, cy }
+            c.emu.write_memory(size_ptr, size.data(), sizeof(size));
+            return TRUE;
+        }
+
+        // user32 stores per-window state bits (button checked/pushed/focus, etc.) in the window object's
+        // state bytes starting at WND offset 0x10. SetWindowState/ClearWindowState set/clear them: the
+        // high byte of `flags` selects the state byte (0x10 + (flags >> 8)) and the low byte is the mask.
+        // The client (e.g. the button wndproc) reads these bytes back from the same shared window object
+        // when painting, so faithfully OR/AND-ing the mask keeps client-side state consistent.
+        BOOL apply_window_state(const syscall_context& c, const hwnd window, const uint32_t flags, const bool set)
+        {
+            auto* win = c.proc.windows.get(window);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            const auto byte_address = win->guest.value() + 0x10 + ((flags >> 8) & 0xFF);
+            const auto mask = static_cast<uint8_t>(flags & 0xFF);
+
+            uint8_t state = 0;
+            c.win_emu.memory.try_read_memory(byte_address, &state, sizeof(state));
+            state = set ? static_cast<uint8_t>(state | mask) : static_cast<uint8_t>(state & ~mask);
+            c.win_emu.memory.write_memory(byte_address, &state, sizeof(state));
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetWindowState(const syscall_context& c, const hwnd window, const uint32_t flags)
+        {
+            return apply_window_state(c, window, flags, true);
+        }
+
+        BOOL handle_NtUserClearWindowState(const syscall_context& c, const hwnd window, const uint32_t flags)
+        {
+            return apply_window_state(c, window, flags, false);
+        }
+
+        // user32 blits the classic checkbox/radio/scrollbar glyphs from a kernel-owned system bitmap onto
+        // a DC via NtUserBitBltSysBmp(hdc, x, y, index). We don't host those system bitmaps, so this is a
+        // success stub (no glyph pixels) — like NtUserDrawIconEx — so control paint completes without the
+        // emulator aborting on an unimplemented syscall. The glyph itself is simply not drawn yet.
+        BOOL handle_NtUserBitBltSysBmp(const syscall_context& /*c*/, const hdc /*dc*/, const int /*x*/, const int /*y*/,
+                                       const uint32_t /*bitmap_index*/)
+        {
+            return TRUE;
+        }
+
         BOOL handle_NtUserGetClientRect(const syscall_context& c, const hwnd window, const emulator_pointer rect_ptr)
         {
             if (rect_ptr == 0)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1334,15 +1334,11 @@ namespace sogen
             {
                 c.proc.mouse_capture_window = window;
             }
-            c.win_emu.log.info("[capture] SetCapture(0x%X) prev=0x%X\n", static_cast<uint32_t>(window),
-                               static_cast<uint32_t>(previous)); // TEMP diagnostic
             return previous;
         }
 
         BOOL handle_NtUserReleaseCapture(const syscall_context& c)
         {
-            c.win_emu.log.info("[capture] ReleaseCapture prev=0x%X\n",
-                               static_cast<uint32_t>(c.proc.mouse_capture_window)); // TEMP diagnostic
             c.proc.mouse_capture_window = 0;
             return TRUE;
         }
@@ -1869,7 +1865,16 @@ namespace sogen
                 guest_win.lpfnWndProc = win.wnd_proc;
                 guest_win.pcls = class_obj_addr;
                 guest_win.cbWndExtra = wnd_class->cbWndExtra;
+                // A child window's control id lives in different WND fields depending on the
+                // user32 build: Windows 11 (26xxx) reads it from wID (WND+0x140), while
+                // Windows Server 2022 (20348) reads it from spmenu (WND+0x98) — which is where
+                // real Windows stores a child's id anyway. Populate both so the builtin control
+                // wndprocs build correct WM_COMMAND notifications regardless of the loaded build.
                 guest_win.wID = has_child_parent ? menu : 0;
+                if (has_child_parent)
+                {
+                    guest_win.spmenu = menu;
+                }
                 guest_win.windowBand = 1; // ZBID_DESKTOP
                 guest_win.fnid = get_builtin_window_fnid(normalized_class);
 
@@ -2838,6 +2843,13 @@ namespace sogen
                     case GWLP_ID:
                         oldValue = guest_win.wID;
                         guest_win.wID = dwNewLong;
+                        // Keep spmenu in sync: builds differ on which field the control id is read
+                        // from (wID@0x140 vs spmenu@0x98). Only child windows store the id in spmenu;
+                        // top-level windows keep a real menu handle there.
+                        if ((guest_win.dwStyle & WS_CHILD) != 0)
+                        {
+                            guest_win.spmenu = dwNewLong;
+                        }
                         if (normalize_builtin_window_class_name(win->class_name) == u"Button")
                         {
                             if (win->name.empty())
@@ -3024,10 +3036,27 @@ namespace sogen
                 c.win_emu.memory.write_memory(ptr + 0x20, &win->dialog_result, sizeof(win->dialog_result));
             }
 
-            const auto guest_win = win->guest.read();
-            if (guest_win.pExtraBytes != 0)
+            uint64_t pExtraBytes = 0;
+            win->guest.access([&](USER_WINDOW& guest_win) {
+                pExtraBytes = guest_win.pExtraBytes;
+                // Mark the window as owning a DLGINFO (WND+0x12 bit 0). user32's "ensure dialog info"
+                // helper gates on this bit: without it, every dialog message re-allocates a fresh
+                // DLGINFO via NtUserSetDialogPointer, so the modal loop and EndDialog end up writing/
+                // reading different DLGINFO blocks and the dialog never ends. The real kernel sets this
+                // bit when a dialog pointer is associated; mirror that here.
+                if (ptr != 0)
+                {
+                    guest_win.bFlags |= 0x1;
+                }
+                else
+                {
+                    guest_win.bFlags &= static_cast<uint8_t>(~0x1);
+                }
+            });
+
+            if (pExtraBytes != 0)
             {
-                c.win_emu.memory.write_memory(guest_win.pExtraBytes + sizeof(uint64_t), &ptr, sizeof(ptr));
+                c.win_emu.memory.write_memory(pExtraBytes + sizeof(uint64_t), &ptr, sizeof(ptr));
             }
 
             return TRUE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -995,9 +995,12 @@ namespace sogen
 
                 if (has_valid_buffer)
                 {
-                    std::array<uint8_t, 2> buffer_bytes{};
-                    c.win_emu.memory.try_read_memory(str->Buffer, buffer_bytes.data(), buffer_bytes.size());
-                    if (str->bAnsi || (buffer_bytes[0] >= 0x20 && buffer_bytes[0] < 0x7F && buffer_bytes[1] != 0))
+                    // The LARGE_STRING header's bAnsi bit authoritatively identifies the encoding
+                    // (SetWindowTextA sets it, ...W clears it). Trust it instead of sniffing bytes:
+                    // byte-sniffing corrupts non-ASCII Unicode, e.g. a title starting with U+4E2D
+                    // ("中" = 2D 4E) looks like a printable ASCII byte followed by a non-zero byte and
+                    // would be misdecoded as the two ANSI characters "-N".
+                    if (str->bAnsi)
                     {
                         return u8_to_u16(read_string<char>(c.win_emu.memory, str->Buffer, length));
                     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2347,7 +2347,7 @@ namespace sogen
         {
             auto& t = c.win_emu.current_thread();
 
-            if (auto pending_msg = t.peek_pending_message(hwnd, msg_filter_min, msg_filter_max, true))
+            if (auto pending_msg = t.peek_pending_message(c.proc, hwnd, msg_filter_min, msg_filter_max, true))
             {
                 message.write(*pending_msg);
                 set_thread_window_context(c, pending_msg->window);
@@ -2433,7 +2433,7 @@ namespace sogen
             auto& t = c.win_emu.current_thread();
 
             const bool should_remove = (remove_message & PM_REMOVE) != 0;
-            std::optional<msg> pending_msg = t.peek_pending_message(hwnd, msg_filter_min, msg_filter_max, should_remove);
+            std::optional<msg> pending_msg = t.peek_pending_message(c.proc, hwnd, msg_filter_min, msg_filter_max, should_remove);
 
             if (pending_msg)
             {
@@ -2455,7 +2455,7 @@ namespace sogen
         BOOL handle_NtUserWaitMessage(const syscall_context& c)
         {
             auto& t = c.win_emu.current_thread();
-            if (t.peek_pending_message(0, 0, 0, false))
+            if (t.peek_pending_message(c.proc, 0, 0, 0, false))
             {
                 return TRUE;
             }

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -143,7 +143,18 @@ namespace sogen
                         {
                             if (const auto guest = this->resolve_guest(event.button.windowID); guest != 0)
                             {
-                                this->post_event(guest, WM_LBUTTONDOWN, 0,
+                                this->post_event(guest, WM_LBUTTONDOWN, MK_LBUTTON,
+                                                 pack_point(static_cast<int>(event.button.x), static_cast<int>(event.button.y)));
+                            }
+                        }
+                        break;
+
+                    case SDL_EVENT_MOUSE_BUTTON_UP:
+                        if (event.button.button == SDL_BUTTON_LEFT)
+                        {
+                            if (const auto guest = this->resolve_guest(event.button.windowID); guest != 0)
+                            {
+                                this->post_event(guest, WM_LBUTTONUP, 0,
                                                  pack_point(static_cast<int>(event.button.x), static_cast<int>(event.button.y)));
                             }
                         }

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -160,6 +160,15 @@ namespace sogen
                         }
                         break;
 
+                    case SDL_EVENT_MOUSE_MOTION:
+                        if (const auto guest = this->resolve_guest(event.motion.windowID); guest != 0)
+                        {
+                            const uint64_t keys = (event.motion.state & SDL_BUTTON_LMASK) ? MK_LBUTTON : 0;
+                            this->post_event(guest, WM_MOUSEMOVE, keys,
+                                             pack_point(static_cast<int>(event.motion.x), static_cast<int>(event.motion.y)));
+                        }
+                        break;
+
                     default:
                         break;
                     }

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -77,9 +77,11 @@ namespace sogen
             }
             // clang-format off
             EM_ASM({
+                const command = UTF8ToString($0);
+                console.debug('[sogen-ui][emit]', command, 'hwnd=' + Number($1 >>> 0)); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
-                    command: UTF8ToString($0),
+                    command: command,
                     hwnd: Number($1 >>> 0),
                 });
             }, command, static_cast<uint32_t>(window));
@@ -218,6 +220,7 @@ namespace sogen
             // clang-format off
             EM_ASM({
                 const pixels = HEAPU8.slice($5, $5 + $6);
+                console.debug('[sogen-ui][emit] present_surface', 'hwnd=' + Number($0 >>> 0), $1 + 'x' + $2); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
                     command: 'present_surface',
@@ -263,31 +266,18 @@ namespace sogen
 
             void pump_events() override
             {
-                std::deque<queued_web_ui_event> events{};
-                {
-                    std::scoped_lock lock{g_web_ui_event_mutex};
-                    events.swap(g_web_ui_events);
-                }
-
-                if (this->sink_)
-                {
-                    for (const auto& event : events)
-                    {
-                        this->sink_(event.event);
-                    }
-                }
-
+                // Drain, yield to the browser (which may enqueue more via the message bridge), then
+                // drain again so freshly-arrived events are handled within this same pump call.
+                this->drain_events();
                 emscripten_sleep(0);
+                this->drain_events();
             }
 
             void deliver_external_event(const ui_event& event)
             {
-                if (this->sink_)
-                {
-                    this->sink_(event);
-                    return;
-                }
-
+                // Always enqueue. Browser 'message' callbacks fire during emscripten_sleep(0), i.e. on the
+                // asyncify-unwound stack mid-emulation; calling the sink (and emu().stop()) re-entrantly from
+                // there is unsafe. pump_events drains the queue at a clean point, matching the SDL backend.
                 enqueue_web_ui_event(event);
             }
 
@@ -339,6 +329,23 @@ namespace sogen
             }
 
           private:
+            void drain_events()
+            {
+                std::deque<queued_web_ui_event> events{};
+                {
+                    std::scoped_lock lock{g_web_ui_event_mutex};
+                    events.swap(g_web_ui_events);
+                }
+
+                if (this->sink_)
+                {
+                    for (const auto& event : events)
+                    {
+                        this->sink_(event.event);
+                    }
+                }
+            }
+
             event_sink sink_{};
         };
     }

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -51,7 +51,6 @@ namespace sogen
                     return;
                 }
 
-                console.log('[sogen-ui][worker-recv]', 'msg=0x' + (message.message >>> 0).toString(16), 'hwnd=' + (message.window >>> 0)); // TEMP diagnostic
                 Module._sogen_web_ui_push_event(
                     message.window >>> 0,
                     message.message >>> 0,
@@ -79,7 +78,6 @@ namespace sogen
             // clang-format off
             EM_ASM({
                 const command = UTF8ToString($0);
-                console.log('[sogen-ui][emit]', command, 'hwnd=' + Number($1 >>> 0)); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
                     command: command,
@@ -221,7 +219,6 @@ namespace sogen
             // clang-format off
             EM_ASM({
                 const pixels = HEAPU8.slice($5, $5 + $6);
-                console.log('[sogen-ui][emit] present_surface', 'hwnd=' + Number($0 >>> 0), $1 + 'x' + $2); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
                     command: 'present_surface',
@@ -336,12 +333,6 @@ namespace sogen
                 {
                     std::scoped_lock lock{g_web_ui_event_mutex};
                     events.swap(g_web_ui_events);
-                }
-
-                if (!events.empty())
-                {
-                    EM_ASM({ console.log('[sogen-ui][drain]', $0, 'event(s), sink=' + $1); }, // TEMP diagnostic
-                           static_cast<int>(events.size()), this->sink_ ? 1 : 0);
                 }
 
                 if (this->sink_)

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -78,7 +78,7 @@ namespace sogen
             // clang-format off
             EM_ASM({
                 const command = UTF8ToString($0);
-                console.debug('[sogen-ui][emit]', command, 'hwnd=' + Number($1 >>> 0)); // TEMP diagnostic
+                console.log('[sogen-ui][emit]', command, 'hwnd=' + Number($1 >>> 0)); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
                     command: command,
@@ -220,7 +220,7 @@ namespace sogen
             // clang-format off
             EM_ASM({
                 const pixels = HEAPU8.slice($5, $5 + $6);
-                console.debug('[sogen-ui][emit] present_surface', 'hwnd=' + Number($0 >>> 0), $1 + 'x' + $2); // TEMP diagnostic
+                console.log('[sogen-ui][emit] present_surface', 'hwnd=' + Number($0 >>> 0), $1 + 'x' + $2); // TEMP diagnostic
                 postMessage({
                     type: 'sogen_ui',
                     command: 'present_surface',

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -51,6 +51,7 @@ namespace sogen
                     return;
                 }
 
+                console.log('[sogen-ui][worker-recv]', 'msg=0x' + (message.message >>> 0).toString(16), 'hwnd=' + (message.window >>> 0)); // TEMP diagnostic
                 Module._sogen_web_ui_push_event(
                     message.window >>> 0,
                     message.message >>> 0,
@@ -335,6 +336,12 @@ namespace sogen
                 {
                     std::scoped_lock lock{g_web_ui_event_mutex};
                     events.swap(g_web_ui_events);
+                }
+
+                if (!events.empty())
+                {
+                    EM_ASM({ console.log('[sogen-ui][drain]', $0, 'event(s), sink=' + $1); }, // TEMP diagnostic
+                           static_cast<int>(events.size()), this->sink_ ? 1 : 0);
                 }
 
                 if (this->sink_)

--- a/src/windows-emulator/ui_backends/web_ui_host.js
+++ b/src/windows-emulator/ui_backends/web_ui_host.js
@@ -16,6 +16,8 @@ export function createSogenUiHost(worker, canvas) {
   const WM_RBUTTONUP = 0x0205;
   const WM_MOUSEMOVE = 0x0200;
 
+  const MK_LBUTTON = 0x0001;
+
   const SC_MINIMIZE = 0xf020;
   const SC_MAXIMIZE = 0xf030;
 
@@ -443,7 +445,7 @@ export function createSogenUiHost(worker, canvas) {
 
     const localX = x - win.rect.left;
     const localY = y - win.rect.top;
-    sendEvent(win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, 0, packPoint(localX, localY));
+    sendEvent(win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(localX, localY));
     composite();
   });
 

--- a/src/windows-emulator/ui_backends/web_ui_host.js
+++ b/src/windows-emulator/ui_backends/web_ui_host.js
@@ -4,6 +4,7 @@ export function createSogenUiHost(worker, canvas) {
   let focusedWindow = 0;
   let dragState = null;
   let hoverState = null;
+  let mouseDownWindow = 0;
 
   const WM_KEYDOWN = 0x0100;
   const WM_KEYUP = 0x0101;
@@ -445,6 +446,7 @@ export function createSogenUiHost(worker, canvas) {
 
     const localX = x - win.rect.left;
     const localY = y - win.rect.top;
+    mouseDownWindow = win.hwnd;
     sendEvent(win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(localX, localY));
     composite();
   });
@@ -463,7 +465,8 @@ export function createSogenUiHost(worker, canvas) {
       return;
     }
 
-    const target = hit && (hit.region === 'client') ? hit.win : windows.get(focusedWindow);
+    const target = (mouseDownWindow ? windows.get(mouseDownWindow) : null) || (hit && (hit.region === 'client') ? hit.win : windows.get(focusedWindow));
+    mouseDownWindow = 0;
     if (!target) {
       return;
     }

--- a/src/windows-emulator/ui_backends/web_ui_host.js
+++ b/src/windows-emulator/ui_backends/web_ui_host.js
@@ -293,6 +293,40 @@ export function createSogenUiHost(worker, canvas) {
     return null;
   }
 
+  function findChildTarget(parent, x, y) {
+    let result = null;
+    for (const child of windows.values()) {
+      if (child.parent !== parent.hwnd || !child.visible || !child.enabled || !pointInRect(child.rect, x, y)) {
+        continue;
+      }
+
+      const childPoint = {
+        x: x - child.rect.left,
+        y: y - child.rect.top,
+      };
+      result = findChildTarget(child, childPoint.x, childPoint.y) || { win: child, point: childPoint };
+    }
+
+    return result;
+  }
+
+  function resolveClientTarget(win, x, y) {
+    return findChildTarget(win, x, y) || { win, point: { x, y } };
+  }
+
+  function windowOrigin(win) {
+    const parent = win.parent ? windows.get(win.parent) : null;
+    if (!parent) {
+      return { x: win.rect.left, y: win.rect.top };
+    }
+
+    const parentOrigin = windowOrigin(parent);
+    return {
+      x: parentOrigin.x + win.rect.left,
+      y: parentOrigin.y + win.rect.top,
+    };
+  }
+
   function packPoint(x, y) {
     return ((y & 0xffff) << 16) | (x & 0xffff);
   }
@@ -444,10 +478,9 @@ export function createSogenUiHost(worker, canvas) {
       return;
     }
 
-    const localX = x - win.rect.left;
-    const localY = y - win.rect.top;
-    mouseDownWindow = win.hwnd;
-    sendEvent(win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(localX, localY));
+    const target = resolveClientTarget(win, x - win.rect.left, y - win.rect.top);
+    mouseDownWindow = target.win.hwnd;
+    sendEvent(target.win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(target.point.x, target.point.y));
     composite();
   });
 
@@ -471,8 +504,9 @@ export function createSogenUiHost(worker, canvas) {
       return;
     }
 
-    const localX = x - target.rect.left;
-    const localY = y - target.rect.top;
+    const origin = windowOrigin(target);
+    const localX = x - origin.x;
+    const localY = y - origin.y;
     sendEvent(target.hwnd, event.button === 2 ? WM_RBUTTONUP : WM_LBUTTONUP, 0, packPoint(localX, localY));
   });
 
@@ -506,9 +540,8 @@ export function createSogenUiHost(worker, canvas) {
     }
 
     if (hit && hit.region === 'client') {
-      const localX = x - hit.win.rect.left;
-      const localY = y - hit.win.rect.top;
-      sendEvent(hit.win.hwnd, WM_MOUSEMOVE, 0, packPoint(localX, localY));
+      const target = resolveClientTarget(hit.win, x - hit.win.rect.left, y - hit.win.rect.top);
+      sendEvent(target.win.hwnd, WM_MOUSEMOVE, 0, packPoint(target.point.x, target.point.y));
     }
   });
 

--- a/src/windows-emulator/ui_backends/web_ui_host.js
+++ b/src/windows-emulator/ui_backends/web_ui_host.js
@@ -4,7 +4,6 @@ export function createSogenUiHost(worker, canvas) {
   let focusedWindow = 0;
   let dragState = null;
   let hoverState = null;
-  let mouseDownWindow = 0;
 
   const WM_KEYDOWN = 0x0100;
   const WM_KEYUP = 0x0101;
@@ -293,40 +292,6 @@ export function createSogenUiHost(worker, canvas) {
     return null;
   }
 
-  function findChildTarget(parent, x, y) {
-    let result = null;
-    for (const child of windows.values()) {
-      if (child.parent !== parent.hwnd || !child.visible || !child.enabled || !pointInRect(child.rect, x, y)) {
-        continue;
-      }
-
-      const childPoint = {
-        x: x - child.rect.left,
-        y: y - child.rect.top,
-      };
-      result = findChildTarget(child, childPoint.x, childPoint.y) || { win: child, point: childPoint };
-    }
-
-    return result;
-  }
-
-  function resolveClientTarget(win, x, y) {
-    return findChildTarget(win, x, y) || { win, point: { x, y } };
-  }
-
-  function windowOrigin(win) {
-    const parent = win.parent ? windows.get(win.parent) : null;
-    if (!parent) {
-      return { x: win.rect.left, y: win.rect.top };
-    }
-
-    const parentOrigin = windowOrigin(parent);
-    return {
-      x: parentOrigin.x + win.rect.left,
-      y: parentOrigin.y + win.rect.top,
-    };
-  }
-
   function packPoint(x, y) {
     return ((y & 0xffff) << 16) | (x & 0xffff);
   }
@@ -478,9 +443,9 @@ export function createSogenUiHost(worker, canvas) {
       return;
     }
 
-    const target = resolveClientTarget(win, x - win.rect.left, y - win.rect.top);
-    mouseDownWindow = target.win.hwnd;
-    sendEvent(target.win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(target.point.x, target.point.y));
+    const localX = x - win.rect.left;
+    const localY = y - win.rect.top;
+    sendEvent(win.hwnd, event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN, event.button === 0 ? MK_LBUTTON : 0, packPoint(localX, localY));
     composite();
   });
 
@@ -498,15 +463,13 @@ export function createSogenUiHost(worker, canvas) {
       return;
     }
 
-    const target = (mouseDownWindow ? windows.get(mouseDownWindow) : null) || (hit && (hit.region === 'client') ? hit.win : windows.get(focusedWindow));
-    mouseDownWindow = 0;
+    const target = hit && (hit.region === 'client') ? hit.win : windows.get(focusedWindow);
     if (!target) {
       return;
     }
 
-    const origin = windowOrigin(target);
-    const localX = x - origin.x;
-    const localY = y - origin.y;
+    const localX = x - target.rect.left;
+    const localY = y - target.rect.top;
     sendEvent(target.hwnd, event.button === 2 ? WM_RBUTTONUP : WM_LBUTTONUP, 0, packPoint(localX, localY));
   });
 
@@ -540,8 +503,9 @@ export function createSogenUiHost(worker, canvas) {
     }
 
     if (hit && hit.region === 'client') {
-      const target = resolveClientTarget(hit.win, x - hit.win.rect.left, y - hit.win.rect.top);
-      sendEvent(target.win.hwnd, WM_MOUSEMOVE, 0, packPoint(target.point.x, target.point.y));
+      const localX = x - hit.win.rect.left;
+      const localY = y - hit.win.rect.top;
+      sendEvent(hit.win.hwnd, WM_MOUSEMOVE, 0, packPoint(localX, localY));
     }
   });
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -950,30 +950,15 @@ namespace sogen
 
     void windows_emulator::handle_ui_event(const ui_event& event)
     {
-        const bool trace_event = event.message != WM_MOUSEMOVE; // TEMP diagnostic (skip the move flood)
-        if (trace_event)
-        {
-            this->log.info("[ui-event] in window=0x%X message=0x%X lParam=0x%llX\n", static_cast<uint32_t>(event.window),
-                           event.message, static_cast<unsigned long long>(event.lParam));
-        }
-
         const auto* win = this->process.windows.get(event.window);
         if (!win)
         {
-            if (trace_event)
-            {
-                this->log.info("[ui-event] window 0x%X not found, dropping\n", static_cast<uint32_t>(event.window));
-            }
             return;
         }
 
         auto* thread = get_thread_by_id(this->process, win->thread_id);
         if (!thread)
         {
-            if (trace_event)
-            {
-                this->log.info("[ui-event] no thread for window 0x%X\n", static_cast<uint32_t>(event.window));
-            }
             return;
         }
 
@@ -985,18 +970,9 @@ namespace sogen
 
         if (is_pointer_message(event.message))
         {
-            const auto capture_before = this->process.mouse_capture_window; // TEMP diagnostic
             const auto target = route_pointer(this->process, event.window, point_x(event.lParam), point_y(event.lParam));
             m.window = target.window;
             m.lParam = pack_point(target.x, target.y);
-            // TEMP diagnostic: show non-move events always, and moves while a capture is held (the
-            // window between a button DOWN and UP where a stray move could clear the pressed state).
-            if (trace_event || capture_before != 0)
-            {
-                this->log.info("[ui-event] routed msg=0x%X wParam=0x%X to window=0x%X local=(%d,%d) capture=0x%X\n", event.message,
-                               static_cast<uint32_t>(event.wParam), static_cast<uint32_t>(target.window), target.x, target.y,
-                               static_cast<uint32_t>(capture_before));
-            }
         }
 
         if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -157,9 +157,19 @@ namespace sogen
                 if (const auto* captured = process.windows.get(process.mouse_capture_window);
                     captured && (captured->style & WS_VISIBLE) != 0)
                 {
-                    if (auto origin = get_window_origin_relative_to_ancestor(process, captured->handle, top_level))
+                    // Capture routes every pointer event to the capturing window, even when the event
+                    // was reported for a different top-level. Translate the top-level-local point into
+                    // the captured window's client space via screen coordinates (origin relative to the
+                    // root) so the contract holds across top-levels; otherwise a captured control could
+                    // miss its button-up and stay stuck. For a captured window under `top_level` this
+                    // reduces to the same offset as before.
+                    const auto captured_origin = get_window_origin_relative_to_ancestor(process, captured->handle, 0);
+                    const auto top_level_origin = get_window_origin_relative_to_ancestor(process, top_level, 0);
+                    if (captured_origin && top_level_origin)
                     {
-                        return {.window = captured->handle, .x = x - origin->x, .y = y - origin->y};
+                        const auto screen_x = top_level_origin->x + x;
+                        const auto screen_y = top_level_origin->y + y;
+                        return {.window = captured->handle, .x = screen_x - captured_origin->x, .y = screen_y - captured_origin->y};
                     }
                 }
                 else

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -63,32 +63,66 @@ namespace sogen
             return static_cast<int16_t>((lparam >> 16) & 0xFFFF);
         }
 
-        bool is_button_window(const window& win)
+        struct child_hit_test_result
         {
-            // window::class_name stores the raw class passed to CreateWindowEx, which for builtin
-            // controls is often an ordinal atom (e.g. "#1") rather than the literal name. Match the
-            // same aliases that syscalls::normalize_builtin_window_class_name maps to "Button".
-            return win.class_name == u"Button" || win.class_name == u"BUTTON" || win.class_name == u"#1";
-        }
+            const window* win{};
+            int x{};
+            int y{};
+        };
 
-        const window* find_button_child_at(const process_context& process, const hwnd parent, const int x, const int y)
+        std::optional<child_hit_test_result> find_child_window_at(const process_context& process, const hwnd parent, const int x,
+                                                                  const int y)
         {
+            std::optional<child_hit_test_result> result{};
             for (const auto& [index, child] : process.windows)
             {
                 (void)index;
-                if (child.parent_handle != parent || !is_button_window(child) || (child.style & WS_VISIBLE) == 0 ||
-                    (child.style & WS_DISABLED) != 0)
+                if (child.parent_handle != parent || (child.style & WS_VISIBLE) == 0 || (child.style & WS_DISABLED) != 0)
                 {
                     continue;
                 }
 
                 if (x >= child.x && x < child.x + child.width && y >= child.y && y < child.y + child.height)
                 {
-                    return &child;
+                    const auto child_x = x - child.x;
+                    const auto child_y = y - child.y;
+                    if (auto descendant = find_child_window_at(process, child.handle, child_x, child_y))
+                    {
+                        result = descendant;
+                    }
+                    else
+                    {
+                        result = child_hit_test_result{.win = &child, .x = child_x, .y = child_y};
+                    }
                 }
             }
 
-            return nullptr;
+            return result;
+        }
+
+        std::optional<POINT> get_window_origin_relative_to_ancestor(const process_context& process, const hwnd window, const hwnd ancestor)
+        {
+            POINT origin{};
+            auto current_handle = window;
+            while (current_handle != 0 && current_handle != ancestor)
+            {
+                const auto* current = process.windows.get(current_handle);
+                if (!current)
+                {
+                    return std::nullopt;
+                }
+
+                origin.x += current->x;
+                origin.y += current->y;
+                current_handle = current->parent_handle;
+            }
+
+            if (current_handle != ancestor)
+            {
+                return std::nullopt;
+            }
+
+            return origin;
         }
 
         void perform_context_switch_work(windows_emulator& win_emu)
@@ -874,27 +908,41 @@ namespace sogen
             return;
         }
 
-        if (event.message == WM_LBUTTONDOWN)
-        {
-            if (const auto* button = find_button_child_at(this->process, event.window, point_x(event.lParam), point_y(event.lParam)))
-            {
-                msg command{};
-                command.window = event.window;
-                command.message = WM_COMMAND;
-                command.wParam = button->guest.read().wID & 0xFFFFull;
-                command.lParam = button->handle;
-                thread->post_message(command);
-                this->switch_thread_ = true;
-                this->emu().stop();
-                return;
-            }
-        }
-
         msg m{};
         m.window = event.window;
         m.message = event.message;
         m.wParam = event.wParam;
         m.lParam = event.lParam;
+
+        if (event.message == WM_LBUTTONDOWN || event.message == WM_LBUTTONUP)
+        {
+            const auto x = point_x(event.lParam);
+            const auto y = point_y(event.lParam);
+
+            if (this->process.mouse_capture_window != 0)
+            {
+                if (const auto* captured = this->process.windows.get(this->process.mouse_capture_window);
+                    captured && (captured->style & WS_VISIBLE) != 0)
+                {
+                    if (auto origin = get_window_origin_relative_to_ancestor(this->process, captured->handle, event.window))
+                    {
+                        m.window = captured->handle;
+                        m.lParam =
+                            static_cast<uint16_t>(x - origin->x) | (static_cast<uint64_t>(static_cast<uint16_t>(y - origin->y)) << 16);
+                    }
+                }
+                else
+                {
+                    this->process.mouse_capture_window = 0;
+                }
+            }
+            else if (const auto child = find_child_window_at(this->process, event.window, x, y))
+            {
+                m.window = child->win->handle;
+                m.lParam = static_cast<uint16_t>(child->x) | (static_cast<uint64_t>(static_cast<uint16_t>(child->y)) << 16);
+            }
+        }
+
         if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)
         {
             if (const auto* child = this->process.windows.get(event.lParam))
@@ -905,7 +953,8 @@ namespace sogen
         }
         thread->post_message(m);
 
-        if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN)
+        if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN || event.message == WM_LBUTTONDOWN ||
+            event.message == WM_LBUTTONUP)
         {
             this->switch_thread_ = true;
             this->emu().stop();

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -946,15 +946,30 @@ namespace sogen
 
     void windows_emulator::handle_ui_event(const ui_event& event)
     {
+        const bool trace_event = event.message != WM_MOUSEMOVE; // TEMP diagnostic (skip the move flood)
+        if (trace_event)
+        {
+            this->log.info("[ui-event] in window=0x%X message=0x%X lParam=0x%llX\n", static_cast<uint32_t>(event.window),
+                           event.message, static_cast<unsigned long long>(event.lParam));
+        }
+
         const auto* win = this->process.windows.get(event.window);
         if (!win)
         {
+            if (trace_event)
+            {
+                this->log.info("[ui-event] window 0x%X not found, dropping\n", static_cast<uint32_t>(event.window));
+            }
             return;
         }
 
         auto* thread = get_thread_by_id(this->process, win->thread_id);
         if (!thread)
         {
+            if (trace_event)
+            {
+                this->log.info("[ui-event] no thread for window 0x%X\n", static_cast<uint32_t>(event.window));
+            }
             return;
         }
 
@@ -969,6 +984,8 @@ namespace sogen
             const auto target = route_pointer(this->process, event.window, point_x(event.lParam), point_y(event.lParam));
             m.window = target.window;
             m.lParam = pack_point(target.x, target.y);
+            this->log.info("[ui-event] routed to window=0x%X local=(%d,%d)\n", static_cast<uint32_t>(target.window), target.x,
+                           target.y); // TEMP diagnostic
         }
 
         if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -130,8 +130,8 @@ namespace sogen
             // All mouse messages go through capture/child hit-testing: while a window holds the mouse
             // capture every mouse message must reach it (so a pressed button still completes its click),
             // and otherwise each is delivered to the child under the cursor (hover, right-click, etc.).
-            return message == WM_MOUSEMOVE || message == WM_LBUTTONDOWN || message == WM_LBUTTONUP ||
-                   message == WM_RBUTTONDOWN || message == WM_RBUTTONUP;
+            return message == WM_MOUSEMOVE || message == WM_LBUTTONDOWN || message == WM_LBUTTONUP || message == WM_RBUTTONDOWN ||
+                   message == WM_RBUTTONUP;
         }
 
         uint64_t pack_point(const int x, const int y)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -985,13 +985,17 @@ namespace sogen
 
         if (is_pointer_message(event.message))
         {
+            const auto capture_before = this->process.mouse_capture_window; // TEMP diagnostic
             const auto target = route_pointer(this->process, event.window, point_x(event.lParam), point_y(event.lParam));
             m.window = target.window;
             m.lParam = pack_point(target.x, target.y);
-            if (trace_event) // TEMP diagnostic (skip the move flood)
+            // TEMP diagnostic: show non-move events always, and moves while a capture is held (the
+            // window between a button DOWN and UP where a stray move could clear the pressed state).
+            if (trace_event || capture_before != 0)
             {
-                this->log.info("[ui-event] routed to window=0x%X local=(%d,%d)\n", static_cast<uint32_t>(target.window), target.x,
-                               target.y);
+                this->log.info("[ui-event] routed msg=0x%X wParam=0x%X to window=0x%X local=(%d,%d) capture=0x%X\n", event.message,
+                               static_cast<uint32_t>(event.wParam), static_cast<uint32_t>(target.window), target.x, target.y,
+                               static_cast<uint32_t>(capture_before));
             }
         }
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -127,7 +127,11 @@ namespace sogen
 
         bool is_pointer_message(const uint32_t message)
         {
-            return message == WM_LBUTTONDOWN || message == WM_LBUTTONUP;
+            // All mouse messages go through capture/child hit-testing: while a window holds the mouse
+            // capture every mouse message must reach it (so a pressed button still completes its click),
+            // and otherwise each is delivered to the child under the cursor (hover, right-click, etc.).
+            return message == WM_MOUSEMOVE || message == WM_LBUTTONDOWN || message == WM_LBUTTONUP ||
+                   message == WM_RBUTTONDOWN || message == WM_RBUTTONUP;
         }
 
         uint64_t pack_point(const int x, const int y)
@@ -984,8 +988,11 @@ namespace sogen
             const auto target = route_pointer(this->process, event.window, point_x(event.lParam), point_y(event.lParam));
             m.window = target.window;
             m.lParam = pack_point(target.x, target.y);
-            this->log.info("[ui-event] routed to window=0x%X local=(%d,%d)\n", static_cast<uint32_t>(target.window), target.x,
-                           target.y); // TEMP diagnostic
+            if (trace_event) // TEMP diagnostic (skip the move flood)
+            {
+                this->log.info("[ui-event] routed to window=0x%X local=(%d,%d)\n", static_cast<uint32_t>(target.window), target.x,
+                               target.y);
+            }
         }
 
         if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -125,6 +125,56 @@ namespace sogen
             return origin;
         }
 
+        bool is_pointer_message(const uint32_t message)
+        {
+            return message == WM_LBUTTONDOWN || message == WM_LBUTTONUP;
+        }
+
+        uint64_t pack_point(const int x, const int y)
+        {
+            return static_cast<uint16_t>(x) | (static_cast<uint64_t>(static_cast<uint16_t>(y)) << 16);
+        }
+
+        struct pointer_target
+        {
+            hwnd window{};
+            int x{};
+            int y{};
+        };
+
+        // Single authority for routing a top-level-local pointer event to its destination window.
+        // Backends only forward (top-level window, top-level-local x/y); capture and child hit-testing
+        // are decided here, never in the host backends.
+        pointer_target route_pointer(process_context& process, const hwnd top_level, const int x, const int y)
+        {
+            // Mouse capture (SetCapture) redirects all pointer input to the capturing window.
+            if (process.mouse_capture_window != 0)
+            {
+                if (const auto* captured = process.windows.get(process.mouse_capture_window);
+                    captured && (captured->style & WS_VISIBLE) != 0)
+                {
+                    if (auto origin = get_window_origin_relative_to_ancestor(process, captured->handle, top_level))
+                    {
+                        return {.window = captured->handle, .x = x - origin->x, .y = y - origin->y};
+                    }
+                }
+                else
+                {
+                    process.mouse_capture_window = 0;
+                }
+
+                return {.window = top_level, .x = x, .y = y};
+            }
+
+            // Otherwise deliver to the deepest visible/enabled child under the cursor.
+            if (const auto child = find_child_window_at(process, top_level, x, y))
+            {
+                return {.window = child->win->handle, .x = child->x, .y = child->y};
+            }
+
+            return {.window = top_level, .x = x, .y = y};
+        }
+
         void perform_context_switch_work(windows_emulator& win_emu)
         {
             auto& threads = win_emu.process.threads;
@@ -914,33 +964,11 @@ namespace sogen
         m.wParam = event.wParam;
         m.lParam = event.lParam;
 
-        if (event.message == WM_LBUTTONDOWN || event.message == WM_LBUTTONUP)
+        if (is_pointer_message(event.message))
         {
-            const auto x = point_x(event.lParam);
-            const auto y = point_y(event.lParam);
-
-            if (this->process.mouse_capture_window != 0)
-            {
-                if (const auto* captured = this->process.windows.get(this->process.mouse_capture_window);
-                    captured && (captured->style & WS_VISIBLE) != 0)
-                {
-                    if (auto origin = get_window_origin_relative_to_ancestor(this->process, captured->handle, event.window))
-                    {
-                        m.window = captured->handle;
-                        m.lParam =
-                            static_cast<uint16_t>(x - origin->x) | (static_cast<uint64_t>(static_cast<uint16_t>(y - origin->y)) << 16);
-                    }
-                }
-                else
-                {
-                    this->process.mouse_capture_window = 0;
-                }
-            }
-            else if (const auto child = find_child_window_at(this->process, event.window, x, y))
-            {
-                m.window = child->win->handle;
-                m.lParam = static_cast<uint16_t>(child->x) | (static_cast<uint64_t>(static_cast<uint16_t>(child->y)) << 16);
-            }
+            const auto target = route_pointer(this->process, event.window, point_x(event.lParam), point_y(event.lParam));
+            m.window = target.window;
+            m.lParam = pack_point(target.x, target.y);
         }
 
         if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)


### PR DESCRIPTION
## Summary

Improves the Windows UI emulation path for built-in controls and manual UI samples.

- Adds USER/GDI support needed for checkbox and radio control painting, including OEM button glyph drawing, control text updates, mouse capture, and brush-origin handling.
- Routes SDL mouse down/up events through child-window hit testing so controls receive input more like real child windows.
- Adds and wires a manual controls sample to exercise checkboxes, radio buttons, status text updates, and button clicks.
- Documents the background-brush/window-surface behavior used by the UI paint path.

## Validation

- `cmake --build --preset=tidy`
- `git diff --check`
- `cmd /c "cd build\release\artifacts\ && analyzer.exe -s test-sample.exe"`

Note: the same smoke command from `build\tidy\artifacts` failed before emulation because that artifacts directory did not contain `registry\SYSTEM`; release artifacts had the registry data and the smoke test passed.