### PR TITLE
Fix GetTickCount advancing 10000x too fast

### DIFF
--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -173,8 +173,9 @@ namespace sogen
         const auto ticks = this->clock_->steady_now();
         const auto duration_100ns =
             std::chrono::duration_cast<std::chrono::duration<uint64_t, std::ratio<1, 10000000>>>(ticks.time_since_epoch()).count();
+        const auto duration_ms = duration_100ns / 10000;
 
-        this->kusd_.TickCount.TickCountQuad = (duration_100ns << 24) / this->kusd_.TickCountMultiplier;
+        this->kusd_.TickCount.TickCountQuad = (duration_ms << 24) / this->kusd_.TickCountMultiplier;
         this->kusd_.TickCount.TickCount.High2Time = this->kusd_.TickCount.TickCount.High1Time;
 
         this->kusd_.InterruptTime.High2Time = static_cast<int32_t>(duration_100ns >> 32);


### PR DESCRIPTION
## Fix `GetTickCount`/`GetTickCount64` advancing 10000× too fast

`kusd_mmio::update()` derived `KUSER_SHARED_DATA.TickCountQuad` from **100 ns units** (the same
`duration_100ns` used for `InterruptTime`). But the guest computes the tick count as
`(TickCountQuad * TickCountMultiplier) >> 24`, which expects `TickCountQuad` derived from
**milliseconds**. Feeding it 100 ns units made every `GetTickCount` / `GetTickCount64` read advance
**10000× too fast** — e.g. a 4 ms frame is reported as ~40 s.

This breaks any guest code that measures time with the tick count (timing, FPS counters, frame pacing,
animation driven by `GetTickCount`).

### Fix

Derive `TickCountQuad` from milliseconds. `InterruptTime` keeps its 100 ns units (it was already
correct), and `SystemTime` is untouched.

```cpp
const auto duration_ms =
    std::chrono::duration_cast<std::chrono::milliseconds>(ticks.time_since_epoch()).count();
this->kusd_.TickCount.TickCountQuad = (static_cast<uint64_t>(duration_ms) << 24) / this->kusd_.TickCountMultiplier;
```

### Why it went unnoticed

`TimeTest` only validates `SystemTime` (within an hour of now); `GetTickCount` was never checked, so the
unit error slipped through.

### Verifying

A guest app that measures frame time with `GetTickCount64` reported ~0.02 FPS (~30000–41000 ms/frame)
before, and ~80–112 FPS (9–12 ms/frame) after — i.e. real time again. `SystemTime` is unchanged, so
`TimeTest` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
