### PR TITLE
windows-emulator: make instruction precision configurable

### DIFF
--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -249,7 +249,7 @@ namespace sogen
         CONTEXT64 ctx{};
         ctx.ContextFlags = CONTEXT64_ALL;
         cpu_context::save(win_emu.emu(), ctx);
-        ctx.Rip = win_emu.emu().supports_instruction_counting() //
+        ctx.Rip = win_emu.uses_instruction_precision() //
                       ? win_emu.current_thread().current_ip
                       : win_emu.emu().read_instruction_pointer();
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -481,7 +481,8 @@ namespace sogen
           registry(emulation_root.empty() ? settings.registry_directory : emulation_root / "registry"),
           mod_manager(memory, file_sys, this->callbacks),
           process(*this->emu_, memory, *this->clock_, this->callbacks),
-          use_relative_time_(settings.use_relative_time)
+          use_relative_time_(settings.use_relative_time),
+          instruction_precision_(settings.use_instruction_precision && this->emu_->supports_instruction_counting())
     {
         this->ui_backend_->set_event_sink([this](const ui_event& event) { this->handle_ui_event(event); });
 #ifndef OS_WINDOWS
@@ -830,7 +831,7 @@ namespace sogen
                         (service == BREAKPOINT_PRINT || service == BREAKPOINT_LOAD_SYMBOLS || service == BREAKPOINT_UNLOAD_SYMBOLS ||
                          service == BREAKPOINT_COMMAND_STRING))
                     {
-                        const auto ip = this->emu().supports_instruction_counting() //
+                        const auto ip = this->uses_instruction_precision() //
                                             ? this->current_thread().current_ip
                                             : this->emu().read_instruction_pointer();
                         this->emu().reg(x86_register::rip, ip + 3);
@@ -897,9 +898,15 @@ namespace sogen
                 return memory_violation_continuation::resume;
             });
 
-        this->emu().hook_memory_execution([&](const uint64_t address) {
-            this->on_instruction_execution(address); //
-        });
+        // The global per-instruction hook drives instruction-quantum thread scheduling and
+        // exact IP tracking. Only register it when instruction precision is active; otherwise
+        // scheduling relies on the wall-clock interrupt thread set up in start().
+        if (this->uses_instruction_precision())
+        {
+            this->emu().hook_memory_execution([&](const uint64_t address) {
+                this->on_instruction_execution(address); //
+            });
+        }
     }
 
     void windows_emulator::start(size_t count)
@@ -931,7 +938,7 @@ namespace sogen
             }
         });
 
-        if (!this->emu().supports_instruction_counting())
+        if (!this->uses_instruction_precision())
         {
             interrupt_thread = std::thread([&] {
                 while (!this->should_stop)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -898,9 +898,6 @@ namespace sogen
                 return memory_violation_continuation::resume;
             });
 
-        // The global per-instruction hook drives instruction-quantum thread scheduling and
-        // exact IP tracking. Only register it when instruction precision is active; otherwise
-        // scheduling relies on the wall-clock interrupt thread set up in start().
         if (this->uses_instruction_precision())
         {
             this->emu().hook_memory_execution([&](const uint64_t address) {

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -98,6 +98,12 @@ namespace sogen
         bool disable_logging{false};
         bool use_relative_time{false};
 
+        // Enables fine-grained, per-instruction precision: instruction-quantum thread
+        // scheduling and exact instruction-pointer tracking. Enabled by default, but
+        // automatically disabled when the backend does not support instruction counting
+        // (e.g. the WHP backend). See windows_emulator::uses_instruction_precision().
+        bool use_instruction_precision{true};
+
         std::filesystem::path emulation_root{};
         std::filesystem::path registry_directory{"./registry"};
 
@@ -218,6 +224,15 @@ namespace sogen
             return this->executed_instructions_;
         }
 
+        // True when per-instruction precision is active: the configured
+        // use_instruction_precision setting AND the backend supports instruction
+        // counting. When false, thread scheduling falls back to coarse, wall-clock
+        // based preemption and the instruction pointer is read live from the backend.
+        bool uses_instruction_precision() const
+        {
+            return this->instruction_precision_;
+        }
+
         stop_reason last_stop_reason() const
         {
             return this->last_stop_reason_;
@@ -294,6 +309,7 @@ namespace sogen
       private:
         std::atomic_bool switch_thread_{false};
         bool use_relative_time_{false}; // TODO: Get rid of that
+        bool instruction_precision_{true};
         std::atomic_bool should_stop{false};
 
         std::unordered_map<uint16_t, uint16_t> port_mappings_{};

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -97,11 +97,6 @@ namespace sogen
     {
         bool disable_logging{false};
         bool use_relative_time{false};
-
-        // Enables fine-grained, per-instruction precision: instruction-quantum thread
-        // scheduling and exact instruction-pointer tracking. Enabled by default, but
-        // automatically disabled when the backend does not support instruction counting
-        // (e.g. the WHP backend). See windows_emulator::uses_instruction_precision().
         bool use_instruction_precision{true};
 
         std::filesystem::path emulation_root{};
@@ -224,10 +219,6 @@ namespace sogen
             return this->executed_instructions_;
         }
 
-        // True when per-instruction precision is active: the configured
-        // use_instruction_precision setting AND the backend supports instruction
-        // counting. When false, thread scheduling falls back to coarse, wall-clock
-        // based preemption and the instruction pointer is read live from the backend.
         bool uses_instruction_precision() const
         {
             return this->instruction_precision_;


### PR DESCRIPTION
## Summary

Makes per-instruction precision configurable in the Windows emulator.

A new `emulator_settings::use_instruction_precision` flag (enabled by default) gates the fine-grained, per-instruction behavior:

- instruction-quantum thread scheduling (the `MAX_INSTRUCTIONS_PER_TIME_SLICE` round-robin quantum), and
- exact instruction-pointer tracking via the cached `current_ip`.

The **effective** precision is `use_instruction_precision && emu().supports_instruction_counting()`, exposed via `windows_emulator::uses_instruction_precision()`. So precision is automatically disabled when either the option is turned off **or** the backend cannot count instructions (e.g. WHP) — without the caller having to know which backend is in use.

## Behavior when precision is off

This routes counting-capable backends (Unicorn/Icicle) through the same paths WHP already relied on:

- the global per-instruction hook (`on_instruction_execution`) is **not** registered;
- thread scheduling falls back to the wall-clock interrupt thread in `start()` (~1s preemption) instead of the instruction quantum;
- the instruction pointer is read live via `read_instruction_pointer()` instead of the cached `current_ip` (DbgPrint IP fixup and `dispatch_exception`).

## Notes

- All previous `supports_instruction_counting()` call sites in the windows-emulator layer now go through `uses_instruction_precision()`.
- Snapshot serialization is unchanged: the flag is derived from settings + backend at construction time.
- Built locally (`windows-emulator` target) — compiles and links cleanly.
