### PR TITLE
gpu-bridge: forward full sampler state (fix dark shadows)

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -16,7 +16,7 @@ namespace sogen::gpu_bridge
     // Identifies a valid bridge and lets the guest detect a host that speaks a different
     // protocol revision before issuing any further commands.
     inline constexpr uint32_t protocol_magic = 0x55504753; // 'SGPU'
-    inline constexpr uint32_t protocol_version = 26;
+    inline constexpr uint32_t protocol_version = 27;
 
     // Windows IOCTL encoding: CTL_CODE(DeviceType, Function, Method, Access).
     //   value = (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
@@ -1102,7 +1102,15 @@ namespace sogen::gpu_bridge
         uint32_t address_mode_u; // VkSamplerAddressMode
         uint32_t address_mode_v;
         uint32_t address_mode_w;
-        uint32_t reserved;
+        uint32_t mipmap_mode;       // VkSamplerMipmapMode
+        uint32_t compare_enable;    // VkBool32 (depth-compare / shadow-map PCF sampler)
+        uint32_t compare_op;        // VkCompareOp
+        uint32_t anisotropy_enable; // VkBool32
+        uint32_t border_color;      // VkBorderColor
+        float mip_lod_bias;
+        float max_anisotropy;
+        float min_lod;
+        float max_lod;
     };
 
     struct create_surface_request
@@ -1905,7 +1913,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_set_dynamic_u32_request) == 16, "wire layout drift");
     static_assert(sizeof(descriptor_set_layout_binding) == 16, "wire layout drift");
     static_assert(sizeof(cmd_bind_descriptor_sets_request) == 32, "wire layout drift");
-    static_assert(sizeof(create_sampler_request) == 32, "wire layout drift");
+    static_assert(sizeof(create_sampler_request) == 64, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_request) == 16, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_response) == 8, "wire layout drift");
     static_assert(sizeof(feature_chain_record) == 8, "wire layout drift");

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -3671,6 +3671,15 @@ extern "C"
         request.address_mode_u = static_cast<uint32_t>(pCreateInfo->addressModeU);
         request.address_mode_v = static_cast<uint32_t>(pCreateInfo->addressModeV);
         request.address_mode_w = static_cast<uint32_t>(pCreateInfo->addressModeW);
+        request.mipmap_mode = static_cast<uint32_t>(pCreateInfo->mipmapMode);
+        request.compare_enable = pCreateInfo->compareEnable;
+        request.compare_op = static_cast<uint32_t>(pCreateInfo->compareOp);
+        request.anisotropy_enable = pCreateInfo->anisotropyEnable;
+        request.border_color = static_cast<uint32_t>(pCreateInfo->borderColor);
+        request.mip_lod_bias = pCreateInfo->mipLodBias;
+        request.max_anisotropy = pCreateInfo->maxAnisotropy;
+        request.min_lod = pCreateInfo->minLod;
+        request.max_lod = pCreateInfo->maxLod;
 
         gb::object_response response{};
         if (!bridge_call(gb::ioctl_create_sampler, &request, sizeof(request), &response, sizeof(response)))

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2100,9 +2100,10 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
                 uint64_t sampler = gpu_bridge::null_object;
-                const int32_t result =
-                    this->vulkan_.create_sampler(request.device, request.mag_filter, request.min_filter, request.address_mode_u,
-                                                 request.address_mode_v, request.address_mode_w, sampler);
+                const int32_t result = this->vulkan_.create_sampler(
+                    request.device, request.mag_filter, request.min_filter, request.address_mode_u, request.address_mode_v,
+                    request.address_mode_w, request.mipmap_mode, request.compare_enable, request.compare_op, request.anisotropy_enable,
+                    request.border_color, request.mip_lod_bias, request.max_anisotropy, request.min_lod, request.max_lod, sampler);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = sampler});
             }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -3016,7 +3016,7 @@ namespace sogen
 
         // Custom border colors carry their RGBA in a VkSamplerCustomBorderColorCreateInfoEXT pNext that the
         // bridge does not forward; without it the enum is invalid, so fall back to opaque black.
-        VkBorderColor border = static_cast<VkBorderColor>(border_color);
+        auto border = static_cast<VkBorderColor>(border_color);
         if (border == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT || border == VK_BORDER_COLOR_INT_CUSTOM_EXT)
         {
             border = VK_BORDER_COLOR_INT_OPAQUE_BLACK;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -3003,7 +3003,9 @@ namespace sogen
     }
 
     int32_t vulkan_host::create_sampler(uint64_t device, uint32_t mag_filter, uint32_t min_filter, uint32_t address_mode_u,
-                                        uint32_t address_mode_v, uint32_t address_mode_w, uint64_t& out_sampler)
+                                        uint32_t address_mode_v, uint32_t address_mode_w, uint32_t mipmap_mode, uint32_t compare_enable,
+                                        uint32_t compare_op, uint32_t anisotropy_enable, uint32_t border_color, float mip_lod_bias,
+                                        float max_anisotropy, float min_lod, float max_lod, uint64_t& out_sampler)
     {
         out_sampler = 0;
         const auto dev = this->impl_->devices.find(device);
@@ -3012,16 +3014,32 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        // Custom border colors carry their RGBA in a VkSamplerCustomBorderColorCreateInfoEXT pNext that the
+        // bridge does not forward; without it the enum is invalid, so fall back to opaque black.
+        VkBorderColor border = static_cast<VkBorderColor>(border_color);
+        if (border == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT || border == VK_BORDER_COLOR_INT_CUSTOM_EXT)
+        {
+            border = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        }
+
         VkSamplerCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
         info.magFilter = static_cast<VkFilter>(mag_filter);
         info.minFilter = static_cast<VkFilter>(min_filter);
-        info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        info.mipmapMode = static_cast<VkSamplerMipmapMode>(mipmap_mode);
         info.addressModeU = static_cast<VkSamplerAddressMode>(address_mode_u);
         info.addressModeV = static_cast<VkSamplerAddressMode>(address_mode_v);
         info.addressModeW = static_cast<VkSamplerAddressMode>(address_mode_w);
-        info.maxLod = VK_LOD_CLAMP_NONE;
-        info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        info.mipLodBias = mip_lod_bias;
+        info.anisotropyEnable = anisotropy_enable ? VK_TRUE : VK_FALSE;
+        info.maxAnisotropy = max_anisotropy < 1.0f ? 1.0f : max_anisotropy;
+        // Depth-compare / PCF sampling (sampler2DShadow): a non-comparison sampler yields undefined results
+        // here, which is what made shadow-mapped sun lighting render as fully shadowed.
+        info.compareEnable = compare_enable ? VK_TRUE : VK_FALSE;
+        info.compareOp = static_cast<VkCompareOp>(compare_op);
+        info.minLod = min_lod;
+        info.maxLod = max_lod;
+        info.borderColor = border;
 
         VkSampler sampler{};
         const VkResult result = dev->second.create_sampler(dev->second.handle, &info, nullptr, &sampler);

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -301,9 +301,12 @@ namespace sogen
         // Updates a buffer region inline from caller-provided data (vkCmdUpdateBuffer).
         int32_t cmd_update_buffer(uint64_t command_buffer, uint64_t buffer, uint64_t offset, const void* data, uint32_t size);
 
-        // A linear/nearest sampler (mag/min filter + per-axis address modes; no mipmapping/anisotropy).
+        // Creates a sampler honoring the guest's full state: filters, per-axis address modes, mip mode/lod,
+        // anisotropy, border color, and depth-compare (the comparison/PCF mode shadow-map sampling needs).
         int32_t create_sampler(uint64_t device, uint32_t mag_filter, uint32_t min_filter, uint32_t address_mode_u, uint32_t address_mode_v,
-                               uint32_t address_mode_w, uint64_t& out_sampler);
+                               uint32_t address_mode_w, uint32_t mipmap_mode, uint32_t compare_enable, uint32_t compare_op,
+                               uint32_t anisotropy_enable, uint32_t border_color, float mip_lod_bias, float max_anisotropy, float min_lod,
+                               float max_lod, uint64_t& out_sampler);
         void destroy_sampler(uint64_t device, uint64_t sampler);
 
         // --- WSI (modeled with offscreen images; "present" reads back and hands pixels to the UI) ---


### PR DESCRIPTION
## Problem

In-game rendering through the GPU bridge (MW2 / iw4x via DXVK) looked noticeably **darker with crushed shadows** vs. native DXVK — same DXVK, same shaders, same GPU, so the difference was in how the bridge set up GPU state.

## Root cause

`create_sampler` only forwarded `magFilter`/`minFilter` and the three address modes, hardcoding everything else — including **`compareEnable = FALSE`**.

DXVK implements D3D9 hardware shadow mapping with **comparison samplers** (`sampler2DShadow` / `OpImageSampleDref`). A RenderDoc capture of an in-game frame confirmed **all 530 main-scene draws sample with `Dref`**. Sampling a shadow texture through a *non-comparison* sampler is undefined in Vulkan, so the sun-shadow term came back as garbage and the whole scene rendered as if fully shadowed.

## Fix

Thread the full `VkSamplerCreateInfo` state across the wire:

- `compareEnable` / `compareOp` (the actual shadow fix)
- `mipmapMode` (was hardcoded `NEAREST` — this also restores trilinear/anisotropic filtering)
- `anisotropyEnable` / `maxAnisotropy`
- `borderColor` (custom border colors, whose `pNext` the bridge doesn't carry, fall back to opaque black)
- `mipLodBias` / `minLod` / `maxLod`

Protocol bumped to **v27** (`create_sampler_request` extended; `static_assert` updated).

## Verification

Built (`release` + 32-bit shim) and run in-game on `mp_rust`; the scene lighting/shadows now match native DXVK. RenderDoc capture used to confirm the `Dref` sampling path.