### PR TITLE
Fix ExtTextOutW DC color sources; sync GDI text/bitmap docs

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -258,15 +258,19 @@ button captions, portable system builtin-class atom resolution (see "System buil
 atom resolution"), and the window/dialog **background** fill (top-level surfaces are now filled
 with the class background brush — gray dialog face instead of white). Still open:
 
-- message-box **icon** pixels (`NtUserDrawIconEx` is a success stub)
-- classic checkbox/radio **check glyph** pixels (`NtUserBitBltSysBmp` is a success stub; box, label,
-  and click/state handling work)
-- finish small-text / batched GDI text path so ordinary `TextOutA/W` works without forcing oversized `ExtTextOutW`
-- replace temporary debug-font text path with more correct font/text handling over time
+- message-box **icon** pixels (`NtUserDrawIconEx` is a success stub) — still open; see update (8) for
+  the feasibility constraint (no stored icon pixel data / icon identity)
+- replace temporary debug-font text path with more correct font/text handling over time — still open
+  (text renders via the 8x8 `debug_font` at a fixed cell, ignoring the selected `HFONT`)
 - add more correct clip/region handling
 - add more correct ROP / brush / pen / DC semantics where builtin paint needs them
 - `NtGdiGetDCDword` only returns the default (0); other indices (MapMode, GraphicsMode, …) would need
   real values if a control relies on them
+
+Since resolved (see update (8)): the classic checkbox/radio **check glyph** (`NtUserBitBltSysBmp` now
+draws it via `draw_system_button_glyph`), and the small-text / **batched GDI text** path
+(`flush_gdi_text_batch` processes the TEB GDI batch, so ordinary `TextOutA/W` works without forcing an
+oversized `ExtTextOutW`).
 
 ## UPDATE 2026-06-07 — input routing consolidated into the emulated win32k layer
 
@@ -527,6 +531,33 @@ fixups) and #3 (dialog shortcut) removed as dead code, `#32770` centralized, and
 items (`invalidate_window_tree`, `route_pointer`) verified load-bearing and reframed as bounded win32k
 simplifications with their principled fixes recorded.
 
+## UPDATE 2026-06-07 (8) — GDI text/bitmap state synced + ExtTextOutW color fix
+
+Surveyed the GDI text/bitmap path and found the doc's "remaining blockers" list had drifted — two items
+listed as open are actually implemented:
+
+- **Batched GDI text** — `flush_gdi_text_batch` (`syscalls/gdi.cpp`) walks the TEB `GdiTebBatch` and
+  replays `TextOut` (`k_gdi_batch_cmd_text_out`) and `PolyPatBlt` records on `NtGdiFlush`, using the
+  foreground/background colors carried in each batch record. Ordinary `TextOutA/W` flows through this, so
+  no oversized `ExtTextOutW` is needed.
+- **Checkbox/radio check glyph** — `NtUserBitBltSysBmp` calls `draw_system_button_glyph`, which draws the
+  glyph; box, label, and click/state already worked.
+
+Fixed a real bug in the **direct** `NtGdiExtTextOutW` path (the non-batched path) where it read the
+wrong DC colors: text was drawn with the DC **pen** color and `ETO_OPAQUE` filled with the DC **brush**
+color. Windows uses the DC **text color** (`SetTextColor` / `crForegroundClr`) for glyphs and the DC
+**background color** (`SetBkColor` / `crBackgroundClr`) for the opaque fill — which the batched path
+already did correctly. Added `get_dc_text_color` / `get_dc_background_color` (reading `DC_ATTR` at
+`0x28` / `0x20`, consistent with the existing ReactOS-derived `DC_ATTR` offsets the file already uses)
+and pointed the direct path at them. Release + smoke pass.
+
+Genuinely still open in this area: **`NtUserDrawIconEx`** (message-box icon) is a success stub, and the
+icon model has no stored pixel data or tracked icon identity — drawing the real system icon would need
+either synthesizing the standard message-box icons as glyphs (like `draw_system_button_glyph`, plus a
+way to know which icon was requested) or loading+rasterizing the real `imageres.dll`/`user32` resource.
+And text still uses the temporary 8x8 `debug_font` at a fixed cell, ignoring the selected `HFONT`
+(size/face/weight) — real font handling remains the large follow-up.
+
 ## Backend parity notes
 
 SDL and web still need separate host backends because their platform integration is genuinely different:
@@ -552,10 +583,12 @@ The remaining design direction is to continue moving Win32 behavior out of host 
 
 ## Next steps
 
-1. Draw the message-box icon (`NtUserDrawIconEx`) and the dialog background.
+1. Draw the message-box icon (`NtUserDrawIconEx`) — needs an icon-identity/pixel-data approach first
+   (see update (8)); the dialog background fill is already done.
 2. Keep builtin control paint on the real callback/user32 path; do not reintroduce manual
    `Button` / `Static` drawing fallbacks.
-3. Continue improving batched text and font handling.
+3. Replace the temporary 8x8 `debug_font` with real `HFONT`-aware font/text handling (batched text
+   plumbing is already in place; the gap is glyph rasterization at the selected size/face).
 
 ## Non-goals for this checkpoint
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -41,6 +41,8 @@ namespace sogen
 
             constexpr uint32_t k_gdi_dc_attr_hbrush_offset = 0x10;
             constexpr uint32_t k_gdi_dc_attr_hpen_offset = 0x18;
+            constexpr uint32_t k_gdi_dc_attr_background_color_offset = 0x20; // DC_ATTR.crBackgroundClr (SetBkColor)
+            constexpr uint32_t k_gdi_dc_attr_text_color_offset = 0x28;       // DC_ATTR.crForegroundClr (SetTextColor)
             constexpr uint32_t k_gdi_dc_attr_pt_current_offset = 0xD8;
             constexpr uint32_t k_gdi_dc_attr_font_offset = 0x128;
 
@@ -610,6 +612,31 @@ namespace sogen
                 }
 
                 return get_brush_color(c, brush_handle);
+            }
+
+            // Reads a COLORREF directly out of the DC_ATTR (the user-mode block gdi32 updates on
+            // SetTextColor / SetBkColor without a syscall), returning `fallback` if the DC is unknown.
+            uint32_t get_dc_attr_color(const syscall_context& c, const hdc dc, const uint32_t offset, const uint32_t fallback)
+            {
+                uint64_t dc_attr = 0;
+                if (!get_gdi_object_address(c, static_cast<uint32_t>(dc), k_gdi_dc_type, dc_attr))
+                {
+                    return fallback;
+                }
+
+                uint32_t colorref = 0;
+                c.win_emu.memory.try_read_memory(dc_attr + offset, &colorref, sizeof(colorref));
+                return colorref_to_bgra(colorref);
+            }
+
+            uint32_t get_dc_text_color(const syscall_context& c, const hdc dc)
+            {
+                return get_dc_attr_color(c, dc, k_gdi_dc_attr_text_color_offset, 0xFF000000u);
+            }
+
+            uint32_t get_dc_background_color(const syscall_context& c, const hdc dc)
+            {
+                return get_dc_attr_color(c, dc, k_gdi_dc_attr_background_color_offset, 0xFFFFFFFFu);
             }
 
             // The base fill for a freshly (re)created top-level window surface, matching what WM_ERASEBKGND
@@ -1856,7 +1883,7 @@ namespace sogen
                 clip_rect.bottom += origin_y;
                 if ((options & ETO_OPAQUE) != 0)
                 {
-                    fill_rect(*surface, clip_rect.left, clip_rect.top, clip_rect.right, clip_rect.bottom, get_dc_brush_color(c, dc));
+                    fill_rect(*surface, clip_rect.left, clip_rect.top, clip_rect.right, clip_rect.bottom, get_dc_background_color(c, dc));
                 }
             }
 
@@ -1867,7 +1894,7 @@ namespace sogen
                 c.emu.read_memory(dx, advances.data(), advances.size() * sizeof(uint32_t));
             }
 
-            const auto color = get_dc_pen_color(c, dc);
+            const auto color = get_dc_text_color(c, dc);
             draw_text(*surface, x + origin_x, y + origin_y, glyphs, color, has_rect && (options & ETO_CLIPPED) != 0 ? &clip_rect : nullptr,
                       advances.empty() ? nullptr : advances.data());
 


### PR DESCRIPTION
## Summary

Follow-up to #1030. Two parts:

**Fix wrong DC color sources in the direct `NtGdiExtTextOutW` path.** The non-batched text path drew glyphs with the DC **pen** color and filled `ETO_OPAQUE` with the DC **brush** color. Windows uses the DC **text color** (`SetTextColor` / `crForegroundClr`) for glyphs and the DC **background color** (`SetBkColor` / `crBackgroundClr`) for the opaque fill — which the batched text path (`flush_gdi_text_batch`) already did via the colors carried in each batch record. Added `get_dc_text_color` / `get_dc_background_color` reading `DC_ATTR` at `0x28` / `0x20` (consistent with the ReactOS-derived `DC_ATTR` offsets the file already uses for `hpen`/`hbrush`/`font`) and pointed the direct path at them.

**Sync `docs/windows-ui-emulation.md`.** The "remaining blockers" list had drifted — two items listed as open are implemented:
- batched GDI text (`flush_gdi_text_batch` replays the TEB `GdiTebBatch` `TextOut`/`PolyPatBlt` records on `NtGdiFlush`), so `TextOutA/W` works without an oversized `ExtTextOutW`;
- the checkbox/radio check glyph (`NtUserBitBltSysBmp` → `draw_system_button_glyph`).

Genuinely still open, now scoped in the doc: `NtUserDrawIconEx` (no stored icon pixel data/identity) and replacing the temporary 8×8 `debug_font` with real `HFONT`-aware text.

## Verification

- Release **and** tidy (clang-tidy) builds clean.
- Smoke suite (`analyzer.exe -s test-sample.exe`) passes.
- Behavior note: the message box renders text via the batched path (unchanged); this fix affects the direct `ExtTextOutW` path, which matters when a guest sets a non-default text/background color.
