### PR TITLE
Clean up host-side USER/win32k cheats

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -300,16 +300,22 @@ principled USER/win32k model over time:
 - **All mouse messages are now child-routed** through `route_pointer` (`is_pointer_message`
   covers `WM_MOUSEMOVE` / `WM_LBUTTON*` / `WM_RBUTTON*`, honoring `SetCapture`). It is still a
   simplified hit-test (see above bullet).
-- **Dialog manager shortcut (now partly redundant).** `handle_dialog_message` + `complete_dialog`
-  (`syscalls/user.cpp`) intercept `WM_COMMAND(BN_CLICKED)` / `WM_KEYDOWN(VK_RETURN/ESCAPE)` /
-  `WM_CLOSE` in host code and write the dialog's `DLGINFO` end-flag + result directly. As of the
-  2026-06-07 (2) cross-build fix, **button-click completion no longer relies on this**: the real
-  `DefDlgProc` → `EndDialog` → modal loop now drives it (a button's `WM_COMMAND` is a synchronous
-  `SendMessage` that never reaches `handle_dialog_message` anyway). The shortcut still backs
-  keyboard (`VK_RETURN`/`VK_ESCAPE`) and `WM_CLOSE` dismissal, which go through the message queue.
-  Follow-up: route those through the real `DefDlgProc` path too, then remove the shortcut.
-- **`WM_COMMAND` control-id fixup** in `handle_ui_event` (`windows_emulator.cpp`) rewrites
-  `wParam` with the child's control id from host code.
+- **Dialog manager shortcut (keyboard / `WM_CLOSE` only).** `handle_dialog_message` + `complete_dialog`
+  (`syscalls/user.cpp`) intercept `WM_KEYDOWN(VK_RETURN/ESCAPE)` / `WM_CLOSE` in host code and write
+  the dialog's `DLGINFO` end-flag + result directly. Button-click completion does **not** use this: the
+  real `DefDlgProc` → `EndDialog` → modal loop drives it (the `WM_COMMAND(BN_CLICKED)` branch was
+  removed as dead code on 2026-06-07 (4) — a button's `WM_COMMAND` is a synchronous same-thread
+  `SendMessage` dispatched in-process, so it never reaches `handle_dialog_message`). Follow-up: route
+  the remaining keyboard/`WM_CLOSE` dismissal through the real `DefDlgProc` path too, then remove the
+  shortcut entirely.
+- **`#32770` (`WC_DIALOG`) is matched by literal string.** `is_dialog_window` and ~7 other sites
+  (`syscalls/user.cpp`, `syscalls/gdi.cpp`) compare `class_name`/`normalize_builtin_window_class_name`
+  against the magic string `u"#32770"`. The value is **portable** — `WC_DIALOG = MAKEINTATOM(0x8002)`
+  is a fixed Win32 ABI atom, formatted as `"#32770"` by `get_atom_name` — so this is not the
+  build-specific atom problem the control classes had (those are resolved via
+  `resolve_builtin_class_atom`). The cleanup is representational: centralize the literal into one
+  predicate (ideally keyed on the structured `fnid` `FNID_DIALOG = 0x02A4` already stored on each
+  window, falling back to the atom) instead of scattering the string.
 - **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
   compensating for the lack of real win32k visibility/repaint propagation.
 
@@ -397,6 +403,32 @@ App windows whose class was registered with `RegisterClassExA` keep an ANSI proc
 `WM_SETTEXT` matches and is not converted — no behavior change for the common case. (Distinguishing a
 `RegisterClassExW` app class would need the register-time A/W flag, which is not yet threaded
 through; builtin controls, the affected case, are handled.)
+
+## UPDATE 2026-06-07 (4) — host-side cheat cleanup: dead `WM_COMMAND` paths removed
+
+Started clearing the host-side USER cheats listed under "Host-side USER logic still to move into the
+emulated USER/win32k path". Two of them turned out to be dead code now that the real user32 paths
+drive control notifications, and were removed:
+
+- **`WM_COMMAND` control-id fixup in `handle_ui_event`** (`windows_emulator.cpp`) rewrote a
+  `WM_COMMAND`'s `wParam` low word with the child's `wID`. No UI backend ever emits a `WM_COMMAND`
+  event — SDL posts only `WM_CLOSE` / `WM_KEYDOWN` / `WM_LBUTTONDOWN` / `WM_LBUTTONUP`, the web host
+  only `WM_LBUTTON*` + keys — so the branch was unreachable. The real `ButtonWndProc` already builds
+  `WM_COMMAND` from the child id (mirrored into both `spmenu` and `wID`, see update (2)). Removed.
+- **`WM_COMMAND(BN_CLICKED)` branch in `handle_dialog_message`** (`syscalls/user.cpp`) called
+  `complete_dialog` on a button click. A button's `WM_COMMAND` is a synchronous same-thread
+  `SendMessage`, which user32 dispatches in-process straight to `DefDlgProc` without a
+  `NtUserMessageCall` syscall, so it never reached `handle_dialog_message`. Completion already goes
+  through the real `DefDlgProc` → `EndDialog` → modal loop (update (2)). Removed; `l_param` (its only
+  consumer) was dropped from `handle_dialog_message`'s signature.
+
+`handle_dialog_message` / `complete_dialog` now only back keyboard (`VK_RETURN`/`VK_ESCAPE`) and
+`WM_CLOSE` dismissal — the next removal target (route those through the real `DefDlgProc` path).
+Verified the standard smoke suite (`analyzer.exe -s test-sample.exe`, incl. Message Queue / User
+Callback) still passes; `messagebox-sample` click→`IDYES` needs the interactive run to confirm.
+
+Also logged the **`#32770` literal-string** cleanup in the TODO list above (centralize the
+`WC_DIALOG` magic string; it is portable, unlike the build-specific control atoms).
 
 ## Backend parity notes
 

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -308,8 +308,20 @@ principled USER/win32k model over time:
   `u"#32770"` literals remain. The value is portable — `WC_DIALOG = MAKEINTATOM(0x8002)` is a fixed
   Win32 ABI atom formatted as `"#32770"` by `get_atom_name` — so unlike the build-specific control-class
   atoms (resolved via `resolve_builtin_class_atom`) the canonical name is reliable. See the update below.)
-- **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
-  compensating for the lack of real win32k visibility/repaint propagation.
+- **`invalidate_window_tree` is a bounded simplification, not a removable cheat** (verified
+  load-bearing on 2026-06-07 (6) — disabling the child recursion leaves the message box with a painted
+  dialog frame but blank buttons/text). On a hidden→visible transition (`NtUserShowWindow`,
+  `NtUserSetWindowPos|SWP_SHOWWINDOW`) it recursively invalidates the window and every `WS_VISIBLE`
+  descendant. It is needed because user32 control wndprocs gate their paint body on the *whole ancestor
+  chain* being visible (`FUN_180008030`), so children created during `WM_INITDIALOG` (while the dialog
+  is hidden) skip painting and never repaint on their own once the ancestor is shown. The behavior is
+  effectively `RedrawWindow(hwnd, RDW_INVALIDATE | RDW_ALLCHILDREN)` and already lives in the emulated
+  win32k layer (`syscalls/user.cpp`), so it is *not* host logic to relocate. It is **correct for the
+  cases exercised today** (a dialog whose children are all newly exposed when shown); it diverges from
+  real win32k only where there is no update-region/clipping model yet — partial exposure, overlapping
+  or occluded siblings, `WS_CLIPCHILDREN`, z-order. The principled version is a real per-window
+  update-region + clipping subsystem (large, coupled to broader GDI region work), tracked separately
+  rather than as a quick removal.
 
 ## UPDATE 2026-06-07 (2) — cross-build support: control id + dialog completion
 
@@ -461,6 +473,21 @@ Centralized into one source of truth in `windows_objects.hpp`:
 
 Pure refactor, behavior-preserving. No `u"#32770"` literals remain except the constant definition.
 Verified: release + tidy (clang-tidy) builds clean, smoke suite passes.
+
+## UPDATE 2026-06-07 (6) — `invalidate_window_tree` confirmed load-bearing (kept)
+
+Investigated the next entry on the host-side cheats list and concluded it is **not** a removable cheat,
+unlike the dialog shortcut. An experiment that disabled the child-subtree recursion (invalidating only
+the shown window) was verified interactively against `messagebox-sample`: the dialog frame still painted
+but the **Yes/No buttons and message text were blank**, because user32 control wndprocs gate their paint
+body on the entire ancestor chain being visible — children created during `WM_INITDIALOG` (dialog still
+hidden) skip painting and do not repaint on their own when the ancestor is later shown.
+
+So the recursion stays. The cheats-list entry was reframed: `invalidate_window_tree` is a bounded
+simplification (≈ `RedrawWindow(RDW_INVALIDATE | RDW_ALLCHILDREN)`) that already lives in the emulated
+win32k layer and is correct for the cases exercised today; the only divergence from real win32k is the
+absence of an update-region/clipping model (partial exposure, sibling occlusion, `WS_CLIPCHILDREN`,
+z-order), which is a separate, larger subsystem rather than a quick removal. No code change.
 
 ## Backend parity notes
 

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -300,22 +300,18 @@ principled USER/win32k model over time:
 - **All mouse messages are now child-routed** through `route_pointer` (`is_pointer_message`
   covers `WM_MOUSEMOVE` / `WM_LBUTTON*` / `WM_RBUTTON*`, honoring `SetCapture`). It is still a
   simplified hit-test (see above bullet).
-- **Dialog manager shortcut (keyboard / `WM_CLOSE` only).** `handle_dialog_message` + `complete_dialog`
-  (`syscalls/user.cpp`) intercept `WM_KEYDOWN(VK_RETURN/ESCAPE)` / `WM_CLOSE` in host code and write
-  the dialog's `DLGINFO` end-flag + result directly. Button-click completion does **not** use this: the
-  real `DefDlgProc` → `EndDialog` → modal loop drives it (the `WM_COMMAND(BN_CLICKED)` branch was
-  removed as dead code on 2026-06-07 (4) — a button's `WM_COMMAND` is a synchronous same-thread
-  `SendMessage` dispatched in-process, so it never reaches `handle_dialog_message`). Follow-up: route
-  the remaining keyboard/`WM_CLOSE` dismissal through the real `DefDlgProc` path too, then remove the
-  shortcut entirely.
-- **`#32770` (`WC_DIALOG`) is matched by literal string.** `is_dialog_window` and ~7 other sites
-  (`syscalls/user.cpp`, `syscalls/gdi.cpp`) compare `class_name`/`normalize_builtin_window_class_name`
-  against the magic string `u"#32770"`. The value is **portable** — `WC_DIALOG = MAKEINTATOM(0x8002)`
-  is a fixed Win32 ABI atom, formatted as `"#32770"` by `get_atom_name` — so this is not the
-  build-specific atom problem the control classes had (those are resolved via
-  `resolve_builtin_class_atom`). The cleanup is representational: centralize the literal into one
-  predicate (ideally keyed on the structured `fnid` `FNID_DIALOG = 0x02A4` already stored on each
-  window, falling back to the atom) instead of scattering the string.
+  (The dialog manager shortcut `handle_dialog_message` / `complete_dialog` was **removed** on
+  2026-06-07 (4) — it turned out to be dead and buggy; the guest's real `DefDlgProc`/`IsDialogMessage`
+  path drives keyboard and `WM_CLOSE` correctly. See the update below.)
+- **`#32770` (`WC_DIALOG`) is matched by literal string.** ~7 sites (`syscalls/user.cpp`,
+  `syscalls/gdi.cpp`) compare `class_name`/`normalize_builtin_window_class_name` against the magic
+  string `u"#32770"` (e.g. `get_builtin_window_fnid`, `ensure_builtin_window_class`, the
+  `NtUserShowWindow` visible check, the gdi.cpp background fill). The value is **portable** —
+  `WC_DIALOG = MAKEINTATOM(0x8002)` is a fixed Win32 ABI atom, formatted as `"#32770"` by
+  `get_atom_name` — so this is not the build-specific atom problem the control classes had (those are
+  resolved via `resolve_builtin_class_atom`). The cleanup is representational: centralize the literal
+  into one predicate (ideally keyed on the structured `fnid` `FNID_DIALOG = 0x02A4` already stored on
+  each window, falling back to the atom) instead of scattering the string.
 - **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
   compensating for the lack of real win32k visibility/repaint propagation.
 
@@ -404,7 +400,7 @@ App windows whose class was registered with `RegisterClassExA` keep an ANSI proc
 `RegisterClassExW` app class would need the register-time A/W flag, which is not yet threaded
 through; builtin controls, the affected case, are handled.)
 
-## UPDATE 2026-06-07 (4) — host-side cheat cleanup: dead `WM_COMMAND` paths removed
+## UPDATE 2026-06-07 (4) — host-side cheat cleanup: dead `WM_COMMAND` paths + dialog shortcut removed
 
 Started clearing the host-side USER cheats listed under "Host-side USER logic still to move into the
 emulated USER/win32k path". Two of them turned out to be dead code now that the real user32 paths
@@ -422,10 +418,26 @@ drive control notifications, and were removed:
   through the real `DefDlgProc` → `EndDialog` → modal loop (update (2)). Removed; `l_param` (its only
   consumer) was dropped from `handle_dialog_message`'s signature.
 
-`handle_dialog_message` / `complete_dialog` now only back keyboard (`VK_RETURN`/`VK_ESCAPE`) and
-`WM_CLOSE` dismissal — the next removal target (route those through the real `DefDlgProc` path).
-Verified the standard smoke suite (`analyzer.exe -s test-sample.exe`, incl. Message Queue / User
-Callback) still passes; `messagebox-sample` click→`IDYES` needs the interactive run to confirm.
+Then the **whole dialog manager shortcut was removed** (`handle_dialog_message`, `complete_dialog`,
+`is_dialog_window`). An experiment that disabled the shortcut and let only the guest's real
+`DefDlgProc`/`IsDialogMessage` path run showed it handles dialog dismissal correctly — and that the
+shortcut was not just redundant but **wrong** for `MB_YESNO`:
+
+- **Enter** → guest activates the default button (Yes) → `IDYES` / `clicked: yes`. The old shortcut
+  hardcoded `VK_RETURN` → `IDOK`, which a YesNo box does not even have.
+- **Esc** → ignored, matching native Windows (a YesNo box has no Cancel button). The old shortcut
+  forced `VK_ESCAPE` → `IDCANCEL`. (For `MB_OKCANCEL`/`MB_YESNOCANCEL` the guest path sends
+  `WM_COMMAND(IDCANCEL)` to the real Cancel button, so it works there too.)
+- **Window X** → correctly disabled (greyed out) for a YesNo box, matching native — the X has no
+  effect because there is no Cancel command. The old shortcut faked `WM_CLOSE` → `IDCANCEL`.
+- **Mouse Yes/No** → unchanged, still driven by the real `ButtonWndProc` → `DefDlgProc` → `EndDialog`.
+
+So the shortcut was deleted outright (verified interactively on the host Win11 DLLs:
+Enter→`clicked: yes`, Esc→no-op, X disabled, mouse Yes/No work). The now-dead dialog bookkeeping went
+with it: the `window` fields `dialog_pointer` / `dialog_flags` / `dialog_result` (and their
+serialization), and the `dialog_flags` re-apply branch in `NtUserSetDialogPointer` — which now only
+sets the `WND+0x12` "has DLGINFO" bit and writes the pointer into the window extra bytes (its real
+kernel job, see update (2)). Standard smoke suite (`analyzer.exe -s test-sample.exe`) still passes.
 
 Also logged the **`#32770` literal-string** cleanup in the TODO list above (centralize the
 `WC_DIALOG` magic string; it is portable, unlike the build-specific control atoms).

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -291,15 +291,31 @@ Now consolidated:
 
 ### Host-side USER logic still to move into the emulated USER/win32k path (TODO)
 
-These are simplifications/cheats that currently live in host C++ and should grow into a more
-principled USER/win32k model over time:
+These are bounded simplifications in the emulated USER/win32k layer (they already live in the
+emulator core, not in a host backend) that should grow into a more principled win32k model over time.
+They are load-bearing and correct for the cases exercised today; the entries below scope exactly where
+they diverge from real win32k:
 
-- **`route_pointer` is a simplified hit-test.** It does not send `WM_NCHITTEST` to the wndproc
-  (so `HTTRANSPARENT`, draggable client areas, and custom hit-testing don't work), emits no
-  `WM_SETCURSOR` / `WM_MOUSEACTIVATE`, and approximates z-order by "last matching child wins".
-- **All mouse messages are now child-routed** through `route_pointer` (`is_pointer_message`
-  covers `WM_MOUSEMOVE` / `WM_LBUTTON*` / `WM_RBUTTON*`, honoring `SetCapture`). It is still a
-  simplified hit-test (see above bullet).
+- **`route_pointer` is a simplified hit-test** (`windows_emulator.cpp`). It already consolidates mouse
+  routing into the win32k layer (the backends only forward `(top-level, top-level-local x/y, buttons)`)
+  and correctly honors `SetCapture` across top-levels. Its divergences from real win32k:
+  - **No `WM_NCHITTEST`** — so `HTTRANSPARENT`, draggable client areas (`HTCAPTION`), and custom
+    hit-testing don't work.
+  - **No `WM_SETCURSOR` / `WM_MOUSEACTIVATE`** — no cursor changes or click-to-activate.
+  - **Approximate z-order** — `find_child_window_at` walks `process.windows` (handle-keyed map) and
+    "last match wins", i.e. handle-allocation order, not the real z-order sibling chain. Harmless while
+    sibling controls don't overlap (dialogs); wrong for overlapping siblings.
+  - **No `WS_EX_TRANSPARENT`** handling.
+  The principled direction is to move hit-testing from eager host-event time (`handle_ui_event`, where
+  guest code can't run) to **message-pop time in the guest thread context** (`GetMessage`/`PeekMessage`),
+  where a synchronous `SendMessage(WM_NCHITTEST)` / `WM_SETCURSOR` / `WM_MOUSEACTIVATE` to the wndproc is
+  possible — mirroring how the kernel raw-input path sends those before delivering a mouse message. That
+  is a real refactor, tracked separately. Two smaller improvements are tractable first: real z-order via
+  the sibling chain (only once `SetWindowPos`/`BringWindowToTop` are confirmed to keep the chain in sync)
+  and `WS_EX_TRANSPARENT` skipping.
+- **All mouse messages are child-routed** through `route_pointer` (`is_pointer_message` covers
+  `WM_MOUSEMOVE` / `WM_LBUTTON*` / `WM_RBUTTON*`, honoring `SetCapture`); still the simplified hit-test
+  above.
   (The dialog manager shortcut `handle_dialog_message` / `complete_dialog` was **removed** on
   2026-06-07 (4) — it turned out to be dead and buggy; the guest's real `DefDlgProc`/`IsDialogMessage`
   path drives keyboard and `WM_CLOSE` correctly. See the update below.)
@@ -488,6 +504,28 @@ simplification (≈ `RedrawWindow(RDW_INVALIDATE | RDW_ALLCHILDREN)`) that alrea
 win32k layer and is correct for the cases exercised today; the only divergence from real win32k is the
 absence of an update-region/clipping model (partial exposure, sibling occlusion, `WS_CLIPCHILDREN`,
 z-order), which is a separate, larger subsystem rather than a quick removal. No code change.
+
+## UPDATE 2026-06-07 (7) — `route_pointer` scoped as a bounded win32k simplification (kept)
+
+Investigated the last entry on the host-side cheats list. Like `invalidate_window_tree`, `route_pointer`
+is load-bearing and already lives in the emulated win32k layer (`windows_emulator.cpp`) — it was created
+to consolidate hit-testing that the SDL/web backends used to duplicate, so it is not host logic to
+relocate. It handles `SetCapture` (including across top-levels) and child hit-testing correctly for the
+cases exercised today.
+
+Confirmed by `grep` that `WM_NCHITTEST` / `WM_SETCURSOR` / `WM_MOUSEACTIVATE` / `HTTRANSPARENT` exist
+nowhere in the tree. The divergences from real win32k (no `WM_NCHITTEST`, no `WM_SETCURSOR` /
+`WM_MOUSEACTIVATE`, handle-order z-order instead of the sibling chain, no `WS_EX_TRANSPARENT`) are now
+scoped precisely in the TODO entry above. The architectural reason the deep parts aren't a quick fix:
+those messages are *synchronously sent*, but hit-testing currently runs at host-event time
+(`handle_ui_event`) where guest code can't run; the principled fix moves hit-testing to message-pop time
+(`GetMessage`/`PeekMessage`) in the guest thread context so the wndproc can be called synchronously. No
+code change.
+
+With this, every entry on the host-side cheats list has been resolved or scoped: #1/#2 (`WM_COMMAND`
+fixups) and #3 (dialog shortcut) removed as dead code, `#32770` centralized, and the two remaining
+items (`invalidate_window_tree`, `route_pointer`) verified load-bearing and reframed as bounded win32k
+simplifications with their principled fixes recorded.
 
 ## Backend parity notes
 

--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -303,15 +303,11 @@ principled USER/win32k model over time:
   (The dialog manager shortcut `handle_dialog_message` / `complete_dialog` was **removed** on
   2026-06-07 (4) — it turned out to be dead and buggy; the guest's real `DefDlgProc`/`IsDialogMessage`
   path drives keyboard and `WM_CLOSE` correctly. See the update below.)
-- **`#32770` (`WC_DIALOG`) is matched by literal string.** ~7 sites (`syscalls/user.cpp`,
-  `syscalls/gdi.cpp`) compare `class_name`/`normalize_builtin_window_class_name` against the magic
-  string `u"#32770"` (e.g. `get_builtin_window_fnid`, `ensure_builtin_window_class`, the
-  `NtUserShowWindow` visible check, the gdi.cpp background fill). The value is **portable** —
-  `WC_DIALOG = MAKEINTATOM(0x8002)` is a fixed Win32 ABI atom, formatted as `"#32770"` by
-  `get_atom_name` — so this is not the build-specific atom problem the control classes had (those are
-  resolved via `resolve_builtin_class_atom`). The cleanup is representational: centralize the literal
-  into one predicate (ideally keyed on the structured `fnid` `FNID_DIALOG = 0x02A4` already stored on
-  each window, falling back to the atom) instead of scattering the string.
+  (The `#32770` / `WC_DIALOG` literal-string matching was **centralized** on 2026-06-07 (5) into the
+  `builtin_dialog_class_name` constant + `window::is_dialog()` in `windows_objects.hpp`; no scattered
+  `u"#32770"` literals remain. The value is portable — `WC_DIALOG = MAKEINTATOM(0x8002)` is a fixed
+  Win32 ABI atom formatted as `"#32770"` by `get_atom_name` — so unlike the build-specific control-class
+  atoms (resolved via `resolve_builtin_class_atom`) the canonical name is reliable. See the update below.)
 - **`invalidate_window_tree`** drives child-subtree repaint on `ShowWindow` / `SetWindowPos`,
   compensating for the lack of real win32k visibility/repaint propagation.
 
@@ -441,6 +437,30 @@ kernel job, see update (2)). Standard smoke suite (`analyzer.exe -s test-sample.
 
 Also logged the **`#32770` literal-string** cleanup in the TODO list above (centralize the
 `WC_DIALOG` magic string; it is portable, unlike the build-specific control atoms).
+
+## UPDATE 2026-06-07 (5) — centralize the `#32770` (`WC_DIALOG`) literal
+
+The dialog class `#32770` was matched by the bare string `u"#32770"` at seven sites across two
+translation units (`syscalls/user.cpp`, `syscalls/gdi.cpp`); `gdi.cpp` even duplicated the literal as a
+*raw* `class_name` compare because `normalize_builtin_window_class_name` is private to `user.cpp`. This
+is `WC_DIALOG = MAKEINTATOM(0x8002)`, a fixed Win32 ABI atom that `get_atom_name` formats as `"#32770"`,
+so — unlike the per-build control-class atoms resolved through `SERVERINFO.atomSysClass` — the canonical
+name is portable and safe to match directly.
+
+Centralized into one source of truth in `windows_objects.hpp`:
+
+- `inline constexpr std::u16string_view builtin_dialog_class_name = u"#32770";` (documented).
+- `window::is_dialog()` for the window-instance checks (`NtUserShowWindow` visibility sync, gdi.cpp
+  background fill). This also fixes the raw-vs-normalized inconsistency — `is_dialog()` is a raw
+  `class_name` compare, which is exactly equivalent because `normalize_builtin_window_class_name` never
+  maps anything *to* `#32770` (it only canonicalizes control aliases), so `normalize(x) == "#32770"`
+  iff `x == "#32770"`. A dialog's stored `class_name` is always literally `"#32770"` (it comes from the
+  `WC_DIALOG` atom).
+- The name-classification helpers (`is_builtin_window_class_name`, `get_builtin_window_fnid`,
+  `ensure_builtin_window_class`) use the constant.
+
+Pure refactor, behavior-preserving. No `u"#32770"` literals remain except the constant definition.
+Verified: release + tidy (clang-tidy) builds clean, smoke suite passes.
 
 ## Backend parity notes
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -630,7 +630,7 @@ namespace sogen
 
                 if (background == 0)
                 {
-                    if (win.class_name == u"#32770")
+                    if (win.is_dialog())
                     {
                         return colorref_to_bgra(k_default_system_colors[color_btnface_index]);
                     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2258,7 +2258,7 @@ namespace sogen
             return s.was_visible ? TRUE : FALSE;
         }
 
-        bool handle_dialog_message(const syscall_context& c, window& dialog, uint32_t message, uint64_t w_param, uint64_t l_param);
+        bool handle_dialog_message(const syscall_context& c, window& dialog, uint32_t message, uint64_t w_param);
 
         uint64_t handle_NtUserMessageCall(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t w_param,
                                           const uint64_t l_param, const uint64_t /*result_info*/, const DWORD /*type*/, const BOOL ansi)
@@ -2318,7 +2318,7 @@ namespace sogen
                 }
             }
 
-            (void)handle_dialog_message(c, *win, msg, w_param, l_param);
+            (void)handle_dialog_message(c, *win, msg, w_param);
 
             message_call_state state{};
             state.window = hwnd;
@@ -2369,7 +2369,7 @@ namespace sogen
                 return 0;
             }
 
-            (void)handle_dialog_message(c, *win, m.message, m.wParam, m.lParam);
+            (void)handle_dialog_message(c, *win, m.message, m.wParam);
 
             message_call_state state{};
             state.window = m.window;
@@ -2423,8 +2423,7 @@ namespace sogen
             return normalize_builtin_window_class_name(win.class_name) == u"#32770";
         }
 
-        bool handle_dialog_message(const syscall_context& c, window& dialog, const uint32_t message, const uint64_t w_param,
-                                   const uint64_t l_param)
+        bool handle_dialog_message(const syscall_context& c, window& dialog, const uint32_t message, const uint64_t w_param)
         {
             if (!is_dialog_window(dialog))
             {
@@ -2433,17 +2432,6 @@ namespace sogen
 
             switch (message)
             {
-            case WM_COMMAND: {
-                const auto control_id = static_cast<uint32_t>(w_param & 0xFFFF);
-                const auto notification = static_cast<uint32_t>((w_param >> 16) & 0xFFFF);
-                if (notification == BN_CLICKED && l_param != 0)
-                {
-                    complete_dialog(c, dialog, control_id != 0 ? control_id : IDOK);
-                    return true;
-                }
-                break;
-            }
-
             case WM_KEYDOWN:
                 if (w_param == VK_RETURN)
                 {
@@ -2482,7 +2470,7 @@ namespace sogen
                 {
                     if (auto* win = c.proc.windows.get(pending_msg->window))
                     {
-                        (void)handle_dialog_message(c, *win, pending_msg->message, pending_msg->wParam, pending_msg->lParam);
+                        (void)handle_dialog_message(c, *win, pending_msg->message, pending_msg->wParam);
                     }
                 }
                 message.write(*pending_msg);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -180,7 +180,7 @@ namespace sogen
         bool is_builtin_window_class_name(const std::u16string_view class_name)
         {
             const auto normalized = normalize_builtin_window_class_name(class_name);
-            return normalized == u"#32770" || normalized == u"Button" || normalized == u"Static";
+            return normalized == builtin_dialog_class_name || normalized == u"Button" || normalized == u"Static";
         }
 
         uint16_t get_builtin_window_fnid(const std::u16string_view class_name)
@@ -190,7 +190,7 @@ namespace sogen
             {
                 return 0x02A1;
             }
-            if (normalized == u"#32770")
+            if (normalized == builtin_dialog_class_name)
             {
                 return 0x02A4;
             }
@@ -253,7 +253,7 @@ namespace sogen
                         wnd_proc = server_info.apfnClientA[k_client_pfn_static_wndproc_index];
                     }
                 }
-                else if (normalized_name == u"#32770")
+                else if (normalized_name == builtin_dialog_class_name)
                 {
                     wnd_proc = server_info.apfnClientW[k_client_pfn_dialog_wndproc_index];
                     if (wnd_proc == 0)
@@ -267,12 +267,12 @@ namespace sogen
             {
                 wnd_extra = 8;
             }
-            else if (normalized_name == u"#32770")
+            else if (normalized_name == builtin_dialog_class_name)
             {
                 wnd_extra = 30; // DLGWINDOWEXTRA
             }
 
-            if (wnd_proc == 0 && normalized_name == u"#32770")
+            if (wnd_proc == 0 && normalized_name == builtin_dialog_class_name)
             {
                 wnd_proc = c.win_emu.mod_manager.ntdll->find_export("NtdllDialogWndProc_W");
             }
@@ -2187,7 +2187,7 @@ namespace sogen
 
             if (win->host_surface_window)
             {
-                if (want_visible && normalize_builtin_window_class_name(win->class_name) == u"#32770")
+                if (want_visible && win->is_dialog())
                 {
                     sync_child_control_titles_from_guest(c, *win);
                 }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2258,8 +2258,6 @@ namespace sogen
             return s.was_visible ? TRUE : FALSE;
         }
 
-        bool handle_dialog_message(const syscall_context& c, window& dialog, uint32_t message, uint64_t w_param);
-
         uint64_t handle_NtUserMessageCall(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t w_param,
                                           const uint64_t l_param, const uint64_t /*result_info*/, const DWORD /*type*/, const BOOL ansi)
         {
@@ -2318,8 +2316,6 @@ namespace sogen
                 }
             }
 
-            (void)handle_dialog_message(c, *win, msg, w_param);
-
             message_call_state state{};
             state.window = hwnd;
             state.message = msg;
@@ -2369,8 +2365,6 @@ namespace sogen
                 return 0;
             }
 
-            (void)handle_dialog_message(c, *win, m.message, m.wParam);
-
             message_call_state state{};
             state.window = m.window;
             state.message = m.message;
@@ -2401,61 +2395,6 @@ namespace sogen
             return {};
         }
 
-        void complete_dialog(const syscall_context& c, window& dialog, const uint64_t result)
-        {
-            if (dialog.dialog_pointer == 0)
-            {
-                return;
-            }
-
-            constexpr uint32_t dialog_flag_end = 0x1;
-            uint32_t flags{};
-            c.win_emu.memory.read_memory(dialog.dialog_pointer + 0x18, &flags, sizeof(flags));
-            flags |= dialog_flag_end;
-            c.win_emu.memory.write_memory(dialog.dialog_pointer + 0x18, &flags, sizeof(flags));
-            c.win_emu.memory.write_memory(dialog.dialog_pointer + 0x20, &result, sizeof(result));
-            dialog.dialog_flags = flags;
-            dialog.dialog_result = result;
-        }
-
-        bool is_dialog_window(const window& win)
-        {
-            return normalize_builtin_window_class_name(win.class_name) == u"#32770";
-        }
-
-        bool handle_dialog_message(const syscall_context& c, window& dialog, const uint32_t message, const uint64_t w_param)
-        {
-            if (!is_dialog_window(dialog))
-            {
-                return false;
-            }
-
-            switch (message)
-            {
-            case WM_KEYDOWN:
-                if (w_param == VK_RETURN)
-                {
-                    complete_dialog(c, dialog, IDOK);
-                    return true;
-                }
-                if (w_param == VK_ESCAPE)
-                {
-                    complete_dialog(c, dialog, IDCANCEL);
-                    return true;
-                }
-                break;
-
-            case WM_CLOSE:
-                complete_dialog(c, dialog, IDCANCEL);
-                return true;
-
-            default:
-                break;
-            }
-
-            return false;
-        }
-
         BOOL handle_NtUserPeekMessage(const syscall_context& c, const emulator_object<msg> message, const hwnd hwnd,
                                       const UINT msg_filter_min, const UINT msg_filter_max, const UINT remove_message)
         {
@@ -2466,13 +2405,6 @@ namespace sogen
 
             if (pending_msg)
             {
-                if (should_remove)
-                {
-                    if (auto* win = c.proc.windows.get(pending_msg->window))
-                    {
-                        (void)handle_dialog_message(c, *win, pending_msg->message, pending_msg->wParam);
-                    }
-                }
                 message.write(*pending_msg);
                 set_thread_window_context(c, pending_msg->window);
                 return TRUE;
@@ -3046,13 +2978,6 @@ namespace sogen
             if (!win)
             {
                 return FALSE;
-            }
-
-            win->dialog_pointer = ptr;
-            if (ptr != 0 && (win->dialog_flags & 0x1) != 0)
-            {
-                c.win_emu.memory.write_memory(ptr + 0x18, &win->dialog_flags, sizeof(win->dialog_flags));
-                c.win_emu.memory.write_memory(ptr + 0x20, &win->dialog_result, sizeof(win->dialog_result));
             }
 
             uint64_t pExtraBytes = 0;

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -981,14 +981,6 @@ namespace sogen
             m.lParam = pack_point(target.x, target.y);
         }
 
-        if (event.message == WM_COMMAND && event.lParam != 0 && (event.wParam & 0xFFFF) == 0)
-        {
-            if (const auto* child = this->process.windows.get(event.lParam))
-            {
-                const auto child_id = child->guest.read().wID;
-                m.wParam = (m.wParam & ~0xFFFFull) | (child_id & 0xFFFFull);
-            }
-        }
         thread->post_message(m);
 
         if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN || event.message == WM_LBUTTONDOWN ||

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -3,6 +3,7 @@
 #include "handles.hpp"
 
 #include <algorithm>
+#include <string_view>
 #include <serialization_helper.hpp>
 #include <utils/file_handle.hpp>
 #include <platform/synchronisation.hpp>
@@ -69,6 +70,12 @@ namespace sogen
         }
     };
 
+    // WC_DIALOG = MAKEINTATOM(0x8002); user32 creates dialogs and message boxes with this fixed
+    // system atom, which the kernel reports as the class name "#32770". The atom value is constant
+    // across Windows builds (unlike the builtin control-class atoms, which vary per build and are
+    // resolved through SERVERINFO.atomSysClass), so matching this canonical name is portable.
+    inline constexpr std::u16string_view builtin_dialog_class_name = u"#32770";
+
     struct window : user_object<USER_WINDOW>
     {
         uint32_t thread_id{};
@@ -96,6 +103,11 @@ namespace sogen
         window(memory_interface& memory)
             : user_object(memory)
         {
+        }
+
+        bool is_dialog() const
+        {
+            return this->class_name == builtin_dialog_class_name;
         }
 
         void serialize_object(utils::buffer_serializer& buffer) const override

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -89,9 +89,6 @@ namespace sogen
         bool erase_pending{};
         std::map<std::u16string, uint64_t> props{};
         emulator_pointer wnd_proc{};
-        emulator_pointer dialog_pointer{};
-        uint32_t dialog_flags{};
-        uint64_t dialog_result{};
         emulator_pointer system_menu_ptr{};
         bool host_surface_window{};
         bool unicode_proc{};
@@ -122,9 +119,6 @@ namespace sogen
             buffer.write(this->erase_pending);
             buffer.write_map(this->props);
             buffer.write(this->wnd_proc);
-            buffer.write(this->dialog_pointer);
-            buffer.write(this->dialog_flags);
-            buffer.write(this->dialog_result);
             buffer.write(this->system_menu_ptr);
             buffer.write(this->host_surface_window);
             buffer.write(this->unicode_proc);
@@ -151,9 +145,6 @@ namespace sogen
             buffer.read(this->erase_pending);
             buffer.read_map(this->props);
             buffer.read(this->wnd_proc);
-            buffer.read(this->dialog_pointer);
-            buffer.read(this->dialog_flags);
-            buffer.read(this->dialog_result);
             buffer.read(this->system_menu_ptr);
             buffer.read(this->host_surface_window);
             buffer.read(this->unicode_proc);


### PR DESCRIPTION
## Summary

A focused pass over the "host-side USER logic" cheats list in `docs/windows-ui-emulation.md`. The list mixed two different things: real cheats (host code faking Win32 behavior the guest can do itself) and bounded simplifications that already live in the emulated win32k layer. This separates them — removing the former, scoping the latter.

## Changes

**Removed dead code (the guest's real user32 paths already drive these):**
- `WM_COMMAND` control-id fixup in `handle_ui_event` — no UI backend ever emits `WM_COMMAND` events; the real `ButtonWndProc` builds it from the mirrored `spmenu`/`wID`.
- `WM_COMMAND(BN_CLICKED)` branch in `handle_dialog_message` — a button's `WM_COMMAND` is a same-thread `SendMessage` dispatched in-process to `DefDlgProc`, so it never reached this code.

**Removed the dialog manager shortcut (`handle_dialog_message` / `complete_dialog` / `is_dialog_window`):**
An experiment that disabled the shortcut showed the guest's real `DefDlgProc`/`IsDialogMessage` path handles dialog dismissal correctly — and that the shortcut was not just redundant but **wrong** for `MB_YESNO`:
- Enter: shortcut returned `IDOK` (not a YesNo button); the real path activates the default button (Yes → `IDYES`).
- Esc: shortcut forced `IDCANCEL`; native ignores it on a box with no Cancel button.
- Window X: shortcut faked `IDCANCEL`; native disables the X on a YesNo box.

The now-dead bookkeeping went with it: the `window` fields `dialog_pointer` / `dialog_flags` / `dialog_result` (+ serialization) and the re-apply branch in `NtUserSetDialogPointer` (which now only sets the `WND+0x12` "has DLGINFO" bit and writes the pointer into the window extra bytes — its real kernel job).

**Centralized the `#32770` (`WC_DIALOG`) literal:**
Seven scattered `u"#32770"` comparisons (incl. a raw-vs-normalized inconsistency in `gdi.cpp`) collapsed into one documented `builtin_dialog_class_name` constant + `window::is_dialog()` in `windows_objects.hpp`. Behavior-preserving (`normalize` never maps anything *to* `#32770`). The atom is portable (`MAKEINTATOM(0x8002)`), unlike the build-specific control-class atoms.

**Scoped the two remaining items as bounded win32k simplifications (kept, doc-only):**
- `invalidate_window_tree` — verified load-bearing (disabling the child recursion leaves a painted dialog frame but blank buttons/text). It's `RDW_INVALIDATE | RDW_ALLCHILDREN`-equivalent and already in the win32k layer; diverges from real win32k only without an update-region/clipping model.
- `route_pointer` — already consolidates hit-testing in the win32k layer and honors `SetCapture`; diverges on `WM_NCHITTEST`/`WM_SETCURSOR`/`WM_MOUSEACTIVATE`, z-order, and `WS_EX_TRANSPARENT`. The doc records the principled fix (move hit-testing to message-pop time in guest context for synchronous sent messages).

## Verification

- Release **and** tidy (clang-tidy) builds clean.
- Smoke suite (`analyzer.exe -s test-sample.exe`) passes.
- Serialization tests (4/4) and full `windows-emulator-test` suite (14/14) pass with a captured root.
- `messagebox-sample` verified interactively at each step (Enter → `clicked: yes`, Esc no-op, X disabled, mouse Yes/No work) on the host Win11 DLLs.
