### PR TITLE
Fix CoreMessaging

### DIFF
--- a/src/emulator-platform/platform/file_management.hpp
+++ b/src/emulator-platform/platform/file_management.hpp
@@ -635,6 +635,15 @@ namespace sogen
         EmulatorTraits<Emu64>::PVOID ViewBase;
     } REMOTE_PORT_VIEW64, *PREMOTE_PORT_VIEW64;
 
+    typedef struct _OBJECT_BASIC_INFORMATION
+    {
+        ULONG Attributes{};
+        ACCESS_MASK GrantedAccess{};
+        ULONG HandleCount{};
+        ULONG PointerCount{};
+        ULONG Reserved[10]{};
+    } OBJECT_BASIC_INFORMATION, *POBJECT_BASIC_INFORMATION;
+
     typedef struct _OBJECT_HANDLE_FLAG_INFORMATION
     {
         BOOLEAN Inherit;

--- a/src/emulator-platform/platform/port.hpp
+++ b/src/emulator-platform/platform/port.hpp
@@ -20,7 +20,8 @@
 namespace sogen
 {
 
-    struct PORT_MESSAGE64
+    template <typename Traits>
+    struct PORT_MESSAGE
     {
         union
         {
@@ -46,7 +47,7 @@ namespace sogen
 
         union
         {
-            CLIENT_ID64 ClientId;
+            CLIENT_ID<Traits> ClientId;
             double DoNotUseThisField;
         };
 
@@ -54,10 +55,13 @@ namespace sogen
 
         union
         {
-            EmulatorTraits<Emu64>::SIZE_T ClientViewSize; // only valid for LPC_CONNECTION_REQUEST messages
-            ULONG CallbackId;                             // only valid for LPC_REQUEST messages
+            typename Traits::SIZE_T ClientViewSize; // only valid for LPC_CONNECTION_REQUEST messages
+            ULONG CallbackId;                       // only valid for LPC_REQUEST messages
         };
     };
+
+    using PORT_MESSAGE32 = PORT_MESSAGE<EmulatorTraits<Emu32>>;
+    using PORT_MESSAGE64 = PORT_MESSAGE<EmulatorTraits<Emu64>>;
 
     struct ALPC_MESSAGE_ATTRIBUTES
     {

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -986,17 +986,15 @@ namespace sogen
 #define BACKUP_SECURITY_INFORMATION              0x00010000L
 #endif
 
-    struct CLIENT_ID32
+    template <typename Traits>
+    struct CLIENT_ID
     {
-        ULONG UniqueProcess;
-        ULONG UniqueThread;
+        typename Traits::HANDLE UniqueProcess;
+        typename Traits::HANDLE UniqueThread;
     };
 
-    struct CLIENT_ID64
-    {
-        DWORD64 UniqueProcess;
-        DWORD64 UniqueThread;
-    };
+    using CLIENT_ID32 = CLIENT_ID<EmulatorTraits<Emu32>>;
+    using CLIENT_ID64 = CLIENT_ID<EmulatorTraits<Emu64>>;
 
     template <typename Traits>
     struct EMU_RTL_SRWLOCK

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -5,26 +5,27 @@
 
 // NOLINTBEGIN(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
 
-#define FNID_START      0x29A
-#define FNID_ARRAY_SIZE 24
+#define FNID_START               0x29A
+#define FNID_ARRAY_SIZE          24
 
-#define FNID_SCROLLBAR  0x29A
-#define FNID_ICONTITLE  0x29B
-#define FNID_MENU       0x29C
-#define FNID_DESKTOP    0x29D
-#define FNID_DEFWINDOW  0x29E
-#define FNID_MESSAGE    0x29F
-#define FNID_SWITCH     0x2A0
-#define FNID_BUTTON     0x2A1
-#define FNID_COMBOBOX   0x2A2
-#define FNID_COMBOLBOX  0x2A3
-#define FNID_DIALOG     0x2A4
-#define FNID_EDIT       0x2A5
-#define FNID_LISTBOX    0x2A6
-#define FNID_MDICLIENT  0x2A7
-#define FNID_STATIC     0x2A8
-#define FNID_IME        0x2A9
-#define FNID_GHOST      0x2AA
+#define FNID_SCROLLBAR           0x29A
+#define FNID_ICONTITLE           0x29B
+#define FNID_MENU                0x29C
+#define FNID_DESKTOP             0x29D
+#define FNID_DEFWINDOW           0x29E
+#define FNID_MESSAGE             0x29F
+#define FNID_SWITCH              0x2A0
+#define FNID_BUTTON              0x2A1
+#define FNID_COMBOBOX            0x2A2
+#define FNID_COMBOLBOX           0x2A3
+#define FNID_DIALOG              0x2A4
+#define FNID_EDIT                0x2A5
+#define FNID_LISTBOX             0x2A6
+#define FNID_MDICLIENT           0x2A7
+#define FNID_STATIC              0x2A8
+#define FNID_IME                 0x2A9
+#define FNID_GHOST               0x2AA
+#define FNID_SENDMESSAGECALLBACK 0x2B8
 
 namespace sogen
 {

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -176,6 +176,7 @@ namespace sogen
 #define WM_RBUTTONDOWN       0x0204
 #define WM_RBUTTONUP         0x0205
 #define WM_COMMAND           0x0111
+#define WM_TIMER             0x0113
 #define WM_WINDOWPOSCHANGING 0x0046
 #define WM_WINDOWPOSCHANGED  0x0047
 #define WM_NCCREATE          0x0081
@@ -201,6 +202,23 @@ namespace sogen
 #define PM_NOREMOVE          0x0000
 #define PM_REMOVE            0x0001
 #define PM_NOYIELD           0x0002
+
+#define QS_KEY               0x0001
+#define QS_MOUSEMOVE         0x0002
+#define QS_MOUSEBUTTON       0x0004
+#define QS_POSTMESSAGE       0x0008
+#define QS_TIMER             0x0010
+#define QS_PAINT             0x0020
+#define QS_SENDMESSAGE       0x0040
+#define QS_HOTKEY            0x0080
+#define QS_ALLPOSTMESSAGE    0x0100
+#define QS_RAWINPUT          0x0400
+#define QS_TOUCH             0x0800
+#define QS_POINTER           0x1000
+#define QS_MOUSE             (QS_MOUSEMOVE | QS_MOUSEBUTTON)
+#define QS_INPUT             (QS_MOUSE | QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
+#define QS_ALLEVENTS         (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY)
+#define QS_ALLINPUT          (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY | QS_SENDMESSAGE)
 
 #define RDW_INVALIDATE       0x0001
 #define RDW_INTERNALPAINT    0x0002

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1463,6 +1463,66 @@ namespace
 
         return t1 != t0;
     }
+
+    bool test_settimer()
+    {
+        MSG msg = {};
+        while (PeekMessageA(&msg, nullptr, WM_TIMER, WM_TIMER, PM_REMOVE))
+        {
+        }
+
+        HANDLE dummy_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!dummy_event)
+        {
+            puts("CreateEventW failed");
+            return false;
+        }
+
+        const auto cleanup_event = sogen::utils::finally([&] { CloseHandle(dummy_event); });
+
+        const UINT_PTR timer_id = SetTimer(nullptr, 0, 10, nullptr);
+        if (!timer_id)
+        {
+            puts("SetTimer failed");
+            return false;
+        }
+
+        const auto cleanup_timer = sogen::utils::finally([&] { KillTimer(nullptr, timer_id); });
+
+        const DWORD wait_result = MsgWaitForMultipleObjects(1, &dummy_event, FALSE, 1000, QS_TIMER);
+
+        if (wait_result != WAIT_OBJECT_0 + 1)
+        {
+            printf("MsgWaitForMultipleObjects returned unexpected result: %lu\n", wait_result);
+            return false;
+        }
+
+        if (!PeekMessageA(&msg, nullptr, WM_TIMER, WM_TIMER, PM_REMOVE))
+        {
+            puts("Expected WM_TIMER message was not available");
+            return false;
+        }
+
+        if (msg.message != WM_TIMER)
+        {
+            puts("Received message was not WM_TIMER");
+            return false;
+        }
+
+        if (msg.hwnd != nullptr)
+        {
+            puts("Expected a thread timer, but WM_TIMER had a window handle");
+            return false;
+        }
+
+        if (msg.wParam != timer_id)
+        {
+            puts("WM_TIMER timer id mismatch");
+            return false;
+        }
+
+        return true;
+    }
 }
 
 #define RUN_TEST(func, name)                 \
@@ -1516,6 +1576,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_apc, "APC")
     RUN_TEST(test_user_callback, "User Callback")
     RUN_TEST(test_message_queue, "Message Queue")
+    RUN_TEST(test_settimer, "User Timer")
     RUN_TEST(test_private_namespace, "Private Namespace")
     RUN_TEST(test_actctx, "Activation Context")
     RUN_TEST(test_mmio, "MMIO")

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -672,7 +672,7 @@ namespace sogen
 
     uint32_t emulator_thread::get_message_queue_status(utils::clock& clock)
     {
-        if ((*this->await_msg_mask & QS_TIMER) != 0)
+        if (this->await_msg_mask && (*this->await_msg_mask & QS_TIMER) != 0)
         {
             (void)this->synthesize_due_user_timer(clock);
         }

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -125,6 +125,16 @@ namespace sogen
                 break;
             }
 
+            case handle_types::port: {
+                const auto* p = c.ports.get(h);
+                if (p && p->has_pending_reply())
+                {
+                    return wait_state::signaled;
+                }
+
+                break;
+            }
+
             case handle_types::thread: {
                 const auto* t = c.threads.get(h);
                 if (t && t->is_terminated())
@@ -201,6 +211,16 @@ namespace sogen
                 return wait_state::signaled;
             }
 
+            case handle_types::port: {
+                auto* port = c.ports.get(h);
+                if (!port || !port->has_pending_reply())
+                {
+                    return std::nullopt;
+                }
+
+                return wait_state::signaled;
+            }
+
             case handle_types::thread: {
                 const auto* thread = c.threads.get(h);
                 if (!thread || !thread->is_terminated())
@@ -213,6 +233,37 @@ namespace sogen
 
             default:
                 throw std::runtime_error("Bad object: " + std::to_string(h.value.type));
+            }
+        }
+
+        uint32_t get_message_queue_status_bits(const msg& queued_message)
+        {
+            switch (queued_message.message)
+            {
+            case WM_TIMER:
+                return QS_TIMER;
+
+            case WM_PAINT:
+                return QS_PAINT;
+
+            case WM_KEYDOWN:
+            case WM_KEYUP:
+                return QS_KEY;
+
+            default:
+                return QS_POSTMESSAGE | QS_ALLPOSTMESSAGE;
+            }
+        }
+
+        template <typename F>
+        void for_each_queue_status_bit(uint32_t mask, F&& callback)
+        {
+            while (mask != 0)
+            {
+                const auto bit = mask & (0 - mask);
+                const auto index = std::countr_zero(bit);
+                callback(bit, index);
+                mask &= ~bit;
             }
         }
     }
@@ -485,6 +536,7 @@ namespace sogen
         this->await_time = {};
         this->await_objects = {};
         this->await_msg = {};
+        this->await_msg_mask = {};
         this->await_io_completion = {};
 
         // TODO: Find out if this is correct
@@ -494,6 +546,138 @@ namespace sogen
         }
 
         this->waiting_for_alert = false;
+    }
+
+    user_timer* emulator_thread::find_user_timer(const hwnd hwnd, const uint64_t timer_id)
+    {
+        const auto it = this->user_timers.find(user_timer_key{
+            .hwnd = hwnd,
+            .timer_id = timer_id,
+        });
+
+        if (it == this->user_timers.end())
+        {
+            return nullptr;
+        }
+
+        return &it->second;
+    }
+
+    user_timer& emulator_thread::create_user_timer(process_context& process, const hwnd hwnd, uint64_t timer_id, const uint64_t timer_proc,
+                                                   const std::chrono::milliseconds interval,
+                                                   const std::chrono::steady_clock::time_point now)
+    {
+        if (hwnd == 0)
+        {
+            timer_id = this->next_user_timer_id;
+            while (this->user_timers.contains(user_timer_key{
+                .hwnd = 0,
+                .timer_id = timer_id,
+            }))
+            {
+                ++timer_id;
+                if (timer_id == 0)
+                {
+                    timer_id = 1;
+                }
+            }
+            this->next_user_timer_id = timer_id + 1;
+            if (this->next_user_timer_id == 0)
+            {
+                this->next_user_timer_id = 1;
+            }
+        }
+        else if (const auto* window = process.windows.get(hwnd); window->thread_id != this->id)
+        {
+            throw std::runtime_error("Attempted to create a user timer in a thread that doesn't own the target window");
+        }
+
+        user_timer timer{};
+        timer.hwnd = hwnd;
+        timer.timer_id = timer_id;
+        timer.timer_proc = timer_proc;
+        timer.interval = interval;
+        timer.due_time = now + interval;
+
+        const auto [it, inserted] = this->user_timers.emplace(
+            user_timer_key{
+                .hwnd = hwnd,
+                .timer_id = timer_id,
+            },
+            std::move(timer));
+
+        if (!inserted)
+        {
+            throw std::runtime_error("User timer already exists");
+        }
+
+        return it->second;
+    }
+
+    bool emulator_thread::delete_user_timer(const hwnd hwnd, const uint64_t timer_id)
+    {
+        const auto it = this->user_timers.find(user_timer_key{
+            .hwnd = hwnd,
+            .timer_id = timer_id,
+        });
+
+        if (it == this->user_timers.end())
+        {
+            return false;
+        }
+
+        this->user_timers.erase(it);
+        return true;
+    }
+
+    bool emulator_thread::synthesize_due_user_timer(utils::clock& clock, const hwnd hwnd_filter, const UINT filter_min,
+                                                    const UINT filter_max)
+    {
+        const auto now = clock.steady_now();
+        for (auto& user_timer : this->user_timers | std::views::values)
+        {
+            if (!user_timer.due_time.has_value() || user_timer.due_time.value() > now)
+            {
+                continue;
+            }
+
+            msg timer_message{};
+            timer_message.window = user_timer.hwnd;
+            timer_message.message = WM_TIMER;
+            timer_message.wParam = user_timer.timer_id;
+            timer_message.lParam = user_timer.timer_proc;
+
+            if (hwnd_filter != 0 && hwnd_filter != static_cast<hwnd>(-1) && timer_message.window != hwnd_filter)
+            {
+                continue;
+            }
+
+            if (hwnd_filter == static_cast<hwnd>(-1) && timer_message.window != 0)
+            {
+                continue;
+            }
+
+            if ((filter_min != 0 || filter_max != 0) && (timer_message.message < filter_min || timer_message.message > filter_max))
+            {
+                continue;
+            }
+
+            this->post_message(timer_message);
+            user_timer.due_time = now + user_timer.interval;
+            return true;
+        }
+
+        return false;
+    }
+
+    uint32_t emulator_thread::get_message_queue_status(utils::clock& clock)
+    {
+        if ((*this->await_msg_mask & QS_TIMER) != 0)
+        {
+            (void)this->synthesize_due_user_timer(clock);
+        }
+
+        return this->message_queue_status_bits;
     }
 
     namespace
@@ -523,9 +707,11 @@ namespace sogen
         }
     }
 
-    std::optional<msg> emulator_thread::peek_pending_message(const process_context& process, hwnd hwnd_filter, UINT filter_min,
-                                                             UINT filter_max, bool remove)
+    std::optional<msg> emulator_thread::peek_pending_message(const process_context& process, utils::clock& clock, hwnd hwnd_filter,
+                                                             UINT filter_min, UINT filter_max, bool remove)
     {
+        (void)this->synthesize_due_user_timer(clock, hwnd_filter, filter_min, filter_max);
+
         for (auto it = message_queue.begin(); it != message_queue.end(); ++it)
         {
             if (hwnd_filter == static_cast<hwnd>(-1))
@@ -548,15 +734,38 @@ namespace sogen
             auto msg = *it;
             if (remove)
             {
+                const auto removed_bits = get_message_queue_status_bits(msg);
+
+                for_each_queue_status_bit(removed_bits, [this](const uint32_t bit, const size_t index) {
+                    if (this->message_queue_status_bit_counts[index] <= 1)
+                    {
+                        this->message_queue_status_bit_counts[index] = 0;
+                        this->message_queue_status_bits &= ~bit;
+                    }
+                    else
+                    {
+                        --this->message_queue_status_bit_counts[index];
+                    }
+                });
+
                 message_queue.erase(it);
             }
             return msg;
         }
+
         return std::nullopt;
     }
 
     void emulator_thread::post_message(const msg& msg)
     {
+        const auto bits = get_message_queue_status_bits(msg);
+
+        for_each_queue_status_bit(bits, [this](const uint32_t /*bit*/, const size_t index) { //
+            ++this->message_queue_status_bit_counts[index];
+        });
+
+        this->message_queue_status_bits |= bits;
+        this->queue_status_changed_bits |= bits;
         message_queue.push_back(msg);
     }
 
@@ -572,6 +781,16 @@ namespace sogen
             return false;
         }
 
+        const auto complete_if_timed_out = [&](const NTSTATUS status) {
+            if (!this->is_await_time_over(clock) || this->has_pending_alertable_apc())
+            {
+                return false;
+            }
+
+            this->mark_as_ready(status);
+            return true;
+        };
+
         if (this->waiting_for_alert)
         {
             if (this->alerted)
@@ -579,46 +798,64 @@ namespace sogen
                 this->mark_as_ready(STATUS_ALERTED);
                 return true;
             }
-            if (this->is_await_time_over(clock))
+
+            return complete_if_timed_out(STATUS_TIMEOUT);
+        }
+
+        if (this->await_msg_mask.has_value() || !this->await_objects.empty())
+        {
+            bool all_signaled = this->await_objects.empty();
+            std::optional<uint32_t> abandoned_index{};
+
+            if (!this->await_objects.empty())
             {
-                this->mark_as_ready(STATUS_TIMEOUT);
+                all_signaled = true;
+                for (uint32_t i = 0; i < this->await_objects.size(); ++i)
+                {
+                    const auto& obj = this->await_objects[i];
+
+                    const auto state = observe_object_signal(process, obj, this->id);
+                    const auto signaled = state != wait_state::not_signaled;
+                    all_signaled &= signaled;
+
+                    if (state == wait_state::abandoned && !abandoned_index.has_value())
+                    {
+                        abandoned_index = i;
+                    }
+
+                    if (signaled && this->await_any)
+                    {
+                        const auto consumed_state = consume_object_signal(process, obj, this->id);
+                        if (!consumed_state.has_value())
+                        {
+                            throw std::runtime_error("Failed to consume object signal!");
+                        }
+
+                        if (this->await_msg_mask.has_value())
+                        {
+                            this->queue_status_changed_bits |= QS_POSTMESSAGE | QS_ALLPOSTMESSAGE;
+                        }
+
+                        this->mark_as_ready(*consumed_state == wait_state::abandoned ? (STATUS_ABANDONED_WAIT_0 + i) : (STATUS_WAIT_0 + i));
+                        return true;
+                    }
+                }
+            }
+
+            bool message_ready = false;
+            if (this->await_msg_mask.has_value())
+            {
+                const auto current_message_bits = this->get_message_queue_status(clock);
+                message_ready = (current_message_bits & *this->await_msg_mask) != 0;
+            }
+
+            if (this->await_msg_mask.has_value() && message_ready && (this->await_any || this->await_objects.empty()))
+            {
+                this->mark_as_ready(static_cast<NTSTATUS>(STATUS_WAIT_0 + this->await_objects.size()));
                 return true;
             }
 
-            return false;
-        }
-
-        if (!this->await_objects.empty())
-        {
-            bool all_signaled = true;
-            std::optional<uint32_t> abandoned_index{};
-            for (uint32_t i = 0; i < this->await_objects.size(); ++i)
-            {
-                const auto& obj = this->await_objects[i];
-
-                const auto state = observe_object_signal(process, obj, this->id);
-                const auto signaled = state != wait_state::not_signaled;
-                all_signaled &= signaled;
-
-                if (state == wait_state::abandoned && !abandoned_index.has_value())
-                {
-                    abandoned_index = i;
-                }
-
-                if (signaled && this->await_any)
-                {
-                    const auto consumed_state = consume_object_signal(process, obj, this->id);
-                    if (!consumed_state.has_value())
-                    {
-                        throw std::runtime_error("Failed to consume object signal!");
-                    }
-
-                    this->mark_as_ready(*consumed_state == wait_state::abandoned ? (STATUS_ABANDONED_WAIT_0 + i) : (STATUS_WAIT_0 + i));
-                    return true;
-                }
-            }
-
-            if (!this->await_any && all_signaled)
+            if (!this->await_any && all_signaled && (!this->await_msg_mask.has_value() || message_ready))
             {
                 for (const auto& obj : this->await_objects)
                 {
@@ -633,24 +870,12 @@ namespace sogen
                 return true;
             }
 
-            if (this->is_await_time_over(clock) && !this->has_pending_alertable_apc())
-            {
-                this->mark_as_ready(STATUS_TIMEOUT);
-                return true;
-            }
-
-            return false;
+            return complete_if_timed_out(STATUS_TIMEOUT);
         }
 
         if (this->await_time.has_value())
         {
-            if (this->is_await_time_over(clock) && !this->has_pending_alertable_apc())
-            {
-                this->mark_as_ready(STATUS_SUCCESS);
-                return true;
-            }
-
-            return false;
+            return complete_if_timed_out(STATUS_SUCCESS);
         }
 
         if (this->await_io_completion.has_value())
@@ -720,7 +945,7 @@ namespace sogen
 
         if (this->await_msg.has_value())
         {
-            if (const auto m = this->peek_pending_message(process, this->await_msg->hwnd_filter, this->await_msg->filter_min,
+            if (const auto m = this->peek_pending_message(process, clock, this->await_msg->hwnd_filter, this->await_msg->filter_min,
                                                           this->await_msg->filter_max, true))
             {
                 this->await_msg->message.write(*m);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -12,6 +12,44 @@ namespace sogen
     struct completion_state;
     struct process_context;
 
+    struct user_timer_key
+    {
+        sogen::hwnd hwnd{};
+        uint64_t timer_id{};
+
+        auto operator<=>(const user_timer_key&) const = default;
+    };
+
+    struct user_timer
+    {
+        std::u16string name{};
+        sogen::hwnd hwnd{};
+        uint64_t timer_id{};
+        uint64_t timer_proc{};
+        std::optional<std::chrono::steady_clock::time_point> due_time{};
+        std::chrono::steady_clock::duration interval{};
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(this->name);
+            buffer.write(this->hwnd);
+            buffer.write(this->timer_id);
+            buffer.write(this->timer_proc);
+            buffer.write_optional(this->due_time);
+            buffer.write(this->interval);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(this->name);
+            buffer.read(this->hwnd);
+            buffer.read(this->timer_id);
+            buffer.read(this->timer_proc);
+            buffer.read_optional(this->due_time);
+            buffer.read(this->interval);
+        }
+    };
+
     struct pending_apc
     {
         uint32_t flags{};
@@ -246,6 +284,7 @@ namespace sogen
         uint32_t suspended{0};
         std::optional<std::chrono::steady_clock::time_point> await_time{};
         std::optional<pending_msg> await_msg{};
+        std::optional<DWORD> await_msg_mask{};
         std::optional<pending_io_completion_wait> await_io_completion{};
 
         bool apc_alertable{false};
@@ -273,7 +312,12 @@ namespace sogen
         std::vector<callback_frame> callback_stack;
         std::optional<uint64_t> callback_return_rax{};
 
+        std::map<user_timer_key, user_timer> user_timers{};
+        uint64_t next_user_timer_id{1};
         std::vector<msg> message_queue;
+        std::array<uint32_t, 32> message_queue_status_bit_counts{};
+        uint32_t message_queue_status_bits{};
+        uint32_t queue_status_changed_bits{};
 
         void mark_as_ready(NTSTATUS status);
 
@@ -288,8 +332,15 @@ namespace sogen
             return this->apc_alertable && !this->pending_apcs.empty();
         }
 
-        std::optional<msg> peek_pending_message(const process_context& process, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
-                                                bool remove = false);
+        user_timer* find_user_timer(hwnd hwnd, uint64_t timer_id);
+        user_timer& create_user_timer(process_context& process, hwnd hwnd, uint64_t timer_id, uint64_t timer_proc,
+                                      std::chrono::milliseconds interval, std::chrono::steady_clock::time_point now);
+        bool delete_user_timer(hwnd hwnd, uint64_t timer_id);
+        bool synthesize_due_user_timer(utils::clock& clock, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
+
+        uint32_t get_message_queue_status(utils::clock& clock);
+        std::optional<msg> peek_pending_message(const process_context& process, utils::clock& clock, hwnd hwnd_filter = 0,
+                                                UINT filter_min = 0, UINT filter_max = 0, bool remove = false);
         void post_message(const msg& msg);
 
         bool is_terminated() const;
@@ -354,6 +405,7 @@ namespace sogen
             buffer.write(this->suspended);
             buffer.write_optional(this->await_time);
             buffer.write_optional(this->await_msg);
+            buffer.write_optional(this->await_msg_mask);
             buffer.write_optional(this->await_io_completion);
 
             buffer.write(this->apc_alertable);
@@ -380,7 +432,12 @@ namespace sogen
             buffer.write_vector(this->callback_stack);
             buffer.write_optional(this->callback_return_rax);
 
+            buffer.write_map(this->user_timers);
+            buffer.write(this->next_user_timer_id);
             buffer.write_vector(this->message_queue);
+            buffer.write(this->message_queue_status_bit_counts);
+            buffer.write(this->message_queue_status_bits);
+            buffer.write(this->queue_status_changed_bits);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -415,6 +472,7 @@ namespace sogen
             buffer.read(this->suspended);
             buffer.read_optional(this->await_time);
             buffer.read_optional(this->await_msg, [this] { return pending_msg{*this->memory_ptr}; });
+            buffer.read_optional(this->await_msg_mask);
             buffer.read_optional(this->await_io_completion, [] { return pending_io_completion_wait{}; });
 
             buffer.read(this->apc_alertable);
@@ -441,7 +499,12 @@ namespace sogen
             buffer.read_vector(this->callback_stack);
             buffer.read_optional(this->callback_return_rax);
 
+            buffer.read_map(this->user_timers);
+            buffer.read(this->next_user_timer_id);
             buffer.read_vector(this->message_queue);
+            buffer.read(this->message_queue_status_bit_counts);
+            buffer.read(this->message_queue_status_bits);
+            buffer.read(this->queue_status_changed_bits);
         }
 
         void leak_memory()

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -26,6 +26,7 @@ namespace sogen
             token,
             window,
             timer,
+            user_timer,
             monitor,
             desktop,
             io_completion,

--- a/src/windows-emulator/io_completion_wait.cpp
+++ b/src/windows-emulator/io_completion_wait.cpp
@@ -30,6 +30,11 @@ namespace sogen
                     return semaphore && semaphore->current_count > 0;
                 }
 
+                case handle_types::port: {
+                    const auto* port = process.ports.get(target_object_handle);
+                    return port != nullptr && port->has_pending_reply();
+                }
+
                 case handle_types::mutant: {
                     const auto* mutant = process.mutants.get(target_object_handle);
                     return mutant && mutant->locked_count == 0;
@@ -79,6 +84,7 @@ namespace sogen
             case handle_types::event:
             case handle_types::thread:
             case handle_types::semaphore:
+            case handle_types::port:
             case handle_types::mutant:
             case handle_types::timer:
                 return true;

--- a/src/windows-emulator/port.cpp
+++ b/src/windows-emulator/port.cpp
@@ -3,6 +3,7 @@
 #include "logger.hpp"
 #include "windows_emulator.hpp"
 #include "ports/api_port.hpp"
+#include "ports/core_messaging_registrar.hpp"
 #include "ports/dns_resolver.hpp"
 #include "ports/lsa_policy_lookup.hpp"
 #include "binary_writer.hpp"
@@ -37,6 +38,7 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
         };
+
     }
 
     std::unique_ptr<port> create_port(const std::u16string_view port)
@@ -59,6 +61,11 @@ namespace sogen
         if (port == u"\\WindowsErrorReportingServicePort")
         {
             return std::make_unique<noop_port>();
+        }
+
+        if (port == u"\\BaseNamedObjects\\CoreMessagingRegistrar")
+        {
+            return create_core_messaging_registrar_port();
         }
 
         if (port == u"\\RPC Control\\ntsvcs")
@@ -120,40 +127,55 @@ namespace sogen
             return {.status = STATUS_INVALID_PARAMETER};
         }
 
-        const auto send_header = c.send_message.read();
+        const auto send_header = lpc_port_message::read(c.send_message);
+
+        const auto data_length = send_header.data_length();
+        const auto total_length = send_header.total_length();
+
+        if (total_length < data_length)
+        {
+            return {.status = STATUS_INVALID_PARAMETER};
+        }
+
+        const auto header_size = send_header.header_size();
+
+        if (header_size != send_header.wire_size())
+        {
+            return {.status = STATUS_INVALID_PARAMETER};
+        }
 
         auto recv_header = send_header;
-        recv_header.u2.s2.Type = LPC_REPLY;
+        recv_header.native.u2.s2.Type = LPC_REPLY;
 
-        if (send_header.u2.s2.Type == LPC_NO_IMPERSONATE)
+        if (send_header.native.u2.s2.Type == LPC_NO_IMPERSONATE)
         {
-            recv_header.u2.s2.Type |= LPC_NO_IMPERSONATE;
+            recv_header.native.u2.s2.Type |= LPC_NO_IMPERSONATE;
         }
 
         lpc_request_context context{};
-        context.send_buffer = c.send_message.value() + sizeof(PORT_MESSAGE64);
-        context.send_buffer_length = send_header.u1.s1.DataLength;
-        context.recv_buffer = c.receive_message ? c.receive_message.value() + sizeof(PORT_MESSAGE64) : 0;
-        context.recv_buffer_length = c.receive_buffer_length >= sizeof(PORT_MESSAGE64)
-                                         ? static_cast<ULONG>(c.receive_buffer_length - sizeof(PORT_MESSAGE64))
-                                         : recv_header.u1.s1.DataLength;
+        context.send_buffer = c.send_message.value() + header_size;
+        context.send_buffer_length = data_length;
+        context.recv_buffer = c.receive_message ? c.receive_message.value() + header_size : 0;
+        context.recv_buffer_length =
+            c.receive_buffer_length >= header_size ? static_cast<ULONG>(c.receive_buffer_length - header_size) : data_length;
 
         auto request_result = this->handle_request(win_emu, context);
         const auto payload_size = request_result.payload ? static_cast<ULONG>(request_result.payload->size()) : context.recv_buffer_length;
 
-        if (sizeof(PORT_MESSAGE64) + payload_size > static_cast<uint16_t>(std::numeric_limits<CSHORT>::max()))
+        if (header_size + payload_size > static_cast<ULONG>(std::numeric_limits<CSHORT>::max()))
         {
             throw std::runtime_error("Response payload too big");
         }
 
-        recv_header.u1.s1.DataLength = static_cast<CSHORT>(payload_size);
-        recv_header.u1.s1.TotalLength = static_cast<CSHORT>(sizeof(PORT_MESSAGE64) + payload_size);
+        recv_header.native.u1.s1.DataLength = static_cast<CSHORT>(payload_size);
+        recv_header.native.u1.s1.TotalLength = static_cast<CSHORT>(header_size + payload_size);
 
         lpc_message_result result{.status = request_result.status, .message = recv_header};
         if (request_result.payload)
         {
             result.payload = std::move(*request_result.payload);
         }
+
         return result;
     }
 

--- a/src/windows-emulator/port.hpp
+++ b/src/windows-emulator/port.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
+#include <string>
 #include <type_traits>
 #include <vector>
 #include <arch_emulator.hpp>
@@ -20,6 +22,133 @@ namespace sogen
     {
         class aligned_binary_writer;
     }
+
+    struct lpc_port_message
+    {
+        PORT_MESSAGE64 native{};
+        bool is_wow64{};
+
+        [[nodiscard]] ULONG data_length() const
+        {
+            return static_cast<ULONG>(native.u1.s1.DataLength);
+        }
+
+        [[nodiscard]] ULONG total_length() const
+        {
+            return static_cast<ULONG>(native.u1.s1.TotalLength);
+        }
+
+        [[nodiscard]] ULONG header_size() const
+        {
+            return total_length() - data_length();
+        }
+
+        [[nodiscard]] ULONG wire_size() const
+        {
+            return wire_size(this->is_wow64);
+        }
+
+        [[nodiscard]] static ULONG wire_size(const bool is_32_bit)
+        {
+            return is_32_bit ? static_cast<ULONG>(sizeof(PORT_MESSAGE32)) : static_cast<ULONG>(sizeof(PORT_MESSAGE64));
+        }
+
+        void write(const emulator_object<PORT_MESSAGE64>& message) const
+        {
+            if (this->is_wow64)
+            {
+                const auto wow64_message = narrow(native);
+                message.get_memory_interface()->write_memory(message.value(), &wow64_message, sizeof(wow64_message));
+                return;
+            }
+
+            message.write(native);
+        }
+
+        static lpc_port_message read(const emulator_object<PORT_MESSAGE64>& message)
+        {
+            lpc_port_message result{};
+
+            const auto prefix = emulator_object<port_message_prefix>{*message.get_memory_interface(), message.value()}.read();
+            const auto data_length = static_cast<ULONG>(prefix.DataLength);
+            const auto total_length = static_cast<ULONG>(prefix.TotalLength);
+            const auto header_size = total_length >= data_length ? total_length - data_length : 0;
+
+            if (header_size == wire_size(true))
+            {
+                const emulator_object<PORT_MESSAGE32> wow64_message{*message.get_memory_interface(), message.value()};
+                result.native = widen(wow64_message.read());
+                result.is_wow64 = true;
+            }
+            else if (header_size == wire_size(false))
+            {
+                result.native = message.read();
+            }
+            else
+            {
+                throw std::runtime_error("Unexpected LPC header size");
+            }
+
+            return result;
+        }
+
+      private:
+        struct port_message_prefix
+        {
+            CSHORT DataLength;
+            CSHORT TotalLength;
+            CSHORT Type;
+            CSHORT DataInfoOffset;
+        };
+
+        template <typename T, typename U>
+        static T narrow(const U value, const char* field_name)
+        {
+            if constexpr (sizeof(T) < sizeof(U))
+            {
+                if (value > static_cast<U>(std::numeric_limits<T>::max()))
+                {
+                    throw std::runtime_error(std::string(field_name) + " does not fit in WOW64 LPC header");
+                }
+            }
+
+            return static_cast<T>(value);
+        }
+
+        static PORT_MESSAGE32 narrow(const PORT_MESSAGE64& message)
+        {
+            PORT_MESSAGE32 result{};
+
+            result.u1.s1.DataLength = message.u1.s1.DataLength;
+            result.u1.s1.TotalLength = message.u1.s1.TotalLength;
+            result.u2.s2.Type = message.u2.s2.Type;
+            result.u2.s2.DataInfoOffset = message.u2.s2.DataInfoOffset;
+            result.ClientId.UniqueProcess =
+                narrow<EmulatorTraits<Emu32>::HANDLE>(message.ClientId.UniqueProcess, "LPC ClientId.UniqueProcess");
+            result.ClientId.UniqueThread =
+                narrow<EmulatorTraits<Emu32>::HANDLE>(message.ClientId.UniqueThread, "LPC ClientId.UniqueThread");
+            result.MessageId = message.MessageId;
+            result.ClientViewSize = narrow<EmulatorTraits<Emu32>::SIZE_T>(message.ClientViewSize, "LPC ClientViewSize");
+
+            return result;
+        }
+
+        static PORT_MESSAGE64 widen(const PORT_MESSAGE32& message)
+        {
+            PORT_MESSAGE64 result{};
+
+            result.u1.s1.DataLength = message.u1.s1.DataLength;
+            result.u1.s1.TotalLength = message.u1.s1.TotalLength;
+            result.u2.s2.Type = message.u2.s2.Type;
+            result.u2.s2.DataInfoOffset = message.u2.s2.DataInfoOffset;
+            result.ClientId.UniqueProcess = message.ClientId.UniqueProcess;
+            result.ClientId.UniqueThread = message.ClientId.UniqueThread;
+            result.MessageId = message.MessageId;
+            result.ClientViewSize = message.ClientViewSize;
+
+            return result;
+        }
+    };
 
     struct lpc_message_context
     {
@@ -111,17 +240,17 @@ namespace sogen
     struct lpc_message_result
     {
         NTSTATUS status{};
-        PORT_MESSAGE64 message{};
+        lpc_port_message message{};
         std::vector<uint8_t> payload{};
 
         [[nodiscard]] ULONG total_length() const
         {
-            if (message.u1.s1.TotalLength != 0)
+            if (message.native.u1.s1.TotalLength != 0)
             {
-                return static_cast<ULONG>(message.u1.s1.TotalLength);
+                return message.total_length();
             }
 
-            return static_cast<ULONG>(sizeof(message) + payload.size());
+            return static_cast<ULONG>(message.wire_size() + payload.size());
         }
 
         void serialize(utils::buffer_serializer& buffer) const
@@ -247,6 +376,11 @@ namespace sogen
         {
             this->assert_validity();
             return this->port_name_;
+        }
+
+        bool has_pending_reply() const
+        {
+            return !reply_queue_.empty();
         }
 
       private:

--- a/src/windows-emulator/ports/core_messaging_registrar.cpp
+++ b/src/windows-emulator/ports/core_messaging_registrar.cpp
@@ -1,0 +1,394 @@
+#include "core_messaging_registrar.hpp"
+
+#include "../logger.hpp"
+#include "../windows_emulator.hpp"
+
+namespace sogen
+{
+
+    namespace
+    {
+        constexpr uint32_t k_request_kind = 0x00000002;
+        constexpr uint32_t k_sync_flags = 0x00010000;
+        constexpr ULONG k_min_request_size = 0x30;
+
+        enum registrar_method : uint32_t
+        {
+            register_thread = 0x00010001,
+            register_port = 0x000E0001,
+            unregister_port = 0x000F0001,
+            resolve_service = 0x00170001,
+            open_endpoint = 0x000A0001,
+            query_coreui_port = 0x00030001,
+            make_identity = 0x00100001,
+            bind_service = 0x00180001,
+        };
+
+        enum registrar_reply : uint32_t
+        {
+            reply_bootstrap = 0x00040000,
+            reply_register_port = 0x00110000,
+            reply_unregister_port = 0x00120000,
+            reply_resolve_service = 0x001D0000,
+            reply_open_endpoint = 0x000D0000,
+            reply_coreui_port = 0x00060000,
+            reply_make_identity = 0x00130000,
+            reply_bind_service = 0x001E0000,
+        };
+
+        constexpr ULONG o_kind = 0x10;
+        constexpr ULONG o_id = 0x14;
+        constexpr ULONG o_flags = 0x18;
+        constexpr ULONG o_nested = 0x20;
+        constexpr ULONG o_body0 = 0x28;
+        constexpr ULONG o_body1 = 0x2C;
+
+        constexpr std::array<uint8_t, 16> guid_generated_identity = {
+            0xA7, 0x78, 0x8F, 0xF0, 0x89, 0x98, 0x26, 0x4C, 0xBE, 0x93, 0x92, 0x36, 0x31, 0xDD, 0xA2, 0x0F,
+        };
+
+        constexpr std::array<uint8_t, 16> guid_input_delivery = {
+            0x46, 0x97, 0x07, 0x7D, 0x22, 0xFC, 0xA7, 0x4D, 0xAA, 0x55, 0x13, 0xC6, 0x0D, 0x91, 0x36, 0xB0,
+        };
+
+        constexpr std::array<uint8_t, 16> guid_input_system_conversation = {
+            0xF8, 0x5B, 0x7D, 0x1E, 0xBD, 0x6D, 0x12, 0x42, 0xA1, 0xC5, 0x59, 0xFE, 0x49, 0xDD, 0x38, 0x50,
+        };
+
+        struct request
+        {
+            ULONG length{};
+            uint32_t kind{};
+            uint32_t id{};
+            uint32_t flags{};
+            uint32_t nested_size{};
+            uint32_t body0{};
+            uint32_t body1{};
+
+            bool common_shape() const
+            {
+                return kind == k_request_kind && flags == k_sync_flags;
+            }
+
+            bool has_body() const
+            {
+                return nested_size >= 0x08 && length >= 0x30;
+            }
+
+            bool matches(const uint32_t method, const uint32_t min_nested, const ULONG min_length) const
+            {
+                return body1 == method && nested_size >= min_nested && length >= min_length;
+            }
+
+            bool bootstrap() const
+            {
+                return length == 0x30 && nested_size == 0x08 && body0 == 0x02 && body1 == register_thread;
+            }
+        };
+
+        struct packet
+        {
+            explicit packet(const uint32_t length, const uint32_t request_id, const uint32_t nested_size)
+                : data(length, 0)
+            {
+                u32(o_kind, 0);
+                u32(o_id, request_id);
+                u32(o_flags, k_sync_flags);
+                u32(o_nested, nested_size);
+            }
+
+            std::vector<uint8_t> data;
+
+            void u16(const ULONG offset, const uint16_t value)
+            {
+                if (offset + sizeof(value) <= data.size())
+                {
+                    std::memcpy(data.data() + offset, &value, sizeof(value));
+                }
+            }
+
+            void u32(const ULONG offset, const uint32_t value)
+            {
+                if (offset + sizeof(value) <= data.size())
+                {
+                    std::memcpy(data.data() + offset, &value, sizeof(value));
+                }
+            }
+
+            void u32s(ULONG offset, std::initializer_list<uint32_t> values)
+            {
+                for (const auto value : values)
+                {
+                    u32(offset, value);
+                    offset += sizeof(uint32_t);
+                }
+            }
+
+            void bytes(const ULONG offset, const void* source, const size_t size)
+            {
+                if (source && offset + size <= data.size())
+                {
+                    std::memcpy(data.data() + offset, source, size);
+                }
+            }
+
+            void guid(const ULONG offset, const std::array<uint8_t, 16>& value)
+            {
+                bytes(offset, value.data(), value.size());
+            }
+
+            void utf16z(ULONG offset, const char16_t* text)
+            {
+                if (!text)
+                {
+                    return;
+                }
+
+                for (;;)
+                {
+                    const auto ch = static_cast<uint16_t>(*text++);
+                    u16(offset, ch);
+                    offset += sizeof(uint16_t);
+
+                    if (ch == 0)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            std::vector<uint8_t> finish()
+            {
+                return std::move(data);
+            }
+        };
+
+        size_t utf16z_size(const char16_t* text)
+        {
+            if (!text)
+            {
+                return 0;
+            }
+
+            size_t chars = 0;
+            while (text[chars])
+            {
+                ++chars;
+            }
+
+            return (chars + 1) * sizeof(uint16_t);
+        }
+
+        bool guid_equal(const uint8_t* lhs, const std::array<uint8_t, 16>& rhs)
+        {
+            return std::memcmp(lhs, rhs.data(), rhs.size()) == 0;
+        }
+
+        request read_request(windows_emulator& win_emu, const lpc_request_context& c)
+        {
+            return {
+                .length = c.send_buffer_length,
+                .kind = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_kind),
+                .id = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_id),
+                .flags = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_flags),
+                .nested_size = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_nested),
+                .body0 = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_body0),
+                .body1 = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_body1),
+            };
+        }
+
+        std::vector<uint8_t> make_simple_reply(const uint32_t request_id, const uint32_t reply_method)
+        {
+            packet out(0x30, request_id, 0x08);
+            out.u32s(o_body0, {0x02, reply_method});
+            return out.finish();
+        }
+
+        std::vector<uint8_t> make_bootstrap_reply(const uint32_t request_id)
+        {
+            packet out(0x60, request_id, 0x38);
+            out.u32s(o_body0, {0x0E, reply_bootstrap, 0x04, 0x00, 0x08, 0x7B, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01});
+            return out.finish();
+        }
+
+        std::vector<uint8_t> make_open_endpoint_reply(const uint32_t request_id)
+        {
+            packet out(0x4C, request_id, 0x24);
+            out.u32s(o_body0, {0x09, reply_open_endpoint, 0x04, 0x00, 0x10});
+            return out.finish();
+        }
+
+        std::vector<uint8_t> make_identity_reply(const uint32_t request_id)
+        {
+            packet out(0x44, request_id, 0x1C);
+            out.u32s(o_body0, {0x07, reply_make_identity, 0x10});
+            out.guid(0x34, guid_generated_identity);
+            return out.finish();
+        }
+
+        std::vector<uint8_t> make_bind_service_reply(const uint32_t request_id)
+        {
+            packet out(0x38, request_id, 0x10);
+            out.u32s(o_body0, {0x04, reply_bind_service, 0x04, 0x00});
+            return out.finish();
+        }
+
+        void append_resolve_payload(packet& out, const bool conversation_variant)
+        {
+            if (conversation_variant)
+            {
+                out.u32s(0x3C, {0x23, 0x08, 0xF6, 0x00, 0x10, 0x03, 0x03, 0x02, 0x00, 0x38, 0x6C4, 0x8A8, 0x00200004, 0x8000, 0x02, 0x00});
+                out.guid(0x7C, guid_input_system_conversation);
+                out.u32s(0x8C, {0x00200005, 0x8000, 0x01, 0x280});
+                return;
+            }
+
+            out.u32s(0x3C, {0x0A, 0x08, 0xF5, 0x00, 0x10, 0x05, 0x03, 0x01, 0x00, 0x38, 0x6C4, 0x8A8, 0x00200010, 0x8000, 0x02, 0x00});
+            out.guid(0x7C, guid_input_delivery);
+            out.u32s(0x8C, {0x00200011, 0x8000, 0x01, 0x280});
+        }
+
+        std::vector<uint8_t> make_resolve_service_reply(const request& req)
+        {
+            packet out(0x9C, req.id, 0x74);
+            out.u32s(o_body0, {0x1D, reply_resolve_service, 0x04, 0x00, 0x04});
+            append_resolve_payload(out, req.body0 >= 0x35);
+            return out.finish();
+        }
+
+        std::vector<uint8_t> make_coreui_port_reply(windows_emulator& win_emu, const lpc_request_context& c, const request& req)
+        {
+            std::array<uint8_t, 16> requested_guid{};
+            win_emu.emu().read_memory(c.send_buffer + 0x4C, requested_guid.data(), requested_guid.size());
+
+            const bool conversation_variant = guid_equal(requested_guid.data(), guid_input_system_conversation);
+            const char16_t* name = conversation_variant
+                                       ? u"\\BaseNamedObjects\\[CoreUI]-PID(1732)-TID(2216) 1e7d5bf8-6dbd-4212-a1c5-59fe49dd3850"
+                                       : u"\\BaseNamedObjects\\[CoreUI]-PID(1732)-TID(2216) 7d079746-fc22-4da7-aa55-13c60d9136b0";
+
+            const uint32_t tail_slot0 = conversation_variant ? 0x03 : 0x02;
+            const uint32_t tail_slot1 = conversation_variant ? 0x4A : 0x49;
+            const std::array<uint32_t, 25> tail = {
+                0x10,       0x00,   0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,       0x00,       0x38,       0x00,   0x00,
+                0x00200000, 0x8000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, tail_slot0, tail_slot1, 0x00200001, 0x8000,
+            };
+
+            const auto name_size = static_cast<uint32_t>(utf16z_size(name));
+            const auto tail_size = static_cast<uint32_t>(sizeof(tail));
+            const auto data_size = static_cast<uint32_t>(0x3C + name_size + tail_size);
+
+            packet out(data_size, req.id, data_size - o_body0);
+            out.u32s(o_body0, {0x48, reply_coreui_port, 0x04, 0x00, name_size});
+            out.utf16z(0x3C, name);
+
+            auto tail_offset = 0x3C + name_size;
+            for (const auto value : tail)
+            {
+                out.u32(tail_offset, value);
+                tail_offset += static_cast<ULONG>(sizeof(uint32_t));
+            }
+
+            return out.finish();
+        }
+
+        struct core_messaging_registrar_port : port
+        {
+            lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
+            {
+                if (c.send_buffer_length < k_min_request_size)
+                {
+                    win_emu.log.error("CoreMessagingRegistrar request too small: 0x%X\n", static_cast<uint32_t>(c.send_buffer_length));
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const auto req = read_request(win_emu, c);
+
+                if (!req.common_shape())
+                {
+                    win_emu.log.error("Unsupported CoreMessagingRegistrar common shape: kind=0x%X flags=0x%X\n", req.kind, req.flags);
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                if (!req.has_body())
+                {
+                    win_emu.log.error("Unsupported CoreMessagingRegistrar nested body: len=0x%X nested=0x%X body=[0x%X, 0x%X]\n",
+                                      static_cast<uint32_t>(req.length), req.nested_size, req.body0, req.body1);
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                switch (req.body1)
+                {
+                case register_thread:
+                    if (req.bootstrap())
+                    {
+                        return {STATUS_SUCCESS, make_bootstrap_reply(req.id)};
+                    }
+                    break;
+
+                case register_port:
+                    if (req.matches(register_port, 0x1C, 0x44))
+                    {
+                        return {STATUS_SUCCESS, make_simple_reply(req.id, reply_register_port)};
+                    }
+                    break;
+
+                case resolve_service:
+                    if (req.matches(resolve_service, 0x40, 0x68))
+                    {
+                        return {STATUS_SUCCESS, make_resolve_service_reply(req)};
+                    }
+                    break;
+
+                case open_endpoint:
+                    if (req.matches(open_endpoint, 0x24, 0x5C))
+                    {
+                        return {STATUS_SUCCESS, make_open_endpoint_reply(req.id)};
+                    }
+                    break;
+
+                case query_coreui_port:
+                    if (req.matches(query_coreui_port, 0x44, 0x6C))
+                    {
+                        return {STATUS_SUCCESS, make_coreui_port_reply(win_emu, c, req)};
+                    }
+                    break;
+
+                case make_identity:
+                    if (req.matches(make_identity, 0x1C, 0x44))
+                    {
+                        return {STATUS_SUCCESS, make_identity_reply(req.id)};
+                    }
+                    break;
+
+                case bind_service:
+                    if (req.matches(bind_service, 0x10, 0x38))
+                    {
+                        return {STATUS_SUCCESS, make_bind_service_reply(req.id)};
+                    }
+                    break;
+
+                case unregister_port:
+                    if (req.matches(unregister_port, 0x1C, 0x44))
+                    {
+                        return {STATUS_SUCCESS, make_simple_reply(req.id, reply_unregister_port)};
+                    }
+                    break;
+
+                default:
+                    break;
+                }
+
+                win_emu.log.error("Unsupported CoreMessagingRegistrar request: len=0x%X kind=0x%X id=0x%X flags=0x%X "
+                                  "nested=0x%X body=[0x%X, 0x%X]\n",
+                                  static_cast<uint32_t>(req.length), req.kind, req.id, req.flags, req.nested_size, req.body0, req.body1);
+                return STATUS_NOT_SUPPORTED;
+            }
+        };
+    }
+
+    std::unique_ptr<port> create_core_messaging_registrar_port()
+    {
+        return std::make_unique<core_messaging_registrar_port>();
+    }
+
+} // namespace sogen

--- a/src/windows-emulator/ports/core_messaging_registrar.cpp
+++ b/src/windows-emulator/ports/core_messaging_registrar.cpp
@@ -12,7 +12,7 @@ namespace sogen
         constexpr uint32_t k_sync_flags = 0x00010000;
         constexpr ULONG k_min_request_size = 0x30;
 
-        enum registrar_method : uint32_t
+        enum class registrar_method : uint32_t
         {
             register_thread = 0x00010001,
             register_port = 0x000E0001,
@@ -24,7 +24,7 @@ namespace sogen
             bind_service = 0x00180001,
         };
 
-        enum registrar_reply : uint32_t
+        enum class registrar_reply : uint32_t
         {
             reply_bootstrap = 0x00040000,
             reply_register_port = 0x00110000,
@@ -63,7 +63,7 @@ namespace sogen
             uint32_t flags{};
             uint32_t nested_size{};
             uint32_t body0{};
-            uint32_t body1{};
+            registrar_method body1{};
 
             bool common_shape() const
             {
@@ -75,14 +75,14 @@ namespace sogen
                 return nested_size >= 0x08 && length >= 0x30;
             }
 
-            bool matches(const uint32_t method, const uint32_t min_nested, const ULONG min_length) const
+            bool matches(const registrar_method method, const uint32_t min_nested, const ULONG min_length) const
             {
                 return body1 == method && nested_size >= min_nested && length >= min_length;
             }
 
             bool bootstrap() const
             {
-                return length == 0x30 && nested_size == 0x08 && body0 == 0x02 && body1 == register_thread;
+                return length == 0x30 && nested_size == 0x08 && body0 == 0x02 && body1 == registrar_method::register_thread;
             }
         };
 
@@ -193,7 +193,7 @@ namespace sogen
                 .flags = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_flags),
                 .nested_size = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_nested),
                 .body0 = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_body0),
-                .body1 = win_emu.emu().read_memory<uint32_t>(c.send_buffer + o_body1),
+                .body1 = win_emu.emu().read_memory<registrar_method>(c.send_buffer + o_body1),
             };
         }
 
@@ -207,21 +207,22 @@ namespace sogen
         std::vector<uint8_t> make_bootstrap_reply(const uint32_t request_id)
         {
             packet out(0x60, request_id, 0x38);
-            out.u32s(o_body0, {0x0E, reply_bootstrap, 0x04, 0x00, 0x08, 0x7B, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01});
+            out.u32s(o_body0, {0x0E, static_cast<unsigned>(registrar_reply::reply_bootstrap), 0x04, 0x00, 0x08, 0x7B, 0x00, 0x10, 0x00,
+                               0x00, 0x00, 0x00, 0x04, 0x01});
             return out.finish();
         }
 
         std::vector<uint8_t> make_open_endpoint_reply(const uint32_t request_id)
         {
             packet out(0x4C, request_id, 0x24);
-            out.u32s(o_body0, {0x09, reply_open_endpoint, 0x04, 0x00, 0x10});
+            out.u32s(o_body0, {0x09, static_cast<unsigned>(registrar_reply::reply_open_endpoint), 0x04, 0x00, 0x10});
             return out.finish();
         }
 
         std::vector<uint8_t> make_identity_reply(const uint32_t request_id)
         {
             packet out(0x44, request_id, 0x1C);
-            out.u32s(o_body0, {0x07, reply_make_identity, 0x10});
+            out.u32s(o_body0, {0x07, static_cast<unsigned>(registrar_reply::reply_make_identity), 0x10});
             out.guid(0x34, guid_generated_identity);
             return out.finish();
         }
@@ -229,7 +230,7 @@ namespace sogen
         std::vector<uint8_t> make_bind_service_reply(const uint32_t request_id)
         {
             packet out(0x38, request_id, 0x10);
-            out.u32s(o_body0, {0x04, reply_bind_service, 0x04, 0x00});
+            out.u32s(o_body0, {0x04, static_cast<unsigned>(registrar_reply::reply_bind_service), 0x04, 0x00});
             return out.finish();
         }
 
@@ -251,7 +252,7 @@ namespace sogen
         std::vector<uint8_t> make_resolve_service_reply(const request& req)
         {
             packet out(0x9C, req.id, 0x74);
-            out.u32s(o_body0, {0x1D, reply_resolve_service, 0x04, 0x00, 0x04});
+            out.u32s(o_body0, {0x1D, static_cast<unsigned>(registrar_reply::reply_resolve_service), 0x04, 0x00, 0x04});
             append_resolve_payload(out, req.body0 >= 0x35);
             return out.finish();
         }
@@ -278,7 +279,7 @@ namespace sogen
             const auto data_size = static_cast<uint32_t>(0x3C + name_size + tail_size);
 
             packet out(data_size, req.id, data_size - o_body0);
-            out.u32s(o_body0, {0x48, reply_coreui_port, 0x04, 0x00, name_size});
+            out.u32s(o_body0, {0x48, static_cast<unsigned>(registrar_reply::reply_coreui_port), 0x04, 0x00, name_size});
             out.utf16z(0x3C, name);
 
             auto tail_offset = 0x3C + name_size;
@@ -312,75 +313,73 @@ namespace sogen
                 if (!req.has_body())
                 {
                     win_emu.log.error("Unsupported CoreMessagingRegistrar nested body: len=0x%X nested=0x%X body=[0x%X, 0x%X]\n",
-                                      static_cast<uint32_t>(req.length), req.nested_size, req.body0, req.body1);
+                                      static_cast<uint32_t>(req.length), req.nested_size, req.body0, static_cast<uint32_t>(req.body1));
                     return STATUS_NOT_SUPPORTED;
                 }
 
                 switch (req.body1)
                 {
-                case register_thread:
+                case registrar_method::register_thread:
                     if (req.bootstrap())
                     {
                         return {STATUS_SUCCESS, make_bootstrap_reply(req.id)};
                     }
                     break;
 
-                case register_port:
-                    if (req.matches(register_port, 0x1C, 0x44))
+                case registrar_method::register_port:
+                    if (req.matches(registrar_method::register_port, 0x1C, 0x44))
                     {
-                        return {STATUS_SUCCESS, make_simple_reply(req.id, reply_register_port)};
+                        return {STATUS_SUCCESS, make_simple_reply(req.id, static_cast<uint32_t>(registrar_reply::reply_register_port))};
                     }
                     break;
 
-                case resolve_service:
-                    if (req.matches(resolve_service, 0x40, 0x68))
+                case registrar_method::resolve_service:
+                    if (req.matches(registrar_method::resolve_service, 0x40, 0x68))
                     {
                         return {STATUS_SUCCESS, make_resolve_service_reply(req)};
                     }
                     break;
 
-                case open_endpoint:
-                    if (req.matches(open_endpoint, 0x24, 0x5C))
+                case registrar_method::open_endpoint:
+                    if (req.matches(registrar_method::open_endpoint, 0x24, 0x5C))
                     {
                         return {STATUS_SUCCESS, make_open_endpoint_reply(req.id)};
                     }
                     break;
 
-                case query_coreui_port:
-                    if (req.matches(query_coreui_port, 0x44, 0x6C))
+                case registrar_method::query_coreui_port:
+                    if (req.matches(registrar_method::query_coreui_port, 0x44, 0x6C))
                     {
                         return {STATUS_SUCCESS, make_coreui_port_reply(win_emu, c, req)};
                     }
                     break;
 
-                case make_identity:
-                    if (req.matches(make_identity, 0x1C, 0x44))
+                case registrar_method::make_identity:
+                    if (req.matches(registrar_method::make_identity, 0x1C, 0x44))
                     {
                         return {STATUS_SUCCESS, make_identity_reply(req.id)};
                     }
                     break;
 
-                case bind_service:
-                    if (req.matches(bind_service, 0x10, 0x38))
+                case registrar_method::bind_service:
+                    if (req.matches(registrar_method::bind_service, 0x10, 0x38))
                     {
                         return {STATUS_SUCCESS, make_bind_service_reply(req.id)};
                     }
                     break;
 
-                case unregister_port:
-                    if (req.matches(unregister_port, 0x1C, 0x44))
+                case registrar_method::unregister_port:
+                    if (req.matches(registrar_method::unregister_port, 0x1C, 0x44))
                     {
-                        return {STATUS_SUCCESS, make_simple_reply(req.id, reply_unregister_port)};
+                        return {STATUS_SUCCESS, make_simple_reply(req.id, static_cast<uint32_t>(registrar_reply::reply_unregister_port))};
                     }
-                    break;
-
-                default:
                     break;
                 }
 
                 win_emu.log.error("Unsupported CoreMessagingRegistrar request: len=0x%X kind=0x%X id=0x%X flags=0x%X "
                                   "nested=0x%X body=[0x%X, 0x%X]\n",
-                                  static_cast<uint32_t>(req.length), req.kind, req.id, req.flags, req.nested_size, req.body0, req.body1);
+                                  static_cast<uint32_t>(req.length), req.kind, req.id, req.flags, req.nested_size, req.body0,
+                                  static_cast<uint32_t>(req.body1));
                 return STATUS_NOT_SUPPORTED;
             }
         };

--- a/src/windows-emulator/ports/core_messaging_registrar.hpp
+++ b/src/windows-emulator/ports/core_messaging_registrar.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "../port.hpp"
+
+namespace sogen
+{
+
+    std::unique_ptr<port> create_core_messaging_registrar_port();
+
+} // namespace sogen

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -712,6 +712,11 @@ namespace sogen
         }
 
         buffer.read(this->threads);
+        this->thread_handles_by_id.clear();
+        for (const auto& [index, thread] : this->threads)
+        {
+            this->thread_handles_by_id[thread.id] = this->threads.make_handle(index);
+        }
 
         this->active_thread = this->threads.get(buffer.read<uint64_t>());
     }
@@ -759,6 +764,46 @@ namespace sogen
         }
     }
 
+    emulator_thread* process_context::find_thread_by_id(const uint32_t thread_id)
+    {
+        if (const auto cached = this->thread_handles_by_id.find(thread_id); cached != this->thread_handles_by_id.end())
+        {
+            if (auto* thread = this->threads.get(cached->second))
+            {
+                if (thread->id == thread_id)
+                {
+                    return thread;
+                }
+            }
+
+            this->thread_handles_by_id.erase(cached);
+        }
+
+        for (auto& [index, thread] : this->threads)
+        {
+            if (thread.id == thread_id)
+            {
+                this->thread_handles_by_id[thread_id] = this->threads.make_handle(index);
+                return &thread;
+            }
+        }
+
+        return nullptr;
+    }
+
+    const emulator_thread* process_context::find_thread_by_id(const uint32_t thread_id) const
+    {
+        for (const auto& thread : this->threads | std::views::values)
+        {
+            if (thread.id == thread_id)
+            {
+                return &thread;
+            }
+        }
+
+        return nullptr;
+    }
+
     // NOLINTNEXTLINE(cert-dcl50-cpp,readability-convert-member-functions-to-static)
     bool process_context::is_current_process_handle(const handle handle) const
     {
@@ -802,6 +847,7 @@ namespace sogen
     {
         emulator_thread t{memory, *this, start_address, argument, stack_size, create_flags, ++this->spawned_thread_count, initial_thread};
         auto [h, thr] = this->threads.store_and_get(std::move(t));
+        this->thread_handles_by_id[thr->id] = h;
         this->callbacks_->on_thread_create(h, *thr);
         return h;
     }

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -330,6 +330,8 @@ namespace sogen
         void deserialize(utils::buffer_deserializer& buffer);
 
         generic_handle_store* get_handle_store(handle handle);
+        emulator_thread* find_thread_by_id(uint32_t thread_id);
+        const emulator_thread* find_thread_by_id(uint32_t thread_id) const;
         bool is_current_process_handle(handle handle) const;
         bool is_current_thread_handle(handle handle) const;
         bool is_object_pseudo_handle(handle handle) const;
@@ -402,6 +404,7 @@ namespace sogen
         user_handle_store<handle_types::window, window> windows{user_handles};
         handle_store<handle_types::timer, timer> timers{};
         handle_store<handle_types::registry, registry_key, 2> registry_keys{};
+        std::map<uint32_t, handle> thread_handles_by_id{};
         std::map<uint16_t, atom_entry> atoms{};
         utils::insensitive_u16string_map<class_entry> classes{};
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -153,6 +153,7 @@ namespace sogen
         hwnd window{};
         UINT message{};
         uint64_t scratch_text{}; // guest buffer holding a re-encoded text payload; freed on completion
+        bool dispatching_result_callback{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -160,6 +161,7 @@ namespace sogen
             buffer.write(this->window);
             buffer.write(this->message);
             buffer.write(this->scratch_text);
+            buffer.write(this->dispatching_result_callback);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -167,6 +169,7 @@ namespace sogen
             buffer.read(this->window);
             buffer.read(this->message);
             buffer.read(this->scratch_text);
+            buffer.read(this->dispatching_result_callback);
         }
     };
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -188,6 +188,8 @@ namespace sogen
                                       emulator_pointer object_information, ULONG object_information_length,
                                       emulator_object<ULONG> return_length);
         NTSTATUS handle_NtCompareObjects(const syscall_context& c, handle first, handle second);
+        DWORD handle_NtUserMsgWaitForMultipleObjectsEx(const syscall_context& c, ULONG count, emulator_object<handle> handles,
+                                                       DWORD timeout, DWORD wake_mask, DWORD flags);
         NTSTATUS handle_NtWaitForMultipleObjects(const syscall_context& c, ULONG count, emulator_object<handle> handles,
                                                  WAIT_TYPE wait_type, BOOLEAN alertable, emulator_object<LARGE_INTEGER> timeout);
         NTSTATUS handle_NtWaitForMultipleObjects32(const syscall_context& c, ULONG count, emulator_object<uint32_t> handles,
@@ -216,7 +218,7 @@ namespace sogen
                                             emulator_object<ULONG> connection_info_length);
         NTSTATUS handle_NtAlpcCreatePort(const syscall_context& c, emulator_object<handle> port_handle,
                                          emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
-                                         emulator_pointer /*port_attributes*/);
+                                         emulator_pointer port_attributes);
         NTSTATUS handle_NtAlpcConnectPort(const syscall_context& c, emulator_object<handle> port_handle,
                                           emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> server_port_name,
                                           emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,
@@ -514,6 +516,7 @@ namespace sogen
         BOOL handle_NtUserValidateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect);
         BOOL handle_NtUserUpdateWindow(const syscall_context& c, hwnd hwnd);
         BOOL handle_NtUserPostMessage(const syscall_context& c, hwnd hwnd, UINT msg, uint64_t wParam, uint64_t lParam);
+        BOOL handle_NtUserPostThreadMessage(const syscall_context& c, DWORD id_thread, UINT msg, uint64_t wParam, uint64_t lParam);
         BOOL handle_NtUserPostQuitMessage(const syscall_context& c, int exit_code);
         NTSTATUS handle_NtUserEnumDisplayDevices(const syscall_context& c,
                                                  emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str_device, DWORD dev_num,
@@ -557,6 +560,15 @@ namespace sogen
                                                  emulator_pointer path_array, emulator_object<UINT32> current_topology_id,
                                                  emulator_pointer reserved);
         NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo(const syscall_context& c, emulator_pointer packet);
+        uint64_t handle_NtUserInitThreadCoreMessagingIocp2(const syscall_context& c, handle window_handle,
+                                                           emulator_object<uint32_t> completion_queue_index);
+        BOOL handle_NtUserDrainThreadCoreMessagingCompletions2();
+        uint64_t handle_NtUserScheduleDispatchNotification(const syscall_context& c, hwnd hwnd);
+        uint64_t handle_NtUserSetTimer(const syscall_context& c, hwnd hwnd, uint64_t timer_id, uint32_t elapsed_ms, uint64_t timer_proc);
+        BOOL handle_NtUserKillTimer(const syscall_context& c, hwnd hwnd, uint64_t timer_id);
+        BOOL handle_NtUserValidateTimerCallback(const syscall_context& c, uint64_t timer_proc);
+        uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, UINT flags);
+        uint32_t handle_NtUserGetQueueStatus(const syscall_context& c, UINT flags);
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -961,6 +973,37 @@ namespace sogen
 
             return STATUS_SUCCESS;
         }
+
+        NTSTATUS handle_NtAllocateReserveObject(const syscall_context& c, const emulator_object<handle> memory_reserve_handle,
+                                                const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
+                                                const DWORD type)
+        {
+            std::u16string name{};
+            if (object_attributes)
+            {
+                const auto attributes = object_attributes.read();
+                if (attributes.ObjectName != 0)
+                {
+                    name = read_unicode_string(c.emu, attributes.ObjectName);
+                }
+            }
+
+            switch (type)
+            {
+            case 1: { // MemoryReserveIoCompletion
+                // TODO: This probably isn't 100% correct.
+                wait_completion_packet packet{};
+                packet.name = std::move(name);
+                memory_reserve_handle.write(c.proc.wait_completion_packets.store(std::move(packet)));
+                return STATUS_SUCCESS;
+            }
+            case 0: // MemoryReserveUserApc
+            default:
+                c.win_emu.log.error("Not supported NtAllocateReserveObject type %d", type);
+                c.emu.stop();
+                return STATUS_NOT_SUPPORTED;
+            }
+        }
     }
 
     // NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
@@ -1285,6 +1328,7 @@ namespace sogen
         add_handler(NtUserSetWindowLong);
         add_handler(NtUserGetAncestor);
         add_handler(NtUserPostMessage);
+        add_handler(NtUserPostThreadMessage);
         add_handler(NtUserRedrawWindow);
         add_handler(NtUserGetCPD);
         add_handler(NtUserSetWindowFNID);
@@ -1328,6 +1372,16 @@ namespace sogen
         add_handler(NtGdiOpenDCW);
         add_handler(NtGdiDdDDIOpenAdapterFromHdc);
         add_handler(NtGdiSelectFont);
+        add_handler(NtUserInitThreadCoreMessagingIocp2);
+        add_handler(NtUserDrainThreadCoreMessagingCompletions2);
+        add_handler(NtUserSetTimer);
+        add_handler(NtUserKillTimer);
+        add_handler(NtUserValidateTimerCallback);
+        add_handler(NtAllocateReserveObject);
+        add_handler(NtUserMsgWaitForMultipleObjectsEx);
+        add_handler(NtUserGetQueueStatusReadonly);
+        add_handler(NtUserGetQueueStatus);
+        add_handler(NtUserScheduleDispatchNotification);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -997,11 +997,10 @@ namespace sogen
                 memory_reserve_handle.write(c.proc.wait_completion_packets.store(std::move(packet)));
                 return STATUS_SUCCESS;
             }
-            case 0: // MemoryReserveUserApc
-            default:
-                c.win_emu.log.error("Not supported NtAllocateReserveObject type %d", type);
-                c.emu.stop();
+            case 0:
+            default: { // MemoryReserveUserApc
                 return STATUS_NOT_SUPPORTED;
+            }
             }
         }
     }

--- a/src/windows-emulator/syscalls/io_completion.cpp
+++ b/src/windows-emulator/syscalls/io_completion.cpp
@@ -308,6 +308,7 @@ namespace sogen
 
             if (!io_completion_wait::is_wait_completion_target_type(resolved_target_handle))
             {
+                c.win_emu.log.error("Wait handle type not supported!\n");
                 return STATUS_OBJECT_TYPE_MISMATCH;
             }
 
@@ -322,6 +323,8 @@ namespace sogen
                     return c.proc.threads.get(resolved_target_handle) != nullptr;
                 case handle_types::semaphore:
                     return c.proc.semaphores.get(resolved_target_handle) != nullptr;
+                case handle_types::port:
+                    return c.proc.ports.get(resolved_target_handle) != nullptr;
                 case handle_types::mutant:
                     return c.proc.mutants.get(resolved_target_handle) != nullptr;
                 case handle_types::timer:

--- a/src/windows-emulator/syscalls/object.cpp
+++ b/src/windows-emulator/syscalls/object.cpp
@@ -379,6 +379,16 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            if (object_information_class == ObjectBasicInformation)
+            {
+                return handle_query<OBJECT_BASIC_INFORMATION>(c.emu, object_information, object_information_length, return_length,
+                                                              [&](OBJECT_BASIC_INFORMATION& info) {
+                                                                  info.GrantedAccess = GENERIC_ALL;
+                                                                  info.HandleCount = 1;
+                                                                  info.PointerCount = 2;
+                                                              });
+            }
+
             if (object_information_class == ObjectHandleFlagInformation)
             {
                 return handle_query<OBJECT_HANDLE_FLAG_INFORMATION>(c.emu, object_information, object_information_length, return_length,
@@ -430,6 +440,7 @@ namespace sogen
             collect_wait32_candidate(c.proc.threads, id, resolved, candidate_count);
             collect_wait32_candidate(c.proc.mutants, id, resolved, candidate_count);
             collect_wait32_candidate(c.proc.semaphores, id, resolved, candidate_count);
+            collect_wait32_candidate(c.proc.ports, id, resolved, candidate_count);
             collect_wait32_candidate(c.proc.timers, id, resolved, candidate_count);
 
             if (candidate_count == 1)
@@ -468,6 +479,9 @@ namespace sogen
             case handle_types::semaphore:
                 return validate_handle_in_store(c.proc.semaphores);
 
+            case handle_types::port:
+                return validate_handle_in_store(c.proc.ports);
+
             case handle_types::timer:
                 if (h.value.is_pseudo)
                 {
@@ -477,6 +491,7 @@ namespace sogen
                 return validate_handle_in_store(c.proc.timers);
 
             default:
+                c.win_emu.log.error("Wait handle type not supported!\n");
                 return STATUS_OBJECT_TYPE_MISMATCH;
             }
         }
@@ -486,6 +501,60 @@ namespace sogen
             const auto first_resolved = c.proc.resolve_object_pseudo_handle(first);
             const auto second_resolved = c.proc.resolve_object_pseudo_handle(second);
             return (first_resolved == second_resolved) ? STATUS_SUCCESS : STATUS_NOT_SAME_OBJECT;
+        }
+
+        DWORD handle_NtUserMsgWaitForMultipleObjectsEx(const syscall_context& c, const ULONG count, const emulator_object<handle> handles,
+                                                       const DWORD timeout, const DWORD wake_mask, const DWORD flags)
+        {
+            constexpr DWORD mwmo_waitall = 0x0001;
+            constexpr DWORD wait_failed = 0xFFFFFFFF;
+            constexpr DWORD infinite_timeout = 0xFFFFFFFF;
+
+            if (count > 64)
+            {
+                return wait_failed;
+            }
+
+            const bool wait_all = (flags & mwmo_waitall) != 0;
+            auto& t = c.win_emu.current_thread();
+            t.await_objects = {};
+            t.await_any = false;
+            t.await_msg_mask = {};
+            t.await_time = {};
+
+            std::vector<handle> wait_handles{};
+            wait_handles.reserve(count);
+            for (ULONG i = 0; i < count; ++i)
+            {
+                const auto h = handles.read(i);
+
+                if (c.proc.is_object_pseudo_handle(h))
+                {
+                    return wait_failed;
+                }
+
+                if (!NT_SUCCESS(validate_wait_handle(c, h)))
+                {
+                    return wait_failed;
+                }
+
+                wait_handles.push_back(h);
+            }
+
+            t.await_objects = std::move(wait_handles);
+            t.await_any = !wait_all;
+            if (wake_mask != 0)
+            {
+                t.await_msg_mask = wake_mask;
+            }
+
+            if (timeout != infinite_timeout)
+            {
+                t.await_time = c.win_emu.clock().steady_now() + std::chrono::milliseconds{timeout};
+            }
+
+            c.win_emu.yield_thread(false);
+            return {};
         }
 
         NTSTATUS handle_NtWaitForMultipleObjects(const syscall_context& c, const ULONG count, const emulator_object<handle> handles,

--- a/src/windows-emulator/syscalls/port.cpp
+++ b/src/windows-emulator/syscalls/port.cpp
@@ -165,10 +165,12 @@ namespace sogen
                     throw std::runtime_error("Unexpected success result returned by port handler");
                 }
 
-                receive_message.write(result.message);
+                result.message.write(receive_message);
+
                 if (!result.payload.empty())
                 {
-                    c.emu.write_memory(receive_message.value() + sizeof(PORT_MESSAGE64), result.payload.data(), result.payload.size());
+                    c.emu.write_memory(receive_message.value() + result.message.header_size(), result.payload.data(),
+                                       result.payload.size());
                 }
             }
 

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -57,6 +57,36 @@ namespace sogen
                 return STATUS_INVALID_HANDLE;
             }
 
+            if (key_information_class == KeyBasicInformation)
+            {
+                auto key_name = std::filesystem::path(key->path.get()).filename().u16string();
+                if (key_name.empty())
+                {
+                    key_name = std::filesystem::path(key->hive.get()).filename().u16string();
+                }
+
+                const auto required_size = offsetof(KEY_BASIC_INFORMATION, Name) + (key_name.size() * 2);
+                result_length.write(static_cast<ULONG>(required_size));
+
+                if (required_size > length)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                KEY_BASIC_INFORMATION info{};
+                info.LastWriteTime.QuadPart = 0;
+                info.TitleIndex = 0;
+                info.NameLength = static_cast<ULONG>(key_name.size() * 2);
+
+                c.emu.write_memory(key_information, &info, offsetof(KEY_BASIC_INFORMATION, Name));
+                if (!key_name.empty())
+                {
+                    c.emu.write_memory(key_information + offsetof(KEY_BASIC_INFORMATION, Name), key_name.data(), info.NameLength);
+                }
+
+                return STATUS_SUCCESS;
+            }
+
             if (key_information_class == KeyNameInformation)
             {
                 auto key_name = (key->hive.get() / key->path.get()).u16string();

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -365,6 +365,10 @@ namespace sogen
                                                                     basic_info.NumberOfProcessors = 4;
                                                                 });
 
+            case SystemRecommendedSharedDataAlignment:
+                return handle_query<ULONG>(c.emu, system_information, system_information_length, return_length,
+                                           [&](ULONG& alignment) { alignment = 64; });
+
             case SystemSupportedProcessorArchitectures: {
                 constexpr auto num_arch = 2;
 
@@ -392,7 +396,7 @@ namespace sogen
             }
 
             default:
-                c.win_emu.log.error("Unsupported system info class: %X\n", info_class);
+                c.win_emu.log.error("Unsupported system info class: 0x%X\n", info_class);
                 c.emu.stop();
                 return STATUS_NOT_SUPPORTED;
             }

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -533,7 +533,7 @@ namespace sogen
                 }
             }
 
-            return STATUS_INVALID_HANDLE;
+            return STATUS_SUCCESS;
         }
 
         NTSTATUS handle_NtAlertThreadByThreadIdEx(const syscall_context& c, const uint64_t thread_id,

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -36,6 +36,13 @@ namespace sogen
         constexpr uint32_t k_color_scrollbar = 0;
         constexpr uint32_t k_color_window = 5;
         constexpr uint32_t k_color_btnface = 15;
+        constexpr auto k_user_timer_minimum = std::chrono::milliseconds{10};
+
+        struct send_message_callback_info
+        {
+            uint64_t callback{};
+            uint64_t data{};
+        };
 
         struct user_callback_capture_buffer
         {
@@ -414,16 +421,10 @@ namespace sogen
                 return;
             }
 
-            for (auto& thread : c.proc.threads | std::views::values)
+            if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
             {
-                if (thread.id != win.thread_id)
-                {
-                    continue;
-                }
-
-                thread.post_message(msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0, .time = 0, .pt = {}});
+                thread->post_message(msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0, .time = 0, .pt = {}});
                 win.paint_message_posted = true;
-                return;
             }
         }
 
@@ -2274,7 +2275,7 @@ namespace sogen
         }
 
         uint64_t handle_NtUserMessageCall(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t w_param,
-                                          const uint64_t l_param, const uint64_t /*result_info*/, const DWORD /*type*/, const BOOL ansi)
+                                          const uint64_t l_param, const uint64_t /*result_info*/, const DWORD type, const BOOL ansi)
         {
             auto* win = c.proc.windows.get(hwnd);
             if (!win)
@@ -2284,6 +2285,22 @@ namespace sogen
 
             if (win->thread_id != c.proc.active_thread->id)
             {
+                // TODO: This is a bit incorrect. We're supposed to wait until the message is received, but this is fine for a first
+                //       minimal version.
+                if (type == FNID_SENDMESSAGECALLBACK)
+                {
+                    if (auto* t = c.proc.find_thread_by_id(win->thread_id))
+                    {
+                        sogen::msg queued_message{};
+                        queued_message.window = hwnd;
+                        queued_message.message = msg;
+                        queued_message.wParam = w_param;
+                        queued_message.lParam = l_param;
+                        t->post_message(queued_message);
+                        return TRUE;
+                    }
+                }
+
                 return 0;
             }
 
@@ -2339,9 +2356,8 @@ namespace sogen
             return {};
         }
 
-        uint64_t completion_NtUserMessageCall(const syscall_context& c, const hwnd /*hwnd*/, const UINT /*msg*/, const uint64_t /*w_param*/,
-                                              const uint64_t /*l_param*/, const uint64_t /*result_info*/, const DWORD /*type*/,
-                                              const BOOL /*ansi*/)
+        uint64_t completion_NtUserMessageCall(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t /*w_param*/,
+                                              const uint64_t /*l_param*/, const uint64_t result_info, const DWORD type, const BOOL /*ansi*/)
         {
             auto& state = c.get_completion_state<message_call_state>();
             if (state.scratch_text != 0)
@@ -2358,6 +2374,41 @@ namespace sogen
                 }
             }
 
+            if (type == FNID_SENDMESSAGECALLBACK)
+            {
+                if (state.dispatching_result_callback)
+                {
+                    return TRUE;
+                }
+
+                if (result_info != 0)
+                {
+                    const auto* win = c.proc.windows.get(hwnd);
+                    if (!win)
+                    {
+                        return TRUE;
+                    }
+
+                    send_message_callback_info callback_info{};
+                    if (c.win_emu.memory.try_read_memory(result_info, &callback_info, sizeof(callback_info)) && callback_info.callback != 0)
+                    {
+                        fn_dword_message args{};
+                        args.pwnd = win->guest.value();
+                        args.msg = msg;
+                        args.wParam = callback_info.data;
+                        args.lParam = c.get_callback_result<uint64_t>();
+                        args.xParam = callback_info.callback;
+                        args.xpfnProc = c.proc.dispatch_client_message;
+
+                        state.dispatching_result_callback = true;
+                        dispatch_user_callback(c, callback_id::NtUserMessageCall, k_fn_dword_callback_id, std::move(state), args);
+                        return {};
+                    }
+                }
+
+                return TRUE;
+            }
+
             return c.get_callback_result<uint64_t>();
         }
 
@@ -2369,13 +2420,37 @@ namespace sogen
             }
 
             const auto m = message.read();
-            auto* win = c.proc.windows.get(m.window);
-            if (!win)
+            auto* win = m.window != 0 ? c.proc.windows.get(m.window) : nullptr;
+            if (m.window != 0 && !win)
             {
                 return 0;
             }
 
-            if (win->thread_id != c.proc.active_thread->id)
+            if (win && win->thread_id != c.proc.active_thread->id)
+            {
+                return 0;
+            }
+
+            if (m.message == WM_TIMER && m.lParam != 0)
+            {
+                set_thread_window_context(c, m.window, win ? win->guest.value() : 0);
+
+                fn_dword_message args{};
+                args.pwnd = win ? win->guest.value() : 0;
+                args.msg = m.message;
+                args.wParam = m.wParam;
+                args.lParam = m.time;
+                args.xParam = m.lParam;
+                args.xpfnProc = c.proc.dispatch_client_message;
+
+                message_call_state state{};
+                state.window = m.window;
+                state.message = m.message;
+                dispatch_user_callback(c, callback_id::NtUserMessageCall, k_fn_dword_callback_id, args);
+                return {};
+            }
+
+            if (!win)
             {
                 return 0;
             }
@@ -2397,7 +2472,7 @@ namespace sogen
         {
             auto& t = c.win_emu.current_thread();
 
-            if (auto pending_msg = t.peek_pending_message(c.proc, hwnd, msg_filter_min, msg_filter_max, true))
+            if (auto pending_msg = t.peek_pending_message(c.proc, c.win_emu.clock(), hwnd, msg_filter_min, msg_filter_max, true))
             {
                 message.write(*pending_msg);
                 set_thread_window_context(c, pending_msg->window);
@@ -2416,7 +2491,8 @@ namespace sogen
             auto& t = c.win_emu.current_thread();
 
             const bool should_remove = (remove_message & PM_REMOVE) != 0;
-            std::optional<msg> pending_msg = t.peek_pending_message(c.proc, hwnd, msg_filter_min, msg_filter_max, should_remove);
+            std::optional<msg> pending_msg =
+                t.peek_pending_message(c.proc, c.win_emu.clock(), hwnd, msg_filter_min, msg_filter_max, should_remove);
 
             if (pending_msg)
             {
@@ -2431,7 +2507,7 @@ namespace sogen
         BOOL handle_NtUserWaitMessage(const syscall_context& c)
         {
             auto& t = c.win_emu.current_thread();
-            if (t.peek_pending_message(c.proc, 0, 0, 0, false))
+            if (t.peek_pending_message(c.proc, c.win_emu.clock()))
             {
                 return TRUE;
             }
@@ -2496,19 +2572,33 @@ namespace sogen
 
             uint32_t target_thread_id = hwnd != 0 ? win->thread_id : c.win_emu.current_thread().id;
 
-            for (auto& thread : c.proc.threads | std::views::values)
+            if (auto* thread = c.proc.find_thread_by_id(target_thread_id))
             {
-                if (thread.id == target_thread_id)
-                {
-                    sogen::msg qmsg{};
-                    qmsg.window = hwnd;
-                    qmsg.message = msg;
-                    qmsg.wParam = wParam;
-                    qmsg.lParam = lParam;
+                sogen::msg qmsg{};
+                qmsg.window = hwnd;
+                qmsg.message = msg;
+                qmsg.wParam = wParam;
+                qmsg.lParam = lParam;
 
-                    thread.post_message(qmsg);
-                    return TRUE;
-                }
+                thread->post_message(qmsg);
+                return TRUE;
+            }
+
+            return FALSE;
+        }
+
+        BOOL handle_NtUserPostThreadMessage(const syscall_context& c, const DWORD id_thread, const UINT msg, const uint64_t wParam,
+                                            const uint64_t lParam)
+        {
+            if (auto* thread = c.proc.find_thread_by_id(id_thread))
+            {
+                sogen::msg qmsg{};
+                qmsg.message = msg;
+                qmsg.wParam = wParam;
+                qmsg.lParam = lParam;
+
+                thread->post_message(qmsg);
+                return TRUE;
             }
 
             return FALSE;
@@ -3388,6 +3478,134 @@ namespace sogen
             default:
                 return STATUS_SUCCESS;
             }
+        }
+
+        uint64_t handle_NtUserInitThreadCoreMessagingIocp2(const syscall_context& c, const handle /*window_handle*/,
+                                                           const emulator_object<uint32_t> completion_queue_index)
+        {
+            io_completion completion{};
+            completion.number_of_concurrent_threads = 1;
+
+            completion_queue_index.write_if_valid(0);
+            return c.proc.io_completions.store(std::move(completion)).bits;
+        }
+
+        BOOL handle_NtUserDrainThreadCoreMessagingCompletions2()
+        {
+            return TRUE;
+        }
+
+        uint64_t handle_NtUserScheduleDispatchNotification(const syscall_context& /*c*/, const hwnd /*hwnd*/)
+        {
+            return 2;
+        }
+
+        uint64_t handle_NtUserSetTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id, const uint32_t elapsed_ms,
+                                       const uint64_t timer_proc)
+        {
+            auto interval = std::chrono::milliseconds{elapsed_ms};
+            if (interval < k_user_timer_minimum)
+            {
+                interval = k_user_timer_minimum;
+            }
+
+            auto* target_thread = c.proc.active_thread;
+
+            if (hwnd != 0)
+            {
+                const auto* win = c.proc.windows.get(hwnd);
+                if (!win)
+                {
+                    set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                    return 0;
+                }
+
+                target_thread = c.proc.find_thread_by_id(win->thread_id);
+
+                if (!target_thread)
+                {
+                    set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                    return 0;
+                }
+            }
+
+            const auto now = c.win_emu.clock().steady_now();
+
+            if (auto* timer = target_thread->find_user_timer(hwnd, timer_id))
+            {
+                timer->interval = interval;
+                timer->due_time = now + interval;
+                timer->timer_proc = timer_proc;
+                return timer_id;
+            }
+
+            return target_thread->create_user_timer(c.proc, hwnd, timer_id, timer_proc, interval, now).timer_id;
+        }
+
+        BOOL handle_NtUserKillTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id)
+        {
+            auto* target_thread = c.proc.active_thread;
+
+            if (hwnd != 0)
+            {
+                const auto* win = c.proc.windows.get(hwnd);
+                if (!win)
+                {
+                    set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                    return FALSE;
+                }
+
+                target_thread = c.proc.find_thread_by_id(win->thread_id);
+
+                if (!target_thread)
+                {
+                    set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                    return FALSE;
+                }
+            }
+
+            if (!target_thread->delete_user_timer(hwnd, timer_id))
+            {
+                return FALSE;
+            }
+
+            return TRUE;
+        }
+
+        BOOL handle_NtUserValidateTimerCallback(const syscall_context& c, const uint64_t timer_proc)
+        {
+            if (timer_proc == 0)
+            {
+                return FALSE;
+            }
+
+            for (const auto& thread : c.proc.threads | std::views::values)
+            {
+                for (const auto& timer : thread.user_timers | std::views::values)
+                {
+                    if (timer.timer_proc == timer_proc)
+                    {
+                        return TRUE;
+                    }
+                }
+            }
+
+            return FALSE;
+        }
+
+        uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, const UINT flags)
+        {
+            const auto thread = c.proc.active_thread;
+            const auto current_bits = thread->get_message_queue_status(c.win_emu.clock()) & flags;
+            const auto changed_bits = thread->queue_status_changed_bits & flags;
+            return current_bits | (changed_bits << 16);
+        }
+
+        uint32_t handle_NtUserGetQueueStatus(const syscall_context& c, const UINT flags)
+        {
+            const auto result = handle_NtUserGetQueueStatusReadonly(c, flags);
+            c.proc.active_thread->queue_status_changed_bits &= ~flags;
+            return result;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3595,7 +3595,7 @@ namespace sogen
 
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, const UINT flags)
         {
-            const auto thread = c.proc.active_thread;
+            auto* thread = c.proc.active_thread;
             const auto current_bits = thread->get_message_queue_status(c.win_emu.clock()) & flags;
             const auto changed_bits = thread->queue_status_changed_bits & flags;
             return current_bits | (changed_bits << 16);


### PR DESCRIPTION
This PR fixes several things in the emulator needed to get CoreMessaging initialization and basic scheduling working in both x86 and x64:

- Adds a `CoreMessagingRegistrar` ALPC port implementation.
- Adds WOW64-aware LPC port message handling by supporting both 32-bit and 64-bit `PORT_MESSAGE` layouts.
- Adds support for creating ALPC ports with `NtAlpcCreatePort`.
- Adds basic support for several new user syscalls, including:
  - `NtUserInitThreadCoreMessagingIocp2`
  - `NtUserDrainThreadCoreMessagingCompletions2`
  - `NtUserScheduleDispatchNotification`
  - `NtUserMsgWaitForMultipleObjectsEx`
  - `NtUserGetQueueStatus`
  - `NtUserGetQueueStatusReadonly`
  - `NtUserSetTimer`
- Improves message queue behavior by tracking queue status bits and synthesizing due `WM_TIMER` messages.
- Allows ports to participate in waits and IO completion wait registration.
- Adds missing object, registry, and system information query handling needed by the CoreMessaging path.
- Adds support for `NtUserDispatchMessage` callbacks and `NtUserPostThreadMessage`.