### PR TITLE
emulator: seed fresh x87 FPU state as empty (fix WoW64 x87 stack overflow)

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -532,7 +532,10 @@ namespace sogen
             XMM_SAVE_AREA32 xmm_state{};
             xmm_state.ControlWord = 0x037F;
             xmm_state.StatusWord = 0;
-            xmm_state.TagWord = 0xFF;
+            // FXSAVE abridged x87 tag: 1 bit per register, 1=valid, 0=empty. A fresh FPU has an empty stack,
+            // so this must be 0x00. 0xFF marks all 8 registers valid (a full stack), which makes the first
+            // guest x87 FLD overflow and produce the x87 indefinite (NaN) under hardware (WHP) execution.
+            xmm_state.TagWord = 0x00;
             xmm_state.MxCsr = 0x1F80;
             xmm_state.MxCsr_Mask = 0xFFFFFFFF;
 

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -189,7 +189,9 @@ namespace sogen
 
             XMM_SAVE_AREA32 xmm_state{};
             xmm_state.ControlWord = 0x037F;
-            xmm_state.TagWord = 0xFF;
+            // FXSAVE abridged x87 tag: 0x00 = empty stack (fresh FPU). 0xFF (all valid) makes the next x87
+            // FLD overflow the stack and yield the x87 indefinite (NaN).
+            xmm_state.TagWord = 0x00;
             xmm_state.MxCsr = 0x1F80;
             xmm_state.MxCsr_Mask = 0xFFFFFFFF;
             static_assert(sizeof(xmm_state) <= sizeof(result.ExtendedRegisters));


### PR DESCRIPTION
The WoW64 thread and exception contexts seeded the FXSAVE area's abridged x87 tag word (XMM_SAVE_AREA32::TagWord) as 0xFF -- 1 bit per register, so 0xFF marks all 8 x87 registers valid, i.e. a full stack. A fresh FPU has an empty stack, which is abridged tag 0x00.

When the guest's FXRSTOR loads this on a real FPU (WHP backend), the x87 stack starts full, so the first guest FLD overflows the stack and yields the x87 indefinite (NaN). This corrupted 32-bit float code that forwards values via x87 FLD/FSTP (e.g. MW2/iw4x Dvar_RegisterVec4): a fresh thread's r_subwindow vec4 registered as (0,1,0,NaN), which collapsed the renderer's subwindow height to ~0 and blew up the projection matrix, flinging the 3D world off-screen (it rendered as vertical lines).

The Unicorn/Icicle interpreters were unaffected because they model the x87 FPU internally; only WHP's native FXRSTOR honored the bogus tag.