### PR TITLE
Fix thread attribute number extraction in NtCreateThreadEx

### DIFF
--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -837,7 +837,7 @@ namespace sogen
             {
                 attributes.access(
                     [&](const PS_ATTRIBUTE<EmulatorTraits<Emu64>>& attribute) {
-                        const auto type = attribute.Attribute & ~PS_ATTRIBUTE_THREAD;
+                        const auto type = attribute.Attribute & PS_ATTRIBUTE_NUMBER_MASK;
 
                         if (type == PsAttributeClientId)
                         {
@@ -847,6 +847,10 @@ namespace sogen
                         else if (type == PsAttributeTebAddress)
                         {
                             write_attribute(c.emu, attribute, thread->teb64->value());
+                        }
+                        else if (type == PsAttributeGroupAffinity || type == PsAttributeIdealProcessor)
+                        {
+                            // Scheduling hints; not modeled by the emulator.
                         }
                         else
                         {


### PR DESCRIPTION
## Problem

`handle_NtCreateThreadEx` logged `Unsupported thread attribute type: 2000c` for some binaries.

The value `0x2000c` decodes as `PS_ATTRIBUTE_INPUT (0x20000) | PsAttributeGroupAffinity (12)` — a perfectly valid input attribute. The attribute number was being extracted with:

```cpp
const auto type = attribute.Attribute & ~PS_ATTRIBUTE_THREAD;
```

which only strips the `PS_ATTRIBUTE_THREAD` flag and leaves the `PS_ATTRIBUTE_INPUT`/`PS_ATTRIBUTE_ADDITIVE` flags attached, so input attributes never matched the bare attribute numbers being compared.

## Fix

- Extract the attribute number with `PS_ATTRIBUTE_NUMBER_MASK` (matching how Windows decodes `PS_ATTRIBUTE`).
- Accept `PsAttributeGroupAffinity` and `PsAttributeIdealProcessor` as no-ops (scheduling hints the emulator doesn't model) instead of logging an error.

## Testing

- `cmake --build --preset=release` succeeds.
- `analyzer.exe -s test-sample.exe` smoke tests all pass.