### PR TITLE
Re-encode WM_SETTEXT to the target wndproc's encoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@ Other applications can also be executed in the emulator:
 
 - Run clang-format on changed files to ensure consistent formatting
 - Do not generate code comments unless they add important information not otherwise deducible from code itself
+- Do not use shortcuts or workarounds. Always prefer clean and idiomatic solutions.

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -352,6 +352,52 @@ both the host (Win11) and Server 2022 roots with `manual-controls-sample` and `m
 The temporary `[ui-event]` / `[capture]` / `[sogen-ui]` input-routing diagnostics used to chase
 this down were removed in the same change; the branch carries no leftover debug logging.
 
+## UPDATE 2026-06-07 (3) — capture routing across top-levels + correct WM_SETTEXT A/W marshalling
+
+Two follow-ups from reviewing the cross-build work.
+
+### Mouse capture is honored across top-levels
+
+`route_pointer` translated a captured window's coordinates only via
+`get_window_origin_relative_to_ancestor(captured, top_level)`, which returns `nullopt` when the
+event was reported for a *different* top-level than the one owning the capture — and then fell back
+to delivering the event to that other top-level. That breaks the `SetCapture` contract for
+press/drag/release across emulator top-levels (a captured control could miss its button-up and stay
+stuck). Fixed by translating through **screen coordinates** (origin relative to the root) so the
+captured window always receives the event; for a captured window under the reporting top-level this
+reduces to the previous offset.
+
+### WM_SETTEXT is re-encoded to the target wndproc's encoding
+
+`SetWindowTextA` on a builtin control (e.g. a `Static`) produced corrupted text. The investigation
+ran through a couple of misleading layers before the real cause:
+
+- **`LARGE_STRING.bAnsi` is not a fixed value.** user32's internal `_DefSetText(hwnd, text, bAnsi)`
+  builds the `LARGE_STRING` for `NtUserDefSetText` from *the wndproc's own encoding*: it sets the
+  `bAnsi` bit for an ANSI proc and clears it for a wide proc (the Unicode-only title path,
+  `xxxSetWindowText`, additionally masks it with `& 0x7fffffff`). So `bAnsi` is authoritative **iff**
+  the buffer reaching the proc already matches the proc's encoding.
+- **The actual bug was on our side.** Tracing `SetWindowTextA` → `NtUserMessageCall(WM_SETTEXT)`
+  showed `ansi=1` with an ANSI buffer (consistent), but the emulator dispatched it through the pinned
+  `apfnClientA[21]` callback and forwarded the **raw ANSI `l_param`** straight to the wide
+  `StaticWndProcW`. The wide proc then called `_DefSetText` with `bAnsi=0` over ANSI bytes →
+  `read_def_set_text_string` saw `bAnsi=0` + ANSI text → corruption. The earlier byte-sniffing
+  heuristic in `read_def_set_text_string` was only masking this.
+
+Real win32k delivers a message's text to a wndproc in the proc's own encoding. The fix records each
+window's wndproc encoding (`window.unicode_proc` — wide for builtin controls, the registered proc
+otherwise) and, in `handle_NtUserMessageCall`, re-encodes the `WM_SETTEXT` string into a scratch
+guest buffer when the caller's encoding (`ansi`) differs from the target proc's. The scratch buffer
+is released in `completion_NtUserMessageCall`. With the payload now matching the proc, `bAnsi` is
+consistent at `NtUserDefSetText`, so `read_def_set_text_string` trusts it and the byte-sniffing
+special case is gone. Verified: `[defsettext]` for the status label flips to `bAnsi=0` + UTF‑16, and
+control text renders correctly.
+
+App windows whose class was registered with `RegisterClassExA` keep an ANSI proc, so an ANSI
+`WM_SETTEXT` matches and is not converted — no behavior change for the common case. (Distinguishing a
+`RegisterClassExW` app class would need the register-time A/W flag, which is not yet threaded
+through; builtin controls, the affected case, are handled.)
+
 ## Backend parity notes
 
 SDL and web still need separate host backends because their platform integration is genuinely different:

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -152,18 +152,21 @@ namespace sogen
     {
         hwnd window{};
         UINT message{};
+        uint64_t scratch_text{}; // guest buffer holding a re-encoded text payload; freed on completion
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write(this->window);
             buffer.write(this->message);
+            buffer.write(this->scratch_text);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read(this->window);
             buffer.read(this->message);
+            buffer.read(this->scratch_text);
         }
     };
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2302,14 +2302,16 @@ namespace sogen
                     {
                         const auto wide = u8_to_u16(read_string<char>(c.win_emu.memory, l_param));
                         const auto bytes = (wide.size() + 1) * sizeof(char16_t);
-                        scratch_text = c.win_emu.memory.allocate_memory(page_align_up(bytes), memory_permission::read_write);
+                        scratch_text =
+                            c.win_emu.memory.allocate_memory(static_cast<size_t>(page_align_up(bytes)), memory_permission::read_write);
                         c.win_emu.memory.write_memory(scratch_text, wide.c_str(), bytes);
                     }
                     else
                     {
                         const auto narrow = u16_to_u8(read_string<char16_t>(c.win_emu.memory, l_param));
                         const auto bytes = narrow.size() + 1;
-                        scratch_text = c.win_emu.memory.allocate_memory(page_align_up(bytes), memory_permission::read_write);
+                        scratch_text =
+                            c.win_emu.memory.allocate_memory(static_cast<size_t>(page_align_up(bytes)), memory_permission::read_write);
                         c.win_emu.memory.write_memory(scratch_text, narrow.c_str(), bytes);
                     }
                     dispatch_l_param = scratch_text;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -995,11 +995,9 @@ namespace sogen
 
                 if (has_valid_buffer)
                 {
-                    // The LARGE_STRING header's bAnsi bit authoritatively identifies the encoding
-                    // (SetWindowTextA sets it, ...W clears it). Trust it instead of sniffing bytes:
-                    // byte-sniffing corrupts non-ASCII Unicode, e.g. a title starting with U+4E2D
-                    // ("中" = 2D 4E) looks like a printable ASCII byte followed by a non-zero byte and
-                    // would be misdecoded as the two ANSI characters "-N".
+                    // bAnsi is reliable: handle_NtUserMessageCall re-encodes WM_SETTEXT to the target
+                    // proc's encoding, so the buffer agrees with bAnsi here (byte-sniffing would
+                    // mis-handle non-ASCII Unicode such as a CJK title).
                     if (str->bAnsi)
                     {
                         return u8_to_u16(read_string<char>(c.win_emu.memory, str->Buffer, length));
@@ -1825,6 +1823,9 @@ namespace sogen
             }
             win.class_name = cls_name;
             const auto normalized_class = normalize_builtin_window_class_name(cls_name);
+            // Builtin controls use the wide (apfnClientW) wndproc (expect UTF-16); app classes keep
+            // their registered proc. Drives the WM_SETTEXT re-encoding so a wide proc never gets ANSI.
+            win.unicode_proc = is_builtin_window_class_name(normalized_class);
             const auto skip_create_messages = false;
             if (normalized_class == u"Button" || normalized_class == u"Static")
             {
@@ -1868,11 +1869,8 @@ namespace sogen
                 guest_win.lpfnWndProc = win.wnd_proc;
                 guest_win.pcls = class_obj_addr;
                 guest_win.cbWndExtra = wnd_class->cbWndExtra;
-                // A child window's control id lives in different WND fields depending on the
-                // user32 build: Windows 11 (26xxx) reads it from wID (WND+0x140), while
-                // Windows Server 2022 (20348) reads it from spmenu (WND+0x98) — which is where
-                // real Windows stores a child's id anyway. Populate both so the builtin control
-                // wndprocs build correct WM_COMMAND notifications regardless of the loaded build.
+                // Control id offset is build-specific: Win11 reads wID (WND+0x140), Server 2022 reads
+                // spmenu (WND+0x98). Populate both so builtin wndprocs emit the right WM_COMMAND id.
                 guest_win.wID = has_child_parent ? menu : 0;
                 if (has_child_parent)
                 {
@@ -2276,6 +2274,9 @@ namespace sogen
                 return 0;
             }
 
+            uint64_t dispatch_l_param = l_param;
+            uint64_t scratch_text = 0;
+
             if (msg == WM_SETTEXT)
             {
                 if (l_param == 0)
@@ -2284,13 +2285,34 @@ namespace sogen
                 }
                 else if (ansi)
                 {
-                    const auto text = u8_to_u16(read_string<char>(c.win_emu.memory, l_param));
-                    update_window_title(c, *win, text);
+                    update_window_title(c, *win, u8_to_u16(read_string<char>(c.win_emu.memory, l_param)));
                 }
                 else
                 {
-                    const auto text = read_string<char16_t>(c.win_emu.memory, l_param);
-                    update_window_title(c, *win, text);
+                    update_window_title(c, *win, read_string<char16_t>(c.win_emu.memory, l_param));
+                }
+
+                // Deliver the text in the target proc's encoding (caller's is `ansi`, proc's is
+                // unicode_proc): when they differ, re-encode into a scratch guest buffer so a wide proc
+                // never reads ANSI as UTF-16. Freed in completion_NtUserMessageCall.
+                const bool caller_unicode = ansi == FALSE;
+                if (l_param != 0 && caller_unicode != win->unicode_proc)
+                {
+                    if (win->unicode_proc)
+                    {
+                        const auto wide = u8_to_u16(read_string<char>(c.win_emu.memory, l_param));
+                        const auto bytes = (wide.size() + 1) * sizeof(char16_t);
+                        scratch_text = c.win_emu.memory.allocate_memory(page_align_up(bytes), memory_permission::read_write);
+                        c.win_emu.memory.write_memory(scratch_text, wide.c_str(), bytes);
+                    }
+                    else
+                    {
+                        const auto narrow = u16_to_u8(read_string<char16_t>(c.win_emu.memory, l_param));
+                        const auto bytes = narrow.size() + 1;
+                        scratch_text = c.win_emu.memory.allocate_memory(page_align_up(bytes), memory_permission::read_write);
+                        c.win_emu.memory.write_memory(scratch_text, narrow.c_str(), bytes);
+                    }
+                    dispatch_l_param = scratch_text;
                 }
             }
 
@@ -2299,7 +2321,8 @@ namespace sogen
             message_call_state state{};
             state.window = hwnd;
             state.message = msg;
-            dispatch_window_message(c, callback_id::NtUserMessageCall, std::move(state), *win, msg, w_param, l_param);
+            state.scratch_text = scratch_text;
+            dispatch_window_message(c, callback_id::NtUserMessageCall, std::move(state), *win, msg, w_param, dispatch_l_param);
             return {};
         }
 
@@ -2308,6 +2331,10 @@ namespace sogen
                                               const BOOL /*ansi*/)
         {
             auto& state = c.get_completion_state<message_call_state>();
+            if (state.scratch_text != 0)
+            {
+                c.win_emu.memory.release_memory(state.scratch_text, 0);
+            }
             if (state.message == WM_PAINT)
             {
                 if (auto* win = c.proc.windows.get(state.window))
@@ -2846,9 +2873,8 @@ namespace sogen
                     case GWLP_ID:
                         oldValue = guest_win.wID;
                         guest_win.wID = dwNewLong;
-                        // Keep spmenu in sync: builds differ on which field the control id is read
-                        // from (wID@0x140 vs spmenu@0x98). Only child windows store the id in spmenu;
-                        // top-level windows keep a real menu handle there.
+                        // Mirror to spmenu too (builds disagree on the id offset; see CreateWindowEx);
+                        // only child windows store the id there, top-level keeps a real menu handle.
                         if ((guest_win.dwStyle & WS_CHILD) != 0)
                         {
                             guest_win.spmenu = dwNewLong;
@@ -3042,11 +3068,9 @@ namespace sogen
             uint64_t pExtraBytes = 0;
             win->guest.access([&](USER_WINDOW& guest_win) {
                 pExtraBytes = guest_win.pExtraBytes;
-                // Mark the window as owning a DLGINFO (WND+0x12 bit 0). user32's "ensure dialog info"
-                // helper gates on this bit: without it, every dialog message re-allocates a fresh
-                // DLGINFO via NtUserSetDialogPointer, so the modal loop and EndDialog end up writing/
-                // reading different DLGINFO blocks and the dialog never ends. The real kernel sets this
-                // bit when a dialog pointer is associated; mirror that here.
+                // WND+0x12 bit 0 marks "has DLGINFO". Without it user32 re-creates the DLGINFO on
+                // every dialog message, so the modal loop and EndDialog touch different blocks and the
+                // dialog never ends. The real kernel sets it when associating the pointer.
                 if (ptr != 0)
                 {
                     guest_win.bFlags |= 0x1;

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -151,18 +151,14 @@ namespace sogen
         // are decided here, never in the host backends.
         pointer_target route_pointer(process_context& process, const hwnd top_level, const int x, const int y)
         {
-            // Mouse capture (SetCapture) redirects all pointer input to the capturing window.
             if (process.mouse_capture_window != 0)
             {
                 if (const auto* captured = process.windows.get(process.mouse_capture_window);
                     captured && (captured->style & WS_VISIBLE) != 0)
                 {
-                    // Capture routes every pointer event to the capturing window, even when the event
-                    // was reported for a different top-level. Translate the top-level-local point into
-                    // the captured window's client space via screen coordinates (origin relative to the
-                    // root) so the contract holds across top-levels; otherwise a captured control could
-                    // miss its button-up and stay stuck. For a captured window under `top_level` this
-                    // reduces to the same offset as before.
+                    // Capture sends every pointer event to the capturing window, even one reported for
+                    // another top-level. Translate via screen coordinates (origin relative to the root)
+                    // so it works across top-levels; for a child of top_level this is the same offset.
                     const auto captured_origin = get_window_origin_relative_to_ancestor(process, captured->handle, 0);
                     const auto top_level_origin = get_window_origin_relative_to_ancestor(process, top_level, 0);
                     if (captured_origin && top_level_origin)

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -94,7 +94,7 @@ namespace sogen
         uint64_t dialog_result{};
         emulator_pointer system_menu_ptr{};
         bool host_surface_window{};
-        bool unicode_proc{}; // wndproc expects UTF-16 text (builtin controls); false => ANSI proc
+        bool unicode_proc{};
 
         window(memory_interface& memory)
             : user_object(memory)

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -94,6 +94,7 @@ namespace sogen
         uint64_t dialog_result{};
         emulator_pointer system_menu_ptr{};
         bool host_surface_window{};
+        bool unicode_proc{}; // wndproc expects UTF-16 text (builtin controls); false => ANSI proc
 
         window(memory_interface& memory)
             : user_object(memory)
@@ -126,6 +127,7 @@ namespace sogen
             buffer.write(this->dialog_result);
             buffer.write(this->system_menu_ptr);
             buffer.write(this->host_surface_window);
+            buffer.write(this->unicode_proc);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -154,6 +156,7 @@ namespace sogen
             buffer.read(this->dialog_result);
             buffer.read(this->system_menu_ptr);
             buffer.read(this->host_surface_window);
+            buffer.read(this->unicode_proc);
         }
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #1027. A wide builtin control wndproc (e.g. `StaticWndProcW`) received the **ANSI** `WM_SETTEXT` payload from `SetWindowTextA` unchanged, then called `_DefSetText` with `bAnsi=0` over ANSI bytes → corrupted control text. The byte-sniffing heuristic in `read_def_set_text_string` was only masking it.

real win32k delivers a message's text to a wndproc in the proc's own encoding. This change:

- tracks each window's wndproc encoding (`window.unicode_proc` — wide for builtin controls, the registered proc otherwise);
- in `handle_NtUserMessageCall`, re-encodes the `WM_SETTEXT` string into a scratch guest buffer when the caller's encoding (`ansi`) differs from the target proc's (freed in `completion_NtUserMessageCall`);
- drops the byte-sniffing special case in `read_def_set_text_string` — `bAnsi` is now consistent at `NtUserDefSetText`, so it is trusted.

App classes registered with `RegisterClassExA` keep an ANSI proc, so an ANSI `WM_SETTEXT` matches and is not converted — no behavior change for the common case.

## Investigation

`_DefSetText(hwnd, text, bAnsi)` builds the `LARGE_STRING` from the **wndproc's own encoding**, so `bAnsi` is authoritative only if the buffer already matches the proc. Tracing `SetWindowTextA` → `NtUserMessageCall(WM_SETTEXT)` showed `ansi=1` + ANSI buffer (consistent), but the emulator forwarded the raw ANSI `l_param` to the wide `StaticWndProcW` without re-encoding — the actual bug. Full write-up in `docs/windows-ui-emulation.md` (UPDATE 2026-06-07 (3)), which also documents the capture-routing-across-top-levels fix from #1027.

## Testing

- `[defsettext]` trace for the status label flips to `bAnsi=0` + UTF-16; control text renders correctly.
- Serialization tests pass (added serialized fields to `window` and `message_call_state`).
- `analyzer -s test-sample.exe` smoke test green.