### PR TITLE
Implement syscalls for DX9/DX11 initialization

### DIFF
--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+// NOLINTBEGIN(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
+
 namespace sogen
 {
 
@@ -381,11 +384,11 @@ namespace sogen
 
     struct EMU_D3DKMT_OPENADAPTERFROMHDC
     {
-        HDC hDc;
+        UINT64 hDc;
         UINT32 hAdapter;
         LUID AdapterLuid;
         UINT VidPnSourceId;
     };
-
-    // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
 } // namespace sogen
+
+// NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)

--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -1,0 +1,268 @@
+#pragma once
+namespace sogen
+{
+
+    struct GDI_HANDLE_ENTRY64
+    {
+        union
+        {
+            EmulatorTraits<Emu64>::PVOID Object;
+            EmulatorTraits<Emu64>::PVOID NextFree;
+        };
+
+        union
+        {
+            struct
+            {
+                USHORT ProcessId;
+                USHORT Lock : 1;
+                USHORT Count : 15;
+            };
+
+            ULONG Value;
+        } Owner;
+
+        USHORT Unique;
+        UCHAR Type;
+        UCHAR Flags;
+        EmulatorTraits<Emu64>::PVOID UserPointer;
+    };
+
+    struct GDI_HANDLE_ENTRY32
+    {
+        uint32_t Object;
+        uint32_t OwnerValue;
+        USHORT Unique;
+        UCHAR Type;
+        UCHAR Flags;
+        uint32_t UserPointer;
+    };
+    static_assert(sizeof(GDI_HANDLE_ENTRY32) == 0x10);
+
+    #define GDI_MAX_HANDLE_COUNT 0xFFFF // 0x4000
+
+    struct GDI_SHARED_MEMORY64
+    {
+        GDI_HANDLE_ENTRY64 Handles[GDI_MAX_HANDLE_COUNT];
+        char pad[0xC8];
+        uint64_t Objects[0x20];
+        uint64_t Data[0x200]; // ?
+    };
+    static_assert(offsetof(GDI_SHARED_MEMORY64, Objects) == 0x1800B0);
+
+    struct EMU_D3DKMT_ADAPTERINFO
+    {
+        UINT32 hAdapter;
+        LUID AdapterLuid;
+        UINT32 NumOfSources;
+        BOOL bPrecisePresentRegionsPreferred;
+    };
+
+    struct EMU_D3DKMT_ENUMADAPTERS2
+    {
+        UINT32 NumAdapters;
+        UINT64 pAdapters;
+    };
+
+    struct EMU_D3DKMT_ENUMADAPTERS_FILTER
+    {
+        UINT64 Value;
+    };
+
+    struct EMU_D3DKMT_ENUMADAPTERS3
+    {
+        EMU_D3DKMT_ENUMADAPTERS_FILTER Filter;
+        UINT32 NumAdapters;
+        UINT32 Padding;
+        UINT64 pAdapters;
+    };
+    static_assert(sizeof(EMU_D3DKMT_ENUMADAPTERS3) == 0x18);
+
+    struct EMU_D3DKMT_GET_PROPERTIES
+    {
+        UINT32 PropertyId;
+        UINT32 Size;
+        UINT64 Reserved;
+        UINT64 pBuffer;
+        UINT64 Reserved2[2];
+    };
+
+    enum class KMTQAITYPE : UINT32
+    {
+        KMTQAITYPE_UMDRIVERPRIVATE = 0,
+        KMTQAITYPE_UMDRIVERNAME = 1,
+        KMTQAITYPE_UMOPENGLINFO = 2,
+        KMTQAITYPE_GETSEGMENTSIZE = 3,
+        KMTQAITYPE_ADAPTERGUID = 4,
+        KMTQAITYPE_FLIPQUEUEINFO = 5,
+        KMTQAITYPE_ADAPTERADDRESS = 6,
+        KMTQAITYPE_SETWORKINGSETINFO = 7,
+        KMTQAITYPE_ADAPTERREGISTRYINFO = 8,
+        KMTQAITYPE_CURRENTDISPLAYMODE = 9,
+        KMTQAITYPE_MODELIST = 10,
+        KMTQAITYPE_CHECKDRIVERUPDATESTATUS = 11,
+        KMTQAITYPE_VIRTUALADDRESSINFO = 12,
+        KMTQAITYPE_DRIVERVERSION = 13,
+        KMTQAITYPE_ADAPTERTYPE = 15,
+        KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT = 16,
+        KMTQAITYPE_WDDM_1_2_CAPS = 17,
+        KMTQAITYPE_UMD_DRIVER_VERSION = 18,
+        KMTQAITYPE_DIRECTFLIP_SUPPORT = 19,
+        KMTQAITYPE_MULTIPLANEOVERLAY_SUPPORT = 20,
+        KMTQAITYPE_DLIST_DRIVER_NAME = 21,
+        KMTQAITYPE_WDDM_1_3_CAPS = 22,
+        KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT = 23,
+        KMTQAITYPE_WDDM_2_0_CAPS = 24,
+        KMTQAITYPE_NODEMETADATA = 25,
+        KMTQAITYPE_CPDRIVERNAME = 26,
+        KMTQAITYPE_XBOX = 27,
+        KMTQAITYPE_INDEPENDENTFLIP_SUPPORT = 28,
+        KMTQAITYPE_MIRACASTCOMPANIONDRIVERNAME = 29,
+        KMTQAITYPE_PHYSICALADAPTERCOUNT = 30,
+        KMTQAITYPE_PHYSICALADAPTERDEVICEIDS = 31,
+        KMTQAITYPE_DRIVERCAPS_EXT = 32,
+        KMTQAITYPE_QUERY_MIRACAST_DRIVER_TYPE = 33,
+        KMTQAITYPE_QUERY_GPUMMU_CAPS = 34,
+        KMTQAITYPE_QUERY_MULTIPLANEOVERLAY_DECODE_SUPPORT = 35,
+        KMTQAITYPE_QUERY_HW_PROTECTION_TEARDOWN_COUNT = 36,
+        KMTQAITYPE_QUERY_ISBADDRIVERFORHWPROTECTIONDISABLED = 37,
+        KMTQAITYPE_MULTIPLANEOVERLAY_SECONDARY_SUPPORT = 38,
+        KMTQAITYPE_INDEPENDENTFLIP_SECONDARY_SUPPORT = 39,
+        KMTQAITYPE_PANELFITTER_SUPPORT = 40,
+        KMTQAITYPE_PHYSICALADAPTERPNPKEY = 41,
+        KMTQAITYPE_GETSEGMENTGROUPSIZE = 42,
+        KMTQAITYPE_MPO3DDI_SUPPORT = 43,
+        KMTQAITYPE_HWDRM_SUPPORT = 44,
+        KMTQAITYPE_MPOKERNELCAPS_SUPPORT = 45,
+        KMTQAITYPE_MULTIPLANEOVERLAY_STRETCH_SUPPORT = 46,
+        KMTQAITYPE_GET_DEVICE_VIDPN_OWNERSHIP_INFO = 47,
+        KMTQAITYPE_QUERYREGISTRY = 48,
+        KMTQAITYPE_KMD_DRIVER_VERSION = 49,
+        KMTQAITYPE_BLOCKLIST_KERNEL = 50,
+        KMTQAITYPE_BLOCKLIST_RUNTIME = 51,
+        KMTQAITYPE_ADAPTERGUID_RENDER = 52,
+        KMTQAITYPE_ADAPTERADDRESS_RENDER = 53,
+        KMTQAITYPE_ADAPTERREGISTRYINFO_RENDER = 54,
+        KMTQAITYPE_CHECKDRIVERUPDATESTATUS_RENDER = 55,
+        KMTQAITYPE_DRIVERVERSION_RENDER = 56,
+        KMTQAITYPE_ADAPTERTYPE_RENDER = 57,
+        KMTQAITYPE_WDDM_1_2_CAPS_RENDER = 58,
+        KMTQAITYPE_WDDM_1_3_CAPS_RENDER = 59,
+        KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID = 60,
+        KMTQAITYPE_NODEPERFDATA = 61,
+        KMTQAITYPE_ADAPTERPERFDATA = 62,
+        KMTQAITYPE_ADAPTERPERFDATA_CAPS = 63,
+        KMTQUITYPE_GPUVERSION = 64,
+        KMTQAITYPE_DRIVER_DESCRIPTION = 65,
+        KMTQAITYPE_DRIVER_DESCRIPTION_RENDER = 66,
+        KMTQAITYPE_SCANOUT_CAPS = 67,
+        KMTQAITYPE_PARAVIRTUALIZATION_RENDER = 68,
+        KMTQAITYPE_SERVICENAME = 69,
+        KMTQAITYPE_WDDM_2_7_CAPS = 70,
+        KMTQAITYPE_DISPLAY_UMDRIVERNAME = 71,
+        KMTQAITYPE_TRACKEDWORKLOAD_SUPPORT = 72,
+        KMTQAITYPE_HYBRID_DLIST_DLL_SUPPORT = 73,
+        KMTQAITYPE_DISPLAY_CAPS = 74,
+        KMTQAITYPE_WDDM_2_9_CAPS = 75,
+        KMTQAITYPE_CROSSADAPTERRESOURCE_SUPPORT = 76,
+        KMTQAITYPE_WDDM_3_0_CAPS = 77,
+    };
+
+    struct EMU_D3DKMT_QUERYADAPTERINFO
+    {
+        UINT32 hAdapter;
+        KMTQAITYPE Type;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+    };
+
+    struct EMU_D3DKMT_CREATEDEVICE
+    {
+        UINT64 hAdapter;
+        UINT32 Flags;
+        UINT32 hDevice;
+        UINT64 pCommandBuffer;
+        UINT32 CommandBufferSize;
+        UINT64 pAllocationList;
+        UINT32 AllocationListSize;
+        UINT64 pPatchLocationList;
+        UINT32 PatchLocationListSize;
+    };
+
+    struct EMU_D3DKMT_ESCAPE
+    {
+        UINT32 hAdapter;
+        UINT32 hDevice;
+        UINT32 Type;
+        UINT32 Flags;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+        UINT32 hContext;
+    };
+
+    struct EMU_D3DKMT_CREATECONTEXT
+    {
+        UINT32 hDevice;
+        UINT32 NodeOrdinal;
+        UINT32 EngineAffinity;
+        UINT32 Flags;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+        UINT32 ClientHint;
+        UINT32 hContext;
+        UINT64 pCommandBuffer;
+        UINT32 CommandBufferSize;
+        UINT64 pAllocationList;
+        UINT32 AllocationListSize;
+        UINT64 pPatchLocationList;
+        UINT32 PatchLocationListSize;
+        UINT64 CommandBuffer;
+    };
+
+    struct EMU_D3DDDI_ALLOCATIONINFO
+    {
+        UINT32 hAllocation;
+        UINT64 pSystemMem;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+        UINT32 VidPnSourceId;
+        UINT32 Flags;
+    };
+
+    struct EMU_D3DKMT_CREATEALLOCATION
+    {
+        UINT32 hDevice;
+        UINT32 hResource;
+        UINT32 hGlobalShare;
+        UINT64 pPrivateRuntimeData;
+        UINT32 PrivateRuntimeDataSize;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+        UINT32 NumAllocations;
+        UINT64 pAllocationInfo;
+        UINT32 Flags;
+        UINT64 hPrivateRuntimeResourceHandle;
+    };
+
+    struct EMU_D3DKMT_LOCK
+    {
+        UINT32 hDevice;
+        UINT32 hAllocation;
+        UINT32 PrivateDriverData;
+        UINT32 NumPages;
+        UINT64 pPages;
+        UINT64 pData;
+        UINT32 Flags;
+        UINT64 GpuVirtualAddress;
+    };
+
+    struct EMU_D3DKMT_OPENADAPTERFROMHDC
+    {
+        HDC hDc;
+        UINT32 hAdapter;
+        LUID AdapterLuid;
+        UINT VidPnSourceId;
+    };
+
+    // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
+} // namespace sogen

--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -39,7 +39,7 @@ namespace sogen
     };
     static_assert(sizeof(GDI_HANDLE_ENTRY32) == 0x10);
 
-    #define GDI_MAX_HANDLE_COUNT 0xFFFF // 0x4000
+#define GDI_MAX_HANDLE_COUNT 0xFFFF // 0x4000
 
     struct GDI_SHARED_MEMORY64
     {
@@ -244,6 +244,44 @@ namespace sogen
         UINT64 hPrivateRuntimeResourceHandle;
     };
 
+    struct EMU_D3DKMT_QUERYRESOURCEINFO
+    {
+        UINT32 hDevice;
+        UINT32 hGlobalShare;
+        UINT64 pPrivateRuntimeData;
+        UINT32 PrivateRuntimeDataSize;
+        UINT32 TotalPrivateDriverDataSize;
+        UINT32 ResourcePrivateDriverDataSize;
+        UINT32 NumAllocations;
+    };
+
+    struct EMU_D3DDDI_OPENALLOCATIONINFO2
+    {
+        UINT32 hAllocation;
+        UINT32 Padding0;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+        UINT32 Padding1;
+        UINT64 GpuVirtualAddress;
+        UINT64 Reserved[6];
+    };
+    static_assert(sizeof(EMU_D3DDDI_OPENALLOCATIONINFO2) == 80);
+
+    struct EMU_D3DKMT_OPENRESOURCE
+    {
+        UINT32 hDevice;
+        UINT32 hGlobalShare;
+        UINT32 NumAllocations;
+        UINT64 pOpenAllocationInfo;
+        UINT64 pPrivateRuntimeData;
+        UINT32 PrivateRuntimeDataSize;
+        UINT64 pResourcePrivateDriverData;
+        UINT32 ResourcePrivateDriverDataSize;
+        UINT64 pTotalPrivateDriverDataBuffer;
+        UINT32 TotalPrivateDriverDataBufferSize;
+        UINT32 hResource;
+    };
+
     struct EMU_D3DKMT_LOCK
     {
         UINT32 hDevice;
@@ -254,6 +292,91 @@ namespace sogen
         UINT64 pData;
         UINT32 Flags;
         UINT64 GpuVirtualAddress;
+    };
+
+    struct EMU_D3DKMT_GETDEVICESTATE
+    {
+        UINT32 hDevice;
+        UINT32 StateType;
+        union
+        {
+            UINT32 State;
+            UINT32 DeviceExecutionState;
+            UINT32 PresentState;
+            UINT32 ResetState;
+        };
+    };
+
+    struct EMU_D3DKMT_MARKDEVICEASERROR
+    {
+        UINT32 hDevice;
+        UINT32 Reason;
+    };
+
+    struct EMU_D3DKMT_DESTROYALLOCATION
+    {
+        UINT32 hDevice;
+        UINT32 hResource;
+        UINT64 phAllocationList;
+        UINT32 AllocationCount;
+    };
+
+    struct EMU_D3DDDICB_DESTROYALLOCATION2FLAGS
+    {
+        union
+        {
+            struct
+            {
+                UINT32 AssumeNotInUse : 1;
+                UINT32 SynchronousDestroy : 1;
+                UINT32 Reserved : 29;
+                UINT32 SystemUseOnly : 1;
+            };
+            UINT32 Value;
+        };
+    };
+
+    struct EMU_D3DKMT_DESTROYALLOCATION2
+    {
+        UINT32 hDevice;
+        UINT32 hResource;
+        UINT64 phAllocationList;
+        UINT32 AllocationCount;
+        EMU_D3DDDICB_DESTROYALLOCATION2FLAGS Flags;
+    };
+
+    struct EMU_D3DDDI_RATIONAL
+    {
+        UINT32 Numerator;
+        UINT32 Denominator;
+    };
+
+    struct EMU_D3DKMT_DISPLAYMODE
+    {
+        UINT32 Width;
+        UINT32 Height;
+        UINT32 Format;
+        UINT32 IntegerRefreshRate;
+        EMU_D3DDDI_RATIONAL RefreshRate;
+        UINT32 ScanLineOrdering;
+        UINT32 DisplayOrientation;
+        UINT32 DisplayFixedOutput;
+        UINT32 Flags;
+    };
+
+    struct EMU_D3DKMT_GETDISPLAYMODELIST
+    {
+        UINT32 hAdapter;
+        UINT32 VidPnSourceId;
+        UINT64 pModeList;
+        UINT32 ModeCount;
+    };
+
+    struct EMU_D3DKMT_GETSHAREDPRIMARYHANDLE
+    {
+        UINT32 hAdapter;
+        UINT32 VidPnSourceId;
+        UINT32 hSharedPrimary;
     };
 
     struct EMU_D3DKMT_OPENADAPTERFROMHDC

--- a/src/emulator-platform/platform/platform.hpp
+++ b/src/emulator-platform/platform/platform.hpp
@@ -17,6 +17,7 @@
 #include "unicode.hpp"
 #include "status.hpp"
 #include "process.hpp"
+#include "gdi.hpp"
 #include "user.hpp"
 #include "kernel_mapped.hpp"
 #include "memory.hpp"

--- a/src/emulator-platform/platform/primitives.hpp
+++ b/src/emulator-platform/platform/primitives.hpp
@@ -28,6 +28,11 @@ namespace sogen
     using ULONGLONG = DWORD64;
     using LONGLONG = std::int64_t;
     using UINT = std::uint32_t;
+    using UINT8 = std::uint8_t;
+    using UINT16 = std::uint16_t;
+    using UINT32 = std::uint32_t;
+    using UINT64 = std::uint64_t;
+    using INT32 = std::int32_t;
     using BOOL = std::int32_t;
 
     typedef union _ULARGE_INTEGER

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -986,44 +986,6 @@ namespace sogen
 #define BACKUP_SECURITY_INFORMATION              0x00010000L
 #endif
 
-    struct GDI_HANDLE_ENTRY64
-    {
-        union
-        {
-            EmulatorTraits<Emu64>::PVOID Object;
-            EmulatorTraits<Emu64>::PVOID NextFree;
-        };
-
-        union
-        {
-            struct
-            {
-                USHORT ProcessId;
-                USHORT Lock : 1;
-                USHORT Count : 15;
-            };
-
-            ULONG Value;
-        } Owner;
-
-        USHORT Unique;
-        UCHAR Type;
-        UCHAR Flags;
-        EmulatorTraits<Emu64>::PVOID UserPointer;
-    };
-
-#define GDI_MAX_HANDLE_COUNT 0xFFFF // 0x4000
-
-    struct GDI_SHARED_MEMORY64
-    {
-        GDI_HANDLE_ENTRY64 Handles[GDI_MAX_HANDLE_COUNT];
-        char pad[0xC8];
-        uint64_t Objects[0x20];
-        uint64_t Data[0x200]; // ?
-    };
-
-    static_assert(offsetof(GDI_SHARED_MEMORY64, Objects) == 0x1800B0);
-
     struct CLIENT_ID32
     {
         ULONG UniqueProcess;

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -424,9 +424,33 @@ namespace sogen
         } u;
     };
 
+    enum class EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE : UINT32
+    {
+        GET_SOURCE_NAME = 1,
+        GET_TARGET_NAME = 2,
+        GET_TARGET_PREFERRED_MODE = 3,
+        GET_ADAPTER_NAME = 4,
+        SET_TARGET_PERSISTENCE = 5,
+        GET_TARGET_BASE_TYPE = 6,
+        GET_SUPPORT_VIRTUAL_RESOLUTION = 7,
+        SET_SUPPORT_VIRTUAL_RESOLUTION = 8,
+        GET_ADVANCED_COLOR_INFO = 9,
+        SET_ADVANCED_COLOR_STATE = 10,
+        GET_SDR_WHITE_LEVEL = 11,
+        GET_MONITOR_SPECIALIZATION = 12,
+        SET_MONITOR_SPECIALIZATION = 13,
+        SET_RESERVED1 = 14,
+        GET_ADVANCED_COLOR_INFO_2 = 15,
+        SET_HDR_STATE = 16,
+        SET_WCG_STATE = 17,
+
+        GET_SOURCE_FROM_HASH = static_cast<uint32_t>(-14),
+        GET_DISPLAY_INFO = static_cast<uint32_t>(-21),
+    };
+
     struct EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER
     {
-        EMULATOR_CAST(int32_t, DISPLAYCONFIG_DEVICE_INFO_TYPE) type;
+        EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE type;
         UINT32 size;
         LUID adapterId;
         UINT32 id;

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -293,18 +293,6 @@ namespace sogen
     };
 
 #ifndef OS_WINDOWS
-    struct LUID
-    {
-        DWORD LowPart;
-        LONG HighPart;
-    };
-
-    struct POINTL
-    {
-        LONG x;
-        LONG y;
-    };
-
     struct RECTL
     {
         LONG left;
@@ -499,6 +487,95 @@ namespace sogen
         EMULATOR_CAST(uint32_t, DISPLAYCONFIG_COLOR_ENCODING) colorEncoding;
         UINT32 bitsPerColorChannel;
     };
+
+    struct EMU_DISPLAYCONFIG_GET_SOURCE_FROM_HASH
+    {
+        UINT32 type;
+        UINT32 size;
+        LUID adapterId;
+        UINT32 sourceId;
+        UINT32 hash;
+        UINT32 reserved[4];
+    };
+
+    struct EMU_DISPLAY_INFO_DEVICE_BLOCK
+    {
+        UINT32 Valid;
+        UINT32 VendorID;
+        UINT32 DeviceID;
+        UINT32 SubSystemVendorID;
+        UINT32 SubSystemID;
+        UINT32 RevisionID;
+        UINT32 WddmVersion;
+        char16_t AdapterDesc[128];
+        char16_t AdapterDevicePath[260];
+    };
+
+    struct EMU_GET_DISPLAY_INFO
+    {
+        UINT32 type;
+        UINT32 size;
+        LUID adapterId;
+        UINT32 id;
+        EMU_DISPLAY_INFO_DEVICE_BLOCK DisplayAdapter;
+        UINT8 padding_0338[0x340 - 0x338];
+        EMU_DISPLAY_INFO_DEVICE_BLOCK RenderAdapter;
+        UINT8 padding_0664[2056 - 0x664];
+    };
+
+    static_assert(sizeof(EMU_DISPLAY_INFO_DEVICE_BLOCK) == 0x324);
+    static_assert(sizeof(EMU_GET_DISPLAY_INFO) == 2056);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO, adapterId) == 8);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO, id) == 16);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter) == 0x14);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter) == 0x340);
+
+    struct EMU_GET_DISPLAY_INFO_EX
+    {
+        UINT32 type;
+        UINT32 size;
+        LUID adapterId;
+        UINT32 sourceId;
+
+        uint8_t padding_0014[836 - 20];
+
+        UINT32 VendorID;
+        UINT32 DeviceID;
+        UINT32 SubSysID0;
+        UINT32 SubSysID1;
+        UINT32 RevisionID;
+        UINT32 WddmVersion;
+        char16_t AdapterDesc[128];
+
+        uint8_t padding_045C[1644 - 1116];
+
+        INT32 DisplayLeft;
+        INT32 DisplayTop;
+        INT32 DisplayWidth;
+        INT32 DisplayHeight;
+        char16_t DeviceName[32];
+
+        uint8_t padding_06BC[2024 - 1724];
+
+        UINT32 FailurePoint;
+
+        uint8_t padding_07EC[2044 - 2028];
+
+        UINT32 ReservedQwordLow;
+        UINT32 ReservedQwordHigh;
+
+        uint8_t padding_0804[2056 - 2052];
+    };
+
+    static_assert(sizeof(EMU_GET_DISPLAY_INFO_EX) == 2056);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, adapterId) == 8);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, sourceId) == 16);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, VendorID) == 836);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, AdapterDesc) == 860);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, DisplayLeft) == 1644);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, DeviceName) == 1660);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, FailurePoint) == 2024);
+    static_assert(offsetof(EMU_GET_DISPLAY_INFO_EX, ReservedQwordLow) == 2044);
 
     // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
 } // namespace sogen

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -292,5 +292,188 @@ namespace sogen
         DWORD dmPanningHeight;
     };
 
+#ifndef OS_WINDOWS
+    struct LUID
+    {
+        DWORD LowPart;
+        LONG HighPart;
+    };
+
+    struct POINTL
+    {
+        LONG x;
+        LONG y;
+    };
+
+    struct RECTL
+    {
+        LONG left;
+        LONG top;
+        LONG right;
+        LONG bottom;
+    };
+
+    struct DISPLAYCONFIG_PATH_SOURCE_INFO
+    {
+        LUID adapterId;
+        UINT32 id;
+        union
+        {
+            UINT32 modeInfoIdx;
+            struct
+            {
+                UINT32 cloneGroupId : 16;
+                UINT32 sourceModeInfoIdx : 16;
+            } s;
+        } u;
+        UINT32 statusFlags;
+    };
+
+    struct DISPLAYCONFIG_RATIONAL
+    {
+        UINT32 Numerator;
+        UINT32 Denominator;
+    };
+
+    struct DISPLAYCONFIG_2DREGION
+    {
+        UINT32 cx;
+        UINT32 cy;
+    };
+
+    struct DISPLAYCONFIG_DESKTOP_IMAGE_INFO
+    {
+        POINTL PathSourceSize;
+        RECTL DesktopImageRegion;
+        RECTL DesktopImageClip;
+    };
+#endif
+
+    struct EMU_DISPLAYCONFIG_PATH_TARGET_INFO
+    {
+        LUID adapterId;
+        UINT32 id;
+        union
+        {
+            UINT32 modeInfoIdx;
+            struct
+            {
+                UINT32 desktopModeInfoIdx : 16;
+                UINT32 targetModeInfoIdx : 16;
+            } s;
+        } u;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY) outputTechnology;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_ROTATION) rotation;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_SCALING) scaling;
+        DISPLAYCONFIG_RATIONAL refreshRate;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_SCANLINE_ORDERING) scanLineOrdering;
+        BOOL targetAvailable;
+        UINT32 statusFlags;
+    };
+
+    struct EMU_DISPLAYCONFIG_PATH_INFO
+    {
+        DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+        EMU_DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+        UINT32 flags;
+    };
+
+    struct EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO
+    {
+        UINT64 pixelRate;
+        DISPLAYCONFIG_RATIONAL hSyncFreq;
+        DISPLAYCONFIG_RATIONAL vSyncFreq;
+        DISPLAYCONFIG_2DREGION activeSize;
+        DISPLAYCONFIG_2DREGION totalSize;
+        union
+        {
+            struct
+            {
+                UINT32 videoStandard : 16;
+                UINT32 vSyncFreqDivider : 6;
+                UINT32 reserved : 10;
+            } AdditionalSignalInfo;
+            UINT32 videoStandard;
+        } u;
+        uint32_t scanLineOrdering;
+    };
+
+    struct EMU_DISPLAYCONFIG_TARGET_MODE
+    {
+        EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetVideoSignalInfo;
+    };
+
+    struct EMU_DISPLAYCONFIG_SOURCE_MODE
+    {
+        UINT32 width;
+        UINT32 height;
+        uint32_t pixelFormat;
+        POINTL position;
+    };
+
+    struct EMU_DISPLAYCONFIG_MODE_INFO
+    {
+        uint32_t infoType;
+        UINT32 id;
+        LUID adapterId;
+        union
+        {
+            EMU_DISPLAYCONFIG_TARGET_MODE targetMode;
+            EMU_DISPLAYCONFIG_SOURCE_MODE sourceMode;
+            DISPLAYCONFIG_DESKTOP_IMAGE_INFO desktopImageInfo;
+        } u;
+    };
+
+    struct EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER
+    {
+        EMULATOR_CAST(int32_t, DISPLAYCONFIG_DEVICE_INFO_TYPE) type;
+        UINT32 size;
+        LUID adapterId;
+        UINT32 id;
+    };
+
+    struct EMU_DISPLAYCONFIG_SOURCE_DEVICE_NAME
+    {
+        EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        char16_t viewGdiDeviceName[32];
+    };
+
+    struct EMU_DISPLAYCONFIG_TARGET_DEVICE_NAME
+    {
+        EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS) flags;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY) outputTechnology;
+        UINT16 edidManufactureId;
+        UINT16 edidProductCodeId;
+        UINT32 connectorInstance;
+        char16_t monitorFriendlyDeviceName[64];
+        char16_t monitorDevicePath[128];
+    };
+
+    struct EMU_DISPLAYCONFIG_ADAPTER_NAME
+    {
+        EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        char16_t adapterDevicePath[128];
+    };
+
+    struct EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO
+    {
+        EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        union
+        {
+            struct
+            {
+                UINT32 advancedColorSupported : 1;     // A type of advanced color is supported
+                UINT32 advancedColorEnabled : 1;       // A type of advanced color is enabled
+                UINT32 wideColorEnforced : 1;          // Wide color gamut is enabled
+                UINT32 advancedColorForceDisabled : 1; // Advanced color is force disabled due to system/OS policy
+                UINT32 reserved : 28;
+            } s;
+            UINT32 value;
+        } u;
+        EMULATOR_CAST(uint32_t, DISPLAYCONFIG_COLOR_ENCODING) colorEncoding;
+        UINT32 bitsPerColorChannel;
+    };
+
     // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
 } // namespace sogen

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -444,8 +444,9 @@ namespace sogen
         SET_HDR_STATE = 16,
         SET_WCG_STATE = 17,
 
+        GET_DISPLAY_INFO = static_cast<uint32_t>(-2),
         GET_SOURCE_FROM_HASH = static_cast<uint32_t>(-14),
-        GET_DISPLAY_INFO = static_cast<uint32_t>(-21),
+        GET_DISPLAY_INFO_EX = static_cast<uint32_t>(-21),
     };
 
     struct EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER

--- a/src/python-bindings/test.py
+++ b/src/python-bindings/test.py
@@ -129,7 +129,7 @@ with tempfile.TemporaryDirectory(prefix="sogen-python-") as temp_dir:
     )
     assert sleep_hits["count"] > 0
     assert app.process.exit_status == 0, f"non-zero exit: {app.process.exit_status}"
-    assert all(arg == 1 for arg in sleep_hits["args"])
+    assert all(arg in {0, 1} for arg in sleep_hits["args"])
 
     app = None
     gc.collect()

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -262,6 +262,9 @@ namespace sogen
                 teb_obj.SameTebFlags.SkipThreadAttach = (create_flags & THREAD_CREATE_FLAGS_SKIP_THREAD_ATTACH) ? 1 : 0;
                 teb_obj.SameTebFlags.LoaderWorker = (create_flags & THREAD_CREATE_FLAGS_LOADER_WORKER) ? 1 : 0;
                 teb_obj.SameTebFlags.SkipLoaderInit = (create_flags & THREAD_CREATE_FLAGS_SKIP_LOADER_INIT) ? 1 : 0;
+                teb_obj.StaticUnicodeString.Length = 0;
+                teb_obj.StaticUnicodeString.MaximumLength = sizeof(teb_obj.StaticUnicodeBuffer);
+                teb_obj.StaticUnicodeString.Buffer = this->teb64->value() + offsetof(TEB64, StaticUnicodeBuffer);
 
                 const auto desktop_info_obj = this->gs_segment->reserve<USER_DESKTOPINFO>();
                 desktop_info_obj.access([&](USER_DESKTOPINFO& info) {
@@ -333,6 +336,7 @@ namespace sogen
             teb_obj.SameTebFlags.SkipThreadAttach = (create_flags & THREAD_CREATE_FLAGS_SKIP_THREAD_ATTACH) ? 1 : 0;
             teb_obj.SameTebFlags.LoaderWorker = (create_flags & THREAD_CREATE_FLAGS_LOADER_WORKER) ? 1 : 0;
             teb_obj.SameTebFlags.SkipLoaderInit = (create_flags & THREAD_CREATE_FLAGS_SKIP_LOADER_INIT) ? 1 : 0;
+            teb_obj.StaticUnicodeString.Length = 0;
             teb_obj.StaticUnicodeString.MaximumLength = sizeof(teb_obj.StaticUnicodeBuffer);
             teb_obj.StaticUnicodeString.Buffer = this->teb64->value() + offsetof(TEB64, StaticUnicodeBuffer);
 
@@ -392,6 +396,9 @@ namespace sogen
             teb32_obj.SkipThreadAttach = (create_flags & THREAD_CREATE_FLAGS_SKIP_THREAD_ATTACH) ? 1 : 0;
             teb32_obj.LoaderWorker = (create_flags & THREAD_CREATE_FLAGS_LOADER_WORKER) ? 1 : 0;
             teb32_obj.SkipLoaderInit = (create_flags & THREAD_CREATE_FLAGS_SKIP_LOADER_INIT) ? 1 : 0;
+            teb32_obj.StaticUnicodeString.Length = 0;
+            teb32_obj.StaticUnicodeString.MaximumLength = sizeof(teb32_obj.StaticUnicodeBuffer);
+            teb32_obj.StaticUnicodeString.Buffer = static_cast<uint32_t>(teb32_addr + offsetof(TEB32, StaticUnicodeBuffer));
 
             // Note: CurrentLocale and other fields will be initialized by WOW64 runtime
         });

--- a/src/windows-emulator/io_completion_wait.cpp
+++ b/src/windows-emulator/io_completion_wait.cpp
@@ -1,5 +1,6 @@
 #include "std_include.hpp"
 #include "io_completion_wait.hpp"
+#include "worker_factory_support.hpp"
 
 namespace sogen
 {
@@ -228,6 +229,7 @@ namespace sogen
                 return false;
             }
 
+            worker_factory_support::on_io_completion_message_dequeued(process, out_message);
             clear_wait_packet_completion_state(process, out_message.wait_packet_handle);
             return true;
         }
@@ -257,6 +259,8 @@ namespace sogen
                 {
                     break;
                 }
+
+                worker_factory_support::on_io_completion_message_dequeued(process, message);
 
                 FILE_IO_COMPLETION_INFORMATION<EmulatorTraits<Emu64>> entry{};
                 entry.KeyContext = message.key_context;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -626,6 +626,8 @@ namespace sogen
         buffer.write(this->last_extended_params_attributes);
         buffer.write(this->last_extended_params_image_machine);
 
+        buffer.write(this->next_luid);
+
         buffer.write_vector(this->default_register_set);
         buffer.write(this->spawned_thread_count);
         buffer.write(this->threads);
@@ -698,6 +700,8 @@ namespace sogen
         buffer.read(this->last_extended_params_numa_node);
         buffer.read(this->last_extended_params_attributes);
         buffer.read(this->last_extended_params_image_machine);
+
+        buffer.read(this->next_luid);
 
         buffer.read_vector(this->default_register_set);
         buffer.read(this->spawned_thread_count);

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -488,6 +488,7 @@ namespace sogen
         this->gdi_dc_save_states.clear();
         this->gdi_bitmap_surfaces.clear();
         this->gdi_window_surfaces.clear();
+        this->dxgk = {};
         this->etw_notification_event.reset();
 
         const auto gdi_shared_table = this->base_allocator.reserve<GDI_SHARED_MEMORY64>();
@@ -590,6 +591,7 @@ namespace sogen
         buffer.write_map(this->gdi_dc_save_states);
         buffer.write_map(this->gdi_bitmap_surfaces);
         buffer.write_map(this->gdi_window_surfaces);
+        buffer.write(this->dxgk);
         buffer.write_optional(this->etw_notification_event);
         buffer.write(this->mouse_capture_window);
 
@@ -662,6 +664,7 @@ namespace sogen
         buffer.read_map(this->gdi_dc_save_states);
         buffer.read_map(this->gdi_bitmap_surfaces);
         buffer.read_map(this->gdi_window_surfaces);
+        buffer.read(this->dxgk);
         buffer.read_optional(this->etw_notification_event);
         buffer.read(this->mouse_capture_window);
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -173,6 +173,81 @@ namespace sogen
             }
         };
 
+        struct dxgk_state
+        {
+            struct dxgk_allocation
+            {
+                uint64_t backing_memory{};
+                uint64_t backing_size{};
+
+                void serialize(utils::buffer_serializer& buffer) const
+                {
+                    buffer.write(this->backing_memory);
+                    buffer.write(this->backing_size);
+                }
+
+                void deserialize(utils::buffer_deserializer& buffer)
+                {
+                    buffer.read(this->backing_memory);
+                    buffer.read(this->backing_size);
+                }
+            };
+
+            uint32_t next_resource_handle{0x8000};
+            uint32_t next_allocation_handle{0x9000};
+            std::map<uint32_t, dxgk_allocation> allocations{};
+
+            uint32_t create_resource()
+            {
+                return ++this->next_resource_handle;
+            }
+
+            uint32_t create_allocation(memory_manager& memory, uint64_t backing_size)
+            {
+                if (backing_size == 0)
+                {
+                    backing_size = 0x1000; // fallback size
+                }
+
+                const auto aligned_size = static_cast<uint64_t>(page_align_up(backing_size));
+                const auto backing_memory = memory.allocate_memory(static_cast<size_t>(aligned_size), memory_permission::read_write);
+
+                const uint32_t handle = ++this->next_allocation_handle;
+
+                this->allocations[handle] = {
+                    .backing_memory = backing_memory,
+                    .backing_size = aligned_size,
+                };
+
+                return handle;
+            }
+
+            const dxgk_allocation* get_allocation(const uint32_t handle) const
+            {
+                const auto it = this->allocations.find(handle);
+                if (it == this->allocations.end())
+                {
+                    return nullptr;
+                }
+
+                return &it->second;
+            }
+
+            void serialize(utils::buffer_serializer& buffer) const
+            {
+                buffer.write(this->next_resource_handle);
+                buffer.write(this->next_allocation_handle);
+                buffer.write_map(this->allocations);
+            }
+
+            void deserialize(utils::buffer_deserializer& buffer)
+            {
+                buffer.read(this->next_resource_handle);
+                buffer.read(this->next_allocation_handle);
+                buffer.read_map(this->allocations);
+            }
+        };
+
         process_context(x86_64_emulator& emu, memory_manager& memory, utils::clock& clock, callbacks& cb)
             : callbacks_(&cb),
               base_allocator(emu),
@@ -253,6 +328,7 @@ namespace sogen
         std::map<uint32_t, gdi_bitmap_surface> gdi_bitmap_surfaces{};
         // Persistent per-top-level-window paint surface; child controls composite into it at their offset.
         std::map<uint32_t, gdi_bitmap_surface> gdi_window_surfaces{};
+        dxgk_state dxgk{};
         std::optional<handle> etw_notification_event{};
         hwnd mouse_capture_window{};
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -177,17 +177,20 @@ namespace sogen
         {
             struct dxgk_allocation
             {
+                uint32_t resource_handle{};
                 uint64_t backing_memory{};
                 uint64_t backing_size{};
 
                 void serialize(utils::buffer_serializer& buffer) const
                 {
+                    buffer.write(this->resource_handle);
                     buffer.write(this->backing_memory);
                     buffer.write(this->backing_size);
                 }
 
                 void deserialize(utils::buffer_deserializer& buffer)
                 {
+                    buffer.read(this->resource_handle);
                     buffer.read(this->backing_memory);
                     buffer.read(this->backing_size);
                 }
@@ -202,7 +205,7 @@ namespace sogen
                 return ++this->next_resource_handle;
             }
 
-            uint32_t create_allocation(memory_manager& memory, uint64_t backing_size)
+            uint32_t create_allocation(memory_manager& memory, const uint32_t resource_handle, uint64_t backing_size)
             {
                 if (backing_size == 0)
                 {
@@ -215,6 +218,7 @@ namespace sogen
                 const uint32_t handle = ++this->next_allocation_handle;
 
                 this->allocations[handle] = {
+                    .resource_handle = resource_handle,
                     .backing_memory = backing_memory,
                     .backing_size = aligned_size,
                 };
@@ -231,6 +235,47 @@ namespace sogen
                 }
 
                 return &it->second;
+            }
+
+            bool destroy_allocation(memory_manager& memory, const uint32_t handle)
+            {
+                const auto it = this->allocations.find(handle);
+                if (it == this->allocations.end())
+                {
+                    return false;
+                }
+
+                if (it->second.backing_memory != 0)
+                {
+                    memory.release_memory(it->second.backing_memory, 0);
+                }
+
+                this->allocations.erase(it);
+                return true;
+            }
+
+            size_t destroy_resource_allocations(memory_manager& memory, const uint32_t resource_handle)
+            {
+                size_t destroy_count = 0;
+
+                for (auto it = this->allocations.begin(); it != this->allocations.end();)
+                {
+                    if (it->second.resource_handle != resource_handle)
+                    {
+                        ++it;
+                        continue;
+                    }
+
+                    if (it->second.backing_memory != 0)
+                    {
+                        memory.release_memory(it->second.backing_memory, 0);
+                    }
+
+                    it = this->allocations.erase(it);
+                    ++destroy_count;
+                }
+
+                return destroy_count;
             }
 
             void serialize(utils::buffer_serializer& buffer) const
@@ -375,6 +420,8 @@ namespace sogen
         uint64_t last_extended_params_numa_node{0};
         uint32_t last_extended_params_attributes{0};
         uint16_t last_extended_params_image_machine{IMAGE_FILE_MACHINE_UNKNOWN};
+
+        uint64_t next_luid{0x1001};
     };
 
 } // namespace sogen

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -214,6 +214,9 @@ namespace sogen
                                             emulator_object<REMOTE_PORT_VIEW64> server_shared_memory,
                                             emulator_object<ULONG> maximum_message_length, emulator_pointer connection_info,
                                             emulator_object<ULONG> connection_info_length);
+        NTSTATUS handle_NtAlpcCreatePort(const syscall_context& c, emulator_object<handle> port_handle,
+                                         emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
+                                         emulator_pointer /*port_attributes*/);
         NTSTATUS handle_NtAlpcConnectPort(const syscall_context& c, emulator_object<handle> port_handle,
                                           emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> server_port_name,
                                           emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,
@@ -611,6 +614,9 @@ namespace sogen
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
         BOOL handle_NtGdiGetRealizationInfo(const syscall_context& c, hdc dc, emulator_pointer realization_info, uint64_t font);
         NTSTATUS handle_NtGdiGetEntry(const syscall_context& c, uint32_t handle_value, emulator_pointer entry_ptr);
+        BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
+        uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
+        uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
         hdc handle_NtGdiOpenDCW(const syscall_context& c);
         NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS2> enum_adapters);
         NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS3> enum_adapters);
@@ -945,11 +951,6 @@ namespace sogen
             return 0;
         }
 
-        NTSTATUS handle_NtPowerInformation()
-        {
-            return STATUS_NOT_SUPPORTED;
-        }
-
         NTSTATUS handle_NtAllocateLocallyUniqueId(const syscall_context& c, const emulator_object<LUID> luid)
         {
             luid.access([&](LUID& l) {
@@ -1181,6 +1182,7 @@ namespace sogen
         add_handler(NtReleaseSemaphore);
         add_handler(NtEnumerateKey);
         add_handler(NtEnumerateValueKey);
+        add_handler(NtAlpcCreatePort);
         add_handler(NtAlpcConnectPortEx);
         add_handler(NtAlpcConnectPort);
         add_handler(NtAlpcQueryInformation);
@@ -1296,7 +1298,6 @@ namespace sogen
         add_handler(NtUserPostQuitMessage);
         add_handler(NtUserGetClassInfoEx);
         add_handler(NtUserCallNoParam);
-        add_handler(NtPowerInformation);
         add_handler(NtUserGetDisplayConfigBufferSizes);
         add_handler(NtUserQueryDisplayConfig);
         add_handler(NtGdiDdDDIEnumAdapters2);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -615,20 +615,20 @@ namespace sogen
         uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
         uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
         NTSTATUS handle_NtGdiOpenDCW();
-        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS2> enum_adapters);
+        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS3> enum_adapters);
+        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, emulator_object<EMU_D3DKMT_GET_PROPERTIES> get_properties);
         NTSTATUS handle_NtGdiDdDDICloseAdapter();
-        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, emulator_pointer parameters);
-        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c, emulator_object<EMU_D3DKMT_QUERYADAPTERINFO> query_adapter);
+        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEDEVICE> device_desc);
+        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, emulator_object<EMU_D3DKMT_ESCAPE> escape_desc);
+        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATECONTEXT> context_desc);
+        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEALLOCATION> allocation_desc);
+        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, emulator_object<EMU_D3DKMT_LOCK> lock_desc);
         NTSTATUS handle_NtGdiDdDDIUnlock();
         NTSTATUS handle_NtGdiDdDDIDestroyContext();
         NTSTATUS handle_NtGdiDdDDIDestroyDevice();
-        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter);
 
         // syscalls/trace.cpp:
         NTSTATUS handle_NtTraceControl(const syscall_context& c, ULONG function_code, uint64_t input_buffer, ULONG input_buffer_length,

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -426,7 +426,6 @@ namespace sogen
 
         // syscalls/user.cpp:
         NTSTATUS handle_NtUserTraceLoggingSendMixedModeTelemetry();
-        NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo();
         NTSTATUS handle_NtUserRegisterWindowMessage();
         uint64_t handle_NtUserGetThreadState(const syscall_context& c, ULONG routine);
         uint64_t handle_NtUserSetThreadState(const syscall_context& c, uint64_t value, uint64_t mask);
@@ -548,8 +547,16 @@ namespace sogen
         BOOL handle_NtUserAllowSetForegroundWindow();
         ULONG handle_NtUserGetAtomName(const syscall_context& c, RTL_ATOM atom,
                                        emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> atom_name);
+        NTSTATUS handle_NtUserGetDisplayConfigBufferSizes(const syscall_context& c, UINT32 flags,
+                                                          emulator_object<UINT32> num_path_array_elements,
+                                                          emulator_object<UINT32> num_mode_info_array_elements);
+        NTSTATUS handle_NtUserQueryDisplayConfig(const syscall_context& c, UINT32 flags, emulator_object<UINT32> num_path_array_elements,
+                                                 emulator_pointer path_array, emulator_object<UINT32> current_topology_id,
+                                                 emulator_pointer reserved);
+        NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo(const syscall_context& c, emulator_pointer packet);
 
         // syscalls/gdi.cpp:
+        NTSTATUS handle_NtDxgkIsFeatureEnabled();
         NTSTATUS handle_NtGdiInit(const syscall_context& c);
         NTSTATUS handle_NtGdiInit2(const syscall_context& c);
         uint32_t handle_NtGdiGetDeviceCaps(const syscall_context& c, hdc dc, uint32_t index);
@@ -607,6 +614,21 @@ namespace sogen
         BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
         uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
         uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
+        NTSTATUS handle_NtGdiOpenDCW();
+        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDICloseAdapter();
+        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, emulator_pointer parameters);
+        NTSTATUS handle_NtGdiDdDDIUnlock();
+        NTSTATUS handle_NtGdiDdDDIDestroyContext();
+        NTSTATUS handle_NtGdiDdDDIDestroyDevice();
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_pointer parameters);
 
         // syscalls/trace.cpp:
         NTSTATUS handle_NtTraceControl(const syscall_context& c, ULONG function_code, uint64_t input_buffer, ULONG input_buffer_length,
@@ -750,12 +772,6 @@ namespace sogen
 
         NTSTATUS handle_NtUserSystemParametersInfo()
         {
-            return STATUS_NOT_SUPPORTED;
-        }
-
-        NTSTATUS handle_NtDxgkIsFeatureEnabled()
-        {
-            // puts("NtDxgkIsFeatureEnabled not supported");
             return STATUS_NOT_SUPPORTED;
         }
 
@@ -916,6 +932,17 @@ namespace sogen
         uint64_t handle_NtUserCallNoParam()
         {
             return 0;
+        }
+
+        NTSTATUS handle_NtPowerInformation()
+        {
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        NTSTATUS handle_NtAllocateLocallyUniqueId(const syscall_context&, emulator_object<LUID> luid)
+        {
+            luid.access([&](LUID& l) { AllocateLocallyUniqueId(&l); });
+            return STATUS_SUCCESS;
         }
     }
 
@@ -1253,6 +1280,26 @@ namespace sogen
         add_handler(NtUserPostQuitMessage);
         add_handler(NtUserGetClassInfoEx);
         add_handler(NtUserCallNoParam);
+        add_handler(NtPowerInformation);
+        add_handler(NtUserGetDisplayConfigBufferSizes);
+        add_handler(NtUserQueryDisplayConfig);
+        add_handler(NtGdiDdDDIEnumAdapters2);
+        add_handler(NtDxgkEnumAdapters3);
+        add_handler(NtDxgkGetProperties);
+        add_handler(NtGdiDdDDICloseAdapter);
+        add_handler(NtGdiDdDDIQueryAdapterInfo);
+        add_handler(NtGdiDdDDICreateDevice);
+        add_handler(NtGdiDdDDIEscape);
+        add_handler(NtGdiDdDDICreateContext);
+        add_handler(NtGdiDdDDICreateAllocation);
+        add_handler(NtGdiDdDDILock);
+        add_handler(NtGdiDdDDIUnlock);
+        add_handler(NtGdiDdDDIDestroyContext);
+        add_handler(NtGdiDdDDIDestroyDevice);
+        add_handler(NtAllocateLocallyUniqueId);
+        add_handler(NtUserAllowSetForegroundWindow);
+        add_handler(NtGdiOpenDCW);
+        add_handler(NtGdiDdDDIOpenAdapterFromHdc);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -611,10 +611,7 @@ namespace sogen
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
         BOOL handle_NtGdiGetRealizationInfo(const syscall_context& c, hdc dc, emulator_pointer realization_info, uint64_t font);
         NTSTATUS handle_NtGdiGetEntry(const syscall_context& c, uint32_t handle_value, emulator_pointer entry_ptr);
-        BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
-        uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
-        uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
-        NTSTATUS handle_NtGdiOpenDCW();
+        hdc handle_NtGdiOpenDCW(const syscall_context& c);
         NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS2> enum_adapters);
         NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, emulator_object<EMU_D3DKMT_ENUMADAPTERS3> enum_adapters);
         NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, emulator_object<EMU_D3DKMT_GET_PROPERTIES> get_properties);
@@ -624,8 +621,22 @@ namespace sogen
         NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, emulator_object<EMU_D3DKMT_ESCAPE> escape_desc);
         NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATECONTEXT> context_desc);
         NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEALLOCATION> allocation_desc);
+        NTSTATUS handle_NtGdiDdDDIQueryResourceInfo(const syscall_context& c, emulator_object<EMU_D3DKMT_QUERYRESOURCEINFO> resource_info);
+        NTSTATUS handle_NtGdiDdDDIOpenResource(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENRESOURCE> open_resource);
         NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, emulator_object<EMU_D3DKMT_LOCK> lock_desc);
         NTSTATUS handle_NtGdiDdDDIUnlock();
+        NTSTATUS handle_NtGdiDdDDIGetDisplayModeList(const syscall_context& c,
+                                                     emulator_object<EMU_D3DKMT_GETDISPLAYMODELIST> display_mode_list);
+        NTSTATUS handle_NtGdiDdDDIGetSharedPrimaryHandle(const syscall_context& c,
+                                                         emulator_object<EMU_D3DKMT_GETSHAREDPRIMARYHANDLE> shared_primary);
+        NTSTATUS handle_NtGdiDdDDIGetDeviceState(const syscall_context& c, emulator_object<EMU_D3DKMT_GETDEVICESTATE> device_state);
+        NTSTATUS handle_NtGdiDdDDIMarkDeviceAsError(const syscall_context& c, emulator_object<EMU_D3DKMT_MARKDEVICEASERROR> mark_error);
+        NTSTATUS handle_NtGdiDdDDIGetCachedHybridQueryValue(const syscall_context& c, emulator_object<uint32_t> value);
+        NTSTATUS handle_NtGdiDdDDICacheHybridQueryValue();
+        NTSTATUS handle_NtGdiDdDDIDestroyAllocation2(const syscall_context& c,
+                                                     emulator_object<EMU_D3DKMT_DESTROYALLOCATION2> destroy_allocation);
+        NTSTATUS handle_NtGdiDdDDIDestroyAllocation(const syscall_context& c,
+                                                    emulator_object<EMU_D3DKMT_DESTROYALLOCATION> destroy_allocation);
         NTSTATUS handle_NtGdiDdDDIDestroyContext();
         NTSTATUS handle_NtGdiDdDDIDestroyDevice();
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter);
@@ -939,9 +950,14 @@ namespace sogen
             return STATUS_NOT_SUPPORTED;
         }
 
-        NTSTATUS handle_NtAllocateLocallyUniqueId(const syscall_context&, emulator_object<LUID> luid)
+        NTSTATUS handle_NtAllocateLocallyUniqueId(const syscall_context& c, const emulator_object<LUID> luid)
         {
-            luid.access([&](LUID& l) { AllocateLocallyUniqueId(&l); });
+            luid.access([&](LUID& l) {
+                const std::uint64_t value = c.proc.next_luid++;
+                l.LowPart = static_cast<std::uint32_t>(value);
+                l.HighPart = static_cast<std::int32_t>(value >> 32);
+            });
+
             return STATUS_SUCCESS;
         }
     }
@@ -1292,14 +1308,25 @@ namespace sogen
         add_handler(NtGdiDdDDIEscape);
         add_handler(NtGdiDdDDICreateContext);
         add_handler(NtGdiDdDDICreateAllocation);
+        add_handler(NtGdiDdDDIQueryResourceInfo);
+        add_handler(NtGdiDdDDIOpenResource);
         add_handler(NtGdiDdDDILock);
+        add_handler(NtGdiDdDDIGetDisplayModeList);
+        add_handler(NtGdiDdDDIGetSharedPrimaryHandle);
+        add_handler(NtGdiDdDDIGetDeviceState);
+        add_handler(NtGdiDdDDIMarkDeviceAsError);
+        add_handler(NtGdiDdDDIGetCachedHybridQueryValue);
+        add_handler(NtGdiDdDDICacheHybridQueryValue);
         add_handler(NtGdiDdDDIUnlock);
+        add_handler(NtGdiDdDDIDestroyAllocation2);
+        add_handler(NtGdiDdDDIDestroyAllocation);
         add_handler(NtGdiDdDDIDestroyContext);
         add_handler(NtGdiDdDDIDestroyDevice);
         add_handler(NtAllocateLocallyUniqueId);
         add_handler(NtUserAllowSetForegroundWindow);
         add_handler(NtGdiOpenDCW);
         add_handler(NtGdiDdDDIOpenAdapterFromHdc);
+        add_handler(NtGdiSelectFont);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -7,6 +7,8 @@
 #include <bit>
 #include <limits>
 
+// #define ENABLE_DXGK_LOGGING
+
 namespace sogen
 {
 
@@ -14,17 +16,6 @@ namespace sogen
     {
         namespace
         {
-            struct GDI_HANDLE_ENTRY32
-            {
-                uint32_t Object;
-                uint32_t OwnerValue;
-                USHORT Unique;
-                UCHAR Type;
-                UCHAR Flags;
-                uint32_t UserPointer;
-            };
-            static_assert(sizeof(GDI_HANDLE_ENTRY32) == 0x10);
-
             constexpr uint8_t k_gdi_dc_type = 0x01;
             constexpr uint8_t k_gdi_region_type = 0x04;
             constexpr uint8_t k_gdi_bitmap_type = 0x05;
@@ -175,6 +166,20 @@ namespace sogen
                 POINTL viewport_org{};
                 std::array<gdi_batch_pat_rect, 1> rects{};
             };
+
+            constexpr uint32_t k_dxgk_adapter_count = 1;
+            constexpr uint32_t k_dxgk_adapter_handle = 0x4000;
+            constexpr uint32_t k_dxgk_device_handle = 0x5000;
+            constexpr uint32_t k_dxgk_context_handle = 0x6000;
+            constexpr LUID k_dxgk_adapter_luid = {0x1000, 0};
+            constexpr uint32_t k_dxgk_adapter_source_count = 1;
+            constexpr size_t k_dxgk_command_buffer_size = 0x1000;
+            constexpr uint64_t k_dxgk_dedicated_video_memory_size = 4ull * 1024 * 1024 * 1024;
+            constexpr uint64_t k_dxgk_shared_system_memory_size = 8ull * 1024 * 1024 * 1024;
+            constexpr uint32_t k_dxgk_fake_vendor_id = 0x10DE;
+            constexpr uint32_t k_dxgk_fake_device_id = 0x1C03;
+            constexpr uint32_t k_dxgk_fake_revision_id = 0xA1;
+            constexpr GUID k_dxgk_adapter_guid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
 
             uint64_t ensure_gdi_shared_table(const syscall_context& c)
             {
@@ -1172,6 +1177,102 @@ namespace sogen
                 const auto unique = static_cast<uint16_t>(handle_value >> 16);
                 return entry.Type != 0 && entry.Unique == unique;
             }
+
+            template <typename... Args>
+            void dxgk_info(const syscall_context& c, const char* fmt, Args&&... args)
+            {
+#ifdef ENABLE_DXGK_LOGGING
+                c.win_emu.log.info(fmt, std::forward<Args>(args)...);
+#else
+                (void)c;
+                (void)fmt;
+                ((void)args, ...);
+#endif
+            }
+
+            template <typename... Args>
+            void dxgk_warn(const syscall_context& c, const char* fmt, Args&&... args)
+            {
+#ifdef ENABLE_DXGK_LOGGING
+                c.win_emu.log.warn(fmt, std::forward<Args>(args)...);
+#else
+                (void)c;
+                (void)fmt;
+                ((void)args, ...);
+#endif
+            }
+
+            template <typename... Args>
+            void dxgk_error(const syscall_context& c, const char* fmt, Args&&... args)
+            {
+#ifdef ENABLE_DXGK_LOGGING
+                c.win_emu.log.error(fmt, std::forward<Args>(args)...);
+#else
+                (void)c;
+                (void)fmt;
+                ((void)args, ...);
+#endif
+            }
+
+            EMU_D3DKMT_ADAPTERINFO make_default_dxgk_adapter_info()
+            {
+                EMU_D3DKMT_ADAPTERINFO adapter_info{};
+                adapter_info.hAdapter = k_dxgk_adapter_handle;
+                adapter_info.AdapterLuid = k_dxgk_adapter_luid;
+                adapter_info.NumOfSources = k_dxgk_adapter_source_count;
+                adapter_info.bPrecisePresentRegionsPreferred = FALSE;
+                return adapter_info;
+            }
+
+            uint64_t infer_warp_allocation_size_from_private_data(const syscall_context& c, const uint64_t private_data,
+                                                                  const uint32_t private_data_size)
+            {
+                if (private_data == 0 || private_data_size < 0x1C)
+                {
+                    return 0;
+                }
+
+                const uint32_t kind = c.emu.read_memory<uint32_t>(private_data + 0x00);
+                const uint32_t width_or_size = c.emu.read_memory<uint32_t>(private_data + 0x04);
+                const uint32_t height = c.emu.read_memory<uint32_t>(private_data + 0x08);
+                const uint32_t pitch = c.emu.read_memory<uint32_t>(private_data + 0x14);
+                const uint32_t byte_size = c.emu.read_memory<uint32_t>(private_data + 0x18);
+
+                if (byte_size == 0)
+                {
+                    return 0;
+                }
+
+                if (kind == 1)
+                {
+                    return width_or_size != 0 && pitch == byte_size ? byte_size : 0;
+                }
+
+                if (kind == 3)
+                {
+                    if (width_or_size == 0 || height == 0 || pitch == 0)
+                    {
+                        return 0;
+                    }
+
+                    const uint64_t minimum_size = static_cast<uint64_t>(pitch) * height;
+                    return byte_size >= minimum_size ? byte_size : 0;
+                }
+
+                return 0;
+            }
+
+            template <typename T>
+            NTSTATUS write_query_adapter_info(const syscall_context& c, const EMU_D3DKMT_QUERYADAPTERINFO& query, const T& value)
+            {
+                if (query.PrivateDriverDataSize < sizeof(T))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                c.emu.write_memory(query.pPrivateDriverData, &value, sizeof(T));
+                return STATUS_SUCCESS;
+            }
         }
 
         // Returns the surface a paint DC should be presented to, and (via present_handle) the host window handle it
@@ -1414,15 +1515,12 @@ namespace sogen
             return allocate_gdi_dc(c, dc_attr);
         }
 
-<<<<<<< HEAD
-        int32_t handle_NtGdiSaveDC(const syscall_context& c, const hdc dc) == == == = NTSTATUS handle_NtGdiOpenDCW()
+        NTSTATUS handle_NtGdiOpenDCW()
         {
             return STATUS_SUCCESS;
         }
 
-        uint64_t handle_NtGdiCreateCompatibleBitmap(const syscall_context& c, const hdc /*dc*/, const uint32_t /*width*/,
-                                                    const uint32_t /*height*/)
->>>>>>> d0f91341 (First version of DX11 skeleton)
+        int32_t handle_NtGdiSaveDC(const syscall_context& c, const hdc dc)
         {
             const auto dc_value = static_cast<uint32_t>(dc);
             auto& stack = c.proc.gdi_dc_save_states[dc_value];
@@ -2261,50 +2359,6 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        struct EMU_D3DKMT_ADAPTERINFO
-        {
-            UINT32 hAdapter;
-            LUID AdapterLuid;
-            UINT32 NumOfSources;
-            BOOL bPrecisePresentRegionsPreferred;
-        };
-
-        struct EMU_D3DKMT_ENUMADAPTERS2
-        {
-            UINT32 NumAdapters;
-            UINT64 pAdapters;
-        };
-
-        struct EMU_D3DKMT_ENUMADAPTERS_FILTER
-        {
-            UINT64 Value;
-        };
-
-        struct EMU_D3DKMT_ENUMADAPTERS3
-        {
-            EMU_D3DKMT_ENUMADAPTERS_FILTER Filter;
-            UINT32 NumAdapters;
-            UINT32 Padding;
-            UINT64 pAdapters;
-        };
-        static_assert(sizeof(EMU_D3DKMT_ENUMADAPTERS3) == 0x18);
-
-        constexpr UINT32 k_dxgk_adapter_count = 1;
-        constexpr UINT32 k_dxgk_adapter_handle = 0x4000;
-        constexpr UINT32 k_dxgk_adapter_luid_low = 0x1000;
-        constexpr UINT32 k_dxgk_adapter_luid_high = 0;
-        constexpr UINT32 k_dxgk_adapter_source_count = 1;
-
-        EMU_D3DKMT_ADAPTERINFO make_default_dxgk_adapter_info()
-        {
-            EMU_D3DKMT_ADAPTERINFO adapter_info{};
-            adapter_info.hAdapter = k_dxgk_adapter_handle;
-            adapter_info.AdapterLuid = {k_dxgk_adapter_luid_low, k_dxgk_adapter_luid_high};
-            adapter_info.NumOfSources = k_dxgk_adapter_source_count;
-            adapter_info.bPrecisePresentRegionsPreferred = FALSE;
-            return adapter_info;
-        }
-
         NTSTATUS write_default_dxgk_adapter_array(const syscall_context& c, const UINT32 num_adapters, const UINT64 adapters_ptr)
         {
             if (adapters_ptr == 0)
@@ -2323,104 +2377,71 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, const emulator_pointer parameters)
+        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, const emulator_object<EMU_D3DKMT_ENUMADAPTERS2> enum_adapters)
         {
-            if (!parameters)
+            if (!enum_adapters)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto desc = c.emu.read_memory<EMU_D3DKMT_ENUMADAPTERS2>(parameters);
-
-            if (desc.pAdapters == 0)
-            {
-                desc.NumAdapters = k_dxgk_adapter_count;
-                c.emu.write_memory(parameters, &desc, sizeof(desc));
-                return STATUS_SUCCESS;
-            }
-
-            const NTSTATUS status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            desc.NumAdapters = k_dxgk_adapter_count;
-            c.emu.write_memory(parameters, &desc, sizeof(desc));
-
-            return STATUS_SUCCESS;
-        }
-
-        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
-            {
-                return STATUS_INVALID_PARAMETER;
-            }
-
-            auto desc = c.emu.read_memory<EMU_D3DKMT_ENUMADAPTERS3>(parameters);
-
-            if (desc.pAdapters == 0)
-            {
-                desc.NumAdapters = k_dxgk_adapter_count;
-                c.emu.write_memory(parameters, &desc, sizeof(desc));
-                return STATUS_SUCCESS;
-            }
-
-            const NTSTATUS status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            desc.NumAdapters = k_dxgk_adapter_count;
-            c.emu.write_memory(parameters, &desc, sizeof(desc));
-
-            return STATUS_SUCCESS;
-        }
-
-        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, const emulator_pointer parameters)
-        {
-            // Structure inferred from GetKernelCachedAdapterId stack layout:
-            // v7[0] = PropertyId (4 bytes)
-            // v7[1] = Size (4 bytes)
-            // v8    = Reserved/Padding (8 bytes)
-            // v9    = pBuffer (8 bytes)
-            // v10   = Reserved (16 bytes)
-            struct EMU_D3DKMT_GET_PROPERTIES
-            {
-                UINT32 PropertyId;
-                UINT32 Size;
-                UINT64 Reserved;
-                UINT64 pBuffer;
-                UINT64 Reserved2[2];
-            };
-
-            if (!parameters)
-            {
-                return STATUS_INVALID_PARAMETER;
-            }
-
-            auto props = c.emu.read_memory<EMU_D3DKMT_GET_PROPERTIES>(parameters);
-
-            // PropertyId 1 and 2 seem to correspond to querying the "Kernel Cached Adapter Id".
-            // 1 = Per-App preference?
-            // 2 = Global preference?
-            // The code checks if the returned data has a valid flag (4th DWORD LOBYTE).
-            if (props.PropertyId == 1 || props.PropertyId == 2)
-            {
-                if (props.Size < 16 || !props.pBuffer)
+            NTSTATUS status = STATUS_SUCCESS;
+            enum_adapters.access([&](EMU_D3DKMT_ENUMADAPTERS2& desc) {
+                if (desc.pAdapters == 0)
                 {
-                    return STATUS_INVALID_PARAMETER;
+                    desc.NumAdapters = k_dxgk_adapter_count;
+                    return;
                 }
 
-                // Inferred output structure:
-                // struct UserPreferredAdapterId {
-                //   UINT32 LuidLow;
-                //   UINT32 LuidHigh;
-                //   UINT32 VidPnSourceId;
-                //   UINT32 Valid; // Checked via LOBYTE(v[3])
-                // };
+                status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
+                if (status != STATUS_SUCCESS)
+                {
+                    return;
+                }
+
+                desc.NumAdapters = k_dxgk_adapter_count;
+            });
+
+            return status;
+        }
+
+        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, const emulator_object<EMU_D3DKMT_ENUMADAPTERS3> enum_adapters)
+        {
+            if (!enum_adapters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            NTSTATUS status = STATUS_SUCCESS;
+            enum_adapters.access([&](EMU_D3DKMT_ENUMADAPTERS3& desc) {
+                if (desc.pAdapters == 0)
+                {
+                    desc.NumAdapters = k_dxgk_adapter_count;
+                    return;
+                }
+
+                status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
+                if (status != STATUS_SUCCESS)
+                {
+                    return;
+                }
+
+                desc.NumAdapters = k_dxgk_adapter_count;
+            });
+
+            return status;
+        }
+
+        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, const emulator_object<EMU_D3DKMT_GET_PROPERTIES> get_properties)
+        {
+            if (!get_properties)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto props = get_properties.read();
+
+            if (props.PropertyId == 1 || props.PropertyId == 2)
+            {
                 struct EMU_PREFERRED_ADAPTER_INFO
                 {
                     UINT32 LuidLow;
@@ -2429,18 +2450,21 @@ namespace sogen
                     UINT32 Flags;
                 } info{};
 
-                // Return the LUID of the emulated adapter defined in EnumAdapters2 (e.g. {0x1000, 0}).
-                // This ensures the helper library "finds" our emulated GPU.
-                info.LuidLow = 0x1000;
-                info.LuidHigh = 0;
-                info.SourceId = 0; // Default source (Monitor 0)
-                info.Flags = 1;    // Mark as valid
+                if (props.Size < sizeof(info) || !props.pBuffer)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                info.LuidLow = k_dxgk_adapter_luid.LowPart;
+                info.LuidHigh = k_dxgk_adapter_luid.HighPart;
+                info.SourceId = 0;
+                info.Flags = 1;
 
                 c.emu.write_memory(props.pBuffer, &info, sizeof(info));
                 return STATUS_SUCCESS;
             }
 
-            c.win_emu.log.error("Unknown PropertyId %d", props.PropertyId);
+            dxgk_error(c, "NtDxgkGetProperties: Unknown PropertyId %d", props.PropertyId);
             return STATUS_NOT_SUPPORTED;
         }
 
@@ -2449,132 +2473,29 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        enum class KMTQAITYPE : UINT32
+        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c,
+                                                   const emulator_object<EMU_D3DKMT_QUERYADAPTERINFO> query_adapter)
         {
-            KMTQAITYPE_UMDRIVERPRIVATE = 0,
-            KMTQAITYPE_UMDRIVERNAME = 1,
-            KMTQAITYPE_UMOPENGLINFO = 2,
-            KMTQAITYPE_GETSEGMENTSIZE = 3,
-            KMTQAITYPE_ADAPTERGUID = 4,
-            KMTQAITYPE_FLIPQUEUEINFO = 5,
-            KMTQAITYPE_ADAPTERADDRESS = 6,
-            KMTQAITYPE_SETWORKINGSETINFO = 7,
-            KMTQAITYPE_ADAPTERREGISTRYINFO = 8,
-            KMTQAITYPE_CURRENTDISPLAYMODE = 9,
-            KMTQAITYPE_MODELIST = 10,
-            KMTQAITYPE_CHECKDRIVERUPDATESTATUS = 11,
-            KMTQAITYPE_VIRTUALADDRESSINFO = 12, // _ADVSCH_
-            KMTQAITYPE_DRIVERVERSION = 13,
-            KMTQAITYPE_ADAPTERTYPE = 15,
-            KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT = 16,
-            KMTQAITYPE_WDDM_1_2_CAPS = 17,
-            KMTQAITYPE_UMD_DRIVER_VERSION = 18,
-            KMTQAITYPE_DIRECTFLIP_SUPPORT = 19,
-            KMTQAITYPE_MULTIPLANEOVERLAY_SUPPORT = 20,
-            KMTQAITYPE_DLIST_DRIVER_NAME = 21,
-            KMTQAITYPE_WDDM_1_3_CAPS = 22,
-            KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT = 23,
-            KMTQAITYPE_WDDM_2_0_CAPS = 24,
-            KMTQAITYPE_NODEMETADATA = 25,
-            KMTQAITYPE_CPDRIVERNAME = 26,
-            KMTQAITYPE_XBOX = 27,
-            KMTQAITYPE_INDEPENDENTFLIP_SUPPORT = 28,
-            KMTQAITYPE_MIRACASTCOMPANIONDRIVERNAME = 29,
-            KMTQAITYPE_PHYSICALADAPTERCOUNT = 30,
-            KMTQAITYPE_PHYSICALADAPTERDEVICEIDS = 31,
-            KMTQAITYPE_DRIVERCAPS_EXT = 32,
-            KMTQAITYPE_QUERY_MIRACAST_DRIVER_TYPE = 33,
-            KMTQAITYPE_QUERY_GPUMMU_CAPS = 34,
-            KMTQAITYPE_QUERY_MULTIPLANEOVERLAY_DECODE_SUPPORT = 35,
-            KMTQAITYPE_QUERY_HW_PROTECTION_TEARDOWN_COUNT = 36,
-            KMTQAITYPE_QUERY_ISBADDRIVERFORHWPROTECTIONDISABLED = 37,
-            KMTQAITYPE_MULTIPLANEOVERLAY_SECONDARY_SUPPORT = 38,
-            KMTQAITYPE_INDEPENDENTFLIP_SECONDARY_SUPPORT = 39,
-            KMTQAITYPE_PANELFITTER_SUPPORT = 40,
-            KMTQAITYPE_PHYSICALADAPTERPNPKEY = 41,
-            KMTQAITYPE_GETSEGMENTGROUPSIZE = 42,
-            KMTQAITYPE_MPO3DDI_SUPPORT = 43,
-            KMTQAITYPE_HWDRM_SUPPORT = 44,
-            KMTQAITYPE_MPOKERNELCAPS_SUPPORT = 45,
-            KMTQAITYPE_MULTIPLANEOVERLAY_STRETCH_SUPPORT = 46,
-            KMTQAITYPE_GET_DEVICE_VIDPN_OWNERSHIP_INFO = 47,
-            KMTQAITYPE_QUERYREGISTRY = 48,
-            KMTQAITYPE_KMD_DRIVER_VERSION = 49,
-            KMTQAITYPE_BLOCKLIST_KERNEL = 50,
-            KMTQAITYPE_BLOCKLIST_RUNTIME = 51,
-            KMTQAITYPE_ADAPTERGUID_RENDER = 52,
-            KMTQAITYPE_ADAPTERADDRESS_RENDER = 53,
-            KMTQAITYPE_ADAPTERREGISTRYINFO_RENDER = 54,
-            KMTQAITYPE_CHECKDRIVERUPDATESTATUS_RENDER = 55,
-            KMTQAITYPE_DRIVERVERSION_RENDER = 56,
-            KMTQAITYPE_ADAPTERTYPE_RENDER = 57,
-            KMTQAITYPE_WDDM_1_2_CAPS_RENDER = 58,
-            KMTQAITYPE_WDDM_1_3_CAPS_RENDER = 59,
-            KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID = 60,
-            KMTQAITYPE_NODEPERFDATA = 61,
-            KMTQAITYPE_ADAPTERPERFDATA = 62,
-            KMTQAITYPE_ADAPTERPERFDATA_CAPS = 63,
-            KMTQUITYPE_GPUVERSION = 64,
-            KMTQAITYPE_DRIVER_DESCRIPTION = 65,
-            KMTQAITYPE_DRIVER_DESCRIPTION_RENDER = 66,
-            KMTQAITYPE_SCANOUT_CAPS = 67,
-            KMTQAITYPE_DISPLAY_UMDRIVERNAME = 71, // Added in 19H2
-            KMTQAITYPE_PARAVIRTUALIZATION_RENDER = 68,
-            KMTQAITYPE_SERVICENAME = 69,
-            KMTQAITYPE_WDDM_2_7_CAPS = 70,
-            KMTQAITYPE_TRACKEDWORKLOAD_SUPPORT = 72,
-            KMTQAITYPE_HYBRID_DLIST_DLL_SUPPORT = 73,
-            KMTQAITYPE_DISPLAY_CAPS = 74,
-            KMTQAITYPE_WDDM_2_9_CAPS = 75,
-            KMTQAITYPE_CROSSADAPTERRESOURCE_SUPPORT = 76,
-            KMTQAITYPE_WDDM_3_0_CAPS = 77,
-        };
-
-        struct EMU_D3DKMT_QUERYADAPTERINFO
-        {
-            UINT32 hAdapter;
-            KMTQAITYPE Type;
-            UINT64 pPrivateDriverData;
-            UINT32 PrivateDriverDataSize;
-        };
-
-        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!query_adapter)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto query = c.emu.read_memory<EMU_D3DKMT_QUERYADAPTERINFO>(parameters);
+            auto query = query_adapter.read();
 
             if (!query.pPrivateDriverData)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            // Optional: Enforce handle check
-            if (query.hAdapter != 0x4000)
+            if (query.hAdapter != k_dxgk_adapter_handle)
             {
-                c.win_emu.log.warn("NtGdiDdDDIQueryAdapterInfo: Querying unknown adapter handle 0x%X", query.hAdapter);
+                dxgk_warn(c, "NtGdiDdDDIQueryAdapterInfo: Querying unknown adapter handle 0x%X", query.hAdapter);
             }
 
             switch (query.Type)
             {
-            case KMTQAITYPE::KMTQAITYPE_UMDRIVERPRIVATE: // 0
-            {
-                // The runtime/UMD is asking for private driver data.
-                // Since we don't have a real KMD, we just zero the buffer
-                // to indicate no specific state is required.
-                if (query.PrivateDriverDataSize > 0)
-                {
-                    std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
-                    c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
-                }
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_UMDRIVERNAME: // 1
-            {
+            case KMTQAITYPE::KMTQAITYPE_UMDRIVERNAME: {
                 if (query.PrivateDriverDataSize < 520) // MAX_PATH * 2
                 {
                     return STATUS_BUFFER_TOO_SMALL;
@@ -2582,19 +2503,17 @@ namespace sogen
 
                 struct EMU_D3DKMT_UMDRIVERNAME
                 {
-                    uint32_t Version; // KMTUMDVERSION
+                    uint32_t Version;
                     char16_t UhDriverName[260];
-                } driverName{};
+                } driver_name{};
 
-                utils::string::copy(driverName.UhDriverName, u"d3d10warp.dll");
+                utils::string::copy(driver_name.UhDriverName, u"d3d10warp.dll");
 
-                c.emu.write_memory(query.pPrivateDriverData, &driverName, sizeof(driverName));
+                c.emu.write_memory(query.pPrivateDriverData, &driver_name, sizeof(driver_name));
                 return STATUS_SUCCESS;
             }
 
-            case KMTQAITYPE::KMTQAITYPE_GETSEGMENTSIZE: // 3
-            {
-                // Handle both legacy (24 byte) and modern (32+ byte) structures
+            case KMTQAITYPE::KMTQAITYPE_GETSEGMENTSIZE: {
                 if (query.PrivateDriverDataSize == 24)
                 {
                     struct EMU_D3DKMT_SEGMENTSIZEINFO_ONLY
@@ -2602,14 +2521,17 @@ namespace sogen
                         UINT64 DedicatedVideoMemorySize;
                         UINT64 DedicatedSystemMemorySize;
                         UINT64 SharedSystemMemorySize;
-                    } segInfo{};
-                    segInfo.DedicatedVideoMemorySize = 4ull * 1024 * 1024 * 1024;
-                    segInfo.DedicatedSystemMemorySize = 0;
-                    segInfo.SharedSystemMemorySize = 8ull * 1024 * 1024 * 1024;
-                    c.emu.write_memory(query.pPrivateDriverData, &segInfo, sizeof(segInfo));
+                    } segment_info{};
+
+                    segment_info.DedicatedVideoMemorySize = k_dxgk_dedicated_video_memory_size;
+                    segment_info.DedicatedSystemMemorySize = 0;
+                    segment_info.SharedSystemMemorySize = k_dxgk_shared_system_memory_size;
+
+                    c.emu.write_memory(query.pPrivateDriverData, &segment_info, sizeof(segment_info));
                     return STATUS_SUCCESS;
                 }
-                else if (query.PrivateDriverDataSize >= 32)
+
+                if (query.PrivateDriverDataSize >= 32)
                 {
                     struct EMU_D3DKMT_QUERYSEGMENT
                     {
@@ -2618,167 +2540,34 @@ namespace sogen
                         UINT64 DedicatedVideoMemorySize;
                         UINT64 DedicatedSystemMemorySize;
                         UINT64 SharedSystemMemorySize;
-                    } segData{};
-                    segData.DedicatedVideoMemorySize = 4ull * 1024 * 1024 * 1024;
-                    segData.DedicatedSystemMemorySize = 0;
-                    segData.SharedSystemMemorySize = 8ull * 1024 * 1024 * 1024;
-                    c.emu.write_memory(query.pPrivateDriverData, &segData, sizeof(segData));
+                    } segment_data{};
+
+                    segment_data.DedicatedVideoMemorySize = k_dxgk_dedicated_video_memory_size;
+                    segment_data.DedicatedSystemMemorySize = 0;
+                    segment_data.SharedSystemMemorySize = k_dxgk_shared_system_memory_size;
+
+                    c.emu.write_memory(query.pPrivateDriverData, &segment_data, sizeof(segment_data));
                     return STATUS_SUCCESS;
                 }
+
                 return STATUS_BUFFER_TOO_SMALL;
             }
 
-            case KMTQAITYPE::KMTQAITYPE_ADAPTERGUID: // 4
-            {
-                if (query.PrivateDriverDataSize < sizeof(GUID))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                GUID adapterGuid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
-                c.emu.write_memory(query.pPrivateDriverData, &adapterGuid, sizeof(GUID));
-                return STATUS_SUCCESS;
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERGUID: {
+                GUID adapter_guid = k_dxgk_adapter_guid;
+                return write_query_adapter_info(c, query, adapter_guid);
             }
 
-            case KMTQAITYPE::KMTQAITYPE_CHECKDRIVERUPDATESTATUS: // 11
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT32 status = 0; // 0 = No update pending
-                c.emu.write_memory(query.pPrivateDriverData, &status, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
+            case KMTQAITYPE::KMTQAITYPE_DRIVERVERSION:
+                return write_query_adapter_info(c, query, 2700);
 
-            case KMTQAITYPE::KMTQAITYPE_DRIVERVERSION: // 13
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT32 wddmVersion = 2700; // WDDM 2.7
-                c.emu.write_memory(query.pPrivateDriverData, &wddmVersion, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE:
+                return write_query_adapter_info(c, query, 3);
 
-            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE: // 15
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT32 adapterType = 0x3; // Render + Display
-                c.emu.write_memory(query.pPrivateDriverData, &adapterType, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
+            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERCOUNT:
+                return write_query_adapter_info(c, query, 1);
 
-            case KMTQAITYPE::KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT: // 16
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT32 contexts = 0;
-                c.emu.write_memory(query.pPrivateDriverData, &contexts, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_UMD_DRIVER_VERSION: // 18
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT64))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT64 version = 0; // Or a specific driver version number
-                c.emu.write_memory(query.pPrivateDriverData, &version, sizeof(UINT64));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_DIRECTFLIP_SUPPORT:            // 19
-            case KMTQAITYPE::KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT: // 23
-            {
-                if (query.PrivateDriverDataSize < sizeof(BOOL))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                BOOL supported = FALSE;
-                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_WDDM_1_3_CAPS: // 22
-            {
-                // Just zero out the buffer to indicate no specific WDDM 1.3 capabilities are claimed
-                if (query.PrivateDriverDataSize > 0)
-                {
-                    std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
-                    c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
-                }
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_NODEMETADATA: // 25
-            {
-                // Input: NodeOrdinal (UINT32) at start of buffer.
-                // Output: NodeType (D3DKMT_NODETYPE, UINT32) at offset 4.
-                if (query.PrivateDriverDataSize < sizeof(UINT32) * 2)
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-
-                // D3DKMT_NODETYPE_3D = 0
-                UINT32 nodeType = 0;
-                // Write to offset 4 (after NodeOrdinal)
-                c.emu.write_memory(query.pPrivateDriverData + 4, &nodeType, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_CPDRIVERNAME: // 26
-            {
-                if (query.PrivateDriverDataSize < 520) // MAX_PATH * 2
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-
-                struct EMU_D3DKMT_CPDRIVERNAME
-                {
-                    char16_t ContentProtectionFileName[260];
-                } cpName{};
-
-                // We don't emulate a specific Content Protection driver.
-                // Returning an empty string/zeroed buffer usually signals this to the runtime
-                // without causing a crash, or implies built-in software handling.
-                c.emu.write_memory(query.pPrivateDriverData, &cpName, sizeof(cpName));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_INDEPENDENTFLIP_SUPPORT: // 28
-            {
-                if (query.PrivateDriverDataSize < sizeof(BOOL))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-
-                // D3DKMT_INDEPENDENTFLIP_SUPPORT
-                // Set to FALSE to disable advanced independent flip optimization.
-                BOOL supported = FALSE;
-                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERCOUNT: // 30
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                UINT32 count = 1; // Single physical adapter
-                c.emu.write_memory(query.pPrivateDriverData, &count, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERDEVICEIDS: // 31
-            {
+            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERDEVICEIDS: {
                 struct EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS
                 {
                     UINT32 VendorID;
@@ -2788,189 +2577,100 @@ namespace sogen
                     UINT32 BusNumber;
                     UINT32 DeviceNumber;
                     UINT32 FunctionNumber;
-                };
+                } ids{};
 
-                if (query.PrivateDriverDataSize < sizeof(EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-
-                EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS ids{};
-
-                // Adapter Name: PCI#VEN_10DE&DEV_1C03...
-                ids.VendorID = 0x10DE; // NVIDIA
-                ids.DeviceID = 0x1C03; // Example Device
+                ids.VendorID = k_dxgk_fake_vendor_id;
+                ids.DeviceID = k_dxgk_fake_device_id;
                 ids.SubSystemID = 0;
-                ids.RevisionID = 0xA1;
+                ids.RevisionID = k_dxgk_fake_revision_id;
                 ids.BusNumber = 0;
                 ids.DeviceNumber = 0;
                 ids.FunctionNumber = 0;
 
-                c.emu.write_memory(query.pPrivateDriverData, &ids, sizeof(ids));
-                return STATUS_SUCCESS;
+                return write_query_adapter_info(c, query, ids);
             }
 
-            case KMTQAITYPE::KMTQAITYPE_MPOKERNELCAPS_SUPPORT: // 45
-            {
-                if (query.PrivateDriverDataSize < sizeof(BOOL))
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE_RENDER:
+                return write_query_adapter_info(c, query, 1);
+
+            case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: {
+                GUID unique_guid = k_dxgk_adapter_guid;
+                return write_query_adapter_info(c, query, unique_guid);
+            }
+
+            default: {
+                dxgk_warn(c, "NtGdiDdDDIQueryAdapterInfo: Unhandled query Type %d", static_cast<UINT32>(query.Type));
+
+                if (query.PrivateDriverDataSize != 0)
                 {
-                    return STATUS_BUFFER_TOO_SMALL;
+                    std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
+                    c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
                 }
-                // Multi-Plane Overlay support: False
-                BOOL supported = FALSE;
-                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
+
                 return STATUS_SUCCESS;
             }
-
-            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE_RENDER: // 57
-            {
-                if (query.PrivateDriverDataSize < sizeof(UINT32))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                // D3DKMT_ADAPTERTYPE bitfield. Bit 0 = RenderSupported.
-                UINT32 renderType = 1;
-                c.emu.write_memory(query.pPrivateDriverData, &renderType, sizeof(UINT32));
-                return STATUS_SUCCESS;
-            }
-
-            case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: // 60
-            {
-                if (query.PrivateDriverDataSize < sizeof(GUID))
-                {
-                    return STATUS_BUFFER_TOO_SMALL;
-                }
-                // Use the same GUID defined in KMTQAITYPE_ADAPTERGUID (Type 4) for consistency
-                GUID uniqueGuid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
-                c.emu.write_memory(query.pPrivateDriverData, &uniqueGuid, sizeof(GUID));
-                return STATUS_SUCCESS;
-            }
-
-            // --- WDDM CAPS and Support ---
-            case KMTQAITYPE::KMTQAITYPE_NODEPERFDATA:              // 61
-            case KMTQAITYPE::KMTQAITYPE_PARAVIRTUALIZATION_RENDER: // 68
-            case KMTQAITYPE::KMTQAITYPE_WDDM_2_7_CAPS:             // 70
-            case KMTQAITYPE::KMTQAITYPE_WDDM_3_0_CAPS:             // 77
-            {
-                std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
-                c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
-                return STATUS_SUCCESS;
-            }
-
-            default:
-                c.win_emu.log.error("NtGdiDdDDIQueryAdapterInfo: Unhandled query Type %d", (UINT32)query.Type);
-                return STATUS_SUCCESS;
             }
         }
 
-        struct EMU_D3DKMT_CREATEDEVICE
+        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, const emulator_object<EMU_D3DKMT_CREATEDEVICE> device_desc)
         {
-            UINT64 hAdapter;
-            UINT32 Flags; // D3DKMT_CREATEDEVICEFLAGS
-            UINT32 hDevice;
-            UINT64 pCommandBuffer;
-            UINT32 CommandBufferSize;
-            UINT64 pAllocationList;
-            UINT32 AllocationListSize;
-            UINT64 pPatchLocationList;
-            UINT32 PatchLocationListSize;
-        };
-
-        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!device_desc)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto create_device = c.emu.read_memory<EMU_D3DKMT_CREATEDEVICE>(parameters);
+            device_desc.access([&](EMU_D3DKMT_CREATEDEVICE& create_device) {
+                if (create_device.hAdapter != k_dxgk_adapter_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDICreateDevice: Invalid Adapter Handle 0x%X", create_device.hAdapter);
+                }
 
-            // Verify the adapter handle matches the one we issued in EnumAdapters2 (0x4000)
-            if (create_device.hAdapter != 0x4000)
-            {
-                c.win_emu.log.warn("NtGdiDdDDICreateDevice: Invalid Adapter Handle 0x%X (Expected 0x4000)", create_device.hAdapter);
-                // In strict emulation we might return STATUS_INVALID_PARAMETER,
-                // but for now, we proceed to keep the app alive.
-            }
+                create_device.hDevice = k_dxgk_device_handle;
+                create_device.pCommandBuffer = 0;
+                create_device.CommandBufferSize = 0;
 
-            // Generate a new handle for this device.
-            // In a real kernel this tracks an object. We use a static handle for the emulator.
-            // We use 0x5000 to clearly distinguish it from the adapter handle.
-            create_device.hDevice = 0x5000;
-
-            // pCommandBuffer is for legacy DirectX 9 era "Legacy Mode".
-            // For WDDM (DX10+), this is typically unused/null.
-            create_device.pCommandBuffer = 0;
-            create_device.CommandBufferSize = 0;
-
-            // pAllocationList/pPatchLocationList:
-            // This is data passed from the User Mode Driver (d3d10warp.dll) to the Kernel Mode Driver.
-            // Since we don't have a real KMD logic to configure hardware, we leave this untouched.
-            // The UMD assumes the KMD processed it.
-
-            // Write the new handle and cleared command buffer info back to guest memory
-            c.emu.write_memory(parameters, &create_device, sizeof(create_device));
-
-            c.win_emu.log.info("NtGdiDdDDICreateDevice: Created Device Handle 0x%X on Adapter 0x%X", create_device.hDevice,
-                               create_device.hAdapter);
+                dxgk_info(c, "NtGdiDdDDICreateDevice: Created Device Handle 0x%X on Adapter 0x%X", create_device.hDevice,
+                          create_device.hAdapter);
+            });
 
             return STATUS_SUCCESS;
         }
 
-        struct EMU_D3DKMT_ESCAPE
+        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, const emulator_object<EMU_D3DKMT_ESCAPE> escape_desc)
         {
-            UINT32 hAdapter;
-            UINT32 hDevice;
-            UINT32 Type;  // D3DKMT_ESCAPETYPE
-            UINT32 Flags; // D3DDDI_ESCAPEFLAGS
-            UINT64 pPrivateDriverData;
-            UINT32 PrivateDriverDataSize;
-            UINT32 hContext;
-        };
-
-        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!escape_desc)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto escape = c.emu.read_memory<EMU_D3DKMT_ESCAPE>(parameters);
+            auto escape = escape_desc.read();
 
-            // Filter by Adapter 0x4000 (The one we created in EnumAdapters2)
-            if (escape.hAdapter != 0x4000)
+            if (escape.hAdapter != k_dxgk_adapter_handle)
             {
-                c.win_emu.log.warn("NtGdiDdDDIEscape: Unknown Adapter 0x%X", escape.hAdapter);
+                dxgk_warn(c, "NtGdiDdDDIEscape: Unknown Adapter 0x%X", escape.hAdapter);
             }
 
-            // Type 0 is D3DKMT_ESCAPE_DRIVERPRIVATE.
-            // The format of pPrivateDriverData is defined by the User Mode Driver (d3d10warp.dll).
             if (escape.Type == 0 && escape.pPrivateDriverData != 0 && escape.PrivateDriverDataSize >= 4)
             {
-                // Read the first DWORD to identify the proprietary command
                 const uint32_t command = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData);
 
-                // Log details for debugging
-                c.win_emu.log.info("NtGdiDdDDIEscape: Cmd 0x%X, Size %d", command, escape.PrivateDriverDataSize);
+                dxgk_info(c, "NtGdiDdDDIEscape: Cmd 0x%X, Size %d", command, escape.PrivateDriverDataSize);
 
                 switch (command)
                 {
-                case 1: // WARP: Get Adapter Info / Handshake
-                {
-                    // Input:  [Cmd (4)][0 (4)][0 (8)]
-                    // Output: [Cmd (4)][Status (4)][LUID (8)]
+                case 1: {
                     if (escape.PrivateDriverDataSize >= 16)
                     {
                         struct WARP_CMD_GET_INFO
                         {
                             UINT32 Command;
-                            UINT32 Status; // 0 = Success
+                            UINT32 Status;
                             UINT32 LuidLow;
                             UINT32 LuidHigh;
                         } info{};
 
                         info.Command = command;
-                        info.Status = 0; // Success
+                        info.Status = 0;
                         info.LuidLow = 5;
                         info.LuidHigh = 1;
 
@@ -2980,26 +2680,14 @@ namespace sogen
                     break;
                 }
 
-                case 3: // WARP: Set Driver Version
-                {
-                    // Usually just informs the kernel of the version.
-                    // We just need to ensure we don't return an error in the buffer if expected.
-                    // Input size is 8 bytes: [Cmd][Version].
-                    // No status field fits here, so we just return STATUS_SUCCESS for the syscall.
+                case 3:
                     return STATUS_SUCCESS;
-                }
 
-                case 4: // WARP: Create Private Context Data
-                {
-                    // Input:  [Cmd (4)][Unk (4)][Args...]
-                    // Output: [Cmd (4)][Status (4)][Args...]
-                    // We simply acknowledge the command by writing Status = 0 (Success) at offset 4.
+                case 4: {
                     if (escape.PrivateDriverDataSize >= 8)
                     {
-                        // Read the existing data to preserve arguments
                         auto buffer = c.emu.read_memory(escape.pPrivateDriverData, escape.PrivateDriverDataSize);
 
-                        // Write Status = 0 (Success) at offset 4
                         uint32_t status = 0;
                         if (buffer.size() >= 8)
                         {
@@ -3010,7 +2698,7 @@ namespace sogen
                     return STATUS_SUCCESS;
                 }
 
-                case 0: // WARP: Capability Check / Reserved
+                case 0:
                     if (escape.PrivateDriverDataSize >= 56)
                     {
                         int one = 1;
@@ -3020,8 +2708,6 @@ namespace sogen
                     break;
 
                 default: {
-                    // For unknown commands, we often just need to write Status = 0 at offset 4
-                    // if the buffer is large enough to contain a header.
                     if (escape.PrivateDriverDataSize >= 8)
                     {
                         uint32_t current_val = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData + 4);
@@ -3039,224 +2725,124 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        struct EMU_D3DKMT_CREATECONTEXT
+        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, const emulator_object<EMU_D3DKMT_CREATECONTEXT> context_desc)
         {
-            UINT32 hDevice;
-            UINT32 NodeOrdinal;
-            UINT32 EngineAffinity;
-            UINT32 Flags; // D3DKMT_CREATECONTEXTFLAGS
-            UINT64 pPrivateDriverData;
-            UINT32 PrivateDriverDataSize;
-            UINT32 ClientHint;            // D3DKMT_CLIENTHINT
-            UINT32 hContext;              // OUT
-            UINT64 pCommandBuffer;        // OUT
-            UINT32 CommandBufferSize;     // OUT
-            UINT64 pAllocationList;       // OUT
-            UINT32 AllocationListSize;    // OUT
-            UINT64 pPatchLocationList;    // OUT
-            UINT32 PatchLocationListSize; // OUT
-            UINT64 CommandBuffer;         // OUT (GPU Virtual Address)
-        };
-
-        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!context_desc)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto create_context = c.emu.read_memory<EMU_D3DKMT_CREATECONTEXT>(parameters);
-
-            if (create_context.hDevice != 0x5000)
-            {
-                c.win_emu.log.warn("NtGdiDdDDICreateContext: Invalid Device Handle 0x%X (Expected 0x5000)", create_context.hDevice);
-            }
-
-            // 1. Generate a Context Handle
-            create_context.hContext = 0x6000;
-
-            // 2. Allocate a Command Buffer in Guest Memory
-            // The driver expects the kernel to provide an initial buffer to write GPU commands into.
-            // Even though we (the emulator) won't execute them, the UMD will crash if this pointer is null.
-            const uint32_t cmdBufSize = 0x1000; // 16KB is a safe default size
-            const auto cmdBufPtr = c.win_emu.memory.allocate_memory(cmdBufSize, memory_permission::read_write);
-
-            // Zero out the allocated memory to be safe
-            std::vector<uint8_t> zeros(cmdBufSize, 0);
-            c.win_emu.memory.write_memory(cmdBufPtr, zeros.data(), cmdBufSize);
-
-            // 3. Fill Output Fields
-            create_context.pCommandBuffer = cmdBufPtr;
-            create_context.CommandBufferSize = cmdBufSize;
-
-            // Allocation List and Patch Location List are used for resource binding/relocation.
-            // For WARP/Software emulation, we can usually leave these blank (0).
-            // If the app crashes, we might need to allocate buffers for these too.
-            create_context.pAllocationList = 0;
-            create_context.AllocationListSize = 0;
-            create_context.pPatchLocationList = 0;
-            create_context.PatchLocationListSize = 0;
-
-            // 4. Write back the result
-            c.emu.write_memory(parameters, &create_context, sizeof(create_context));
-
-            c.win_emu.log.info("NtGdiDdDDICreateContext: Created Context 0x%X on Device 0x%X (CmdBuf: 0x%llX)", create_context.hContext,
-                               create_context.hDevice, cmdBufPtr);
-
-            return STATUS_SUCCESS;
-        }
-
-        struct EMU_D3DDDI_ALLOCATIONINFO
-        {
-            UINT32 hAllocation;
-            UINT64 pSystemMem;
-            UINT64 pPrivateDriverData;
-            UINT32 PrivateDriverDataSize;
-            UINT32 VidPnSourceId;
-            UINT32 Flags;
-        };
-
-        struct EMU_D3DKMT_CREATEALLOCATION
-        {
-            UINT32 hDevice;
-            UINT32 hResource;
-            UINT32 hGlobalShare;
-            UINT64 pPrivateRuntimeData;
-            UINT32 PrivateRuntimeDataSize;
-            UINT64 pPrivateDriverData;
-            UINT32 PrivateDriverDataSize;
-            UINT32 NumAllocations;
-            UINT64 pAllocationInfo;
-            UINT32 Flags;
-            UINT64 hPrivateRuntimeResourceHandle;
-        };
-
-        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
-            {
-                return STATUS_INVALID_PARAMETER;
-            }
-
-            auto create_alloc = c.emu.read_memory<EMU_D3DKMT_CREATEALLOCATION>(parameters);
-
-            if (create_alloc.hDevice != 0x5000)
-            {
-                c.win_emu.log.warn("NtGdiDdDDICreateAllocation: Unexpected Device Handle 0x%X", create_alloc.hDevice);
-            }
-
-            // Static counters to ensure unique handles during the session
-            static UINT32 s_resource_handle_counter = 0x8000;
-            static UINT32 s_alloc_handle_counter = 0x9000;
-
-            // If the caller didn't provide an existing resource handle (grouping), create one.
-            // D3DKMT can group multiple allocations (e.g., surfaces in a mip chain) under one resource.
-            if (create_alloc.hResource == 0)
-            {
-                create_alloc.hResource = ++s_resource_handle_counter;
-            }
-
-            if (create_alloc.NumAllocations > 0 && create_alloc.pAllocationInfo != 0)
-            {
-                const size_t info_size = sizeof(EMU_D3DDDI_ALLOCATIONINFO);
-
-                for (UINT32 i = 0; i < create_alloc.NumAllocations; ++i)
+            context_desc.access([&](EMU_D3DKMT_CREATECONTEXT& create_context) {
+                if (create_context.hDevice != k_dxgk_device_handle)
                 {
-                    const emulator_pointer current_info_ptr = create_alloc.pAllocationInfo + (i * info_size);
-                    auto alloc_info = c.emu.read_memory<EMU_D3DDDI_ALLOCATIONINFO>(current_info_ptr);
-
-                    // Generate a unique kernel-mode handle for this allocation
-                    alloc_info.hAllocation = ++s_alloc_handle_counter;
-
-                    // If the driver provided system memory, we generally leave it alone.
-                    // If it didn't, and it's a primary surface, we might need to back it.
-                    // For now, we rely on the GpuVirtualAddress assignment above.
-
-                    c.emu.write_memory(current_info_ptr, &alloc_info, info_size);
-
-                    c.win_emu.log.info("NtGdiDdDDICreateAllocation: Alloc %d/%d -> Handle 0x%X", i + 1, create_alloc.NumAllocations,
-                                       alloc_info.hAllocation);
+                    dxgk_warn(c, "NtGdiDdDDICreateContext: Invalid Device Handle 0x%X", create_context.hDevice);
                 }
-            }
 
-            // Write back the modified struct (specifically the hResource)
-            c.emu.write_memory(parameters, &create_alloc, sizeof(create_alloc));
+                create_context.hContext = k_dxgk_context_handle;
+
+                const auto cmd_buffer_size = k_dxgk_command_buffer_size;
+                const auto cmd_buffer_ptr = c.win_emu.memory.allocate_memory(cmd_buffer_size, memory_permission::read_write);
+
+                std::vector<uint8_t> zeros(cmd_buffer_size, 0);
+                c.win_emu.memory.write_memory(cmd_buffer_ptr, zeros.data(), cmd_buffer_size);
+
+                create_context.pCommandBuffer = cmd_buffer_ptr;
+                create_context.CommandBufferSize = cmd_buffer_size;
+                create_context.pAllocationList = 0;
+                create_context.AllocationListSize = 0;
+                create_context.pPatchLocationList = 0;
+                create_context.PatchLocationListSize = 0;
+
+                dxgk_info(c, "NtGdiDdDDICreateContext: Created Context 0x%X on Device 0x%X (CmdBuf: 0x%llX)", create_context.hContext,
+                          create_context.hDevice, cmd_buffer_ptr);
+            });
 
             return STATUS_SUCCESS;
         }
 
-        struct EMU_D3DKMT_LOCK
+        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c,
+                                                   const emulator_object<EMU_D3DKMT_CREATEALLOCATION> allocation_desc)
         {
-            UINT32 hDevice;
-            UINT32 hAllocation;
-            UINT32 PrivateDriverData;
-            UINT32 NumPages;
-            UINT64 pPages;
-            UINT64 pData;             // OUT: CPU Virtual Address
-            UINT32 Flags;             // D3DDDI_LOCKFLAGS
-            UINT64 GpuVirtualAddress; // OUT: GPU Virtual Address
-        };
-
-        std::unordered_map<UINT32, uint64_t> g_allocation_map;
-
-        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!allocation_desc)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto lock_params = c.emu.read_memory<EMU_D3DKMT_LOCK>(parameters);
+            allocation_desc.access([&](EMU_D3DKMT_CREATEALLOCATION& create_alloc) {
+                if (create_alloc.hDevice != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDICreateAllocation: Unexpected Device Handle 0x%X", create_alloc.hDevice);
+                }
 
-            if (lock_params.hDevice != 0x5000 && lock_params.hDevice != 0)
-            {
-                c.win_emu.log.warn("NtGdiDdDDILock: Locking on unknown device 0x%X", lock_params.hDevice);
-            }
+                if (create_alloc.hResource == 0)
+                {
+                    create_alloc.hResource = c.proc.dxgk.create_resource();
+                }
 
-            uint64_t backing_memory = 0;
+                if (create_alloc.NumAllocations > 0 && create_alloc.pAllocationInfo != 0)
+                {
+                    for (UINT32 allocation_index = 0; allocation_index < create_alloc.NumAllocations; ++allocation_index)
+                    {
+                        constexpr size_t info_size = sizeof(EMU_D3DDDI_ALLOCATIONINFO);
+                        const emulator_pointer current_info_ptr = create_alloc.pAllocationInfo + (allocation_index * info_size);
+                        const emulator_object<EMU_D3DDDI_ALLOCATIONINFO> allocation_info{c.emu, current_info_ptr};
 
-            // 1. Try to find the allocation in our tracking map
-            auto it = g_allocation_map.find(lock_params.hAllocation);
-            if (it != g_allocation_map.end())
-            {
-                backing_memory = it->second;
-            }
-            else
-            {
-                // 2. Fallback: If we didn't track it (or it was created implicitly), allocate it now.
-                // This prevents the application from crashing on a null pointer dereference.
-                c.win_emu.log.warn("NtGdiDdDDILock: Request to lock unknown handle 0x%X. Allocating lazy buffer.", lock_params.hAllocation);
+                        allocation_info.access([&](EMU_D3DDDI_ALLOCATIONINFO& alloc_info) {
+                            const uint64_t backing_size = infer_warp_allocation_size_from_private_data(c, alloc_info.pPrivateDriverData,
+                                                                                                       alloc_info.PrivateDriverDataSize);
 
-                // Allocate a safe default size (e.g., 64KB) to handle generic surface data.
-                // In a real scenario, we would parse PrivateDriverData to find the sub-resource size.
-                constexpr size_t fallback_size = 64 * 1024;
-                backing_memory = c.win_emu.memory.allocate_memory(fallback_size, memory_permission::read_write);
+                            alloc_info.hAllocation = c.proc.dxgk.create_allocation(c.win_emu.memory, backing_size);
 
-                // Register it so subsequent locks work
-                g_allocation_map[lock_params.hAllocation] = backing_memory;
-            }
+                            const auto* allocation = c.proc.dxgk.get_allocation(alloc_info.hAllocation);
+                            const auto actual_size = allocation ? allocation->backing_size : 0ull;
+                            const auto backing_memory = allocation ? allocation->backing_memory : 0ull;
 
-            // 3. Handle Offset (Optional)
-            // D3DKMT_LOCK usually locks the whole allocation, but PrivateDriverData *can* imply an offset.
-            // For WARP/Generic emulation, simply returning the base address is usually sufficient.
-
-            // 4. Update the Output Parameters
-            // In our emulation, the "System Memory" pointer (pData) and the "GPU Address"
-            // are the same guest virtual address.
-            lock_params.pData = backing_memory;
-            lock_params.GpuVirtualAddress = backing_memory;
-
-            c.emu.write_memory(parameters, &lock_params, sizeof(lock_params));
-
-            c.win_emu.log.info("NtGdiDdDDILock: Handle 0x%X -> Address 0x%llX", lock_params.hAllocation, backing_memory);
+                            dxgk_info(c, "NtGdiDdDDICreateAllocation: Alloc %u/%u -> Handle 0x%X Size=0x%llX Address=0x%llX",
+                                      allocation_index + 1, create_alloc.NumAllocations, alloc_info.hAllocation, actual_size,
+                                      backing_memory);
+                        });
+                    }
+                }
+            });
 
             return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, const emulator_object<EMU_D3DKMT_LOCK> lock_desc)
+        {
+            if (!lock_desc)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            NTSTATUS status = STATUS_SUCCESS;
+
+            lock_desc.access([&](EMU_D3DKMT_LOCK& lock_params) {
+                if (lock_params.hDevice != k_dxgk_device_handle && lock_params.hDevice != 0)
+                {
+                    dxgk_warn(c, "NtGdiDdDDILock: Locking on unknown device 0x%X", lock_params.hDevice);
+                }
+
+                const auto* allocation = c.proc.dxgk.get_allocation(lock_params.hAllocation);
+                if (allocation == nullptr)
+                {
+                    dxgk_warn(c, "NtGdiDdDDILock: Unknown allocation handle 0x%X", lock_params.hAllocation);
+                    status = STATUS_INVALID_HANDLE;
+                    return;
+                }
+
+                lock_params.pData = allocation->backing_memory;
+                lock_params.GpuVirtualAddress = allocation->backing_memory;
+
+                dxgk_info(c, "NtGdiDdDDILock: Handle 0x%X -> Address=0x%llX Size=0x%llX", lock_params.hAllocation,
+                          allocation->backing_memory, allocation->backing_size);
+            });
+
+            return status;
         }
 
         NTSTATUS handle_NtGdiDdDDIUnlock()
         {
-            // Unlock is generally a no-op in this type of emulation
-            // because we aren't actually locking physical pages or managing contention.
             return STATUS_SUCCESS;
         }
 
@@ -3270,28 +2856,19 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        struct EMU_D3DKMT_OPENADAPTERFROMHDC
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context&,
+                                                     const emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter)
         {
-            HDC hDc;
-            UINT32 hAdapter;
-            LUID AdapterLuid;
-            UINT VidPnSourceId;
-        };
-
-        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, const emulator_pointer parameters)
-        {
-            if (!parameters)
+            if (!open_adapter)
             {
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto open_params = c.emu.read_memory<EMU_D3DKMT_OPENADAPTERFROMHDC>(parameters);
-
-            open_params.hAdapter = 0x4000;
-            open_params.AdapterLuid = {0x1000, 0};
-            open_params.VidPnSourceId = 0;
-
-            c.emu.write_memory(parameters, &open_params, sizeof(open_params));
+            open_adapter.access([](EMU_D3DKMT_OPENADAPTERFROMHDC& open_params) {
+                open_params.hAdapter = k_dxgk_adapter_handle;
+                open_params.AdapterLuid = k_dxgk_adapter_luid;
+                open_params.VidPnSourceId = 0;
+            });
 
             return STATUS_SUCCESS;
         }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1241,11 +1241,11 @@ namespace sogen
                     return 0;
                 }
 
-                const uint32_t kind = c.emu.read_memory<uint32_t>(private_data + 0x00);
-                const uint32_t width_or_size = c.emu.read_memory<uint32_t>(private_data + 0x04);
-                const uint32_t height = c.emu.read_memory<uint32_t>(private_data + 0x08);
-                const uint32_t pitch = c.emu.read_memory<uint32_t>(private_data + 0x14);
-                const uint32_t byte_size = c.emu.read_memory<uint32_t>(private_data + 0x18);
+                const auto kind = c.emu.read_memory<uint32_t>(private_data + 0x00);
+                const auto width_or_size = c.emu.read_memory<uint32_t>(private_data + 0x04);
+                const auto height = c.emu.read_memory<uint32_t>(private_data + 0x08);
+                const auto pitch = c.emu.read_memory<uint32_t>(private_data + 0x14);
+                const auto byte_size = c.emu.read_memory<uint32_t>(private_data + 0x18);
 
                 if (byte_size == 0)
                 {
@@ -2571,7 +2571,7 @@ namespace sogen
                 struct EMU_D3DKMT_UMDRIVERNAME
                 {
                     uint32_t Version;
-                    char16_t UhDriverName[260];
+                    char16_t UhDriverName[260]; // NOLINT
                 } driver_name{};
 
                 utils::string::copy(driver_name.UhDriverName, u"d3d10warp.dll");
@@ -2767,7 +2767,7 @@ namespace sogen
 
             if (escape.Type == 0 && escape.pPrivateDriverData != 0 && escape.PrivateDriverDataSize >= 4)
             {
-                const uint32_t command = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData);
+                const auto command = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData);
 
                 dxgk_info(c, "NtGdiDdDDIEscape: Cmd 0x%X, Size %d", command, escape.PrivateDriverDataSize);
 
@@ -2825,7 +2825,7 @@ namespace sogen
                 default: {
                     if (escape.PrivateDriverDataSize >= 8)
                     {
-                        uint32_t current_val = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData + 4);
+                        const auto current_val = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData + 4);
                         if (current_val != 0)
                         {
                             uint32_t success = 0;
@@ -3080,7 +3080,7 @@ namespace sogen
                             const auto backing_memory = allocation ? allocation->backing_memory : 0ull;
 
                             alloc_info.GpuVirtualAddress = backing_memory;
-                            std::fill(std::begin(alloc_info.Reserved), std::end(alloc_info.Reserved), 0ull);
+                            std::ranges::fill(alloc_info.Reserved, 0ull);
 
                             dxgk_info(c, "NtGdiDdDDIOpenResource: Alloc %u/%u -> Handle 0x%X Size=0x%llX Address=0x%llX",
                                       allocation_index + 1, params.NumAllocations, alloc_info.hAllocation, actual_size, backing_memory);
@@ -3289,11 +3289,6 @@ namespace sogen
                 open_params.VidPnSourceId = 0;
             });
 
-            return STATUS_SUCCESS;
-        }
-
-        NTSTATUS handle_NtGdiSelectFont()
-        {
             return STATUS_SUCCESS;
         }
     }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1183,6 +1183,12 @@ namespace sogen
             return resolve_dc_surface(c, dc, origin_x, origin_y, present_handle);
         }
 
+        NTSTATUS handle_NtDxgkIsFeatureEnabled()
+        {
+            // puts("NtDxgkIsFeatureEnabled not supported");
+            return STATUS_NOT_SUPPORTED;
+        }
+
         NTSTATUS handle_NtGdiInit(const syscall_context& c)
         {
             if (ensure_gdi_shared_table(c) == 0)
@@ -1408,7 +1414,15 @@ namespace sogen
             return allocate_gdi_dc(c, dc_attr);
         }
 
-        int32_t handle_NtGdiSaveDC(const syscall_context& c, const hdc dc)
+<<<<<<< HEAD
+        int32_t handle_NtGdiSaveDC(const syscall_context& c, const hdc dc) == == == = NTSTATUS handle_NtGdiOpenDCW()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        uint64_t handle_NtGdiCreateCompatibleBitmap(const syscall_context& c, const hdc /*dc*/, const uint32_t /*width*/,
+                                                    const uint32_t /*height*/)
+>>>>>>> d0f91341 (First version of DX11 skeleton)
         {
             const auto dc_value = static_cast<uint32_t>(dc);
             auto& stack = c.proc.gdi_dc_save_states[dc_value];
@@ -2244,6 +2258,1041 @@ namespace sogen
             }
 
             c.emu.write_memory(entry_ptr, &entry, sizeof(entry));
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DKMT_ADAPTERINFO
+        {
+            UINT32 hAdapter;
+            LUID AdapterLuid;
+            UINT32 NumOfSources;
+            BOOL bPrecisePresentRegionsPreferred;
+        };
+
+        struct EMU_D3DKMT_ENUMADAPTERS2
+        {
+            UINT32 NumAdapters;
+            UINT64 pAdapters;
+        };
+
+        struct EMU_D3DKMT_ENUMADAPTERS_FILTER
+        {
+            UINT64 Value;
+        };
+
+        struct EMU_D3DKMT_ENUMADAPTERS3
+        {
+            EMU_D3DKMT_ENUMADAPTERS_FILTER Filter;
+            UINT32 NumAdapters;
+            UINT32 Padding;
+            UINT64 pAdapters;
+        };
+        static_assert(sizeof(EMU_D3DKMT_ENUMADAPTERS3) == 0x18);
+
+        constexpr UINT32 k_dxgk_adapter_count = 1;
+        constexpr UINT32 k_dxgk_adapter_handle = 0x4000;
+        constexpr UINT32 k_dxgk_adapter_luid_low = 0x1000;
+        constexpr UINT32 k_dxgk_adapter_luid_high = 0;
+        constexpr UINT32 k_dxgk_adapter_source_count = 1;
+
+        EMU_D3DKMT_ADAPTERINFO make_default_dxgk_adapter_info()
+        {
+            EMU_D3DKMT_ADAPTERINFO adapter_info{};
+            adapter_info.hAdapter = k_dxgk_adapter_handle;
+            adapter_info.AdapterLuid = {k_dxgk_adapter_luid_low, k_dxgk_adapter_luid_high};
+            adapter_info.NumOfSources = k_dxgk_adapter_source_count;
+            adapter_info.bPrecisePresentRegionsPreferred = FALSE;
+            return adapter_info;
+        }
+
+        NTSTATUS write_default_dxgk_adapter_array(const syscall_context& c, const UINT32 num_adapters, const UINT64 adapters_ptr)
+        {
+            if (adapters_ptr == 0)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (num_adapters < k_dxgk_adapter_count)
+            {
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+
+            const auto adapter_info = make_default_dxgk_adapter_info();
+            c.emu.write_memory(adapters_ptr, &adapter_info, sizeof(adapter_info));
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIEnumAdapters2(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto desc = c.emu.read_memory<EMU_D3DKMT_ENUMADAPTERS2>(parameters);
+
+            if (desc.pAdapters == 0)
+            {
+                desc.NumAdapters = k_dxgk_adapter_count;
+                c.emu.write_memory(parameters, &desc, sizeof(desc));
+                return STATUS_SUCCESS;
+            }
+
+            const NTSTATUS status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
+            if (status != STATUS_SUCCESS)
+            {
+                return status;
+            }
+
+            desc.NumAdapters = k_dxgk_adapter_count;
+            c.emu.write_memory(parameters, &desc, sizeof(desc));
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtDxgkEnumAdapters3(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto desc = c.emu.read_memory<EMU_D3DKMT_ENUMADAPTERS3>(parameters);
+
+            if (desc.pAdapters == 0)
+            {
+                desc.NumAdapters = k_dxgk_adapter_count;
+                c.emu.write_memory(parameters, &desc, sizeof(desc));
+                return STATUS_SUCCESS;
+            }
+
+            const NTSTATUS status = write_default_dxgk_adapter_array(c, desc.NumAdapters, desc.pAdapters);
+            if (status != STATUS_SUCCESS)
+            {
+                return status;
+            }
+
+            desc.NumAdapters = k_dxgk_adapter_count;
+            c.emu.write_memory(parameters, &desc, sizeof(desc));
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtDxgkGetProperties(const syscall_context& c, const emulator_pointer parameters)
+        {
+            // Structure inferred from GetKernelCachedAdapterId stack layout:
+            // v7[0] = PropertyId (4 bytes)
+            // v7[1] = Size (4 bytes)
+            // v8    = Reserved/Padding (8 bytes)
+            // v9    = pBuffer (8 bytes)
+            // v10   = Reserved (16 bytes)
+            struct EMU_D3DKMT_GET_PROPERTIES
+            {
+                UINT32 PropertyId;
+                UINT32 Size;
+                UINT64 Reserved;
+                UINT64 pBuffer;
+                UINT64 Reserved2[2];
+            };
+
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto props = c.emu.read_memory<EMU_D3DKMT_GET_PROPERTIES>(parameters);
+
+            // PropertyId 1 and 2 seem to correspond to querying the "Kernel Cached Adapter Id".
+            // 1 = Per-App preference?
+            // 2 = Global preference?
+            // The code checks if the returned data has a valid flag (4th DWORD LOBYTE).
+            if (props.PropertyId == 1 || props.PropertyId == 2)
+            {
+                if (props.Size < 16 || !props.pBuffer)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                // Inferred output structure:
+                // struct UserPreferredAdapterId {
+                //   UINT32 LuidLow;
+                //   UINT32 LuidHigh;
+                //   UINT32 VidPnSourceId;
+                //   UINT32 Valid; // Checked via LOBYTE(v[3])
+                // };
+                struct EMU_PREFERRED_ADAPTER_INFO
+                {
+                    UINT32 LuidLow;
+                    UINT32 LuidHigh;
+                    UINT32 SourceId;
+                    UINT32 Flags;
+                } info{};
+
+                // Return the LUID of the emulated adapter defined in EnumAdapters2 (e.g. {0x1000, 0}).
+                // This ensures the helper library "finds" our emulated GPU.
+                info.LuidLow = 0x1000;
+                info.LuidHigh = 0;
+                info.SourceId = 0; // Default source (Monitor 0)
+                info.Flags = 1;    // Mark as valid
+
+                c.emu.write_memory(props.pBuffer, &info, sizeof(info));
+                return STATUS_SUCCESS;
+            }
+
+            c.win_emu.log.error("Unknown PropertyId %d", props.PropertyId);
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        NTSTATUS handle_NtGdiDdDDICloseAdapter()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        enum class KMTQAITYPE : UINT32
+        {
+            KMTQAITYPE_UMDRIVERPRIVATE = 0,
+            KMTQAITYPE_UMDRIVERNAME = 1,
+            KMTQAITYPE_UMOPENGLINFO = 2,
+            KMTQAITYPE_GETSEGMENTSIZE = 3,
+            KMTQAITYPE_ADAPTERGUID = 4,
+            KMTQAITYPE_FLIPQUEUEINFO = 5,
+            KMTQAITYPE_ADAPTERADDRESS = 6,
+            KMTQAITYPE_SETWORKINGSETINFO = 7,
+            KMTQAITYPE_ADAPTERREGISTRYINFO = 8,
+            KMTQAITYPE_CURRENTDISPLAYMODE = 9,
+            KMTQAITYPE_MODELIST = 10,
+            KMTQAITYPE_CHECKDRIVERUPDATESTATUS = 11,
+            KMTQAITYPE_VIRTUALADDRESSINFO = 12, // _ADVSCH_
+            KMTQAITYPE_DRIVERVERSION = 13,
+            KMTQAITYPE_ADAPTERTYPE = 15,
+            KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT = 16,
+            KMTQAITYPE_WDDM_1_2_CAPS = 17,
+            KMTQAITYPE_UMD_DRIVER_VERSION = 18,
+            KMTQAITYPE_DIRECTFLIP_SUPPORT = 19,
+            KMTQAITYPE_MULTIPLANEOVERLAY_SUPPORT = 20,
+            KMTQAITYPE_DLIST_DRIVER_NAME = 21,
+            KMTQAITYPE_WDDM_1_3_CAPS = 22,
+            KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT = 23,
+            KMTQAITYPE_WDDM_2_0_CAPS = 24,
+            KMTQAITYPE_NODEMETADATA = 25,
+            KMTQAITYPE_CPDRIVERNAME = 26,
+            KMTQAITYPE_XBOX = 27,
+            KMTQAITYPE_INDEPENDENTFLIP_SUPPORT = 28,
+            KMTQAITYPE_MIRACASTCOMPANIONDRIVERNAME = 29,
+            KMTQAITYPE_PHYSICALADAPTERCOUNT = 30,
+            KMTQAITYPE_PHYSICALADAPTERDEVICEIDS = 31,
+            KMTQAITYPE_DRIVERCAPS_EXT = 32,
+            KMTQAITYPE_QUERY_MIRACAST_DRIVER_TYPE = 33,
+            KMTQAITYPE_QUERY_GPUMMU_CAPS = 34,
+            KMTQAITYPE_QUERY_MULTIPLANEOVERLAY_DECODE_SUPPORT = 35,
+            KMTQAITYPE_QUERY_HW_PROTECTION_TEARDOWN_COUNT = 36,
+            KMTQAITYPE_QUERY_ISBADDRIVERFORHWPROTECTIONDISABLED = 37,
+            KMTQAITYPE_MULTIPLANEOVERLAY_SECONDARY_SUPPORT = 38,
+            KMTQAITYPE_INDEPENDENTFLIP_SECONDARY_SUPPORT = 39,
+            KMTQAITYPE_PANELFITTER_SUPPORT = 40,
+            KMTQAITYPE_PHYSICALADAPTERPNPKEY = 41,
+            KMTQAITYPE_GETSEGMENTGROUPSIZE = 42,
+            KMTQAITYPE_MPO3DDI_SUPPORT = 43,
+            KMTQAITYPE_HWDRM_SUPPORT = 44,
+            KMTQAITYPE_MPOKERNELCAPS_SUPPORT = 45,
+            KMTQAITYPE_MULTIPLANEOVERLAY_STRETCH_SUPPORT = 46,
+            KMTQAITYPE_GET_DEVICE_VIDPN_OWNERSHIP_INFO = 47,
+            KMTQAITYPE_QUERYREGISTRY = 48,
+            KMTQAITYPE_KMD_DRIVER_VERSION = 49,
+            KMTQAITYPE_BLOCKLIST_KERNEL = 50,
+            KMTQAITYPE_BLOCKLIST_RUNTIME = 51,
+            KMTQAITYPE_ADAPTERGUID_RENDER = 52,
+            KMTQAITYPE_ADAPTERADDRESS_RENDER = 53,
+            KMTQAITYPE_ADAPTERREGISTRYINFO_RENDER = 54,
+            KMTQAITYPE_CHECKDRIVERUPDATESTATUS_RENDER = 55,
+            KMTQAITYPE_DRIVERVERSION_RENDER = 56,
+            KMTQAITYPE_ADAPTERTYPE_RENDER = 57,
+            KMTQAITYPE_WDDM_1_2_CAPS_RENDER = 58,
+            KMTQAITYPE_WDDM_1_3_CAPS_RENDER = 59,
+            KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID = 60,
+            KMTQAITYPE_NODEPERFDATA = 61,
+            KMTQAITYPE_ADAPTERPERFDATA = 62,
+            KMTQAITYPE_ADAPTERPERFDATA_CAPS = 63,
+            KMTQUITYPE_GPUVERSION = 64,
+            KMTQAITYPE_DRIVER_DESCRIPTION = 65,
+            KMTQAITYPE_DRIVER_DESCRIPTION_RENDER = 66,
+            KMTQAITYPE_SCANOUT_CAPS = 67,
+            KMTQAITYPE_DISPLAY_UMDRIVERNAME = 71, // Added in 19H2
+            KMTQAITYPE_PARAVIRTUALIZATION_RENDER = 68,
+            KMTQAITYPE_SERVICENAME = 69,
+            KMTQAITYPE_WDDM_2_7_CAPS = 70,
+            KMTQAITYPE_TRACKEDWORKLOAD_SUPPORT = 72,
+            KMTQAITYPE_HYBRID_DLIST_DLL_SUPPORT = 73,
+            KMTQAITYPE_DISPLAY_CAPS = 74,
+            KMTQAITYPE_WDDM_2_9_CAPS = 75,
+            KMTQAITYPE_CROSSADAPTERRESOURCE_SUPPORT = 76,
+            KMTQAITYPE_WDDM_3_0_CAPS = 77,
+        };
+
+        struct EMU_D3DKMT_QUERYADAPTERINFO
+        {
+            UINT32 hAdapter;
+            KMTQAITYPE Type;
+            UINT64 pPrivateDriverData;
+            UINT32 PrivateDriverDataSize;
+        };
+
+        NTSTATUS handle_NtGdiDdDDIQueryAdapterInfo(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto query = c.emu.read_memory<EMU_D3DKMT_QUERYADAPTERINFO>(parameters);
+
+            if (!query.pPrivateDriverData)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            // Optional: Enforce handle check
+            if (query.hAdapter != 0x4000)
+            {
+                c.win_emu.log.warn("NtGdiDdDDIQueryAdapterInfo: Querying unknown adapter handle 0x%X", query.hAdapter);
+            }
+
+            switch (query.Type)
+            {
+            case KMTQAITYPE::KMTQAITYPE_UMDRIVERPRIVATE: // 0
+            {
+                // The runtime/UMD is asking for private driver data.
+                // Since we don't have a real KMD, we just zero the buffer
+                // to indicate no specific state is required.
+                if (query.PrivateDriverDataSize > 0)
+                {
+                    std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
+                    c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
+                }
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_UMDRIVERNAME: // 1
+            {
+                if (query.PrivateDriverDataSize < 520) // MAX_PATH * 2
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                struct EMU_D3DKMT_UMDRIVERNAME
+                {
+                    uint32_t Version; // KMTUMDVERSION
+                    char16_t UhDriverName[260];
+                } driverName{};
+
+                utils::string::copy(driverName.UhDriverName, u"d3d10warp.dll");
+
+                c.emu.write_memory(query.pPrivateDriverData, &driverName, sizeof(driverName));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_GETSEGMENTSIZE: // 3
+            {
+                // Handle both legacy (24 byte) and modern (32+ byte) structures
+                if (query.PrivateDriverDataSize == 24)
+                {
+                    struct EMU_D3DKMT_SEGMENTSIZEINFO_ONLY
+                    {
+                        UINT64 DedicatedVideoMemorySize;
+                        UINT64 DedicatedSystemMemorySize;
+                        UINT64 SharedSystemMemorySize;
+                    } segInfo{};
+                    segInfo.DedicatedVideoMemorySize = 4ull * 1024 * 1024 * 1024;
+                    segInfo.DedicatedSystemMemorySize = 0;
+                    segInfo.SharedSystemMemorySize = 8ull * 1024 * 1024 * 1024;
+                    c.emu.write_memory(query.pPrivateDriverData, &segInfo, sizeof(segInfo));
+                    return STATUS_SUCCESS;
+                }
+                else if (query.PrivateDriverDataSize >= 32)
+                {
+                    struct EMU_D3DKMT_QUERYSEGMENT
+                    {
+                        UINT32 PhysicalAdapterIndex;
+                        UINT32 Padding;
+                        UINT64 DedicatedVideoMemorySize;
+                        UINT64 DedicatedSystemMemorySize;
+                        UINT64 SharedSystemMemorySize;
+                    } segData{};
+                    segData.DedicatedVideoMemorySize = 4ull * 1024 * 1024 * 1024;
+                    segData.DedicatedSystemMemorySize = 0;
+                    segData.SharedSystemMemorySize = 8ull * 1024 * 1024 * 1024;
+                    c.emu.write_memory(query.pPrivateDriverData, &segData, sizeof(segData));
+                    return STATUS_SUCCESS;
+                }
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERGUID: // 4
+            {
+                if (query.PrivateDriverDataSize < sizeof(GUID))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                GUID adapterGuid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
+                c.emu.write_memory(query.pPrivateDriverData, &adapterGuid, sizeof(GUID));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_CHECKDRIVERUPDATESTATUS: // 11
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT32 status = 0; // 0 = No update pending
+                c.emu.write_memory(query.pPrivateDriverData, &status, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_DRIVERVERSION: // 13
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT32 wddmVersion = 2700; // WDDM 2.7
+                c.emu.write_memory(query.pPrivateDriverData, &wddmVersion, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE: // 15
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT32 adapterType = 0x3; // Render + Display
+                c.emu.write_memory(query.pPrivateDriverData, &adapterType, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT: // 16
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT32 contexts = 0;
+                c.emu.write_memory(query.pPrivateDriverData, &contexts, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_UMD_DRIVER_VERSION: // 18
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT64))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT64 version = 0; // Or a specific driver version number
+                c.emu.write_memory(query.pPrivateDriverData, &version, sizeof(UINT64));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_DIRECTFLIP_SUPPORT:            // 19
+            case KMTQAITYPE::KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT: // 23
+            {
+                if (query.PrivateDriverDataSize < sizeof(BOOL))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                BOOL supported = FALSE;
+                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_WDDM_1_3_CAPS: // 22
+            {
+                // Just zero out the buffer to indicate no specific WDDM 1.3 capabilities are claimed
+                if (query.PrivateDriverDataSize > 0)
+                {
+                    std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
+                    c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
+                }
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_NODEMETADATA: // 25
+            {
+                // Input: NodeOrdinal (UINT32) at start of buffer.
+                // Output: NodeType (D3DKMT_NODETYPE, UINT32) at offset 4.
+                if (query.PrivateDriverDataSize < sizeof(UINT32) * 2)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                // D3DKMT_NODETYPE_3D = 0
+                UINT32 nodeType = 0;
+                // Write to offset 4 (after NodeOrdinal)
+                c.emu.write_memory(query.pPrivateDriverData + 4, &nodeType, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_CPDRIVERNAME: // 26
+            {
+                if (query.PrivateDriverDataSize < 520) // MAX_PATH * 2
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                struct EMU_D3DKMT_CPDRIVERNAME
+                {
+                    char16_t ContentProtectionFileName[260];
+                } cpName{};
+
+                // We don't emulate a specific Content Protection driver.
+                // Returning an empty string/zeroed buffer usually signals this to the runtime
+                // without causing a crash, or implies built-in software handling.
+                c.emu.write_memory(query.pPrivateDriverData, &cpName, sizeof(cpName));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_INDEPENDENTFLIP_SUPPORT: // 28
+            {
+                if (query.PrivateDriverDataSize < sizeof(BOOL))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                // D3DKMT_INDEPENDENTFLIP_SUPPORT
+                // Set to FALSE to disable advanced independent flip optimization.
+                BOOL supported = FALSE;
+                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERCOUNT: // 30
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                UINT32 count = 1; // Single physical adapter
+                c.emu.write_memory(query.pPrivateDriverData, &count, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERDEVICEIDS: // 31
+            {
+                struct EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS
+                {
+                    UINT32 VendorID;
+                    UINT32 DeviceID;
+                    UINT32 SubSystemID;
+                    UINT32 RevisionID;
+                    UINT32 BusNumber;
+                    UINT32 DeviceNumber;
+                    UINT32 FunctionNumber;
+                };
+
+                if (query.PrivateDriverDataSize < sizeof(EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS ids{};
+
+                // Adapter Name: PCI#VEN_10DE&DEV_1C03...
+                ids.VendorID = 0x10DE; // NVIDIA
+                ids.DeviceID = 0x1C03; // Example Device
+                ids.SubSystemID = 0;
+                ids.RevisionID = 0xA1;
+                ids.BusNumber = 0;
+                ids.DeviceNumber = 0;
+                ids.FunctionNumber = 0;
+
+                c.emu.write_memory(query.pPrivateDriverData, &ids, sizeof(ids));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_MPOKERNELCAPS_SUPPORT: // 45
+            {
+                if (query.PrivateDriverDataSize < sizeof(BOOL))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                // Multi-Plane Overlay support: False
+                BOOL supported = FALSE;
+                c.emu.write_memory(query.pPrivateDriverData, &supported, sizeof(BOOL));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE_RENDER: // 57
+            {
+                if (query.PrivateDriverDataSize < sizeof(UINT32))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                // D3DKMT_ADAPTERTYPE bitfield. Bit 0 = RenderSupported.
+                UINT32 renderType = 1;
+                c.emu.write_memory(query.pPrivateDriverData, &renderType, sizeof(UINT32));
+                return STATUS_SUCCESS;
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: // 60
+            {
+                if (query.PrivateDriverDataSize < sizeof(GUID))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+                // Use the same GUID defined in KMTQAITYPE_ADAPTERGUID (Type 4) for consistency
+                GUID uniqueGuid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
+                c.emu.write_memory(query.pPrivateDriverData, &uniqueGuid, sizeof(GUID));
+                return STATUS_SUCCESS;
+            }
+
+            // --- WDDM CAPS and Support ---
+            case KMTQAITYPE::KMTQAITYPE_NODEPERFDATA:              // 61
+            case KMTQAITYPE::KMTQAITYPE_PARAVIRTUALIZATION_RENDER: // 68
+            case KMTQAITYPE::KMTQAITYPE_WDDM_2_7_CAPS:             // 70
+            case KMTQAITYPE::KMTQAITYPE_WDDM_3_0_CAPS:             // 77
+            {
+                std::vector<uint8_t> zeros(query.PrivateDriverDataSize, 0);
+                c.emu.write_memory(query.pPrivateDriverData, zeros.data(), zeros.size());
+                return STATUS_SUCCESS;
+            }
+
+            default:
+                c.win_emu.log.error("NtGdiDdDDIQueryAdapterInfo: Unhandled query Type %d", (UINT32)query.Type);
+                return STATUS_SUCCESS;
+            }
+        }
+
+        struct EMU_D3DKMT_CREATEDEVICE
+        {
+            UINT64 hAdapter;
+            UINT32 Flags; // D3DKMT_CREATEDEVICEFLAGS
+            UINT32 hDevice;
+            UINT64 pCommandBuffer;
+            UINT32 CommandBufferSize;
+            UINT64 pAllocationList;
+            UINT32 AllocationListSize;
+            UINT64 pPatchLocationList;
+            UINT32 PatchLocationListSize;
+        };
+
+        NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto create_device = c.emu.read_memory<EMU_D3DKMT_CREATEDEVICE>(parameters);
+
+            // Verify the adapter handle matches the one we issued in EnumAdapters2 (0x4000)
+            if (create_device.hAdapter != 0x4000)
+            {
+                c.win_emu.log.warn("NtGdiDdDDICreateDevice: Invalid Adapter Handle 0x%X (Expected 0x4000)", create_device.hAdapter);
+                // In strict emulation we might return STATUS_INVALID_PARAMETER,
+                // but for now, we proceed to keep the app alive.
+            }
+
+            // Generate a new handle for this device.
+            // In a real kernel this tracks an object. We use a static handle for the emulator.
+            // We use 0x5000 to clearly distinguish it from the adapter handle.
+            create_device.hDevice = 0x5000;
+
+            // pCommandBuffer is for legacy DirectX 9 era "Legacy Mode".
+            // For WDDM (DX10+), this is typically unused/null.
+            create_device.pCommandBuffer = 0;
+            create_device.CommandBufferSize = 0;
+
+            // pAllocationList/pPatchLocationList:
+            // This is data passed from the User Mode Driver (d3d10warp.dll) to the Kernel Mode Driver.
+            // Since we don't have a real KMD logic to configure hardware, we leave this untouched.
+            // The UMD assumes the KMD processed it.
+
+            // Write the new handle and cleared command buffer info back to guest memory
+            c.emu.write_memory(parameters, &create_device, sizeof(create_device));
+
+            c.win_emu.log.info("NtGdiDdDDICreateDevice: Created Device Handle 0x%X on Adapter 0x%X", create_device.hDevice,
+                               create_device.hAdapter);
+
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DKMT_ESCAPE
+        {
+            UINT32 hAdapter;
+            UINT32 hDevice;
+            UINT32 Type;  // D3DKMT_ESCAPETYPE
+            UINT32 Flags; // D3DDDI_ESCAPEFLAGS
+            UINT64 pPrivateDriverData;
+            UINT32 PrivateDriverDataSize;
+            UINT32 hContext;
+        };
+
+        NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto escape = c.emu.read_memory<EMU_D3DKMT_ESCAPE>(parameters);
+
+            // Filter by Adapter 0x4000 (The one we created in EnumAdapters2)
+            if (escape.hAdapter != 0x4000)
+            {
+                c.win_emu.log.warn("NtGdiDdDDIEscape: Unknown Adapter 0x%X", escape.hAdapter);
+            }
+
+            // Type 0 is D3DKMT_ESCAPE_DRIVERPRIVATE.
+            // The format of pPrivateDriverData is defined by the User Mode Driver (d3d10warp.dll).
+            if (escape.Type == 0 && escape.pPrivateDriverData != 0 && escape.PrivateDriverDataSize >= 4)
+            {
+                // Read the first DWORD to identify the proprietary command
+                const uint32_t command = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData);
+
+                // Log details for debugging
+                c.win_emu.log.info("NtGdiDdDDIEscape: Cmd 0x%X, Size %d", command, escape.PrivateDriverDataSize);
+
+                switch (command)
+                {
+                case 1: // WARP: Get Adapter Info / Handshake
+                {
+                    // Input:  [Cmd (4)][0 (4)][0 (8)]
+                    // Output: [Cmd (4)][Status (4)][LUID (8)]
+                    if (escape.PrivateDriverDataSize >= 16)
+                    {
+                        struct WARP_CMD_GET_INFO
+                        {
+                            UINT32 Command;
+                            UINT32 Status; // 0 = Success
+                            UINT32 LuidLow;
+                            UINT32 LuidHigh;
+                        } info{};
+
+                        info.Command = command;
+                        info.Status = 0; // Success
+                        info.LuidLow = 5;
+                        info.LuidHigh = 1;
+
+                        c.emu.write_memory(escape.pPrivateDriverData, &info, sizeof(info));
+                        return STATUS_SUCCESS;
+                    }
+                    break;
+                }
+
+                case 3: // WARP: Set Driver Version
+                {
+                    // Usually just informs the kernel of the version.
+                    // We just need to ensure we don't return an error in the buffer if expected.
+                    // Input size is 8 bytes: [Cmd][Version].
+                    // No status field fits here, so we just return STATUS_SUCCESS for the syscall.
+                    return STATUS_SUCCESS;
+                }
+
+                case 4: // WARP: Create Private Context Data
+                {
+                    // Input:  [Cmd (4)][Unk (4)][Args...]
+                    // Output: [Cmd (4)][Status (4)][Args...]
+                    // We simply acknowledge the command by writing Status = 0 (Success) at offset 4.
+                    if (escape.PrivateDriverDataSize >= 8)
+                    {
+                        // Read the existing data to preserve arguments
+                        auto buffer = c.emu.read_memory(escape.pPrivateDriverData, escape.PrivateDriverDataSize);
+
+                        // Write Status = 0 (Success) at offset 4
+                        uint32_t status = 0;
+                        if (buffer.size() >= 8)
+                        {
+                            std::memcpy(&buffer[4], &status, sizeof(status));
+                            c.emu.write_memory(escape.pPrivateDriverData, buffer.data(), buffer.size());
+                        }
+                    }
+                    return STATUS_SUCCESS;
+                }
+
+                case 0: // WARP: Capability Check / Reserved
+                    if (escape.PrivateDriverDataSize >= 56)
+                    {
+                        int one = 1;
+                        c.emu.write_memory(escape.pPrivateDriverData + 28, &one, sizeof(one));
+                        return STATUS_SUCCESS;
+                    }
+                    break;
+
+                default: {
+                    // For unknown commands, we often just need to write Status = 0 at offset 4
+                    // if the buffer is large enough to contain a header.
+                    if (escape.PrivateDriverDataSize >= 8)
+                    {
+                        uint32_t current_val = c.emu.read_memory<uint32_t>(escape.pPrivateDriverData + 4);
+                        if (current_val != 0)
+                        {
+                            uint32_t success = 0;
+                            c.emu.write_memory(escape.pPrivateDriverData + 4, &success, sizeof(success));
+                        }
+                    }
+                    break;
+                }
+                }
+            }
+
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DKMT_CREATECONTEXT
+        {
+            UINT32 hDevice;
+            UINT32 NodeOrdinal;
+            UINT32 EngineAffinity;
+            UINT32 Flags; // D3DKMT_CREATECONTEXTFLAGS
+            UINT64 pPrivateDriverData;
+            UINT32 PrivateDriverDataSize;
+            UINT32 ClientHint;            // D3DKMT_CLIENTHINT
+            UINT32 hContext;              // OUT
+            UINT64 pCommandBuffer;        // OUT
+            UINT32 CommandBufferSize;     // OUT
+            UINT64 pAllocationList;       // OUT
+            UINT32 AllocationListSize;    // OUT
+            UINT64 pPatchLocationList;    // OUT
+            UINT32 PatchLocationListSize; // OUT
+            UINT64 CommandBuffer;         // OUT (GPU Virtual Address)
+        };
+
+        NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto create_context = c.emu.read_memory<EMU_D3DKMT_CREATECONTEXT>(parameters);
+
+            if (create_context.hDevice != 0x5000)
+            {
+                c.win_emu.log.warn("NtGdiDdDDICreateContext: Invalid Device Handle 0x%X (Expected 0x5000)", create_context.hDevice);
+            }
+
+            // 1. Generate a Context Handle
+            create_context.hContext = 0x6000;
+
+            // 2. Allocate a Command Buffer in Guest Memory
+            // The driver expects the kernel to provide an initial buffer to write GPU commands into.
+            // Even though we (the emulator) won't execute them, the UMD will crash if this pointer is null.
+            const uint32_t cmdBufSize = 0x1000; // 16KB is a safe default size
+            const auto cmdBufPtr = c.win_emu.memory.allocate_memory(cmdBufSize, memory_permission::read_write);
+
+            // Zero out the allocated memory to be safe
+            std::vector<uint8_t> zeros(cmdBufSize, 0);
+            c.win_emu.memory.write_memory(cmdBufPtr, zeros.data(), cmdBufSize);
+
+            // 3. Fill Output Fields
+            create_context.pCommandBuffer = cmdBufPtr;
+            create_context.CommandBufferSize = cmdBufSize;
+
+            // Allocation List and Patch Location List are used for resource binding/relocation.
+            // For WARP/Software emulation, we can usually leave these blank (0).
+            // If the app crashes, we might need to allocate buffers for these too.
+            create_context.pAllocationList = 0;
+            create_context.AllocationListSize = 0;
+            create_context.pPatchLocationList = 0;
+            create_context.PatchLocationListSize = 0;
+
+            // 4. Write back the result
+            c.emu.write_memory(parameters, &create_context, sizeof(create_context));
+
+            c.win_emu.log.info("NtGdiDdDDICreateContext: Created Context 0x%X on Device 0x%X (CmdBuf: 0x%llX)", create_context.hContext,
+                               create_context.hDevice, cmdBufPtr);
+
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DDDI_ALLOCATIONINFO
+        {
+            UINT32 hAllocation;
+            UINT64 pSystemMem;
+            UINT64 pPrivateDriverData;
+            UINT32 PrivateDriverDataSize;
+            UINT32 VidPnSourceId;
+            UINT32 Flags;
+        };
+
+        struct EMU_D3DKMT_CREATEALLOCATION
+        {
+            UINT32 hDevice;
+            UINT32 hResource;
+            UINT32 hGlobalShare;
+            UINT64 pPrivateRuntimeData;
+            UINT32 PrivateRuntimeDataSize;
+            UINT64 pPrivateDriverData;
+            UINT32 PrivateDriverDataSize;
+            UINT32 NumAllocations;
+            UINT64 pAllocationInfo;
+            UINT32 Flags;
+            UINT64 hPrivateRuntimeResourceHandle;
+        };
+
+        NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto create_alloc = c.emu.read_memory<EMU_D3DKMT_CREATEALLOCATION>(parameters);
+
+            if (create_alloc.hDevice != 0x5000)
+            {
+                c.win_emu.log.warn("NtGdiDdDDICreateAllocation: Unexpected Device Handle 0x%X", create_alloc.hDevice);
+            }
+
+            // Static counters to ensure unique handles during the session
+            static UINT32 s_resource_handle_counter = 0x8000;
+            static UINT32 s_alloc_handle_counter = 0x9000;
+
+            // If the caller didn't provide an existing resource handle (grouping), create one.
+            // D3DKMT can group multiple allocations (e.g., surfaces in a mip chain) under one resource.
+            if (create_alloc.hResource == 0)
+            {
+                create_alloc.hResource = ++s_resource_handle_counter;
+            }
+
+            if (create_alloc.NumAllocations > 0 && create_alloc.pAllocationInfo != 0)
+            {
+                const size_t info_size = sizeof(EMU_D3DDDI_ALLOCATIONINFO);
+
+                for (UINT32 i = 0; i < create_alloc.NumAllocations; ++i)
+                {
+                    const emulator_pointer current_info_ptr = create_alloc.pAllocationInfo + (i * info_size);
+                    auto alloc_info = c.emu.read_memory<EMU_D3DDDI_ALLOCATIONINFO>(current_info_ptr);
+
+                    // Generate a unique kernel-mode handle for this allocation
+                    alloc_info.hAllocation = ++s_alloc_handle_counter;
+
+                    // If the driver provided system memory, we generally leave it alone.
+                    // If it didn't, and it's a primary surface, we might need to back it.
+                    // For now, we rely on the GpuVirtualAddress assignment above.
+
+                    c.emu.write_memory(current_info_ptr, &alloc_info, info_size);
+
+                    c.win_emu.log.info("NtGdiDdDDICreateAllocation: Alloc %d/%d -> Handle 0x%X", i + 1, create_alloc.NumAllocations,
+                                       alloc_info.hAllocation);
+                }
+            }
+
+            // Write back the modified struct (specifically the hResource)
+            c.emu.write_memory(parameters, &create_alloc, sizeof(create_alloc));
+
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DKMT_LOCK
+        {
+            UINT32 hDevice;
+            UINT32 hAllocation;
+            UINT32 PrivateDriverData;
+            UINT32 NumPages;
+            UINT64 pPages;
+            UINT64 pData;             // OUT: CPU Virtual Address
+            UINT32 Flags;             // D3DDDI_LOCKFLAGS
+            UINT64 GpuVirtualAddress; // OUT: GPU Virtual Address
+        };
+
+        std::unordered_map<UINT32, uint64_t> g_allocation_map;
+
+        NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto lock_params = c.emu.read_memory<EMU_D3DKMT_LOCK>(parameters);
+
+            if (lock_params.hDevice != 0x5000 && lock_params.hDevice != 0)
+            {
+                c.win_emu.log.warn("NtGdiDdDDILock: Locking on unknown device 0x%X", lock_params.hDevice);
+            }
+
+            uint64_t backing_memory = 0;
+
+            // 1. Try to find the allocation in our tracking map
+            auto it = g_allocation_map.find(lock_params.hAllocation);
+            if (it != g_allocation_map.end())
+            {
+                backing_memory = it->second;
+            }
+            else
+            {
+                // 2. Fallback: If we didn't track it (or it was created implicitly), allocate it now.
+                // This prevents the application from crashing on a null pointer dereference.
+                c.win_emu.log.warn("NtGdiDdDDILock: Request to lock unknown handle 0x%X. Allocating lazy buffer.", lock_params.hAllocation);
+
+                // Allocate a safe default size (e.g., 64KB) to handle generic surface data.
+                // In a real scenario, we would parse PrivateDriverData to find the sub-resource size.
+                constexpr size_t fallback_size = 64 * 1024;
+                backing_memory = c.win_emu.memory.allocate_memory(fallback_size, memory_permission::read_write);
+
+                // Register it so subsequent locks work
+                g_allocation_map[lock_params.hAllocation] = backing_memory;
+            }
+
+            // 3. Handle Offset (Optional)
+            // D3DKMT_LOCK usually locks the whole allocation, but PrivateDriverData *can* imply an offset.
+            // For WARP/Generic emulation, simply returning the base address is usually sufficient.
+
+            // 4. Update the Output Parameters
+            // In our emulation, the "System Memory" pointer (pData) and the "GPU Address"
+            // are the same guest virtual address.
+            lock_params.pData = backing_memory;
+            lock_params.GpuVirtualAddress = backing_memory;
+
+            c.emu.write_memory(parameters, &lock_params, sizeof(lock_params));
+
+            c.win_emu.log.info("NtGdiDdDDILock: Handle 0x%X -> Address 0x%llX", lock_params.hAllocation, backing_memory);
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIUnlock()
+        {
+            // Unlock is generally a no-op in this type of emulation
+            // because we aren't actually locking physical pages or managing contention.
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIDestroyContext()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIDestroyDevice()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_D3DKMT_OPENADAPTERFROMHDC
+        {
+            HDC hDc;
+            UINT32 hAdapter;
+            LUID AdapterLuid;
+            UINT VidPnSourceId;
+        };
+
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, const emulator_pointer parameters)
+        {
+            if (!parameters)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto open_params = c.emu.read_memory<EMU_D3DKMT_OPENADAPTERFROMHDC>(parameters);
+
+            open_params.hAdapter = 0x4000;
+            open_params.AdapterLuid = {0x1000, 0};
+            open_params.VidPnSourceId = 0;
+
+            c.emu.write_memory(parameters, &open_params, sizeof(open_params));
+
             return STATUS_SUCCESS;
         }
     }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -171,6 +171,7 @@ namespace sogen
             constexpr uint32_t k_dxgk_adapter_handle = 0x4000;
             constexpr uint32_t k_dxgk_device_handle = 0x5000;
             constexpr uint32_t k_dxgk_context_handle = 0x6000;
+            constexpr uint32_t k_dxgk_shared_primary_handle = 0x7000;
             constexpr LUID k_dxgk_adapter_luid = {0x1000, 0};
             constexpr uint32_t k_dxgk_adapter_source_count = 1;
             constexpr size_t k_dxgk_command_buffer_size = 0x1000;
@@ -179,6 +180,11 @@ namespace sogen
             constexpr uint32_t k_dxgk_fake_vendor_id = 0x10DE;
             constexpr uint32_t k_dxgk_fake_device_id = 0x1C03;
             constexpr uint32_t k_dxgk_fake_revision_id = 0xA1;
+            constexpr uint32_t k_dxgk_open_resource_resource_private_size = 0x18;
+            constexpr uint32_t k_dxgk_open_resource_allocation_private_size = 0x18;
+            constexpr uint32_t k_dxgk_open_resource_descriptor_size = 0x80;
+            constexpr uint32_t k_dxgk_open_resource_total_private_size =
+                k_dxgk_open_resource_allocation_private_size + k_dxgk_open_resource_descriptor_size;
             constexpr GUID k_dxgk_adapter_guid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
 
             uint64_t ensure_gdi_shared_table(const syscall_context& c)
@@ -1098,6 +1104,7 @@ namespace sogen
                 case 0xA:  // VERTRES
                 case 0x75: // DESKTOPVERTRES
                     return k_default_height;
+                case 14:
                 case 0x28: // PLANES
                 case 0x2A: // NUMBRUSHES
                 case 0x2C: // NUMPENS
@@ -1105,6 +1112,8 @@ namespace sogen
                 case 0x58: // LOGPIXELSX
                 case 0x5A: // LOGPIXELSY
                     return k_default_dpi;
+                case 12:
+                    return 32;
                 default:
                     return 0;
                 }
@@ -1272,6 +1281,64 @@ namespace sogen
 
                 c.emu.write_memory(query.pPrivateDriverData, &value, sizeof(T));
                 return STATUS_SUCCESS;
+            }
+
+            template <typename TDestroyAllocation>
+            NTSTATUS destroy_dxgk_allocations(const syscall_context& c, const emulator_object<TDestroyAllocation> destroy_allocation)
+            {
+                if (!destroy_allocation)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                NTSTATUS status = STATUS_SUCCESS;
+
+                destroy_allocation.access([&](const TDestroyAllocation& params) {
+                    if (params.hDevice != 0 && params.hDevice != k_dxgk_device_handle)
+                    {
+                        dxgk_warn(c, "DestroyAllocation: Unexpected device 0x%X", params.hDevice);
+                    }
+
+                    if (params.AllocationCount == 0)
+                    {
+                        if (params.hResource == 0)
+                        {
+                            return;
+                        }
+
+                        const auto destroy_count = c.proc.dxgk.destroy_resource_allocations(c.win_emu.memory, params.hResource);
+                        if (destroy_count == 0)
+                        {
+                            dxgk_warn(c, "DestroyAllocation: Unknown resource handle 0x%X", params.hResource);
+                            return;
+                        }
+
+                        dxgk_info(c, "DestroyAllocation: destroyed %zu allocation(s) for resource 0x%X", destroy_count, params.hResource);
+                        return;
+                    }
+
+                    if (params.phAllocationList == 0)
+                    {
+                        dxgk_warn(c, "DestroyAllocation: AllocationCount=%u but phAllocationList is null", params.AllocationCount);
+                        status = STATUS_INVALID_PARAMETER;
+                        return;
+                    }
+
+                    const emulator_object<UINT32> allocation_list{c.emu, params.phAllocationList};
+                    for (UINT32 i = 0; i < params.AllocationCount; ++i)
+                    {
+                        const auto allocation_handle = allocation_list.read(i);
+                        if (!c.proc.dxgk.destroy_allocation(c.win_emu.memory, allocation_handle))
+                        {
+                            dxgk_warn(c, "DestroyAllocation: Unknown allocation handle 0x%X", allocation_handle);
+                            continue;
+                        }
+
+                        dxgk_info(c, "DestroyAllocation: destroyed allocation 0x%X", allocation_handle);
+                    }
+                });
+
+                return status;
             }
         }
 
@@ -1515,9 +1582,9 @@ namespace sogen
             return allocate_gdi_dc(c, dc_attr);
         }
 
-        NTSTATUS handle_NtGdiOpenDCW()
+        hdc handle_NtGdiOpenDCW(const syscall_context& c)
         {
-            return STATUS_SUCCESS;
+            return ensure_default_hdc(c);
         }
 
         int32_t handle_NtGdiSaveDC(const syscall_context& c, const hdc dc)
@@ -2558,14 +2625,61 @@ namespace sogen
                 return write_query_adapter_info(c, query, adapter_guid);
             }
 
-            case KMTQAITYPE::KMTQAITYPE_DRIVERVERSION:
-                return write_query_adapter_info(c, query, 2700);
+            case KMTQAITYPE::KMTQAITYPE_FLIPQUEUEINFO: {
+                struct EMU_D3DKMT_FLIPQUEUEINFO
+                {
+                    UINT32 MaxHardwareFlipQueueLength;
+                    UINT32 MaxSoftwareFlipQueueLength;
+                    UINT32 FlipFlags;
+                } flip_queue_info{};
 
-            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE:
+                if (query.PrivateDriverDataSize < sizeof(flip_queue_info))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                flip_queue_info.MaxHardwareFlipQueueLength = 0;
+                flip_queue_info.MaxSoftwareFlipQueueLength = 0x1F;
+                flip_queue_info.FlipFlags = 0;
+
+                return write_query_adapter_info(c, query, flip_queue_info);
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_DRIVERVERSION: {
+                return write_query_adapter_info(c, query, 3200);
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_WDDM_1_2_CAPS: {
+                struct EMU_D3DKMT_WDDM_1_2_CAPS
+                {
+                    UINT32 Value0;
+                    UINT32 Value1;
+                    UINT32 Value2;
+                } caps{};
+
+                if (query.PrivateDriverDataSize < sizeof(caps))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                caps.Value0 = 0x190;
+                caps.Value1 = 0x0C8;
+                caps.Value2 = 0x1DF;
+
+                return write_query_adapter_info(c, query, caps);
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_WDDM_1_3_CAPS: {
+                return write_query_adapter_info(c, query, 0x34u);
+            }
+
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE: {
                 return write_query_adapter_info(c, query, 3);
+            }
 
-            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERCOUNT:
+            case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERCOUNT: {
                 return write_query_adapter_info(c, query, 1);
+            }
 
             case KMTQAITYPE::KMTQAITYPE_PHYSICALADAPTERDEVICEIDS: {
                 struct EMU_D3DKMT_PHYSICAL_ADAPTER_DEVICE_IDS
@@ -2590,8 +2704,9 @@ namespace sogen
                 return write_query_adapter_info(c, query, ids);
             }
 
-            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE_RENDER:
+            case KMTQAITYPE::KMTQAITYPE_ADAPTERTYPE_RENDER: {
                 return write_query_adapter_info(c, query, 1);
+            }
 
             case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: {
                 GUID unique_guid = k_dxgk_adapter_guid;
@@ -2791,7 +2906,7 @@ namespace sogen
                             const uint64_t backing_size = infer_warp_allocation_size_from_private_data(c, alloc_info.pPrivateDriverData,
                                                                                                        alloc_info.PrivateDriverDataSize);
 
-                            alloc_info.hAllocation = c.proc.dxgk.create_allocation(c.win_emu.memory, backing_size);
+                            alloc_info.hAllocation = c.proc.dxgk.create_allocation(c.win_emu.memory, create_alloc.hResource, backing_size);
 
                             const auto* allocation = c.proc.dxgk.get_allocation(alloc_info.hAllocation);
                             const auto actual_size = allocation ? allocation->backing_size : 0ull;
@@ -2806,6 +2921,178 @@ namespace sogen
             });
 
             return STATUS_SUCCESS;
+        }
+
+        bool write_warp_open_resource_resource_private_data(const syscall_context& c, const uint64_t buffer, const uint32_t buffer_size,
+                                                            const uint64_t allocation_private)
+        {
+            if (buffer == 0 || buffer_size < k_dxgk_open_resource_resource_private_size)
+            {
+                return false;
+            }
+
+            std::vector<uint8_t> resource_private_data(k_dxgk_open_resource_resource_private_size, 0);
+            std::memcpy(resource_private_data.data() + 0x08, &allocation_private, sizeof(allocation_private));
+
+            c.emu.write_memory(buffer, resource_private_data.data(), resource_private_data.size());
+
+            dxgk_info(c, "NtGdiDdDDIOpenResource: resource private data=0x%llX alloc_private=0x%llX size=0x%X", buffer, allocation_private,
+                      buffer_size);
+            return true;
+        }
+
+        bool write_warp_open_resource_allocation_private_data(const syscall_context& c, const uint64_t buffer, const uint32_t buffer_size)
+        {
+            if (buffer == 0 || buffer_size < k_dxgk_open_resource_total_private_size)
+            {
+                return false;
+            }
+
+            std::vector<uint8_t> private_data(k_dxgk_open_resource_total_private_size, 0);
+
+            const uint64_t allocation_private = buffer;
+            const uint64_t descriptor = buffer + k_dxgk_open_resource_allocation_private_size;
+
+            const auto write_private = [&](const size_t offset, const auto value) {
+                std::memcpy(private_data.data() + offset, &value, sizeof(value));
+            };
+
+            write_private(0x08, descriptor);
+
+            const size_t descriptor_offset = k_dxgk_open_resource_allocation_private_size;
+            write_private(descriptor_offset + 0x00, 2u);
+            write_private(descriptor_offset + 0x04, k_default_width);
+            write_private(descriptor_offset + 0x08, k_default_height);
+            write_private(descriptor_offset + 0x0C, 1u);
+            write_private(descriptor_offset + 0x10, 0x57u);
+            write_private(descriptor_offset + 0x1C, 1u);
+            write_private(descriptor_offset + 0x20, 1u);
+
+            c.emu.write_memory(buffer, private_data.data(), private_data.size());
+
+            dxgk_info(c, "NtGdiDdDDIOpenResource: allocation private data=0x%llX descriptor=0x%llX size=0x%X", allocation_private,
+                      descriptor, buffer_size);
+            return true;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIQueryResourceInfo(const syscall_context& c,
+                                                    const emulator_object<EMU_D3DKMT_QUERYRESOURCEINFO> resource_info)
+        {
+            if (!resource_info)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            resource_info.access([&](EMU_D3DKMT_QUERYRESOURCEINFO& params) {
+                if (params.hDevice != 0 && params.hDevice != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIQueryResourceInfo: Unexpected device 0x%X", params.hDevice);
+                }
+
+                if (params.hGlobalShare != k_dxgk_shared_primary_handle && params.hGlobalShare <= 0x8000)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIQueryResourceInfo: Unexpected global share 0x%X", params.hGlobalShare);
+                }
+
+                if (params.pPrivateRuntimeData != 0 && params.PrivateRuntimeDataSize != 0)
+                {
+                    std::vector<uint8_t> zeros(params.PrivateRuntimeDataSize, 0);
+                    c.emu.write_memory(params.pPrivateRuntimeData, zeros.data(), zeros.size());
+                }
+
+                params.PrivateRuntimeDataSize = 0;
+                params.TotalPrivateDriverDataSize = k_dxgk_open_resource_total_private_size;
+                params.ResourcePrivateDriverDataSize = k_dxgk_open_resource_resource_private_size;
+                params.NumAllocations = 1;
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIOpenResource(const syscall_context& c, const emulator_object<EMU_D3DKMT_OPENRESOURCE> open_resource)
+        {
+            if (!open_resource)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            NTSTATUS status = STATUS_SUCCESS;
+
+            open_resource.access([&](EMU_D3DKMT_OPENRESOURCE& params) {
+                if (params.hDevice != 0 && params.hDevice != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIOpenResource: Unexpected device 0x%X", params.hDevice);
+                }
+
+                if (params.hGlobalShare != k_dxgk_shared_primary_handle && params.hGlobalShare <= 0x8000)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIOpenResource: Unexpected global share 0x%X", params.hGlobalShare);
+                }
+
+                if (params.pTotalPrivateDriverDataBuffer == 0 ||
+                    params.TotalPrivateDriverDataBufferSize < k_dxgk_open_resource_total_private_size)
+                {
+                    status = STATUS_BUFFER_TOO_SMALL;
+                    return;
+                }
+
+                if (params.pResourcePrivateDriverData == 0 ||
+                    params.ResourcePrivateDriverDataSize < k_dxgk_open_resource_resource_private_size)
+                {
+                    status = STATUS_BUFFER_TOO_SMALL;
+                    return;
+                }
+
+                params.hResource = c.proc.dxgk.create_resource();
+
+                const auto backing_size = static_cast<uint64_t>(k_default_width) * static_cast<uint64_t>(k_default_height) * 4ull;
+                const auto allocation_private_data = params.pTotalPrivateDriverDataBuffer;
+
+                if (allocation_private_data != 0 &&
+                    write_warp_open_resource_allocation_private_data(c, allocation_private_data, params.TotalPrivateDriverDataBufferSize))
+                {
+                    params.TotalPrivateDriverDataBufferSize = k_dxgk_open_resource_total_private_size;
+                }
+
+                if (params.pResourcePrivateDriverData != 0)
+                {
+                    write_warp_open_resource_resource_private_data(c, params.pResourcePrivateDriverData,
+                                                                   params.ResourcePrivateDriverDataSize, allocation_private_data);
+                }
+
+                if (params.NumAllocations > 0 && params.pOpenAllocationInfo != 0)
+                {
+                    constexpr size_t info_size = sizeof(EMU_D3DDDI_OPENALLOCATIONINFO2);
+
+                    for (UINT32 allocation_index = 0; allocation_index < params.NumAllocations; ++allocation_index)
+                    {
+                        const emulator_pointer info_ptr = params.pOpenAllocationInfo + (allocation_index * info_size);
+                        const emulator_object<EMU_D3DDDI_OPENALLOCATIONINFO2> allocation_info{c.emu, info_ptr};
+
+                        allocation_info.access([&](EMU_D3DDDI_OPENALLOCATIONINFO2& alloc_info) {
+                            alloc_info.hAllocation = c.proc.dxgk.create_allocation(c.win_emu.memory, params.hResource, backing_size);
+                            alloc_info.pPrivateDriverData = allocation_private_data;
+                            alloc_info.PrivateDriverDataSize =
+                                allocation_private_data != 0 ? k_dxgk_open_resource_allocation_private_size : 0;
+
+                            const auto* allocation = c.proc.dxgk.get_allocation(alloc_info.hAllocation);
+                            const auto actual_size = allocation ? allocation->backing_size : 0ull;
+                            const auto backing_memory = allocation ? allocation->backing_memory : 0ull;
+
+                            alloc_info.GpuVirtualAddress = backing_memory;
+                            std::fill(std::begin(alloc_info.Reserved), std::end(alloc_info.Reserved), 0ull);
+
+                            dxgk_info(c, "NtGdiDdDDIOpenResource: Alloc %u/%u -> Handle 0x%X Size=0x%llX Address=0x%llX",
+                                      allocation_index + 1, params.NumAllocations, alloc_info.hAllocation, actual_size, backing_memory);
+                        });
+                    }
+                }
+
+                dxgk_info(c, "NtGdiDdDDIOpenResource: share=0x%X -> resource=0x%X allocs=%u", params.hGlobalShare, params.hResource,
+                          params.NumAllocations);
+            });
+
+            return status;
         }
 
         NTSTATUS handle_NtGdiDdDDILock(const syscall_context& c, const emulator_object<EMU_D3DKMT_LOCK> lock_desc)
@@ -2841,9 +3128,141 @@ namespace sogen
             return status;
         }
 
+        NTSTATUS handle_NtGdiDdDDIGetDisplayModeList(const syscall_context& c,
+                                                     const emulator_object<EMU_D3DKMT_GETDISPLAYMODELIST> display_mode_list)
+        {
+            if (!display_mode_list)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            NTSTATUS status = STATUS_SUCCESS;
+
+            display_mode_list.access([&](EMU_D3DKMT_GETDISPLAYMODELIST& params) {
+                if (params.hAdapter != k_dxgk_adapter_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIGetDisplayModeList: Unknown adapter 0x%X", params.hAdapter);
+                }
+
+                const auto capacity = params.ModeCount;
+                params.ModeCount = 1;
+
+                if (params.pModeList == 0)
+                {
+                    return;
+                }
+
+                if (capacity < 1)
+                {
+                    status = STATUS_BUFFER_TOO_SMALL;
+                    return;
+                }
+
+                const emulator_object<EMU_D3DKMT_DISPLAYMODE> mode{c.emu, params.pModeList};
+                mode.access([](EMU_D3DKMT_DISPLAYMODE& current_mode) {
+                    current_mode.Width = k_default_width;
+                    current_mode.Height = k_default_height;
+                    current_mode.Format = 22;
+                    current_mode.IntegerRefreshRate = 60;
+                    current_mode.RefreshRate = {.Numerator = 60, .Denominator = 1};
+                    current_mode.ScanLineOrdering = 1;
+                    current_mode.DisplayOrientation = 1;
+                    current_mode.DisplayFixedOutput = 0;
+                    current_mode.Flags = 0;
+                });
+            });
+
+            return status;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIGetSharedPrimaryHandle(const syscall_context& c,
+                                                         const emulator_object<EMU_D3DKMT_GETSHAREDPRIMARYHANDLE> shared_primary)
+        {
+            if (!shared_primary)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            shared_primary.access([&](EMU_D3DKMT_GETSHAREDPRIMARYHANDLE& params) {
+                if (params.hAdapter != k_dxgk_adapter_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIGetSharedPrimaryHandle: Unknown adapter 0x%X", params.hAdapter);
+                }
+
+                params.hSharedPrimary = k_dxgk_shared_primary_handle;
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIGetDeviceState(const syscall_context& c, const emulator_object<EMU_D3DKMT_GETDEVICESTATE> device_state)
+        {
+            if (!device_state)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            device_state.access([&](EMU_D3DKMT_GETDEVICESTATE& state) {
+                if (state.hDevice != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIGetDeviceState: Unknown device 0x%X", state.hDevice);
+                }
+
+                state.State = 0;
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIMarkDeviceAsError(const syscall_context& c,
+                                                    const emulator_object<EMU_D3DKMT_MARKDEVICEASERROR> mark_error)
+        {
+            if (!mark_error)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            mark_error.access([&](const EMU_D3DKMT_MARKDEVICEASERROR& params) {
+                if (params.hDevice != 0 && params.hDevice != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIMarkDeviceAsError: Unexpected device 0x%X", params.hDevice);
+                }
+
+                dxgk_info(c, "NtGdiDdDDIMarkDeviceAsError: device=0x%X reason=0x%X", params.hDevice, params.Reason);
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIGetCachedHybridQueryValue(const syscall_context&, const emulator_object<uint32_t> value)
+        {
+            if (value)
+            {
+                value.write(3);
+            }
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDICacheHybridQueryValue()
+        {
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtGdiDdDDIUnlock()
         {
             return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIDestroyAllocation2(const syscall_context& c,
+                                                     const emulator_object<EMU_D3DKMT_DESTROYALLOCATION2> destroy_allocation)
+        {
+            return destroy_dxgk_allocations(c, destroy_allocation);
+        }
+
+        NTSTATUS handle_NtGdiDdDDIDestroyAllocation(const syscall_context& c,
+                                                    const emulator_object<EMU_D3DKMT_DESTROYALLOCATION> destroy_allocation)
+        {
+            return destroy_dxgk_allocations(c, destroy_allocation);
         }
 
         NTSTATUS handle_NtGdiDdDDIDestroyContext()
@@ -2870,6 +3289,11 @@ namespace sogen
                 open_params.VidPnSourceId = 0;
             });
 
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiSelectFont()
+        {
             return STATUS_SUCCESS;
         }
     }

--- a/src/windows-emulator/syscalls/port.cpp
+++ b/src/windows-emulator/syscalls/port.cpp
@@ -54,6 +54,38 @@ namespace sogen
                                         maximum_message_length, connection_info, connection_info_length);
         }
 
+        NTSTATUS handle_NtAlpcCreatePort(const syscall_context& c, const emulator_object<handle> port_handle,
+                                         const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
+                                         const emulator_pointer /*port_attributes*/)
+        {
+            if (!port_handle)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            std::u16string port_name{};
+
+            if (object_attributes)
+            {
+                const auto attributes = object_attributes.read();
+
+                if (attributes.ObjectName)
+                {
+                    emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> name{c.emu, attributes.ObjectName};
+                    port_name = std::u16string(read_unicode_string(c.emu, name));
+                }
+            }
+
+            c.win_emu.callbacks.on_generic_access("Creating ALPC port", port_name);
+
+            port_container container{std::move(port_name), c.win_emu, {}};
+
+            const auto new_handle = c.proc.ports.store(std::move(container));
+            port_handle.write(new_handle);
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtAlpcConnectPort(const syscall_context& c, const emulator_object<handle> port_handle,
                                           const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> server_port_name,
                                           const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3198,21 +3198,21 @@ namespace sogen
                     UINT32 targetId;
                     EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetSignalInfo;
                     UINT32 outputTechnology;
-                    UINT8 padding2[40];
+                    UINT8 padding2[40]; // NOLINT
                     UINT32 sourceWidth;
                     UINT32 sourceHeight;
-                    UINT8 padding3[84];
+                    UINT8 padding3[84]; // NOLINT
                 } internal_path{};
 
                 internal_path.flags = 0x2000000000020003ULL;
-                internal_path.adapterId = {0x1000, 0};
+                internal_path.adapterId = {.LowPart = 0x1000, .HighPart = 0};
                 internal_path.sourceId = 0;
                 internal_path.targetId = 0;
                 internal_path.targetSignalInfo.pixelRate = 148500000;
-                internal_path.targetSignalInfo.hSyncFreq = {67500, 1};
-                internal_path.targetSignalInfo.vSyncFreq = {60, 1};
-                internal_path.targetSignalInfo.activeSize = {1920, 1080};
-                internal_path.targetSignalInfo.totalSize = {2200, 1125};
+                internal_path.targetSignalInfo.hSyncFreq = {.Numerator = 67500, .Denominator = 1};
+                internal_path.targetSignalInfo.vSyncFreq = {.Numerator = 60, .Denominator = 1};
+                internal_path.targetSignalInfo.activeSize = {.cx = 1920, .cy = 1080};
+                internal_path.targetSignalInfo.totalSize = {.cx = 2200, .cy = 1125};
                 internal_path.targetSignalInfo.scanLineOrdering = 1; // PROGRESSIVE
                 internal_path.targetSignalInfo.u.videoStandard = 0;
                 internal_path.outputTechnology = 5; // HDMI
@@ -3293,20 +3293,10 @@ namespace sogen
             }
 
             case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_SOURCE_FROM_HASH: {
-                struct DISPLAYCONFIG_GET_SOURCE_FROM_HASH
-                {
-                    UINT32 type;
-                    UINT32 size;
-                    LUID adapterId;
-                    UINT32 sourceId;
-                    UINT32 hash;
-                    UINT32 reserved[4];
-                };
+                const emulator_object<EMU_DISPLAYCONFIG_GET_SOURCE_FROM_HASH> source_from_hash{c.emu, packet};
 
-                const emulator_object<DISPLAYCONFIG_GET_SOURCE_FROM_HASH> source_from_hash{c.emu, packet};
-
-                source_from_hash.access([](DISPLAYCONFIG_GET_SOURCE_FROM_HASH& req) {
-                    req.adapterId = {0x1000, 0}; // Must match k_dxgk_adapter_luid!
+                source_from_hash.access([](EMU_DISPLAYCONFIG_GET_SOURCE_FROM_HASH& req) {
+                    req.adapterId = {.LowPart = 0x1000, .HighPart = 0}; // Must match k_dxgk_adapter_luid!
                     req.sourceId = 0;
                 });
 
@@ -3314,42 +3304,6 @@ namespace sogen
             }
 
             case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_DISPLAY_INFO: {
-                struct EMU_DISPLAY_INFO_DEVICE_BLOCK
-                {
-                    UINT32 Valid;
-                    UINT32 VendorID;
-                    UINT32 DeviceID;
-                    UINT32 SubSystemVendorID;
-                    UINT32 SubSystemID;
-                    UINT32 RevisionID;
-                    UINT32 WddmVersion;
-                    char16_t AdapterDesc[128];
-                    char16_t AdapterDevicePath[260];
-                };
-
-                struct EMU_GET_DISPLAY_INFO
-                {
-                    UINT32 type;
-                    UINT32 size;
-                    LUID adapterId;
-                    UINT32 id;
-                    EMU_DISPLAY_INFO_DEVICE_BLOCK DisplayAdapter;
-                    UINT8 padding_0338[0x340 - 0x338];
-                    EMU_DISPLAY_INFO_DEVICE_BLOCK RenderAdapter;
-                    UINT8 padding_0664[2056 - 0x664];
-                };
-
-                static_assert(sizeof(EMU_DISPLAY_INFO_DEVICE_BLOCK) == 0x324);
-                static_assert(sizeof(EMU_GET_DISPLAY_INFO) == 2056);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, adapterId) == 8);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, id) == 16);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter) == 0x14);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter.AdapterDesc) == 0x30);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter.AdapterDevicePath) == 0x130);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter) == 0x340);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter.AdapterDesc) == 0x35C);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter.AdapterDevicePath) == 0x45C);
-
                 if (header.size < sizeof(EMU_GET_DISPLAY_INFO))
                 {
                     return STATUS_BUFFER_TOO_SMALL;
@@ -3389,61 +3343,14 @@ namespace sogen
             }
 
             case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_DISPLAY_INFO_EX: {
-                struct EMU_GET_DISPLAY_INFO
-                {
-                    UINT32 type;
-                    UINT32 size;
-                    LUID adapterId;
-                    UINT32 sourceId;
-
-                    uint8_t padding_0014[836 - 20];
-
-                    UINT32 VendorID;
-                    UINT32 DeviceID;
-                    UINT32 SubSysID0;
-                    UINT32 SubSysID1;
-                    UINT32 RevisionID;
-                    UINT32 WddmVersion;
-                    char16_t AdapterDesc[128];
-
-                    uint8_t padding_045C[1644 - 1116];
-
-                    INT32 DisplayLeft;
-                    INT32 DisplayTop;
-                    INT32 DisplayWidth;
-                    INT32 DisplayHeight;
-                    char16_t DeviceName[32];
-
-                    uint8_t padding_06BC[2024 - 1724];
-
-                    UINT32 FailurePoint;
-
-                    uint8_t padding_07EC[2044 - 2028];
-
-                    UINT32 ReservedQwordLow;
-                    UINT32 ReservedQwordHigh;
-
-                    uint8_t padding_0804[2056 - 2052];
-                };
-
-                static_assert(sizeof(EMU_GET_DISPLAY_INFO) == 2056);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, adapterId) == 8);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, sourceId) == 16);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, VendorID) == 836);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, AdapterDesc) == 860);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayLeft) == 1644);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DeviceName) == 1660);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, FailurePoint) == 2024);
-                static_assert(offsetof(EMU_GET_DISPLAY_INFO, ReservedQwordLow) == 2044);
-
-                if (header.size < sizeof(EMU_GET_DISPLAY_INFO))
+                if (header.size < sizeof(EMU_GET_DISPLAY_INFO_EX))
                 {
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                const emulator_object<EMU_GET_DISPLAY_INFO> display_info{c.emu, packet};
+                const emulator_object<EMU_GET_DISPLAY_INFO_EX> display_info{c.emu, packet};
 
-                display_info.access([](EMU_GET_DISPLAY_INFO& info) {
+                display_info.access([](EMU_GET_DISPLAY_INFO_EX& info) {
                     const bool known_adapter =
                         info.adapterId.LowPart == 0x1000 && info.adapterId.HighPart == 0; // Must match k_dxgk_adapter_luid!
                     const bool known_source = info.sourceId == 0;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3169,21 +3169,6 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        struct EMU_CCD_PATH_INFO
-        {
-            UINT64 flags;
-            UINT64 padding1;
-            LUID adapterId;
-            UINT32 sourceId;
-            UINT32 targetId;
-            EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetSignalInfo;
-            UINT32 outputTechnology;
-            UINT8 padding2[40];
-            UINT32 sourceWidth;
-            UINT32 sourceHeight;
-            UINT8 padding3[84];
-        };
-
         NTSTATUS handle_NtUserQueryDisplayConfig(const syscall_context& c, const UINT32 /*flags*/,
                                                  const emulator_object<UINT32> num_path_array_elements, const emulator_pointer path_array,
                                                  const emulator_object<UINT32> current_topology_id, const emulator_pointer /*reserved*/)
@@ -3204,7 +3189,21 @@ namespace sogen
 
             if (path_array && num_paths >= 1)
             {
-                EMU_CCD_PATH_INFO internal_path{};
+                struct EMU_CCD_PATH_INFO
+                {
+                    UINT64 flags;
+                    UINT64 padding1;
+                    LUID adapterId;
+                    UINT32 sourceId;
+                    UINT32 targetId;
+                    EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetSignalInfo;
+                    UINT32 outputTechnology;
+                    UINT8 padding2[40];
+                    UINT32 sourceWidth;
+                    UINT32 sourceHeight;
+                    UINT8 padding3[84];
+                } internal_path{};
+
                 internal_path.flags = 0x2000000000020003ULL;
                 internal_path.adapterId = {0x1000, 0};
                 internal_path.sourceId = 0;
@@ -3238,204 +3237,176 @@ namespace sogen
 
             switch (header.type)
             {
-            case 1: // DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
-            {
-                EMU_DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName{};
-                sourceName.header = header;
-                utils::string::copy(sourceName.viewGdiDeviceName, u"\\\\.\\DISPLAY1");
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_SOURCE_NAME: {
+                const emulator_object<EMU_DISPLAYCONFIG_SOURCE_DEVICE_NAME> source_name{c.emu, packet};
 
-                c.emu.write_memory(packet, &sourceName, sizeof(sourceName));
+                source_name.access([&](EMU_DISPLAYCONFIG_SOURCE_DEVICE_NAME& sourceName) {
+                    sourceName.header = header;
+                    utils::string::copy(sourceName.viewGdiDeviceName, u"\\\\.\\DISPLAY1");
+                });
+
                 return STATUS_SUCCESS;
             }
 
-            case 2: // DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
-            {
-                EMU_DISPLAYCONFIG_TARGET_DEVICE_NAME targetName{};
-                targetName.header = header;
-                targetName.flags = 0x1;          // DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_FRIENDLY_NAME_FROM_EDID
-                targetName.outputTechnology = 5; // HDMI
-                targetName.edidManufactureId = 0xABCD;
-                targetName.edidProductCodeId = 0x1234;
-                targetName.connectorInstance = 1;
-                utils::string::copy(targetName.monitorFriendlyDeviceName, u"Generic PnP Monitor");
-                utils::string::copy(targetName.monitorDevicePath,
-                                    u"\\\\?\\DISPLAY#GSM0001#4&1234567&0&UID0#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}");
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_TARGET_NAME: {
+                const emulator_object<EMU_DISPLAYCONFIG_TARGET_DEVICE_NAME> target_name{c.emu, packet};
 
-                c.emu.write_memory(packet, &targetName, sizeof(targetName));
+                target_name.access([&](EMU_DISPLAYCONFIG_TARGET_DEVICE_NAME& targetName) {
+                    targetName.header = header;
+                    targetName.flags = 0x1;
+                    targetName.outputTechnology = 5;
+                    targetName.edidManufactureId = 0xABCD;
+                    targetName.edidProductCodeId = 0x1234;
+                    targetName.connectorInstance = 1;
+                    utils::string::copy(targetName.monitorFriendlyDeviceName, u"Generic PnP Monitor");
+                    utils::string::copy(targetName.monitorDevicePath,
+                                        u"\\\\?\\DISPLAY#GSM0001#4&1234567&0&UID0#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}");
+                });
+
                 return STATUS_SUCCESS;
             }
 
-            case 4: // DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME
-            {
-                EMU_DISPLAYCONFIG_ADAPTER_NAME adapterName{};
-                adapterName.header = header;
-                utils::string::copy(
-                    adapterName.adapterDevicePath,
-                    u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_ADAPTER_NAME: {
+                const emulator_object<EMU_DISPLAYCONFIG_ADAPTER_NAME> adapter_name{c.emu, packet};
 
-                c.emu.write_memory(packet, &adapterName, sizeof(adapterName));
+                adapter_name.access([&](EMU_DISPLAYCONFIG_ADAPTER_NAME& adapterName) {
+                    adapterName.header = header;
+                    utils::string::copy(
+                        adapterName.adapterDevicePath,
+                        u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+                });
+
                 return STATUS_SUCCESS;
             }
 
-            case 9: // DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO
-            {
-                EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO colorInfo{};
-                colorInfo.header = header;
-                colorInfo.u.value = 0;
-                colorInfo.colorEncoding = 0; // DISPLAYCONFIG_COLOR_ENCODING_RGB
-                colorInfo.bitsPerColorChannel = 8;
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_ADVANCED_COLOR_INFO: {
+                const emulator_object<EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO> color_info{c.emu, packet};
 
-                c.emu.write_memory(packet, &colorInfo, sizeof(colorInfo));
+                color_info.access([&](EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO& colorInfo) {
+                    colorInfo.header = header;
+                    colorInfo.u.value = 0;
+                    colorInfo.colorEncoding = 0;
+                    colorInfo.bitsPerColorChannel = 8;
+                });
+
                 return STATUS_SUCCESS;
             }
 
-            case -14: { // DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_FROM_HASH (internal)
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_SOURCE_FROM_HASH: {
                 struct DISPLAYCONFIG_GET_SOURCE_FROM_HASH
                 {
                     UINT32 type;
                     UINT32 size;
-                    LUID adapterId;     // Offset 8:  Output
-                    UINT32 sourceId;    // Offset 16: Output
-                    UINT32 hash;        // Offset 20: Input
-                    UINT32 reserved[4]; // Offset 24-39
+                    LUID adapterId;
+                    UINT32 sourceId;
+                    UINT32 hash;
+                    UINT32 reserved[4];
                 };
 
-                auto req = c.emu.read_memory<DISPLAYCONFIG_GET_SOURCE_FROM_HASH>(packet);
+                const emulator_object<DISPLAYCONFIG_GET_SOURCE_FROM_HASH> source_from_hash{c.emu, packet};
 
-                // The caller wants to find which adapter+source corresponds to this hash
-                // For a simple emulator with one display, always return our adapter
-                req.adapterId = {0x1000, 0}; // Must match NtGdiDdDDIEnumAdapters2!
-                req.sourceId = 0;            // Source 0
+                source_from_hash.access([](DISPLAYCONFIG_GET_SOURCE_FROM_HASH& req) {
+                    req.adapterId = {0x1000, 0}; // Must match k_dxgk_adapter_luid!
+                    req.sourceId = 0;
+                });
 
-                c.emu.write_memory(packet, &req, sizeof(req));
                 return STATUS_SUCCESS;
             }
 
-            case -21: { // _DISPLAYCONFIG_GET_DISPLAY_INFO (internal DXGI structure)
-                constexpr UINT32 STRUCT_SIZE = 2056;
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_DISPLAY_INFO: {
+                struct EMU_GET_DISPLAY_INFO
+                {
+                    UINT32 type;
+                    UINT32 size;
+                    LUID adapterId;
+                    UINT32 sourceId;
 
-                if (header.size < STRUCT_SIZE)
+                    uint8_t padding_0014[836 - 20];
+
+                    UINT32 VendorID;
+                    UINT32 DeviceID;
+                    UINT32 SubSysID0;
+                    UINT32 SubSysID1;
+                    UINT32 RevisionID;
+                    UINT32 WddmVersion;
+                    char16_t AdapterDesc[128];
+
+                    uint8_t padding_045C[1644 - 1116];
+
+                    INT32 DisplayLeft;
+                    INT32 DisplayTop;
+                    INT32 DisplayWidth;
+                    INT32 DisplayHeight;
+                    char16_t DeviceName[32];
+
+                    uint8_t padding_06BC[2024 - 1724];
+
+                    UINT32 FailurePoint;
+
+                    uint8_t padding_07EC[2044 - 2028];
+
+                    UINT32 ReservedQwordLow;
+                    UINT32 ReservedQwordHigh;
+
+                    uint8_t padding_0804[2056 - 2052];
+                };
+
+                static_assert(sizeof(EMU_GET_DISPLAY_INFO) == 2056);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, adapterId) == 8);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, sourceId) == 16);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, VendorID) == 836);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, AdapterDesc) == 860);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayLeft) == 1644);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DeviceName) == 1660);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, FailurePoint) == 2024);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, ReservedQwordLow) == 2044);
+
+                if (header.size < sizeof(EMU_GET_DISPLAY_INFO))
                 {
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                // Read the full buffer
-                std::vector<uint8_t> buffer(STRUCT_SIZE, 0);
-                c.emu.read_memory(packet, buffer.data(), STRUCT_SIZE);
+                const emulator_object<EMU_GET_DISPLAY_INFO> display_info{c.emu, packet};
 
-                auto get_u32 = [&](size_t offset) -> UINT32& { return *reinterpret_cast<UINT32*>(&buffer[offset]); };
-                auto get_i32 = [&](size_t offset) -> INT32& { return *reinterpret_cast<INT32*>(&buffer[offset]); };
-                auto get_u64 = [&](size_t offset) -> UINT64& { return *reinterpret_cast<UINT64*>(&buffer[offset]); };
+                display_info.access([](EMU_GET_DISPLAY_INFO& info) {
+                    const bool known_adapter =
+                        info.adapterId.LowPart == 0x1000 && info.adapterId.HighPart == 0; // Must match k_dxgk_adapter_luid!
+                    const bool known_source = info.sourceId == 0;
 
-                // Parse input
-                LUID adapterId;
-                adapterId.LowPart = get_u32(8);
-                adapterId.HighPart = get_u32(12);
-                UINT32 sourceId = get_u32(16);
+                    info.FailurePoint = 0;
 
-                // Validate adapter matches our emulated one
-                if (adapterId.LowPart != 0x1000 || adapterId.HighPart != 0)
-                {
-                    // Unknown adapter - clear everything and return
-                    get_u32(2024) = 0; // No failure point
-                    c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
-                    return STATUS_SUCCESS;
-                }
+                    if (!known_adapter || !known_source)
+                    {
+                        return;
+                    }
 
-                // Only sourceId 0 exists (NumOfSources = 1)
-                if (sourceId >= 1)
-                {
-                    // No display for this source - leave offsets 1644-1656 as zero
-                    get_u32(2024) = 0;
-                    c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
-                    return STATUS_SUCCESS;
-                }
+                    info.VendorID = 0x10DE;
+                    info.DeviceID = 0x1C03;
+                    info.SubSysID0 = 0;
+                    info.SubSysID1 = 0;
+                    info.RevisionID = 0xA1;
+                    info.WddmVersion = 2700;
 
-                // === Fill in adapter information ===
+                    utils::string::copy(info.AdapterDesc, u"NVIDIA GeForce GTX 1060 6GB");
 
-                // Offset 836: VendorID
-                get_u32(836) = 0x10DE; // NVIDIA
+                    info.DisplayLeft = 0;
+                    info.DisplayTop = 0;
+                    info.DisplayWidth = 1920;
+                    info.DisplayHeight = 1080;
 
-                // Offset 840: DeviceID
-                get_u32(840) = 0x1C03;
+                    utils::string::copy(info.DeviceName, u"\\\\.\\DISPLAY1");
 
-                // Offset 844: SubSysID part
-                get_u32(844) = 0;
+                    info.ReservedQwordLow = 0;
+                    info.ReservedQwordHigh = 0;
+                });
 
-                // Offset 848: SubSysID part
-                get_u32(848) = 0;
-
-                // Offset 852: RevisionID
-                get_u32(852) = 0xA1;
-
-                // Offset 856: WDDM version (copied to SAdapterDesc+384)
-                get_u32(856) = 2700; // WDDM 2.7
-
-                // Offset 860: Adapter description (wchar_t[128])
-                const char16_t* adapterDesc = u"NVIDIA GeForce GTX 1060 6GB";
-                auto* descPtr = reinterpret_cast<char16_t*>(&buffer[860]);
-                size_t i = 0;
-                while (adapterDesc[i] && i < 127)
-                {
-                    descPtr[i] = adapterDesc[i];
-                    ++i;
-                }
-                descPtr[i] = 0;
-
-                // === CRITICAL: Display detection fields ===
-                // These MUST have at least v51 or v52 non-zero for a normal display
-                // If all zero: no output created
-                // If v51=v52=0 but v53|v54!=0: headless display
-
-                // Offset 1644 (v51): Display width or rect.left - MUST BE NON-ZERO for normal display
-                get_i32(1644) = 0;
-
-                // Offset 1648 (v52): Display height or rect.top - MUST BE NON-ZERO for normal display
-                get_i32(1648) = 0;
-
-                // Offset 1652 (v53): Additional display info
-                get_i32(1652) = 1920;
-
-                // Offset 1656 (v54): Additional display info
-                get_i32(1656) = 1080;
-
-                // Offset 1660 (0x67C): Device name (wchar_t[32])
-                // Must match what GetMonitorInfoW returns: "\\.\DISPLAY1"
-                const char16_t* deviceName = u"\\\\.\\DISPLAY1";
-                auto* namePtr = reinterpret_cast<char16_t*>(&buffer[1660]);
-                i = 0;
-                while (deviceName[i] && i < 31)
-                {
-                    namePtr[i] = deviceName[i];
-                    ++i;
-                }
-                namePtr[i] = 0;
-
-                // === Output fields ===
-
-                // Offset 2024: Failure point (0 = success)
-                get_u32(2024) = 0;
-
-                // Offset 2044: Some QWORD read into adapter desc
-                get_u64(2044) = 0;
-
-                c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
-                return STATUS_SUCCESS;
-            }
-
-            case -34: {
                 return STATUS_SUCCESS;
             }
 
             default:
-                c.win_emu.log.error("Unknown DisplayConfig Info Type: %d", header.type);
+                // c.win_emu.log.warn("Unknown DisplayConfig Info Type: %d", header.type);
                 return STATUS_SUCCESS;
             }
-        }
-
-        NTSTATUS handle_NtUserAllowSetForegroundWindow()
-        {
-            return STATUS_SUCCESS;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1102,11 +1102,6 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo()
-        {
-            return STATUS_NOT_SUPPORTED;
-        }
-
         NTSTATUS handle_NtUserRegisterWindowMessage()
         {
             return STATUS_NOT_SUPPORTED;
@@ -3157,6 +3152,290 @@ namespace sogen
             }
 
             return result;
+        }
+
+        NTSTATUS handle_NtUserGetDisplayConfigBufferSizes(const syscall_context& /*c*/, const UINT32 /*flags*/,
+                                                          const emulator_object<UINT32> num_path_array_elements,
+                                                          const emulator_object<UINT32> num_mode_info_array_elements)
+        {
+            if (!num_path_array_elements || !num_mode_info_array_elements)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            num_path_array_elements.write(1);
+            num_mode_info_array_elements.write(2);
+
+            return STATUS_SUCCESS;
+        }
+
+        struct EMU_CCD_PATH_INFO
+        {
+            UINT64 flags;
+            UINT64 padding1;
+            LUID adapterId;
+            UINT32 sourceId;
+            UINT32 targetId;
+            EMU_DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetSignalInfo;
+            UINT32 outputTechnology;
+            UINT8 padding2[40];
+            UINT32 sourceWidth;
+            UINT32 sourceHeight;
+            UINT8 padding3[84];
+        };
+
+        NTSTATUS handle_NtUserQueryDisplayConfig(const syscall_context& c, const UINT32 /*flags*/,
+                                                 const emulator_object<UINT32> num_path_array_elements, const emulator_pointer path_array,
+                                                 const emulator_object<UINT32> current_topology_id, const emulator_pointer /*reserved*/)
+        {
+            if (!num_path_array_elements)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            const auto num_paths = num_path_array_elements.read();
+
+            num_path_array_elements.write(1);
+
+            if (current_topology_id)
+            {
+                current_topology_id.write(0x1); // DISPLAYCONFIG_TOPOLOGY_INTERNAL
+            }
+
+            if (path_array && num_paths >= 1)
+            {
+                EMU_CCD_PATH_INFO internal_path{};
+                internal_path.flags = 0x2000000000020003ULL;
+                internal_path.adapterId = {0x1000, 0};
+                internal_path.sourceId = 0;
+                internal_path.targetId = 0;
+                internal_path.targetSignalInfo.pixelRate = 148500000;
+                internal_path.targetSignalInfo.hSyncFreq = {67500, 1};
+                internal_path.targetSignalInfo.vSyncFreq = {60, 1};
+                internal_path.targetSignalInfo.activeSize = {1920, 1080};
+                internal_path.targetSignalInfo.totalSize = {2200, 1125};
+                internal_path.targetSignalInfo.scanLineOrdering = 1; // PROGRESSIVE
+                internal_path.targetSignalInfo.u.videoStandard = 0;
+                internal_path.outputTechnology = 5; // HDMI
+                internal_path.padding2[17] = 1;
+                internal_path.sourceWidth = 1920;
+                internal_path.sourceHeight = 1080;
+
+                c.emu.write_memory(path_array, &internal_path, sizeof(internal_path));
+            }
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtUserDisplayConfigGetDeviceInfo(const syscall_context& c, const emulator_pointer packet)
+        {
+            if (!packet)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            auto header = c.emu.read_memory<EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER>(packet);
+
+            switch (header.type)
+            {
+            case 1: // DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
+            {
+                EMU_DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName{};
+                sourceName.header = header;
+                utils::string::copy(sourceName.viewGdiDeviceName, u"\\\\.\\DISPLAY1");
+
+                c.emu.write_memory(packet, &sourceName, sizeof(sourceName));
+                return STATUS_SUCCESS;
+            }
+
+            case 2: // DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
+            {
+                EMU_DISPLAYCONFIG_TARGET_DEVICE_NAME targetName{};
+                targetName.header = header;
+                targetName.flags = 0x1;          // DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_FRIENDLY_NAME_FROM_EDID
+                targetName.outputTechnology = 5; // HDMI
+                targetName.edidManufactureId = 0xABCD;
+                targetName.edidProductCodeId = 0x1234;
+                targetName.connectorInstance = 1;
+                utils::string::copy(targetName.monitorFriendlyDeviceName, u"Generic PnP Monitor");
+                utils::string::copy(targetName.monitorDevicePath,
+                                    u"\\\\?\\DISPLAY#GSM0001#4&1234567&0&UID0#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}");
+
+                c.emu.write_memory(packet, &targetName, sizeof(targetName));
+                return STATUS_SUCCESS;
+            }
+
+            case 4: // DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME
+            {
+                EMU_DISPLAYCONFIG_ADAPTER_NAME adapterName{};
+                adapterName.header = header;
+                utils::string::copy(
+                    adapterName.adapterDevicePath,
+                    u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+
+                c.emu.write_memory(packet, &adapterName, sizeof(adapterName));
+                return STATUS_SUCCESS;
+            }
+
+            case 9: // DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO
+            {
+                EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO colorInfo{};
+                colorInfo.header = header;
+                colorInfo.u.value = 0;
+                colorInfo.colorEncoding = 0; // DISPLAYCONFIG_COLOR_ENCODING_RGB
+                colorInfo.bitsPerColorChannel = 8;
+
+                c.emu.write_memory(packet, &colorInfo, sizeof(colorInfo));
+                return STATUS_SUCCESS;
+            }
+
+            case -14: { // DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_FROM_HASH (internal)
+                struct DISPLAYCONFIG_GET_SOURCE_FROM_HASH
+                {
+                    UINT32 type;
+                    UINT32 size;
+                    LUID adapterId;     // Offset 8:  Output
+                    UINT32 sourceId;    // Offset 16: Output
+                    UINT32 hash;        // Offset 20: Input
+                    UINT32 reserved[4]; // Offset 24-39
+                };
+
+                auto req = c.emu.read_memory<DISPLAYCONFIG_GET_SOURCE_FROM_HASH>(packet);
+
+                // The caller wants to find which adapter+source corresponds to this hash
+                // For a simple emulator with one display, always return our adapter
+                req.adapterId = {0x1000, 0}; // Must match NtGdiDdDDIEnumAdapters2!
+                req.sourceId = 0;            // Source 0
+
+                c.emu.write_memory(packet, &req, sizeof(req));
+                return STATUS_SUCCESS;
+            }
+
+            case -21: { // _DISPLAYCONFIG_GET_DISPLAY_INFO (internal DXGI structure)
+                constexpr UINT32 STRUCT_SIZE = 2056;
+
+                if (header.size < STRUCT_SIZE)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                // Read the full buffer
+                std::vector<uint8_t> buffer(STRUCT_SIZE, 0);
+                c.emu.read_memory(packet, buffer.data(), STRUCT_SIZE);
+
+                auto get_u32 = [&](size_t offset) -> UINT32& { return *reinterpret_cast<UINT32*>(&buffer[offset]); };
+                auto get_i32 = [&](size_t offset) -> INT32& { return *reinterpret_cast<INT32*>(&buffer[offset]); };
+                auto get_u64 = [&](size_t offset) -> UINT64& { return *reinterpret_cast<UINT64*>(&buffer[offset]); };
+
+                // Parse input
+                LUID adapterId;
+                adapterId.LowPart = get_u32(8);
+                adapterId.HighPart = get_u32(12);
+                UINT32 sourceId = get_u32(16);
+
+                // Validate adapter matches our emulated one
+                if (adapterId.LowPart != 0x1000 || adapterId.HighPart != 0)
+                {
+                    // Unknown adapter - clear everything and return
+                    get_u32(2024) = 0; // No failure point
+                    c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
+                    return STATUS_SUCCESS;
+                }
+
+                // Only sourceId 0 exists (NumOfSources = 1)
+                if (sourceId >= 1)
+                {
+                    // No display for this source - leave offsets 1644-1656 as zero
+                    get_u32(2024) = 0;
+                    c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
+                    return STATUS_SUCCESS;
+                }
+
+                // === Fill in adapter information ===
+
+                // Offset 836: VendorID
+                get_u32(836) = 0x10DE; // NVIDIA
+
+                // Offset 840: DeviceID
+                get_u32(840) = 0x1C03;
+
+                // Offset 844: SubSysID part
+                get_u32(844) = 0;
+
+                // Offset 848: SubSysID part
+                get_u32(848) = 0;
+
+                // Offset 852: RevisionID
+                get_u32(852) = 0xA1;
+
+                // Offset 856: WDDM version (copied to SAdapterDesc+384)
+                get_u32(856) = 2700; // WDDM 2.7
+
+                // Offset 860: Adapter description (wchar_t[128])
+                const char16_t* adapterDesc = u"NVIDIA GeForce GTX 1060 6GB";
+                auto* descPtr = reinterpret_cast<char16_t*>(&buffer[860]);
+                size_t i = 0;
+                while (adapterDesc[i] && i < 127)
+                {
+                    descPtr[i] = adapterDesc[i];
+                    ++i;
+                }
+                descPtr[i] = 0;
+
+                // === CRITICAL: Display detection fields ===
+                // These MUST have at least v51 or v52 non-zero for a normal display
+                // If all zero: no output created
+                // If v51=v52=0 but v53|v54!=0: headless display
+
+                // Offset 1644 (v51): Display width or rect.left - MUST BE NON-ZERO for normal display
+                get_i32(1644) = 0;
+
+                // Offset 1648 (v52): Display height or rect.top - MUST BE NON-ZERO for normal display
+                get_i32(1648) = 0;
+
+                // Offset 1652 (v53): Additional display info
+                get_i32(1652) = 1920;
+
+                // Offset 1656 (v54): Additional display info
+                get_i32(1656) = 1080;
+
+                // Offset 1660 (0x67C): Device name (wchar_t[32])
+                // Must match what GetMonitorInfoW returns: "\\.\DISPLAY1"
+                const char16_t* deviceName = u"\\\\.\\DISPLAY1";
+                auto* namePtr = reinterpret_cast<char16_t*>(&buffer[1660]);
+                i = 0;
+                while (deviceName[i] && i < 31)
+                {
+                    namePtr[i] = deviceName[i];
+                    ++i;
+                }
+                namePtr[i] = 0;
+
+                // === Output fields ===
+
+                // Offset 2024: Failure point (0 = success)
+                get_u32(2024) = 0;
+
+                // Offset 2044: Some QWORD read into adapter desc
+                get_u64(2044) = 0;
+
+                c.emu.write_memory(packet, buffer.data(), STRUCT_SIZE);
+                return STATUS_SUCCESS;
+            }
+
+            case -34: {
+                return STATUS_SUCCESS;
+            }
+
+            default:
+                c.win_emu.log.error("Unknown DisplayConfig Info Type: %d", header.type);
+                return STATUS_SUCCESS;
+            }
+        }
+
+        NTSTATUS handle_NtUserAllowSetForegroundWindow()
+        {
+            return STATUS_SUCCESS;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3314,6 +3314,81 @@ namespace sogen
             }
 
             case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_DISPLAY_INFO: {
+                struct EMU_DISPLAY_INFO_DEVICE_BLOCK
+                {
+                    UINT32 Valid;
+                    UINT32 VendorID;
+                    UINT32 DeviceID;
+                    UINT32 SubSystemVendorID;
+                    UINT32 SubSystemID;
+                    UINT32 RevisionID;
+                    UINT32 WddmVersion;
+                    char16_t AdapterDesc[128];
+                    char16_t AdapterDevicePath[260];
+                };
+
+                struct EMU_GET_DISPLAY_INFO
+                {
+                    UINT32 type;
+                    UINT32 size;
+                    LUID adapterId;
+                    UINT32 id;
+                    EMU_DISPLAY_INFO_DEVICE_BLOCK DisplayAdapter;
+                    UINT8 padding_0338[0x340 - 0x338];
+                    EMU_DISPLAY_INFO_DEVICE_BLOCK RenderAdapter;
+                    UINT8 padding_0664[2056 - 0x664];
+                };
+
+                static_assert(sizeof(EMU_DISPLAY_INFO_DEVICE_BLOCK) == 0x324);
+                static_assert(sizeof(EMU_GET_DISPLAY_INFO) == 2056);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, adapterId) == 8);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, id) == 16);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter) == 0x14);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter.AdapterDesc) == 0x30);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, DisplayAdapter.AdapterDevicePath) == 0x130);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter) == 0x340);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter.AdapterDesc) == 0x35C);
+                static_assert(offsetof(EMU_GET_DISPLAY_INFO, RenderAdapter.AdapterDevicePath) == 0x45C);
+
+                if (header.size < sizeof(EMU_GET_DISPLAY_INFO))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                const emulator_object<EMU_GET_DISPLAY_INFO> display_info{c.emu, packet};
+
+                display_info.access([](EMU_GET_DISPLAY_INFO& info) {
+                    const bool known_adapter =
+                        info.adapterId.LowPart == 0x1000 && info.adapterId.HighPart == 0; // Must match k_dxgk_adapter_luid!
+
+                    if (!known_adapter)
+                    {
+                        return;
+                    }
+
+                    const auto fill_block = [](EMU_DISPLAY_INFO_DEVICE_BLOCK& block) {
+                        block.Valid = 1;
+                        block.VendorID = 0x10DE;
+                        block.DeviceID = 0x1C03;
+                        block.SubSystemVendorID = 0x10DE;
+                        block.SubSystemID = 0;
+                        block.RevisionID = 0xA1;
+                        block.WddmVersion = 3200;
+
+                        utils::string::copy(block.AdapterDesc, u"NVIDIA GeForce GTX 1060 6GB");
+                        utils::string::copy(
+                            block.AdapterDevicePath,
+                            u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+                    };
+
+                    fill_block(info.DisplayAdapter);
+                    fill_block(info.RenderAdapter);
+                });
+
+                return STATUS_SUCCESS;
+            }
+
+            case EMU_DISPLAYCONFIG_DEVICE_INFO_TYPE::GET_DISPLAY_INFO_EX: {
                 struct EMU_GET_DISPLAY_INFO
                 {
                     UINT32 type;
@@ -3404,7 +3479,6 @@ namespace sogen
             }
 
             default:
-                // c.win_emu.log.warn("Unknown DisplayConfig Info Type: %d", header.type);
                 return STATUS_SUCCESS;
             }
         }

--- a/src/windows-emulator/syscalls/worker_factory.cpp
+++ b/src/windows-emulator/syscalls/worker_factory.cpp
@@ -2,11 +2,67 @@
 #include "../emulator_utils.hpp"
 #include "../io_completion_wait.hpp"
 #include "../syscall_utils.hpp"
+#include "../worker_factory_support.hpp"
 
 #include <limits>
 
 namespace sogen
 {
+    namespace worker_factory_support
+    {
+        bool enqueue_release_completion(process_context& process, const handle worker_factory_handle)
+        {
+            auto* factory = process.worker_factories.get(worker_factory_handle);
+            if (!factory)
+            {
+                return false;
+            }
+
+            auto* completion = process.io_completions.get(factory->io_completion_handle);
+            if (!completion)
+            {
+                return false;
+            }
+
+            io_completion_message message{};
+            message.io_status_block.Status = STATUS_SUCCESS;
+            message.io_status_block.Information = 0;
+            message.worker_factory_handle = worker_factory_handle;
+            message.worker_factory_release = true;
+            completion->enqueue(message);
+            return true;
+        }
+
+        void on_io_completion_message_dequeued(process_context& process, const io_completion_message& message)
+        {
+            if (!message.worker_factory_release || message.worker_factory_handle.bits == 0)
+            {
+                return;
+            }
+
+            auto* factory = process.worker_factories.get(message.worker_factory_handle);
+            if (!factory)
+            {
+                return;
+            }
+
+            if (factory->pending_release_count > 0)
+            {
+                --factory->pending_release_count;
+            }
+
+            if (factory->shutdown || factory->pending_release_count == 0)
+            {
+                factory->release_pending = false;
+                return;
+            }
+
+            if (!enqueue_release_completion(process, message.worker_factory_handle))
+            {
+                factory->release_pending = false;
+            }
+        }
+    }
 
     namespace syscalls
     {
@@ -75,6 +131,11 @@ namespace sogen
                 }
 
                 auto desired = std::max(factory.thread_minimum, factory.binding_count);
+                if (factory.release_pending || factory.pending_release_count != 0)
+                {
+                    desired = std::max(desired, 1u);
+                }
+
                 desired = std::min(desired, limit);
 
                 while (factory.worker_threads.size() < desired)
@@ -87,6 +148,7 @@ namespace sogen
                     factory.worker_threads.push_back(thread_handle);
                 }
             }
+
         }
 
         NTSTATUS handle_NtCreateWorkerFactory(const syscall_context& c, const emulator_object<handle> worker_factory_handle,
@@ -339,6 +401,24 @@ namespace sogen
             if (!factory)
             {
                 return STATUS_INVALID_HANDLE;
+            }
+
+            if (factory->pending_release_count == std::numeric_limits<uint32_t>::max())
+            {
+                return STATUS_UNSUCCESSFUL;
+            }
+
+            ++factory->pending_release_count;
+            if (!factory->release_pending)
+            {
+                factory->release_pending = true;
+
+                if (!worker_factory_support::enqueue_release_completion(c.proc, worker_factory_handle))
+                {
+                    factory->release_pending = false;
+                    --factory->pending_release_count;
+                    return STATUS_INVALID_HANDLE;
+                }
             }
 
             ensure_worker_factory_threads(c, *factory);

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -495,12 +495,17 @@ namespace sogen
         IO_STATUS_BLOCK<EmulatorTraits<Emu64>> io_status_block{};
         handle wait_packet_handle{};
 
+        handle worker_factory_handle{};
+        bool worker_factory_release{};
+
         void serialize(utils::buffer_serializer& buffer) const
         {
             buffer.write(this->key_context);
             buffer.write(this->apc_context);
             buffer.write(this->io_status_block);
             buffer.write(this->wait_packet_handle);
+            buffer.write(this->worker_factory_handle);
+            buffer.write(this->worker_factory_release);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
@@ -509,6 +514,8 @@ namespace sogen
             buffer.read(this->apc_context);
             buffer.read(this->io_status_block);
             buffer.read(this->wait_packet_handle);
+            buffer.read(this->worker_factory_handle);
+            buffer.read(this->worker_factory_release);
         }
     };
 
@@ -631,6 +638,8 @@ namespace sogen
         uint32_t last_info_class{};
         uint32_t last_info_length{};
         uint64_t last_info_value{};
+        uint32_t pending_release_count{};
+        bool release_pending{};
         std::vector<handle> worker_threads{};
 
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -658,6 +667,8 @@ namespace sogen
             buffer.write(this->last_info_class);
             buffer.write(this->last_info_length);
             buffer.write(this->last_info_value);
+            buffer.write(this->pending_release_count);
+            buffer.write(this->release_pending);
             buffer.write_vector(this->worker_threads);
         }
 
@@ -686,6 +697,8 @@ namespace sogen
             buffer.read(this->last_info_class);
             buffer.read(this->last_info_length);
             buffer.read(this->last_info_value);
+            buffer.read(this->pending_release_count);
+            buffer.read(this->release_pending);
             buffer.read_vector(this->worker_threads);
         }
     };

--- a/src/windows-emulator/worker_factory_support.hpp
+++ b/src/windows-emulator/worker_factory_support.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace sogen
+{
+    struct handle;
+    struct io_completion_message;
+    struct process_context;
+
+    namespace worker_factory_support
+    {
+        bool enqueue_release_completion(process_context& process, handle worker_factory_handle);
+        void on_io_completion_message_dequeued(process_context& process, const io_completion_message& message);
+    }
+} // namespace sogen


### PR DESCRIPTION
This PR implements enough of the DXGK/D3DKMT and DisplayConfig syscall surface for DX9/DX11 initialization to succeed.

I’ve had this done for a while, but didn’t have time to submit it as a PR. Since some recent changes may overlap with what was already done in this branch (e.g. #1039), I might as well get this PR up now.

Main changes:

* Adds basic DXGK/D3DKMT adapter enumeration and property/query handling.
* Adds D3DKMT device, context, allocation, lock, resource, shared primary, and display mode handling.
* Adds destroy-allocation and related cleanup paths for D3DKMT resources.
* Adds WARP/private-driver escape handling needed by D3D initialization.
* Adds DisplayConfig support for querying paths, source/target names, adapter names, advanced color info, and DXGI display information.
* Adds `NtGdiOpenDCW`, `NtDxgkIsFeatureEnabled`, `NtPowerInformation`, and `NtAllocateLocallyUniqueId`.
* Adds worker factory release notifications through I/O completion.
* Adds minimal ALPC port creation support. (This probably will conflict with https://github.com/momo5502/sogen/pull/1038, depending on which one gets merged first)
* Adds the required platform structs for the new GDI, DXGK, D3DKMT, and DisplayConfig handlers.
