### PR TITLE
Add sogen.linux Python bindings with path, port, and syscall hooks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,9 @@ page/public/64/linux-analyzer.wasm
 __pycache__/
 devdocs/
 dist_local/
+
+# Local analysis tooling, roots, and IDE config (do not publish)
+tools/
+root/
+root.zip
+.claude/

--- a/examples/python/linux_basic_usage.py
+++ b/examples/python/linux_basic_usage.py
@@ -1,0 +1,66 @@
+"""sogen.linux Tier 3 example: path mappings, port mappings, rich syscall info."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import sogen
+
+
+def build_hello_binary() -> Path:
+    source = Path(__file__).resolve().parents[2] / "deps" / "sogen-linux-files" / "test" / "linux" / "hello.S"
+    with tempfile.TemporaryDirectory(prefix="sogen-linux-example-") as tmp:
+        out = Path(tmp) / "hello"
+        obj = Path(tmp) / "hello.o"
+        subprocess.check_call(["as", "-64", "-o", str(obj), str(source)])
+        subprocess.check_call(["ld", "-o", str(out), str(obj)])
+        data = out.read_bytes()
+    dest = Path(tempfile.gettempdir()) / "sogen-linux-hello"
+    dest.write_bytes(data)
+    dest.chmod(0o755)
+    return dest
+
+
+def main() -> None:
+    binary = os.getenv("LINUX_SAMPLE") or str(build_hello_binary())
+    emulation_root = os.getenv("LINUX_EMULATION_ROOT", "")
+
+    with tempfile.TemporaryDirectory(prefix="sogen-linux-tier3-") as tmp:
+        tmp_path = Path(tmp)
+        mapped_file = tmp_path / "secret.txt"
+        mapped_file.write_text("mapped-content\n")
+
+        stdout_lines: list[str] = []
+        syscalls: list[str] = []
+
+        app = sogen.linux.create_application(
+            binary,
+            emulation_root=emulation_root,
+            env={"PATH": "/usr/bin:/bin", "HOME": "/root", "TERM": "xterm"},
+            path_mappings={"/tmp/secret.txt": mapped_file},
+            port_mappings={28970: 28980},
+            verbose=False,
+        )
+
+        app.callbacks.on_stdout = lambda text: stdout_lines.append(text)
+
+        def on_syscall(info: sogen.linux.SyscallInfo) -> sogen.linux.SyscallContinuation:
+            syscalls.append(f"{info.name}({list(info.args)})")
+            return sogen.linux.SyscallContinuation.run_handler
+
+        app.callbacks.on_syscall = on_syscall
+
+        assert app.get_host_port(28970) == 28980
+        assert app.get_emulator_port(28980) == 28970
+
+        app.start()
+        print("stdout:", "".join(stdout_lines).rstrip())
+        print("syscalls:", syscalls)
+        print("exit status:", app.process.exit_status)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/linux-emulator-test/linux_emulation_test_utils.hpp
+++ b/src/linux-emulator-test/linux_emulation_test_utils.hpp
@@ -138,9 +138,9 @@ namespace sogen::linux_test
 
         linux_emulator_result result{};
 
-        linux_emu.on_stdout = [&result](const std::string_view data) { result.captured_stdout += data; };
+        linux_emu.callbacks.on_stdout = [&result](const std::string_view data) { result.captured_stdout += data; };
 
-        linux_emu.on_stderr = [&result](const std::string_view data) { result.captured_stderr += data; };
+        linux_emu.callbacks.on_stderr = [&result](const std::string_view data) { result.captured_stderr += data; };
 
         if (!enable_verbose_logging())
         {

--- a/src/linux-emulator/linux_emulator.cpp
+++ b/src/linux-emulator/linux_emulator.cpp
@@ -83,6 +83,8 @@ namespace sogen
           memory(*this->emu_),
           mod_manager(this->memory)
     {
+        this->mod_manager.on_module_loaded = [this](linux_mapped_module& module) { this->callbacks.on_module_load(module); };
+
         // Set up GDT for 64-bit long mode
         setup_gdt(*this->emu_, this->memory);
 
@@ -217,6 +219,21 @@ namespace sogen
         // Hook memory violations — try to deliver as SIGSEGV to user handler
         this->emu().hook_memory_violation(
             [this](const uint64_t address, const size_t size, const memory_operation operation, const memory_violation_type type) {
+                if (this->callbacks.on_memory_violate)
+                {
+                    const auto cont = this->callbacks.on_memory_violate(address, size, operation, type);
+                    if (cont == memory_violation_continuation::stop)
+                    {
+                        this->stop();
+                        return memory_violation_continuation::stop;
+                    }
+
+                    if (cont != memory_violation_continuation::resume)
+                    {
+                        return cont;
+                    }
+                }
+
                 const char* type_str = (type == memory_violation_type::unmapped) ? "unmapped" : "protection";
                 const char* op_str = "unknown";
 
@@ -270,7 +287,10 @@ namespace sogen
             ++this->process.active_thread->executed_instructions;
         }
 
-        (void)address;
+        if (this->callbacks.on_instruction)
+        {
+            this->callbacks.on_instruction(address);
+        }
 
         if (this->on_periodic_event && (this->executed_instructions_ % 0x20000) == 0)
         {

--- a/src/linux-emulator/linux_emulator.hpp
+++ b/src/linux-emulator/linux_emulator.hpp
@@ -5,6 +5,7 @@
 #include <arch_emulator.hpp>
 #include <platform/compiler.hpp>
 
+#include "linux_emulator_callbacks.hpp"
 #include "linux_logger.hpp"
 #include "linux_file_system.hpp"
 #include "linux_memory_manager.hpp"
@@ -14,6 +15,7 @@
 #include "procfs.hpp"
 #include "vdso.hpp"
 #include "module/linux_module_manager.hpp"
+#include "linux_socket.hpp"
 
 namespace sogen
 {
@@ -55,9 +57,7 @@ namespace sogen
             return *this->emu_;
         }
 
-        // Callbacks for emulated stdout/stderr output
-        std::function<void(std::string_view data)> on_stdout{};
-        std::function<void(std::string_view data)> on_stderr{};
+        linux_emulator_callbacks callbacks{};
 
         // Callback invoked periodically during emulation (every 0x20000 instructions).
         // Used by the web debugger for ASYNCIFY yield and event handling.
@@ -71,8 +71,55 @@ namespace sogen
             return this->executed_instructions_;
         }
 
+        uint16_t get_host_port(const uint16_t emulator_port) const
+        {
+            const auto entry = this->port_mappings_.find(emulator_port);
+            if (entry == this->port_mappings_.end())
+            {
+                return emulator_port;
+            }
+
+            return entry->second;
+        }
+
+        uint16_t get_emulator_port(const uint16_t host_port) const
+        {
+            for (const auto& mapping : this->port_mappings_)
+            {
+                if (mapping.second == host_port)
+                {
+                    return mapping.first;
+                }
+            }
+
+            return host_port;
+        }
+
+        void map_port(const uint16_t emulator_port, const uint16_t host_port)
+        {
+            if (emulator_port != host_port)
+            {
+                this->port_mappings_[emulator_port] = host_port;
+                return;
+            }
+
+            const auto entry = this->port_mappings_.find(emulator_port);
+            if (entry != this->port_mappings_.end())
+            {
+                this->port_mappings_.erase(entry);
+            }
+        }
+
+        void close_socket(const int fd)
+        {
+            this->sockets_.erase(fd);
+        }
+
+        linux_socket_table sockets_{};
+
       private:
         std::atomic_bool should_stop{false};
+        std::unordered_map<uint16_t, uint16_t> port_mappings_{};
 
         void setup_hooks();
         void on_instruction_execution(uint64_t address);

--- a/src/linux-emulator/linux_emulator_callbacks.hpp
+++ b/src/linux-emulator/linux_emulator_callbacks.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "std_include.hpp"
+
+#include <hook_interface.hpp>
+#include <utils/function.hpp>
+
+#include "module/elf_mapping.hpp"
+#include "linux_syscall_info.hpp"
+
+namespace sogen
+{
+
+    enum class linux_syscall_hook_continuation : uint8_t
+    {
+        run_handler,
+        skip_handler,
+        stop,
+    };
+
+    struct linux_emulator_callbacks
+    {
+        utils::optional_function<void(std::string_view data)> on_stdout{};
+        utils::optional_function<void(std::string_view data)> on_stderr{};
+        utils::optional_function<linux_syscall_hook_continuation(const linux_syscall_info& info)> on_syscall{};
+        utils::callback_list<void(const linux_mapped_module& module)> on_module_load{};
+        utils::optional_function<void(uint64_t address)> on_instruction{};
+        utils::optional_function<memory_violation_continuation(uint64_t address, size_t size, memory_operation operation,
+                                                               memory_violation_type type)>
+            on_memory_violate{};
+    };
+
+} // namespace sogen

--- a/src/linux-emulator/linux_file_system.hpp
+++ b/src/linux-emulator/linux_file_system.hpp
@@ -15,11 +15,27 @@ namespace sogen
         {
         }
 
+        void map(std::string guest_path, std::filesystem::path host_path)
+        {
+            guest_path = normalize_guest_path(guest_path);
+            if (guest_path.empty())
+            {
+                return;
+            }
+
+            this->path_mappings_[std::move(guest_path)] = std::move(host_path);
+        }
+
         std::filesystem::path translate(const std::string_view guest_path) const
         {
             if (guest_path.empty())
             {
                 return this->root_;
+            }
+
+            if (const auto mapped = this->resolve_path_mapping(guest_path); mapped.has_value())
+            {
+                return *mapped;
             }
 
             // Handle special paths that should not be translated
@@ -173,6 +189,64 @@ namespace sogen
       private:
         std::filesystem::path root_{};
         std::vector<std::filesystem::path> passthrough_prefixes_{};
+        std::map<std::string, std::filesystem::path, std::less<>> path_mappings_{};
+
+        static std::string normalize_guest_path(std::string_view guest_path)
+        {
+            if (guest_path.empty())
+            {
+                return {};
+            }
+
+            auto normalized = std::filesystem::path{guest_path}.lexically_normal().string();
+            if (!normalized.empty() && normalized.front() != '/')
+            {
+                normalized.insert(normalized.begin(), '/');
+            }
+
+            return normalized;
+        }
+
+        std::optional<std::filesystem::path> resolve_path_mapping(const std::string_view guest_path) const
+        {
+            const auto normalized = normalize_guest_path(guest_path);
+            if (normalized.empty())
+            {
+                return std::nullopt;
+            }
+
+            if (const auto exact = this->path_mappings_.find(normalized); exact != this->path_mappings_.end())
+            {
+                return exact->second;
+            }
+
+            std::string best_prefix{};
+            std::filesystem::path best_host{};
+            for (const auto& [guest, host] : this->path_mappings_)
+            {
+                if (normalized == guest || normalized.starts_with(guest + "/"))
+                {
+                    if (guest.size() > best_prefix.size())
+                    {
+                        best_prefix = guest;
+                        best_host = host;
+                    }
+                }
+            }
+
+            if (best_prefix.empty())
+            {
+                return std::nullopt;
+            }
+
+            if (normalized == best_prefix)
+            {
+                return best_host;
+            }
+
+            const auto suffix = normalized.substr(best_prefix.size() + 1);
+            return (best_host / suffix).lexically_normal();
+        }
 
         static bool is_within(const std::filesystem::path& path, const std::filesystem::path& prefix)
         {

--- a/src/linux-emulator/linux_socket.hpp
+++ b/src/linux-emulator/linux_socket.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "std_include.hpp"
+
+#include <network/socket.hpp>
+
+namespace sogen
+{
+
+    struct linux_socket_state
+    {
+        int domain{};
+        int type{};
+        int protocol{};
+        bool listening{};
+        bool connected{};
+        int so_reuseaddr{};
+        int so_keepalive{};
+        int so_reuseport{};
+        int so_sndbuf{65536};
+        int so_rcvbuf{65536};
+        int so_error{};
+
+        uint16_t bound_port{};
+        uint32_t bound_addr{};
+
+        uint16_t peer_port{};
+        uint32_t peer_addr{};
+
+        std::unique_ptr<network::socket> host_socket{};
+    };
+
+    class linux_socket_table
+    {
+      public:
+        linux_socket_state& emplace(const int fd, linux_socket_state&& state)
+        {
+            return this->states_.emplace(fd, std::move(state)).first->second;
+        }
+
+        linux_socket_state* get(const int fd)
+        {
+            const auto it = this->states_.find(fd);
+            if (it == this->states_.end())
+            {
+                return nullptr;
+            }
+
+            return &it->second;
+        }
+
+        const linux_socket_state* get(const int fd) const
+        {
+            const auto it = this->states_.find(fd);
+            if (it == this->states_.end())
+            {
+                return nullptr;
+            }
+
+            return &it->second;
+        }
+
+        void erase(const int fd)
+        {
+            auto it = this->states_.find(fd);
+            if (it == this->states_.end())
+            {
+                return;
+            }
+
+            if (it->second.host_socket)
+            {
+                it->second.host_socket->close();
+            }
+
+            this->states_.erase(it);
+        }
+
+      private:
+        std::map<int, linux_socket_state> states_{};
+    };
+
+} // namespace sogen

--- a/src/linux-emulator/linux_syscall_dispatcher.cpp
+++ b/src/linux-emulator/linux_syscall_dispatcher.cpp
@@ -1,6 +1,7 @@
 #include "std_include.hpp"
 #include "linux_syscall_dispatcher.hpp"
 #include "linux_emulator.hpp"
+#include "linux_emulator_callbacks.hpp"
 
 // NOLINTBEGIN(google-build-using-namespace)
 namespace sogen
@@ -171,6 +172,35 @@ namespace sogen
         auto& e = emu_ref.emu();
         const auto syscall_id = e.reg(x86_register::rax);
 
+        const linux_syscall_handler_entry* entry = nullptr;
+        std::string_view syscall_name{};
+
+        if (syscall_id >= this->handlers_.size())
+        {
+            syscall_name = "unknown";
+        }
+        else
+        {
+            entry = &this->handlers_[static_cast<size_t>(syscall_id)];
+            syscall_name = entry->name.empty() ? "unknown" : std::string_view{entry->name};
+        }
+
+        if (emu_ref.callbacks.on_syscall)
+        {
+            const auto info = make_linux_syscall_info(e, syscall_id, syscall_name);
+            const auto cont = emu_ref.callbacks.on_syscall(info);
+            if (cont == linux_syscall_hook_continuation::stop)
+            {
+                emu_ref.stop();
+                return;
+            }
+
+            if (cont == linux_syscall_hook_continuation::skip_handler)
+            {
+                return;
+            }
+        }
+
         if (syscall_id >= this->handlers_.size())
         {
             emu_ref.log.warn("Unimplemented syscall: %" PRIu64 "\n", syscall_id);
@@ -178,16 +208,15 @@ namespace sogen
             return;
         }
 
-        const auto& entry = this->handlers_[static_cast<size_t>(syscall_id)];
-        if (!entry.handler)
+        if (!entry->handler)
         {
-            emu_ref.log.warn("Unimplemented syscall: %" PRIu64 " (%s)\n", syscall_id, entry.name.empty() ? "unknown" : entry.name.c_str());
+            emu_ref.log.warn("Unimplemented syscall: %" PRIu64 " (%s)\n", syscall_id, entry->name.empty() ? "unknown" : entry->name.c_str());
             e.reg(x86_register::rax, static_cast<uint64_t>(-LINUX_ENOSYS));
             return;
         }
 
         linux_syscall_context ctx{.emu_ref = emu_ref, .emu = e, .proc = emu_ref.process};
-        entry.handler(ctx);
+        entry->handler(ctx);
     }
 
     void linux_syscall_dispatcher::add_handlers()

--- a/src/linux-emulator/linux_syscall_info.cpp
+++ b/src/linux-emulator/linux_syscall_info.cpp
@@ -1,0 +1,46 @@
+#include "linux_syscall_info.hpp"
+
+#include "linux_emulator_utils.hpp"
+
+namespace sogen
+{
+
+    linux_syscall_info make_linux_syscall_info(x86_64_emulator& emu, const uint64_t number, const std::string_view name)
+    {
+        linux_syscall_info info{};
+        info.number = number;
+        info.name = name;
+        info.emu = &emu;
+
+        for (size_t i = 0; i < info.args.size(); ++i)
+        {
+            info.args[i] = get_linux_syscall_argument(emu, i);
+        }
+
+        return info;
+    }
+
+    std::optional<std::string> linux_syscall_info::read_c_string(const size_t arg_index, const size_t max_len) const
+    {
+        if (this->emu == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        const auto address = this->arg(arg_index);
+        if (address == 0)
+        {
+            return std::nullopt;
+        }
+
+        try
+        {
+            return read_string<char>(*this->emu, address, max_len);
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    }
+
+} // namespace sogen

--- a/src/linux-emulator/linux_syscall_info.hpp
+++ b/src/linux-emulator/linux_syscall_info.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "std_include.hpp"
+
+#include <arch_emulator.hpp>
+
+namespace sogen
+{
+
+    struct linux_syscall_info
+    {
+        uint64_t number{};
+        std::string_view name{};
+        std::array<uint64_t, 6> args{};
+        x86_64_emulator* emu{};
+
+        uint64_t arg(const size_t index) const
+        {
+            return this->args.at(index);
+        }
+
+        std::optional<std::string> read_c_string(const size_t arg_index, const size_t max_len = 4096) const;
+    };
+
+    linux_syscall_info make_linux_syscall_info(x86_64_emulator& emu, const uint64_t number, const std::string_view name);
+
+} // namespace sogen

--- a/src/linux-emulator/module/linux_module_manager.cpp
+++ b/src/linux-emulator/module/linux_module_manager.cpp
@@ -19,7 +19,13 @@ namespace sogen
             throw std::runtime_error("Module already mapped at base 0x" + std::to_string(base));
         }
 
-        return &it->second;
+        auto* module = &it->second;
+        if (this->on_module_loaded)
+        {
+            this->on_module_loaded(*module);
+        }
+
+        return module;
     }
 
     void linux_module_manager::map_main_modules(const std::filesystem::path& executable_path)

--- a/src/linux-emulator/module/linux_module_manager.hpp
+++ b/src/linux-emulator/module/linux_module_manager.hpp
@@ -4,6 +4,8 @@
 #include "../linux_memory_manager.hpp"
 #include "elf_mapping.hpp"
 
+#include <utils/function.hpp>
+
 #include <utils/io.hpp>
 
 namespace sogen
@@ -37,6 +39,8 @@ namespace sogen
 
         // Add an additional library search directory
         void add_library_path(const std::filesystem::path& path);
+
+        utils::optional_function<void(linux_mapped_module&)> on_module_loaded{};
 
         // Resolve a library name (e.g., "libm.so.6") to a host filesystem path using the
         // standard search order: DT_RPATH, LD_LIBRARY_PATH (configured paths), DT_RUNPATH,

--- a/src/linux-emulator/syscalls/file.cpp
+++ b/src/linux-emulator/syscalls/file.cpp
@@ -611,7 +611,7 @@ namespace sogen
         {
             // stdout / stderr: invoke callback if set, otherwise write to host
             const auto sv = std::string_view(reinterpret_cast<const char*>(buffer.data()), count);
-            auto& callback = (fd == 1) ? c.emu_ref.on_stdout : c.emu_ref.on_stderr;
+            auto& callback = (fd == 1) ? c.emu_ref.callbacks.on_stdout : c.emu_ref.callbacks.on_stderr;
 
             if (callback)
             {
@@ -740,6 +740,12 @@ namespace sogen
 
         // Tear down any per-fd directory iteration state.
         cleanup_directory_fd_state(fd);
+
+        auto* fd_entry = c.proc.fds.get(fd);
+        if (fd_entry && fd_entry->type == fd_type::socket)
+        {
+            c.emu_ref.close_socket(fd);
+        }
 
         if (!c.proc.fds.close(fd))
         {
@@ -1059,7 +1065,7 @@ namespace sogen
             if (fd == 1 || fd == 2)
             {
                 const auto sv = std::string_view(reinterpret_cast<const char*>(buffer.data()), static_cast<size_t>(iov_len));
-                auto& callback = (fd == 1) ? c.emu_ref.on_stdout : c.emu_ref.on_stderr;
+                auto& callback = (fd == 1) ? c.emu_ref.callbacks.on_stdout : c.emu_ref.callbacks.on_stderr;
 
                 if (callback)
                 {

--- a/src/linux-emulator/syscalls/io.cpp
+++ b/src/linux-emulator/syscalls/io.cpp
@@ -245,9 +245,9 @@ namespace sogen
         constexpr uint32_t EPOLLOUT = 0x004;
 
         // Poll event flags
-        constexpr int16_t POLLIN = 0x0001;
-        constexpr int16_t POLLOUT = 0x0004;
-        constexpr int16_t POLLNVAL = 0x0020;
+        constexpr int16_t LINUX_POLLIN = 0x0001;
+        constexpr int16_t LINUX_POLLOUT = 0x0004;
+        constexpr int16_t LINUX_POLLNVAL = 0x0020;
 
 #pragma pack(push, 1)
         struct linux_epoll_event
@@ -459,14 +459,14 @@ namespace sogen
             auto* fd_entry = c.proc.fds.get(pfd.fd);
             if (!fd_entry)
             {
-                pfd.revents = POLLNVAL;
+                pfd.revents = LINUX_POLLNVAL;
                 c.emu.write_memory(entry_addr, &pfd, sizeof(pfd));
                 ++ready_count;
                 continue;
             }
 
             // Check readiness
-            if (pfd.events & POLLIN)
+            if (pfd.events & LINUX_POLLIN)
             {
                 if (fd_entry->type == fd_type::file && fd_entry->handle)
                 {
@@ -476,19 +476,19 @@ namespace sogen
                     fseek(fd_entry->handle, pos, SEEK_SET);
                     if (pos < end)
                     {
-                        pfd.revents |= POLLIN;
+                        pfd.revents |= LINUX_POLLIN;
                     }
                 }
                 // stdin: report not ready (would block)
                 // pipes: could check but simplified for now
             }
 
-            if (pfd.events & POLLOUT)
+            if (pfd.events & LINUX_POLLOUT)
             {
                 // Most fds are writable
                 if (fd_entry->type == fd_type::file || fd_entry->type == fd_type::pipe_write || fd_entry->type == fd_type::socket)
                 {
-                    pfd.revents |= POLLOUT;
+                    pfd.revents |= LINUX_POLLOUT;
                 }
             }
 

--- a/src/linux-emulator/syscalls/socket.cpp
+++ b/src/linux-emulator/syscalls/socket.cpp
@@ -1,6 +1,11 @@
 #include "../std_include.hpp"
 #include "../linux_emulator.hpp"
 #include "../linux_syscall_dispatcher.hpp"
+#include "../linux_socket.hpp"
+
+#include <network/address.hpp>
+#include <network/tcp_client_socket.hpp>
+#include <network/udp_socket.hpp>
 
 #include <cstring>
 
@@ -9,45 +14,11 @@ namespace sogen
 
     using namespace linux_errno; // NOLINT(google-build-using-namespace)
 
-    // Linux socket constants
     namespace
     {
-        // Address families
-        constexpr int AF_UNIX = 1;
-        constexpr int AF_INET = 2;
-        constexpr int AF_INET6 = 10;
-
-        // Socket types (lower bits)
-        constexpr int SOCK_STREAM = 1;
-        constexpr int SOCK_DGRAM = 2;
-        constexpr int SOCK_RAW = 3;
         constexpr int SOCK_TYPE_MASK = 0xF;
 
-        // Socket type flags (upper bits)
-        constexpr int SOCK_CLOEXEC = 02000000;
-
-        // Shutdown how
-        // constexpr int SHUT_RD = 0;
-        // constexpr int SHUT_WR = 1;
-        // constexpr int SHUT_RDWR = 2;
-
-        // SOL_SOCKET
-        constexpr int SOL_SOCKET = 1;
-
-        // Socket options
-        constexpr int SO_REUSEADDR = 2;
-        constexpr int SO_TYPE = 3;
-        constexpr int SO_ERROR = 4;
-        constexpr int SO_KEEPALIVE = 9;
-        constexpr int SO_REUSEPORT = 15;
-        constexpr int SO_SNDBUF = 7;
-        constexpr int SO_RCVBUF = 8;
-
-        // Message flags
-        // constexpr int MSG_DONTWAIT = 0x40;
-
         // Linux sockaddr_in (16 bytes)
-        // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
         struct linux_sockaddr_in
         {
@@ -57,32 +28,102 @@ namespace sogen
             uint8_t sin_zero[8];
         };
 #pragma pack(pop)
-        // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
         static_assert(sizeof(linux_sockaddr_in) == 16);
 
-        struct socket_state
+        bool read_sockaddr_in(const linux_syscall_context& c, const uint64_t addr_ptr, const uint32_t addrlen, linux_sockaddr_in& sin)
         {
-            int domain{};
-            int type{};
-            int protocol{};
-            bool listening{};
-            bool connected{};
-            int so_reuseaddr{};
-            int so_keepalive{};
-            int so_reuseport{};
-            int so_sndbuf{65536};
-            int so_rcvbuf{65536};
-            int so_error{};
+            if (addr_ptr == 0 || addrlen < sizeof(uint16_t))
+            {
+                return false;
+            }
 
-            // Bound address info
-            uint16_t bound_port{};
-            uint32_t bound_addr{};
-        };
+            uint16_t family{};
+            c.emu.read_memory(addr_ptr, &family, sizeof(family));
+            if (family != AF_INET || addrlen < sizeof(linux_sockaddr_in))
+            {
+                return false;
+            }
 
-        // Simple socket state storage — maps fd to socket metadata
-        // We store this alongside the fd_table since linux_fd doesn't have socket state
-        std::map<int, socket_state> g_socket_states;
+            c.emu.read_memory(addr_ptr, &sin, sizeof(sin));
+            return true;
+        }
+
+        network::address make_host_address(const linux_emulator& emu_ref, const linux_sockaddr_in& sin)
+        {
+            sockaddr_in host_addr{};
+            host_addr.sin_family = AF_INET;
+            host_addr.sin_port = htons(emu_ref.get_host_port(ntohs(sin.sin_port)));
+            std::memcpy(&host_addr.sin_addr, &sin.sin_addr, sizeof(host_addr.sin_addr));
+            return network::address{host_addr};
+        }
+
+        void write_sockaddr_in(x86_64_emulator& emu, const uint64_t addr_ptr, const uint64_t addrlen_ptr, const uint16_t port,
+                               const uint32_t addr)
+        {
+            linux_sockaddr_in sin{};
+            sin.sin_family = AF_INET;
+            sin.sin_port = port;
+            sin.sin_addr = addr;
+
+            if (addr_ptr != 0)
+            {
+                emu.write_memory(addr_ptr, &sin, sizeof(sin));
+            }
+
+            if (addrlen_ptr != 0)
+            {
+                uint32_t len = sizeof(linux_sockaddr_in);
+                emu.write_memory(addrlen_ptr, &len, sizeof(len));
+            }
+        }
+
+        int64_t map_host_socket_error()
+        {
+            switch (GET_SOCKET_ERROR())
+            {
+            case EWOULDBLOCK:
+                return -LINUX_EAGAIN;
+            case ECONNREFUSED:
+                return -LINUX_ECONNREFUSED;
+            case ECONNRESET:
+                return -LINUX_ECONNRESET;
+            case ETIMEDOUT:
+                return -LINUX_ETIMEDOUT;
+            case EINPROGRESS:
+                return -LINUX_EINPROGRESS;
+            case EADDRINUSE:
+                return -LINUX_EADDRINUSE;
+            case EADDRNOTAVAIL:
+                return -LINUX_EADDRNOTAVAIL;
+            case ENETUNREACH:
+                return -LINUX_ENETUNREACH;
+            case EHOSTUNREACH:
+                return -LINUX_EHOSTUNREACH;
+            case ENOTCONN:
+                return -LINUX_ENOTCONN;
+            default:
+                return -LINUX_EINVAL;
+            }
+        }
+
+        std::unique_ptr<network::socket> create_host_socket(const int domain, const int type)
+        {
+            if (domain == AF_INET || domain == AF_INET6)
+            {
+                if (type == SOCK_STREAM)
+                {
+                    return std::make_unique<network::tcp_client_socket>(domain);
+                }
+
+                if (type == SOCK_DGRAM)
+                {
+                    return std::make_unique<network::udp_socket>(domain);
+                }
+            }
+
+            return nullptr;
+        }
     }
 
     void sys_socket(const linux_syscall_context& c)
@@ -94,14 +135,12 @@ namespace sogen
         const auto type = type_raw & SOCK_TYPE_MASK;
         const bool cloexec = (type_raw & SOCK_CLOEXEC) != 0;
 
-        // Validate domain
         if (domain != AF_UNIX && domain != AF_INET && domain != AF_INET6)
         {
             write_linux_syscall_result(c, -LINUX_EAFNOSUPPORT);
             return;
         }
 
-        // Validate type
         if (type != SOCK_STREAM && type != SOCK_DGRAM && type != SOCK_RAW)
         {
             write_linux_syscall_result(c, -LINUX_EINVAL);
@@ -115,12 +154,11 @@ namespace sogen
 
         const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
 
-        // Track socket state
-        socket_state ss{};
-        ss.domain = domain;
-        ss.type = type;
-        ss.protocol = protocol;
-        g_socket_states[fd_num] = ss;
+        linux_socket_state state{};
+        state.domain = domain;
+        state.type = type;
+        state.protocol = protocol;
+        c.emu_ref.sockets_.emplace(fd_num, std::move(state));
 
         write_linux_syscall_result(c, fd_num);
     }
@@ -128,7 +166,8 @@ namespace sogen
     void sys_connect(const linux_syscall_context& c)
     {
         const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-        // addr is arg 1, addrlen is arg 2
+        const auto addr_ptr = get_linux_syscall_argument(c.emu, 1);
+        const auto addrlen = static_cast<uint32_t>(get_linux_syscall_argument(c.emu, 2));
 
         auto* fd_entry = c.proc.fds.get(sockfd);
         if (!fd_entry || fd_entry->type != fd_type::socket)
@@ -137,9 +176,60 @@ namespace sogen
             return;
         }
 
-        // We don't actually connect anywhere — stub that returns ECONNREFUSED
-        // In a full implementation, we'd proxy to the host's network stack
-        write_linux_syscall_result(c, -LINUX_ECONNREFUSED);
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr)
+        {
+            write_linux_syscall_result(c, -LINUX_EBADF);
+            return;
+        }
+
+        if (state->domain == AF_UNIX)
+        {
+            state->connected = true;
+            write_linux_syscall_result(c, 0);
+            return;
+        }
+
+        linux_sockaddr_in sin{};
+        if (!read_sockaddr_in(c, addr_ptr, addrlen, sin))
+        {
+            write_linux_syscall_result(c, -LINUX_EINVAL);
+            return;
+        }
+
+        auto host_socket = create_host_socket(state->domain, state->type);
+        if (!host_socket)
+        {
+            write_linux_syscall_result(c, -LINUX_EPROTONOSUPPORT);
+            return;
+        }
+
+        host_socket->set_blocking(false);
+        const auto target = make_host_address(c.emu_ref, sin);
+
+        bool connected = false;
+        if (auto* tcp = dynamic_cast<network::tcp_client_socket*>(host_socket.get()))
+        {
+            connected = tcp->connect(target);
+        }
+        else
+        {
+            connected = true;
+        }
+
+        if (!connected)
+        {
+            write_linux_syscall_result(c, map_host_socket_error());
+            return;
+        }
+
+        state->host_socket = std::move(host_socket);
+        state->connected = true;
+        state->peer_port = sin.sin_port;
+        state->peer_addr = sin.sin_addr;
+        state->so_error = 0;
+
+        write_linux_syscall_result(c, 0);
     }
 
     void sys_accept(const linux_syscall_context& c)
@@ -153,30 +243,21 @@ namespace sogen
             return;
         }
 
-        // No actual network — return EAGAIN (non-blocking) or block forever
-        // Return EAGAIN so we don't deadlock
         write_linux_syscall_result(c, -LINUX_EAGAIN);
     }
 
     void sys_accept4(const linux_syscall_context& c)
     {
-        const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-
-        auto* fd_entry = c.proc.fds.get(sockfd);
-        if (!fd_entry || fd_entry->type != fd_type::socket)
-        {
-            write_linux_syscall_result(c, -LINUX_EBADF);
-            return;
-        }
-
-        write_linux_syscall_result(c, -LINUX_EAGAIN);
+        sys_accept(c);
     }
 
     void sys_sendto(const linux_syscall_context& c)
     {
         const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-        // buf is arg 1, len is arg 2, flags is arg 3, dest_addr is arg 4, addrlen is arg 5
+        const auto buf_addr = get_linux_syscall_argument(c.emu, 1);
         const auto len = static_cast<size_t>(get_linux_syscall_argument(c.emu, 2));
+        const auto dest_addr = get_linux_syscall_argument(c.emu, 4);
+        const auto addrlen = static_cast<uint32_t>(get_linux_syscall_argument(c.emu, 5));
 
         auto* fd_entry = c.proc.fds.get(sockfd);
         if (!fd_entry || fd_entry->type != fd_type::socket)
@@ -185,20 +266,66 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end() || !it->second.connected)
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr || !state->host_socket)
         {
             write_linux_syscall_result(c, -LINUX_ENOTCONN);
             return;
         }
 
-        // Pretend we sent everything
-        write_linux_syscall_result(c, static_cast<int64_t>(len));
+        std::vector<std::byte> buffer(len);
+        if (len > 0)
+        {
+            c.emu.read_memory(buf_addr, buffer.data(), len);
+        }
+
+        sent_size sent = -1;
+        if (dest_addr != 0)
+        {
+            linux_sockaddr_in sin{};
+            if (!read_sockaddr_in(c, dest_addr, addrlen, sin))
+            {
+                write_linux_syscall_result(c, -LINUX_EINVAL);
+                return;
+            }
+
+            const auto target = make_host_address(c.emu_ref, sin);
+            if (auto* udp = dynamic_cast<network::udp_socket*>(state->host_socket.get()))
+            {
+                if (!udp->send(target, buffer.data(), buffer.size()))
+                {
+                    write_linux_syscall_result(c, map_host_socket_error());
+                    return;
+                }
+
+                sent = static_cast<sent_size>(len);
+            }
+            else
+            {
+                write_linux_syscall_result(c, -LINUX_EOPNOTSUPP);
+                return;
+            }
+        }
+        else
+        {
+            sent = ::send(state->host_socket->get_socket(), buffer.data(), static_cast<send_size>(buffer.size()), 0);
+            if (sent < 0)
+            {
+                write_linux_syscall_result(c, map_host_socket_error());
+                return;
+            }
+        }
+
+        write_linux_syscall_result(c, sent);
     }
 
     void sys_recvfrom(const linux_syscall_context& c)
     {
         const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
+        const auto buf_addr = get_linux_syscall_argument(c.emu, 1);
+        const auto len = static_cast<size_t>(get_linux_syscall_argument(c.emu, 2));
+        const auto src_addr = get_linux_syscall_argument(c.emu, 4);
+        const auto addrlen_ptr = get_linux_syscall_argument(c.emu, 5);
 
         auto* fd_entry = c.proc.fds.get(sockfd);
         if (!fd_entry || fd_entry->type != fd_type::socket)
@@ -207,35 +334,48 @@ namespace sogen
             return;
         }
 
-        // No data available
-        write_linux_syscall_result(c, -LINUX_EAGAIN);
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr || !state->host_socket)
+        {
+            write_linux_syscall_result(c, -LINUX_ENOTCONN);
+            return;
+        }
+
+        std::vector<std::byte> buffer(len);
+        sent_size received = ::recv(state->host_socket->get_socket(), buffer.data(), static_cast<send_size>(buffer.size()), 0);
+        if (received < 0)
+        {
+            write_linux_syscall_result(c, map_host_socket_error());
+            return;
+        }
+
+        if (received == 0)
+        {
+            state->connected = false;
+            write_linux_syscall_result(c, 0);
+            return;
+        }
+
+        if (len > 0)
+        {
+            c.emu.write_memory(buf_addr, buffer.data(), static_cast<size_t>(received));
+        }
+
+        if (src_addr != 0 && state->domain == AF_INET)
+        {
+            write_sockaddr_in(c.emu, src_addr, addrlen_ptr, state->peer_port, state->peer_addr);
+        }
+
+        write_linux_syscall_result(c, received);
     }
 
     void sys_sendmsg(const linux_syscall_context& c)
     {
-        const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-
-        auto* fd_entry = c.proc.fds.get(sockfd);
-        if (!fd_entry || fd_entry->type != fd_type::socket)
-        {
-            write_linux_syscall_result(c, -LINUX_EBADF);
-            return;
-        }
-
         write_linux_syscall_result(c, -LINUX_ENOTCONN);
     }
 
     void sys_recvmsg(const linux_syscall_context& c)
     {
-        const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-
-        auto* fd_entry = c.proc.fds.get(sockfd);
-        if (!fd_entry || fd_entry->type != fd_type::socket)
-        {
-            write_linux_syscall_result(c, -LINUX_EBADF);
-            return;
-        }
-
         write_linux_syscall_result(c, -LINUX_EAGAIN);
     }
 
@@ -250,11 +390,16 @@ namespace sogen
             return;
         }
 
-        // Clean up socket state
-        auto it = g_socket_states.find(sockfd);
-        if (it != g_socket_states.end())
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state != nullptr)
         {
-            it->second.connected = false;
+            if (state->host_socket)
+            {
+                state->host_socket->close();
+                state->host_socket.reset();
+            }
+
+            state->connected = false;
         }
 
         write_linux_syscall_result(c, 0);
@@ -273,33 +418,26 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end())
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
         }
 
-        // Read the address family
-        uint16_t family{};
-        c.emu.read_memory(addr_ptr, &family, sizeof(family));
-
-        if (family == AF_INET && addrlen >= sizeof(linux_sockaddr_in))
+        linux_sockaddr_in sin{};
+        if (read_sockaddr_in(c, addr_ptr, addrlen, sin))
         {
-            linux_sockaddr_in sin{};
-            c.emu.read_memory(addr_ptr, &sin, sizeof(sin));
-            it->second.bound_port = sin.sin_port;
-            it->second.bound_addr = sin.sin_addr;
+            state->bound_port = sin.sin_port;
+            state->bound_addr = sin.sin_addr;
         }
 
-        // Pretend bind succeeded
         write_linux_syscall_result(c, 0);
     }
 
     void sys_listen(const linux_syscall_context& c)
     {
         const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-        // backlog is arg 1
 
         auto* fd_entry = c.proc.fds.get(sockfd);
         if (!fd_entry || fd_entry->type != fd_type::socket)
@@ -308,10 +446,9 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it != g_socket_states.end())
+        if (auto* state = c.emu_ref.sockets_.get(sockfd))
         {
-            it->second.listening = true;
+            state->listening = true;
         }
 
         write_linux_syscall_result(c, 0);
@@ -332,15 +469,15 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end())
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
         }
 
         int val = 0;
-        if (optval_addr && optlen >= sizeof(int))
+        if (optval_addr != 0 && optlen >= sizeof(int))
         {
             c.emu.read_memory(optval_addr, &val, sizeof(val));
         }
@@ -350,26 +487,25 @@ namespace sogen
             switch (optname)
             {
             case SO_REUSEADDR:
-                it->second.so_reuseaddr = val;
+                state->so_reuseaddr = val;
                 break;
             case SO_REUSEPORT:
-                it->second.so_reuseport = val;
+                state->so_reuseport = val;
                 break;
             case SO_KEEPALIVE:
-                it->second.so_keepalive = val;
+                state->so_keepalive = val;
                 break;
             case SO_SNDBUF:
-                it->second.so_sndbuf = val;
+                state->so_sndbuf = val;
                 break;
             case SO_RCVBUF:
-                it->second.so_rcvbuf = val;
+                state->so_rcvbuf = val;
                 break;
             default:
                 break;
             }
         }
 
-        // Pretend all setsockopt calls succeed
         write_linux_syscall_result(c, 0);
     }
 
@@ -388,8 +524,8 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end())
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
@@ -402,26 +538,26 @@ namespace sogen
             switch (optname)
             {
             case SO_REUSEADDR:
-                val = it->second.so_reuseaddr;
+                val = state->so_reuseaddr;
                 break;
             case SO_REUSEPORT:
-                val = it->second.so_reuseport;
+                val = state->so_reuseport;
                 break;
             case SO_KEEPALIVE:
-                val = it->second.so_keepalive;
+                val = state->so_keepalive;
                 break;
             case SO_SNDBUF:
-                val = it->second.so_sndbuf;
+                val = state->so_sndbuf;
                 break;
             case SO_RCVBUF:
-                val = it->second.so_rcvbuf;
+                val = state->so_rcvbuf;
                 break;
             case SO_TYPE:
-                val = it->second.type;
+                val = state->type;
                 break;
             case SO_ERROR:
-                val = it->second.so_error;
-                it->second.so_error = 0; // Clear after reading
+                val = state->so_error;
+                state->so_error = 0;
                 break;
             default:
                 val = 0;
@@ -429,14 +565,14 @@ namespace sogen
             }
         }
 
-        if (optval_addr)
+        if (optval_addr != 0)
         {
             c.emu.write_memory(optval_addr, &val, sizeof(val));
         }
-        if (optlen_addr)
+        if (optlen_addr != 0)
         {
-            uint32_t len = sizeof(int);
-            c.emu.write_memory(optlen_addr, &len, sizeof(len));
+            uint32_t optlen = sizeof(int);
+            c.emu.write_memory(optlen_addr, &optlen, sizeof(optlen));
         }
 
         write_linux_syscall_result(c, 0);
@@ -458,7 +594,6 @@ namespace sogen
             return;
         }
 
-        // Create two connected socket fds
         linux_fd fd1{};
         fd1.type = fd_type::socket;
         fd1.close_on_exec = cloexec;
@@ -470,21 +605,20 @@ namespace sogen
         const auto fd1_num = c.proc.fds.allocate(std::move(fd1));
         const auto fd2_num = c.proc.fds.allocate(std::move(fd2));
 
-        socket_state ss1{};
+        linux_socket_state ss1{};
         ss1.domain = domain;
         ss1.type = type;
         ss1.protocol = protocol;
         ss1.connected = true;
-        g_socket_states[fd1_num] = ss1;
+        c.emu_ref.sockets_.emplace(fd1_num, std::move(ss1));
 
-        socket_state ss2{};
+        linux_socket_state ss2{};
         ss2.domain = domain;
         ss2.type = type;
         ss2.protocol = protocol;
         ss2.connected = true;
-        g_socket_states[fd2_num] = ss2;
+        c.emu_ref.sockets_.emplace(fd2_num, std::move(ss2));
 
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         int32_t sv[2] = {fd1_num, fd2_num};
         c.emu.write_memory(sv_addr, sv, sizeof(sv));
 
@@ -504,29 +638,20 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end())
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
         }
 
-        if (it->second.domain == AF_INET)
+        if (state->domain == AF_INET)
         {
-            linux_sockaddr_in sin{};
-            sin.sin_family = AF_INET;
-            sin.sin_port = it->second.bound_port;
-            sin.sin_addr = it->second.bound_addr;
-
-            c.emu.write_memory(addr_ptr, &sin, sizeof(sin));
-
-            uint32_t len = sizeof(linux_sockaddr_in);
-            c.emu.write_memory(addrlen_ptr, &len, sizeof(len));
+            write_sockaddr_in(c.emu, addr_ptr, addrlen_ptr, state->bound_port, state->bound_addr);
         }
         else
         {
-            // Return a minimal sockaddr with just the family
-            auto family = static_cast<uint16_t>(it->second.domain);
+            auto family = static_cast<uint16_t>(state->domain);
             c.emu.write_memory(addr_ptr, &family, sizeof(family));
 
             uint32_t len = sizeof(uint16_t);
@@ -539,6 +664,8 @@ namespace sogen
     void sys_getpeername(const linux_syscall_context& c)
     {
         const auto sockfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
+        const auto addr_ptr = get_linux_syscall_argument(c.emu, 1);
+        const auto addrlen_ptr = get_linux_syscall_argument(c.emu, 2);
 
         auto* fd_entry = c.proc.fds.get(sockfd);
         if (!fd_entry || fd_entry->type != fd_type::socket)
@@ -547,32 +674,20 @@ namespace sogen
             return;
         }
 
-        auto it = g_socket_states.find(sockfd);
-        if (it == g_socket_states.end() || !it->second.connected)
+        auto* state = c.emu_ref.sockets_.get(sockfd);
+        if (state == nullptr || !state->connected)
         {
             write_linux_syscall_result(c, -LINUX_ENOTCONN);
             return;
         }
 
-        // Return a synthetic peer address
-        const auto addr_ptr = get_linux_syscall_argument(c.emu, 1);
-        const auto addrlen_ptr = get_linux_syscall_argument(c.emu, 2);
-
-        if (it->second.domain == AF_INET)
+        if (state->domain == AF_INET)
         {
-            linux_sockaddr_in sin{};
-            sin.sin_family = AF_INET;
-            sin.sin_port = 0;
-            sin.sin_addr = 0x7F000001; // 127.0.0.1
-
-            c.emu.write_memory(addr_ptr, &sin, sizeof(sin));
-
-            uint32_t len = sizeof(linux_sockaddr_in);
-            c.emu.write_memory(addrlen_ptr, &len, sizeof(len));
+            write_sockaddr_in(c.emu, addr_ptr, addrlen_ptr, state->peer_port, state->peer_addr);
         }
         else
         {
-            auto family = static_cast<uint16_t>(it->second.domain);
+            auto family = static_cast<uint16_t>(state->domain);
             c.emu.write_memory(addr_ptr, &family, sizeof(family));
 
             uint32_t len = sizeof(uint16_t);

--- a/src/python-bindings/CMakeLists.txt
+++ b/src/python-bindings/CMakeLists.txt
@@ -17,7 +17,7 @@ if(SOGEN_DISABLE_NANOBIND_LEAK_WARNINGS)
   target_compile_definitions(sogen PRIVATE SOGEN_DISABLE_NANOBIND_LEAK_WARNINGS=1)
 endif()
 
-target_link_libraries(sogen PRIVATE windows-emulator disassembler backend-selection)
+target_link_libraries(sogen PRIVATE windows-emulator linux-emulator disassembler backend-selection)
 
 target_compile_features(sogen PRIVATE cxx_std_20)
 if(MSVC)

--- a/src/python-bindings/sogen_bindings.hpp
+++ b/src/python-bindings/sogen_bindings.hpp
@@ -73,5 +73,6 @@ namespace sogen::py
 
     void register_types_bindings(nb::module_& m);
     void register_windows_runtime_bindings(nb::module_& m);
+    void register_linux_runtime_bindings(nb::module_& m);
     void register_runtime_bindings(nb::module_& m);
 }

--- a/src/python-bindings/sogen_linux_bindings.cpp
+++ b/src/python-bindings/sogen_linux_bindings.cpp
@@ -1,0 +1,164 @@
+#include "sogen_linux_internal.hpp"
+
+namespace sogen::py
+{
+    namespace
+    {
+        template <auto Member>
+        void bind_linux_callback_property(nb::class_<linux_callback_registry>& c, const char* name, const char* slot_name)
+        {
+            c.def_prop_rw(
+                name, [](linux_callback_registry& self) { return self.*Member; },
+                [slot_name](linux_callback_registry& self, nb::object callback) { self.set(slot_name, std::move(callback)); },
+                nb::arg("callback").none());
+        }
+    }
+
+    void register_linux_runtime_bindings(nb::module_& m)
+    {
+        nb::enum_<linux_syscall_continuation>(m, "SyscallContinuation")
+            .value("run_handler", linux_syscall_continuation::run_handler)
+            .value("skip_handler", linux_syscall_continuation::skip_handler)
+            .value("stop", linux_syscall_continuation::stop)
+            .export_values();
+
+        nb::class_<linux_syscall_info>(m, "SyscallInfo")
+            .def_prop_ro("number", [](const linux_syscall_info& self) { return self.number; })
+            .def_prop_ro("name", [](const linux_syscall_info& self) { return std::string(self.name); })
+            .def_prop_ro("args", [](const linux_syscall_info& self) {
+                std::vector<uint64_t> args(self.args.begin(), self.args.end());
+                return args;
+            })
+            .def("arg", &linux_syscall_info::arg, nb::arg("index"))
+            .def("read_c_string", &linux_syscall_info::read_c_string, nb::arg("index"), nb::arg("max_len") = 4096);
+
+        nb::class_<linux_exported_symbol>(m, "ExportedSymbol")
+            .def_prop_ro("name", [](const linux_exported_symbol& self) { return self.name; })
+            .def_prop_ro("rva", [](const linux_exported_symbol& self) { return self.rva; })
+            .def_prop_ro("address", [](const linux_exported_symbol& self) { return self.address; });
+
+        nb::class_<linux_mapped_section>(m, "MappedSection")
+            .def_prop_ro("name", [](const linux_mapped_section& self) { return self.name; })
+            .def_prop_ro("start", [](const linux_mapped_section& self) { return self.start; })
+            .def_prop_ro("length", [](const linux_mapped_section& self) { return self.length; })
+            .def_prop_ro("permissions", [](const linux_mapped_section& self) { return self.permissions; });
+
+        nb::class_<linux_mapped_module>(m, "MappedModule")
+            .def_prop_ro("name", [](const linux_mapped_module& self) { return self.name; })
+            .def_prop_ro("path", [](const linux_mapped_module& self) { return self.path; })
+            .def_prop_ro("image_base", [](const linux_mapped_module& self) { return self.image_base; })
+            .def_prop_ro("size_of_image", [](const linux_mapped_module& self) { return self.size_of_image; })
+            .def_prop_ro("entry_point", [](const linux_mapped_module& self) { return self.entry_point; })
+            .def_prop_ro("exports", [](const linux_mapped_module& self) { return self.exports; })
+            .def_prop_ro("needed_libraries", [](const linux_mapped_module& self) { return self.needed_libraries; })
+            .def_prop_ro("sections", [](const linux_mapped_module& self) { return self.sections; });
+
+        nb::class_<linux_hook_handle>(m, "Hook")
+            .def("remove", &linux_hook_handle::remove)
+            .def_prop_ro("active", &linux_hook_handle::active);
+
+        nb::class_<linux_syscall_hook_registry>(m, "SyscallHooks")
+            .def("__setitem__", &linux_syscall_hook_registry::set_item)
+            .def("__delitem__", &linux_syscall_hook_registry::del_item)
+            .def("clear", &linux_syscall_hook_registry::clear);
+
+        nb::class_<linux_hook_registry>(m, "Hooks")
+            .def("memory_execution", &linux_hook_registry::memory_execution)
+            .def("memory_execution_at", &linux_hook_registry::memory_execution_at)
+            .def("memory_read", &linux_hook_registry::memory_read)
+            .def("memory_write", &linux_hook_registry::memory_write)
+            .def("instruction", &linux_hook_registry::instruction)
+            .def("interrupt", &linux_hook_registry::interrupt)
+            .def("memory_violation", &linux_hook_registry::memory_violation)
+            .def("basic_block", &linux_hook_registry::basic_block)
+            .def_prop_ro("syscalls", [](linux_hook_registry& self) -> linux_syscall_hook_registry& { return *self.syscalls; },
+                         nb::rv_policy::reference_internal);
+
+        nb::class_<linux_memory_manager>(m, "MemoryManager")
+            .def("read_memory",
+                 [](const linux_memory_manager& self, uint64_t address, size_t size) { return read_memory_bytes(self, address, size); })
+            .def("write_memory",
+                 [](linux_memory_manager& self, uint64_t address, const nb::bytes& buffer) { write_memory_bytes(self, address, buffer); })
+            .def(
+                "allocate_memory",
+                [](linux_memory_manager& self, size_t size, memory_permission permissions, uint64_t start) {
+                    return self.allocate_memory(size, permissions, start);
+                },
+                nb::arg("size"), nb::arg("permissions"), nb::arg("start") = 0)
+            .def("protect_memory", &linux_memory_manager::protect_memory)
+            .def("release_memory", &linux_memory_manager::release_memory)
+            .def("find_free_allocation_base",
+                 static_cast<uint64_t (linux_memory_manager::*)(size_t, uint64_t) const>(&linux_memory_manager::find_free_allocation_base))
+            .def_prop_rw("mmap_base", &linux_memory_manager::get_mmap_base, &linux_memory_manager::set_mmap_base);
+
+        nb::class_<linux_thread>(m, "Thread")
+            .def_prop_ro("id", [](const linux_thread& self) { return self.tid; })
+            .def_prop_ro("stack_base", [](const linux_thread& self) { return self.stack_base; })
+            .def_prop_ro("stack_size", [](const linux_thread& self) { return self.stack_size; })
+            .def_prop_ro("executed_instructions", [](const linux_thread& self) { return self.executed_instructions; });
+
+        auto callbacks_class = nb::class_<linux_callback_registry>(m, "Callbacks");
+        bind_linux_callback_property<&linux_callback_registry::stdout_cb>(callbacks_class, "on_stdout", "stdout");
+        bind_linux_callback_property<&linux_callback_registry::stderr_cb>(callbacks_class, "on_stderr", "stderr");
+        bind_linux_callback_property<&linux_callback_registry::syscall_cb>(callbacks_class, "on_syscall", "syscall");
+        bind_linux_callback_property<&linux_callback_registry::module_load_cb>(callbacks_class, "on_module_load", "module_load");
+        bind_linux_callback_property<&linux_callback_registry::instruction_cb>(callbacks_class, "on_instruction", "instruction");
+        bind_linux_callback_property<&linux_callback_registry::memory_violate_cb>(callbacks_class, "on_memory_violate", "memory_violate");
+
+        nb::class_<sogen_linux_process_context>(m, "ProcessContext")
+            .def_prop_ro("exit_status",
+                         [](const sogen_linux_process_context& self) -> nb::object {
+                             if (!self.exit_status().has_value())
+                             {
+                                 return nb::none();
+                             }
+
+                             return nb::int_(*self.exit_status());
+                         })
+            .def_prop_ro("pid", &sogen_linux_process_context::pid)
+            .def_prop_ro("active_thread", &sogen_linux_process_context::active_thread, nb::rv_policy::reference_internal);
+
+        nb::class_<sogen_linux_emulator>(m, "Emulator")
+            .def("start", &sogen_linux_emulator::start, nb::arg("count") = 0, nb::call_guard<nb::gil_scoped_release>())
+            .def("stop", &sogen_linux_emulator::stop)
+            .def_prop_ro("executed_instructions",
+                         [](const sogen_linux_emulator& self) { return self.native().get_executed_instructions(); })
+            .def_prop_ro("backend_name", [](const sogen_linux_emulator& self) { return self.native().emu().get_name(); })
+            .def_prop_ro("emulation_root", [](const sogen_linux_emulator& self) { return self.native().emulation_root; })
+            .def_prop_ro("process", &sogen_linux_emulator::process, nb::rv_policy::reference_internal)
+            .def_prop_ro("memory", &sogen_linux_emulator::memory, nb::rv_policy::reference_internal)
+            .def_prop_ro("current_thread", &sogen_linux_emulator::current_thread, nb::rv_policy::reference_internal)
+            .def_prop_ro("current_thread_id",
+                         [](const sogen_linux_emulator& self) -> nb::object {
+                             const auto id = self.current_thread_id();
+                             if (!id.has_value())
+                             {
+                                 return nb::none();
+                             }
+
+                             return nb::int_(*id);
+                         })
+            .def_prop_ro(
+                "callbacks", [](sogen_linux_emulator& self) -> linux_callback_registry& { return *self.callbacks; },
+                nb::rv_policy::reference_internal)
+            .def_prop_ro(
+                "hooks", [](sogen_linux_emulator& self) -> linux_hook_registry& { return *self.hooks; }, nb::rv_policy::reference_internal)
+            .def("read_memory", &sogen_linux_emulator::read_memory)
+            .def("write_memory", &sogen_linux_emulator::write_memory)
+            .def("read_register", &sogen_linux_emulator::read_register)
+            .def("write_register", &sogen_linux_emulator::write_register)
+            .def("get_host_port", &sogen_linux_emulator::get_host_port)
+            .def("get_emulator_port", &sogen_linux_emulator::get_emulator_port)
+            .def("map_port", &sogen_linux_emulator::map_port);
+
+        nb::setattr(m, "LinuxEmulator", m.attr("Emulator"));
+
+        m.def("create_application", [](nb::object application, nb::kwargs kwargs) { // NOLINT(performance-unnecessary-value-param)
+            return sogen_linux_emulator(create_linux_application_emulator(application, nb::none(), kwargs));
+        });
+        m.def("create_application",
+              [](nb::object application, nb::object application_args, nb::kwargs kwargs) { // NOLINT(performance-unnecessary-value-param)
+                  return sogen_linux_emulator(create_linux_application_emulator(application, application_args, kwargs));
+              });
+    }
+}

--- a/src/python-bindings/sogen_linux_callbacks.cpp
+++ b/src/python-bindings/sogen_linux_callbacks.cpp
@@ -1,0 +1,110 @@
+#include "sogen_linux_internal.hpp"
+
+namespace sogen::py
+{
+    namespace
+    {
+        template <typename... Args>
+        void invoke_callback(const nb::object& cb, Args&&... args)
+        {
+            if (cb.is_none())
+            {
+                return;
+            }
+
+            nb::gil_scoped_acquire gil{};
+            cb(std::forward<Args>(args)...);
+        }
+
+        struct linux_callback_slot
+        {
+            std::string_view name;
+            nb::object linux_callback_registry::* member;
+        };
+
+        constexpr std::array linux_callback_slots{
+            linux_callback_slot{.name = "stdout", .member = &linux_callback_registry::stdout_cb},
+            linux_callback_slot{.name = "stderr", .member = &linux_callback_registry::stderr_cb},
+            linux_callback_slot{.name = "syscall", .member = &linux_callback_registry::syscall_cb},
+            linux_callback_slot{.name = "module_load", .member = &linux_callback_registry::module_load_cb},
+            linux_callback_slot{.name = "instruction", .member = &linux_callback_registry::instruction_cb},
+            linux_callback_slot{.name = "memory_violate", .member = &linux_callback_registry::memory_violate_cb},
+        };
+    }
+
+    nb::object linux_callback_registry::* linux_callback_registry::slot_for(const std::string_view name)
+    {
+        const auto key = name.starts_with("on_") ? name.substr(3) : name;
+        for (const auto& slot : linux_callback_slots)
+        {
+            if (slot.name == key)
+            {
+                return slot.member;
+            }
+        }
+
+        return nullptr;
+    }
+
+    linux_callback_registry::linux_callback_registry(linux_emulator& emulator, std::shared_ptr<linux_syscall_hook_registry> syscall_hooks)
+        : emu(&emulator),
+          syscall_hooks(std::move(syscall_hooks))
+    {
+        this->emu->callbacks.on_stdout = [this](const std::string_view data) { invoke_callback(this->stdout_cb, std::string(data)); };
+        this->emu->callbacks.on_stderr = [this](const std::string_view data) { invoke_callback(this->stderr_cb, std::string(data)); };
+
+        this->emu->callbacks.on_syscall = [this](const linux_syscall_info& info) {
+            if (this->syscall_hooks)
+            {
+                const auto named = this->syscall_hooks->invoke(info);
+                if (named != linux_syscall_hook_continuation::run_handler)
+                {
+                    return named;
+                }
+            }
+
+            if (this->syscall_cb.is_none())
+            {
+                return linux_syscall_hook_continuation::run_handler;
+            }
+
+            nb::gil_scoped_acquire gil{};
+            return coerce_linux_syscall_continuation(this->syscall_cb(nb::cast(info)));
+        };
+
+        this->emu->callbacks.on_module_load.add([this](const linux_mapped_module& module) { invoke_callback(this->module_load_cb, module); });
+        this->emu->callbacks.on_instruction = [this](const uint64_t address) { invoke_callback(this->instruction_cb, address); };
+
+        this->emu->callbacks.on_memory_violate = [this](const uint64_t address, const size_t size, const memory_operation operation,
+                                                        const memory_violation_type type) {
+            if (this->memory_violate_cb.is_none())
+            {
+                return memory_violation_continuation::resume;
+            }
+
+            nb::gil_scoped_acquire gil{};
+            return coerce_memory_violation_continuation(this->memory_violate_cb(address, size, operation, type));
+        };
+    }
+
+    void linux_callback_registry::set(const std::string_view name, nb::object callable)
+    {
+        const auto member = slot_for(name);
+        if (member == nullptr)
+        {
+            throw std::invalid_argument(std::string("Unknown callback: ") + std::string(name));
+        }
+
+        if (!callable.is_none() && !PyCallable_Check(callable.ptr()))
+        {
+            throw std::invalid_argument(std::string("Callback must be callable: ") + std::string(name));
+        }
+
+        this->*member = std::move(callable);
+    }
+
+    void linux_callback_registry::clear(const std::string_view name)
+    {
+        set(name, nb::none());
+    }
+}

--- a/src/python-bindings/sogen_linux_helpers.cpp
+++ b/src/python-bindings/sogen_linux_helpers.cpp
@@ -1,0 +1,191 @@
+#include "sogen_linux_internal.hpp"
+
+namespace sogen::py
+{
+    linux_syscall_hook_continuation coerce_linux_syscall_continuation(nb::handle result)
+    {
+        if (result.is_none())
+        {
+            return linux_syscall_hook_continuation::run_handler;
+        }
+
+        if (nb::isinstance<nb::bool_>(result))
+        {
+            return nb::cast<bool>(result) ? linux_syscall_hook_continuation::skip_handler
+                                          : linux_syscall_hook_continuation::run_handler;
+        }
+
+        if (nb::isinstance<linux_syscall_continuation>(result))
+        {
+            switch (nb::cast<linux_syscall_continuation>(result))
+            {
+            case linux_syscall_continuation::run_handler:
+                return linux_syscall_hook_continuation::run_handler;
+            case linux_syscall_continuation::skip_handler:
+                return linux_syscall_hook_continuation::skip_handler;
+            case linux_syscall_continuation::stop:
+                return linux_syscall_hook_continuation::stop;
+            }
+        }
+
+        return nb::cast<linux_syscall_hook_continuation>(result);
+    }
+
+    namespace
+    {
+        template <typename T>
+        T get_kwarg(const nb::kwargs& kwargs, const char* name, T default_value)
+        {
+            if (!kwargs.contains(name))
+            {
+                return default_value;
+            }
+
+            return nb::cast<T>(kwargs[name]);
+        }
+
+        std::vector<std::string> parse_string_arguments(const nb::object& object)
+        {
+            std::vector<std::string> result{};
+            if (object.is_none())
+            {
+                return result;
+            }
+
+            const auto seq = nb::cast<nb::sequence>(object);
+            result.reserve(static_cast<size_t>(nb::len(seq)));
+            for (const auto& item : seq)
+            {
+                result.emplace_back(nb::cast<std::string>(item));
+            }
+
+            return result;
+        }
+
+        std::vector<std::string> parse_environment(const nb::object& object)
+        {
+            std::vector<std::string> result{};
+            if (object.is_none())
+            {
+                result.emplace_back("PATH=/usr/bin:/bin");
+                result.emplace_back("HOME=/root");
+                result.emplace_back("TERM=xterm");
+                return result;
+            }
+
+            const auto dict = nb::cast<nb::dict>(object);
+            for (const auto& item : dict)
+            {
+                const auto key = nb::cast<std::string>(item.first);
+                const auto value = nb::cast<std::string>(item.second);
+                result.emplace_back(key + "=" + value);
+            }
+
+            return result;
+        }
+
+        std::vector<std::string> build_argv(const std::filesystem::path& executable, const std::vector<std::string>& args)
+        {
+            if (!args.empty())
+            {
+                return args;
+            }
+
+            return {executable.filename().string()};
+        }
+
+        backend_type get_backend_type(const nb::kwargs& kwargs)
+        {
+            return get_kwarg<backend_type>(kwargs, "backend", backend_type::unicorn);
+        }
+
+        std::unordered_map<std::string, std::filesystem::path> parse_path_mappings(const nb::object& object)
+        {
+            std::unordered_map<std::string, std::filesystem::path> result{};
+            if (object.is_none())
+            {
+                return result;
+            }
+
+            const auto dict = nb::cast<nb::dict>(object);
+            for (const auto& item : dict)
+            {
+                result.emplace(nb::cast<std::string>(item.first), nb::cast<std::filesystem::path>(item.second));
+            }
+
+            return result;
+        }
+
+        std::unordered_map<uint16_t, uint16_t> parse_port_mappings(const nb::object& object)
+        {
+            std::unordered_map<uint16_t, uint16_t> result{};
+            if (object.is_none())
+            {
+                return result;
+            }
+
+            const auto dict = nb::cast<nb::dict>(object);
+            for (const auto& item : dict)
+            {
+                result.emplace(nb::cast<uint16_t>(item.first), nb::cast<uint16_t>(item.second));
+            }
+
+            return result;
+        }
+    }
+
+    std::unique_ptr<linux_emulator> create_linux_application_emulator(const nb::object& application, const nb::object& args,
+                                                                      const nb::kwargs& kwargs)
+    {
+        const auto executable = nb::cast<std::filesystem::path>(application);
+        auto argv = build_argv(executable, parse_string_arguments(args));
+        auto envp = parse_environment(kwargs.contains("env") ? kwargs["env"] : nb::none());
+        const auto emulation_root = get_kwarg<std::filesystem::path>(kwargs, "emulation_root", {});
+
+        auto linux_emu = std::make_unique<linux_emulator>(create_x86_64_emulator(get_backend_type(kwargs)), emulation_root, executable,
+                                                          std::move(argv), std::move(envp));
+
+        const auto disable_logging = get_kwarg<bool>(kwargs, "disable_logging", false);
+        const auto verbose = get_kwarg<bool>(kwargs, "verbose", true);
+        if (disable_logging || !verbose)
+        {
+            linux_emu->log.disable_output(true);
+        }
+
+        if (kwargs.contains("library_paths"))
+        {
+            const auto seq = nb::cast<nb::sequence>(kwargs["library_paths"]);
+            for (const auto& item : seq)
+            {
+                linux_emu->mod_manager.add_library_path(nb::cast<std::filesystem::path>(item));
+            }
+        }
+
+        if (kwargs.contains("passthrough_prefixes"))
+        {
+            const auto seq = nb::cast<nb::sequence>(kwargs["passthrough_prefixes"]);
+            for (const auto& item : seq)
+            {
+                linux_emu->file_sys.add_passthrough_prefix(nb::cast<std::filesystem::path>(item));
+            }
+        }
+
+        if (kwargs.contains("path_mappings"))
+        {
+            for (const auto& [guest, host] : parse_path_mappings(kwargs["path_mappings"]))
+            {
+                linux_emu->file_sys.map(guest, host);
+            }
+        }
+
+        if (kwargs.contains("port_mappings"))
+        {
+            for (const auto& [emulator_port, host_port] : parse_port_mappings(kwargs["port_mappings"]))
+            {
+                linux_emu->map_port(emulator_port, host_port);
+            }
+        }
+
+        return linux_emu;
+    }
+}

--- a/src/python-bindings/sogen_linux_hooks.cpp
+++ b/src/python-bindings/sogen_linux_hooks.cpp
@@ -1,0 +1,215 @@
+#include "sogen_linux_internal.hpp"
+
+namespace sogen::py
+{
+    linux_hook_handle::linux_hook_handle(linux_emulator& emulator, emulator_hook* hook, nb::object owner)
+        : emu(&emulator),
+          hook(hook),
+          owner(std::move(owner))
+    {
+    }
+
+    linux_hook_handle::~linux_hook_handle()
+    {
+        this->remove();
+    }
+
+    linux_hook_handle::linux_hook_handle(linux_hook_handle&& other) noexcept
+        : emu(other.emu),
+          hook(other.hook),
+          owner(std::move(other.owner))
+    {
+        other.hook = nullptr;
+    }
+
+    linux_hook_handle& linux_hook_handle::operator=(linux_hook_handle&& other) noexcept
+    {
+        if (this != &other)
+        {
+            this->remove();
+            this->emu = other.emu;
+            this->hook = other.hook;
+            this->owner = std::move(other.owner);
+            other.hook = nullptr;
+        }
+
+        return *this;
+    }
+
+    void linux_hook_handle::remove()
+    {
+        if (!this->emu || !this->hook)
+        {
+            return;
+        }
+
+        try
+        {
+            this->emu->emu().delete_hook(this->hook);
+        }
+        catch (...)
+        {
+        }
+
+        this->hook = nullptr;
+    }
+
+    linux_syscall_hook_registry::linux_syscall_hook_registry(linux_emulator& emulator)
+        : emu(&emulator)
+    {
+    }
+
+    void linux_syscall_hook_registry::clear()
+    {
+        this->entries.clear();
+    }
+
+    void linux_syscall_hook_registry::del_item(const std::string& key)
+    {
+        this->entries.erase(key);
+    }
+
+    void linux_syscall_hook_registry::set_item(const std::string& key, nb::object callback)
+    {
+        if (callback.is_none())
+        {
+            this->entries.erase(key);
+            return;
+        }
+
+        if (!callback.is_none() && !PyCallable_Check(callback.ptr()))
+        {
+            throw std::invalid_argument("Syscall hook callback must be callable");
+        }
+
+        this->entries[key] = std::move(callback);
+    }
+
+    linux_syscall_hook_continuation linux_syscall_hook_registry::invoke(const linux_syscall_info& info) const
+    {
+        const auto it = this->entries.find(std::string{info.name});
+        if (it == this->entries.end() || it->second.is_none())
+        {
+            return linux_syscall_hook_continuation::run_handler;
+        }
+
+        nb::gil_scoped_acquire gil{};
+        return coerce_linux_syscall_continuation(it->second(nb::cast(info)));
+    }
+
+    linux_hook_registry::linux_hook_registry(linux_emulator& emulator)
+        : emu(&emulator),
+          syscalls(std::make_shared<linux_syscall_hook_registry>(emulator))
+    {
+    }
+
+    linux_hook_handle linux_hook_registry::make_hook(emulator_hook* hook)
+    {
+        return {*this->emu, hook, nb::cast(this, nb::rv_policy::reference_internal)};
+    }
+
+    linux_hook_handle linux_hook_registry::memory_execution(nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_memory_execution([cb = std::move(callback)](const uint64_t address) {
+            nb::gil_scoped_acquire gil{};
+            cb(address);
+        });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::memory_execution_at(const uint64_t address, nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_memory_execution(address, [cb = std::move(callback)](const uint64_t addr) {
+            nb::gil_scoped_acquire gil{};
+            cb(addr);
+        });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::memory_read(const uint64_t address, const uint64_t size, nb::object callback)
+    {
+        auto* hook =
+            this->emu->emu().hook_memory_read(address, size, [cb = std::move(callback)](const uint64_t addr, const void* data, size_t length) {
+                nb::gil_scoped_acquire gil{};
+                cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
+            });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::memory_write(const uint64_t address, const uint64_t size, nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_memory_write(address, size,
+                                                          [cb = std::move(callback)](const uint64_t addr, const void* data, size_t length) {
+                                                              nb::gil_scoped_acquire gil{};
+                                                              cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
+                                                          });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::instruction(const int instruction_type, nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_instruction(static_cast<x86_hookable_instructions>(instruction_type),
+                                                       [cb = std::move(callback)](const uint64_t data) {
+                                                           nb::gil_scoped_acquire gil{};
+                                                           return coerce_instruction_continuation(cb(data));
+                                                       });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::interrupt(nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_interrupt([cb = std::move(callback)](const int interrupt) {
+            nb::gil_scoped_acquire gil{};
+            cb(interrupt);
+        });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::memory_violation(nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_memory_violation(
+            [cb = std::move(callback)](const uint64_t address, const size_t size, const memory_operation operation,
+                                       const memory_violation_type type) {
+                nb::gil_scoped_acquire gil{};
+                return coerce_memory_violation_continuation(cb(address, size, operation, type));
+            });
+        return make_hook(hook);
+    }
+
+    linux_hook_handle linux_hook_registry::basic_block(nb::object callback)
+    {
+        auto* hook = this->emu->emu().hook_basic_block([cb = std::move(callback)](const sogen::basic_block& block) {
+            nb::gil_scoped_acquire gil{};
+            cb(block);
+        });
+        return make_hook(hook);
+    }
+
+    sogen_linux_emulator::sogen_linux_emulator(std::unique_ptr<linux_emulator> emulator)
+        : emu(std::move(emulator)),
+          hooks(std::make_shared<linux_hook_registry>(*this->emu)),
+          callbacks(std::make_shared<linux_callback_registry>(*this->emu, this->hooks->syscalls))
+    {
+    }
+
+    sogen_linux_process_context sogen_linux_emulator::process() const
+    {
+        return {this->emu->process, nb::cast(this, nb::rv_policy::reference_internal)};
+    }
+
+    std::optional<uint32_t> sogen_linux_emulator::current_thread_id() const
+    {
+        if (this->emu->process.active_thread == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        return this->emu->process.active_thread->tid;
+    }
+
+    sogen_linux_process_context::sogen_linux_process_context(linux_process_context& context, nb::object owner)
+        : ctx(&context),
+          owner(std::move(owner))
+    {
+    }
+}

--- a/src/python-bindings/sogen_linux_internal.hpp
+++ b/src/python-bindings/sogen_linux_internal.hpp
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/string_view.h>
+#include <nanobind/stl/vector.h>
+
+#include <backend_selection.hpp>
+#include <disassembler.hpp>
+#include <hook_interface.hpp>
+#include <linux_emulator.hpp>
+#include <linux_emulator_callbacks.hpp>
+#include <linux_syscall_info.hpp>
+#include <x86_register.hpp>
+
+namespace nb = nanobind;
+
+namespace sogen::py
+{
+    using sogen::backend_type;
+    using sogen::basic_block;
+    using sogen::emulator_hook;
+    using sogen::instruction_hook_continuation;
+    using sogen::linux_emulator;
+    using sogen::linux_exported_symbol;
+    using sogen::linux_mapped_module;
+    using sogen::linux_mapped_section;
+    using sogen::linux_memory_manager;
+    using sogen::linux_process_context;
+    using sogen::linux_syscall_hook_continuation;
+    using sogen::linux_syscall_info;
+    using sogen::linux_thread;
+    using sogen::memory_interface;
+    using sogen::memory_operation;
+    using sogen::memory_permission;
+    using sogen::memory_violation_continuation;
+    using sogen::memory_violation_type;
+    using sogen::x86_hookable_instructions;
+    using sogen::x86_register;
+
+    enum class linux_syscall_continuation
+    {
+        run_handler,
+        skip_handler,
+        stop,
+    };
+
+    struct linux_hook_handle
+    {
+        linux_emulator* emu{};
+        emulator_hook* hook{};
+        nb::object owner = nb::none();
+
+        linux_hook_handle() = default;
+        linux_hook_handle(linux_emulator& emulator, emulator_hook* hook, nb::object owner);
+        ~linux_hook_handle();
+
+        linux_hook_handle(const linux_hook_handle&) = delete;
+        linux_hook_handle& operator=(const linux_hook_handle&) = delete;
+        linux_hook_handle(linux_hook_handle&& other) noexcept;
+        linux_hook_handle& operator=(linux_hook_handle&& other) noexcept;
+
+        bool active() const
+        {
+            return this->hook != nullptr;
+        }
+        void remove();
+    };
+
+    struct linux_syscall_hook_registry
+    {
+        linux_emulator* emu{};
+        std::map<std::string, nb::object, std::less<>> entries{};
+
+        explicit linux_syscall_hook_registry(linux_emulator& emulator);
+
+        void clear();
+        void del_item(const std::string& key);
+        void set_item(const std::string& key, nb::object callback);
+
+        linux_syscall_hook_continuation invoke(const linux_syscall_info& info) const;
+    };
+
+    struct linux_hook_registry
+    {
+        linux_emulator* emu{};
+        std::shared_ptr<linux_syscall_hook_registry> syscalls{};
+
+        explicit linux_hook_registry(linux_emulator& emulator);
+
+        linux_hook_handle make_hook(emulator_hook* hook);
+
+        linux_hook_handle memory_execution(nb::object callback);
+        linux_hook_handle memory_execution_at(uint64_t address, nb::object callback);
+        linux_hook_handle memory_read(uint64_t address, uint64_t size, nb::object callback);
+        linux_hook_handle memory_write(uint64_t address, uint64_t size, nb::object callback);
+        linux_hook_handle instruction(int instruction_type, nb::object callback);
+        linux_hook_handle interrupt(nb::object callback);
+        linux_hook_handle memory_violation(nb::object callback);
+        linux_hook_handle basic_block(nb::object callback);
+    };
+
+    struct linux_callback_registry
+    {
+        linux_emulator* emu{};
+        std::shared_ptr<linux_syscall_hook_registry> syscall_hooks{};
+
+        nb::object stdout_cb = nb::none();
+        nb::object stderr_cb = nb::none();
+        nb::object syscall_cb = nb::none();
+        nb::object module_load_cb = nb::none();
+        nb::object instruction_cb = nb::none();
+        nb::object memory_violate_cb = nb::none();
+
+        explicit linux_callback_registry(linux_emulator& emulator, std::shared_ptr<linux_syscall_hook_registry> syscall_hooks);
+
+        void set(std::string_view name, nb::object callable);
+        void clear(std::string_view name);
+
+        static nb::object linux_callback_registry::* slot_for(std::string_view name);
+    };
+
+    nb::bytes read_memory_bytes(const memory_interface& memory, uint64_t address, size_t size);
+    void write_memory_bytes(memory_interface& memory, uint64_t address, const nb::bytes& buffer);
+    instruction_hook_continuation coerce_instruction_continuation(nb::handle result);
+    memory_violation_continuation coerce_memory_violation_continuation(nb::handle result);
+    linux_syscall_hook_continuation coerce_linux_syscall_continuation(nb::handle result);
+    std::unique_ptr<linux_emulator> create_linux_application_emulator(const nb::object& application, const nb::object& args,
+                                                                      const nb::kwargs& kwargs);
+
+    struct sogen_linux_process_context
+    {
+        linux_process_context* ctx{};
+        nb::object owner = nb::none();
+
+        sogen_linux_process_context(linux_process_context& context, nb::object owner);
+
+        std::optional<int> exit_status() const
+        {
+            return this->ctx->exit_status;
+        }
+        uint32_t pid() const
+        {
+            return this->ctx->pid;
+        }
+        linux_thread* active_thread() const
+        {
+            return this->ctx->active_thread;
+        }
+    };
+
+    struct sogen_linux_emulator
+    {
+        std::unique_ptr<linux_emulator> emu{};
+        std::shared_ptr<linux_hook_registry> hooks{};
+        std::shared_ptr<linux_callback_registry> callbacks{};
+
+        explicit sogen_linux_emulator(std::unique_ptr<linux_emulator> emulator);
+
+        linux_emulator& native() const
+        {
+            return *this->emu;
+        }
+
+        void start(size_t count = 0) const
+        {
+            this->emu->start(count);
+        }
+        void stop() const
+        {
+            this->emu->stop();
+        }
+
+        sogen_linux_process_context process() const;
+
+        linux_memory_manager& memory() const
+        {
+            return this->emu->memory;
+        }
+        linux_thread* current_thread() const
+        {
+            return this->emu->process.active_thread;
+        }
+        std::optional<uint32_t> current_thread_id() const;
+
+        nb::bytes read_memory(uint64_t address, size_t size) const
+        {
+            return read_memory_bytes(this->emu->memory, address, size);
+        }
+        void write_memory(uint64_t address, const nb::bytes& buffer) const
+        {
+            write_memory_bytes(this->emu->memory, address, buffer);
+        }
+        uint64_t read_register(x86_register reg) const
+        {
+            return this->emu->emu().reg<uint64_t>(reg);
+        }
+        void write_register(x86_register reg, uint64_t value) const
+        {
+            this->emu->emu().reg<uint64_t>(reg, value);
+        }
+
+        uint16_t get_host_port(uint16_t emulator_port) const
+        {
+            return this->emu->get_host_port(emulator_port);
+        }
+        uint16_t get_emulator_port(uint16_t host_port) const
+        {
+            return this->emu->get_emulator_port(host_port);
+        }
+        void map_port(uint16_t emulator_port, uint16_t host_port) const
+        {
+            this->emu->map_port(emulator_port, host_port);
+        }
+    };
+
+    void register_linux_runtime_bindings(nb::module_& m);
+}

--- a/src/python-bindings/sogen_module.cpp
+++ b/src/python-bindings/sogen_module.cpp
@@ -15,6 +15,10 @@ namespace sogen::py
 
             auto windows = m.def_submodule("windows", "Windows emulator bindings");
             register_windows_runtime_bindings(windows);
+
+            auto linux_mod = m.def_submodule("linux", "Linux emulator bindings");
+            register_linux_runtime_bindings(linux_mod);
+
             register_runtime_bindings(m);
         }
     }


### PR DESCRIPTION
Expose Linux emulation through a Python API mirroring sogen.windows patterns, including guest path mappings, host port proxying, and rich SyscallInfo callbacks.