### PR TITLE
Fix some Unicode filesystem issues

### DIFF
--- a/src/analyzer/CMakeLists.txt
+++ b/src/analyzer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(analyzer main.cpp)
 
 if(WIN)
   target_sources(analyzer PRIVATE resource.rc)
+  target_link_libraries(analyzer PRIVATE shell32)
 endif()
 
 sogen_assign_source_group(main.cpp)

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -6,7 +6,7 @@
 #include <windows.h>
 #endif
 
-#include "emulator-platform/platform/unicode.hpp"
+#include <emulator-platform/platform/platform.hpp>
 
 namespace sogen
 {

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -4,6 +4,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 #include <emulator-platform/platform/platform.hpp>
@@ -24,7 +25,7 @@ namespace
 }
 
 #ifdef _WIN32
-int dispatch_main(int argc, wchar_t** wargv)
+int dispatch_wmain(int argc, wchar_t** wargv)
 {
     std::vector<std::string> utf8_storage;
     utf8_storage.reserve(argc);
@@ -52,16 +53,22 @@ int dispatch_main(int argc, wchar_t** wargv)
     return sogen::windows_main(argc, argv_utf8.data());
 }
 
-int wmain(int argc, wchar_t** argv)
+int dispatch_current_command_line()
 {
-    return dispatch_main(argc, argv);
-}
+    int argc = 0;
+    auto** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv)
+    {
+        return 1;
+    }
 
-int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
-{
-    return dispatch_main(__argc, __wargv);
+    const auto result = dispatch_wmain(argc, argv);
+    LocalFree(argv);
+    return result;
 }
-#else
+#endif
+
+#ifndef _WIN32
 int dispatch_main(int argc, char** argv)
 {
     if (should_use_linux_analyzer())
@@ -71,9 +78,22 @@ int dispatch_main(int argc, char** argv)
 
     return sogen::windows_main(argc, argv);
 }
+#endif
 
 int main(int argc, char** argv)
 {
+#ifdef _WIN32
+    (void)argc;
+    (void)argv;
+    return dispatch_current_command_line();
+#else
     return dispatch_main(argc, argv);
+#endif
+}
+
+#ifdef _WIN32
+int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
+{
+    return dispatch_current_command_line();
 }
 #endif

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -6,6 +6,8 @@
 #include <windows.h>
 #endif
 
+#include "emulator-platform/platform/unicode.hpp"
+
 namespace sogen
 {
     int windows_main(int argc, char** argv);
@@ -22,20 +24,6 @@ namespace
 }
 
 #ifdef _WIN32
-std::string wide_to_utf8(const std::wstring& w)
-{
-    if (w.empty())
-        return {};
-
-    int size = WideCharToMultiByte(CP_UTF8, 0, w.data(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
-
-    std::string out(size, '\0');
-
-    WideCharToMultiByte(CP_UTF8, 0, w.data(), static_cast<int>(w.size()), out.data(), size, nullptr, nullptr);
-
-    return out;
-}
-
 int dispatch_main(int argc, wchar_t** wargv)
 {
     std::vector<std::string> utf8_storage;
@@ -43,7 +31,7 @@ int dispatch_main(int argc, wchar_t** wargv)
 
     for (int i = 0; i < argc; ++i)
     {
-        utf8_storage.push_back(wide_to_utf8(wargv[i]));
+        utf8_storage.push_back(sogen::w_to_u8(wargv[i]));
     }
 
     std::vector<char*> argv_utf8;

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -69,7 +69,7 @@ int wmain(int argc, wchar_t** argv)
     return dispatch_main(argc, argv);
 }
 
-int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 {
     return dispatch_main(__argc, __wargv);
 }

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -1,4 +1,6 @@
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -19,6 +21,59 @@ namespace
     }
 }
 
+#ifdef _WIN32
+std::string wide_to_utf8(const std::wstring& w)
+{
+    if (w.empty())
+        return {};
+
+    int size = WideCharToMultiByte(CP_UTF8, 0, w.data(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
+
+    std::string out(size, '\0');
+
+    WideCharToMultiByte(CP_UTF8, 0, w.data(), static_cast<int>(w.size()), out.data(), size, nullptr, nullptr);
+
+    return out;
+}
+
+int dispatch_main(int argc, wchar_t** wargv)
+{
+    std::vector<std::string> utf8_storage;
+    utf8_storage.reserve(argc);
+
+    for (int i = 0; i < argc; ++i)
+    {
+        utf8_storage.push_back(wide_to_utf8(wargv[i]));
+    }
+
+    std::vector<char*> argv_utf8;
+    argv_utf8.reserve(argc + 1);
+
+    for (auto& arg : utf8_storage)
+    {
+        argv_utf8.push_back(arg.data());
+    }
+
+    argv_utf8.push_back(nullptr);
+
+    if (should_use_linux_analyzer())
+    {
+        return sogen::linux_main(argc, argv_utf8.data());
+    }
+
+    return sogen::windows_main(argc, argv_utf8.data());
+}
+
+int wmain(int argc, wchar_t** argv)
+{
+    return dispatch_main(argc, argv);
+}
+
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
+{
+    return dispatch_main(__argc, __wargv);
+}
+#else
 int dispatch_main(int argc, char** argv)
 {
     if (should_use_linux_analyzer())
@@ -32,11 +87,5 @@ int dispatch_main(int argc, char** argv)
 int main(int argc, char** argv)
 {
     return dispatch_main(argc, argv);
-}
-
-#ifdef _WIN32
-int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
-{
-    return dispatch_main(__argc, __argv);
 }
 #endif

--- a/src/common/utils/stat.cpp
+++ b/src/common/utils/stat.cpp
@@ -86,15 +86,16 @@ namespace sogen
         return do_stat(handle, stat);
     }
 
-    bool compat_stat(const char* file_name, struct compat_stat* stat)
+    bool compat_stat(const std::filesystem::path& file_name, struct compat_stat* stat)
     {
-        if (file_name == nullptr)
+        if (file_name.empty())
         {
             return false;
         }
 
-        auto* const file_handle = CreateFileA(file_name, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                              nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        auto* const file_handle =
+            CreateFileW(file_name.c_str(), FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
         if (file_handle == INVALID_HANDLE_VALUE)
         {
@@ -160,10 +161,10 @@ namespace sogen
         return true;
     }
 
-    bool compat_stat(const char* file_name, struct compat_stat* stat)
+    bool compat_stat(const std::filesystem::path& file_name, struct compat_stat* stat)
     {
         struct stat file_stat{};
-        if (::stat(file_name, &file_stat) != 0)
+        if (::stat(file_name.string().c_str(), &file_stat) != 0)
         {
             return false;
         }

--- a/src/common/utils/stat.hpp
+++ b/src/common/utils/stat.hpp
@@ -2,6 +2,8 @@
 
 #include <platform/platform.hpp>
 
+#include <filesystem>
+
 namespace sogen
 {
 
@@ -21,7 +23,7 @@ namespace sogen
     };
 
     bool compat_fstat(int fd, struct compat_stat* stat);
-    bool compat_stat(const char* file_name, struct compat_stat* stat);
+    bool compat_stat(const std::filesystem::path& file_name, struct compat_stat* stat);
 
     LARGE_INTEGER convert_timespec_to_filetime(timespec timespec);
 } // namespace sogen

--- a/src/emulator-platform/platform/file_management.hpp
+++ b/src/emulator-platform/platform/file_management.hpp
@@ -118,13 +118,23 @@ namespace sogen
 #define SEC_IMAGE_NO_EXECUTE       (SEC_IMAGE | SEC_NOCACHE)
 #endif
 
+#ifndef CTL_CODE
 #define CTL_CODE(DeviceType, Function, Method, Access) (((DeviceType) << 16) | ((Access) << 14) | ((Function) << 2) | (Method))
+#endif
 
-#define METHOD_BUFFERED                                0
+#define METHOD_BUFFERED 0
 
-#define FILE_ANY_ACCESS                                0
-#define FILE_READ_ACCESS                               (0x0001) // file & pipe
-#define FILE_WRITE_ACCESS                              (0x0002) // file & pipe
+#ifndef FILE_ANY_ACCESS
+#define FILE_ANY_ACCESS 0
+#endif
+
+#ifndef FILE_READ_ACCESS
+#define FILE_READ_ACCESS (0x0001) // file & pipe
+#endif
+
+#ifndef FILE_WRITE_ACCESS
+#define FILE_WRITE_ACCESS (0x0002) // file & pipe
+#endif
 
     typedef enum _FSINFOCLASS
     {

--- a/src/emulator-platform/platform/unicode.hpp
+++ b/src/emulator-platform/platform/unicode.hpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <type_traits>
 
+#include "primitives.hpp"
 #include "traits.hpp"
 
 namespace sogen

--- a/src/emulator-platform/platform/unicode.hpp
+++ b/src/emulator-platform/platform/unicode.hpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <type_traits>
 
+#include "traits.hpp"
+
 namespace sogen
 {
 

--- a/src/tools/sandbox/CMakeLists.txt
+++ b/src/tools/sandbox/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(sandbox PRIVATE
   windows-emulator
   whp-emulator
   emulator-common
+  shell32
 )
 
 sogen_strip_target(sandbox)

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -53,7 +53,7 @@ namespace sogen::sandbox
         int run(const std::span<const std::string_view> args)
         {
             application_settings app_settings{
-                .application = args[0],
+                .application = std::u8string(args[0].begin(), args[0].end()),
                 .arguments = parse_arguments(args),
             };
 
@@ -92,14 +92,20 @@ namespace sogen::sandbox
             return static_cast<int>(*exit_status);
         }
 
-        int run_main(const int argc, char** argv)
+        int run_main(const int argc, wchar_t** wargv)
         {
             try
             {
-                std::vector<std::string_view> args{};
+                std::vector<std::string> args{};
                 for (int i = 1; i < argc; ++i)
                 {
-                    args.emplace_back(argv[i]);
+                    args.emplace_back(w_to_u8(wargv[i]));
+                }
+
+                std::vector<std::string_view> views{};
+                for (const auto& str : args)
+                {
+                    views.push_back(str);
                 }
 
                 if (args.empty())
@@ -108,7 +114,7 @@ namespace sogen::sandbox
                     return 1;
                 }
 
-                return run(args);
+                return run(views);
             }
             catch (const std::exception& e)
             {
@@ -124,12 +130,12 @@ namespace sogen::sandbox
     }
 }
 
-int main(const int argc, char** argv)
+int wmain(const int argc, wchar_t** argv)
 {
     return sogen::sandbox::run_main(argc, argv);
 }
 
 int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
 {
-    return sogen::sandbox::run_main(__argc, __argv);
+    return sogen::sandbox::run_main(__argc, __wargv);
 }

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -4,6 +4,8 @@
 #include <utils/interupt_handler.hpp>
 #include <utils/win.hpp>
 
+#include <shellapi.h>
+
 #include <array>
 #include <atomic>
 #include <cstdio>
@@ -128,15 +130,31 @@ namespace sogen::sandbox
 
             return 1;
         }
+
+        int run_current_command_line()
+        {
+            int argc = 0;
+            auto** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+            if (!argv)
+            {
+                return 1;
+            }
+
+            const auto result = run_main(argc, argv);
+            LocalFree(argv);
+            return result;
+        }
     }
 }
 
 int wmain(const int argc, wchar_t** argv)
 {
-    return sogen::sandbox::run_main(argc, argv);
+    (void)argc;
+    (void)argv;
+    return sogen::sandbox::run_current_command_line();
 }
 
 int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
 {
-    return sogen::sandbox::run_main(__argc, __wargv);
+    return sogen::sandbox::run_current_command_line();
 }

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -103,6 +103,7 @@ namespace sogen::sandbox
                 }
 
                 std::vector<std::string_view> views{};
+                views.reserve(args.size());
                 for (const auto& str : args)
                 {
                     views.push_back(str);

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -527,7 +527,7 @@ namespace sogen
             }
 
             application_settings app_settings{
-                .application = args[0],
+                .application = std::u8string(args[0].begin(), args[0].end()),
                 .arguments = parse_arguments(args),
                 .environment = options.environment,
             };

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1857,10 +1857,10 @@ namespace sogen
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 
-            const auto local_filename = c.win_emu.file_sys.translate(filename).u8string();
+            const auto local_filename = c.win_emu.file_sys.translate(filename);
 
             struct compat_stat file_stat{};
-            if (!compat_stat(reinterpret_cast<const char*>(local_filename.c_str()), &file_stat))
+            if (!compat_stat(local_filename, &file_stat))
             {
                 return STATUS_OBJECT_NAME_NOT_FOUND;
             }
@@ -1916,10 +1916,10 @@ namespace sogen
                 return STATUS_OBJECT_NAME_NOT_FOUND;
             }
 
-            const auto local_filename = c.win_emu.file_sys.translate(filepath).u8string();
+            const auto local_filename = c.win_emu.file_sys.translate(filepath);
 
             struct compat_stat file_stat{};
-            if (!compat_stat(reinterpret_cast<const char*>(local_filename.c_str()), &file_stat))
+            if (!compat_stat(local_filename, &file_stat))
             {
                 return STATUS_OBJECT_NAME_NOT_FOUND;
             }

--- a/src/windows-gdb-stub/windows_filesystem.cpp
+++ b/src/windows-gdb-stub/windows_filesystem.cpp
@@ -3,7 +3,9 @@
 #include <ios>
 #include <limits>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
 #endif
 #include <sys/stat.h>
@@ -89,16 +91,24 @@ namespace sogen
         return mode;
     }
 
-    std::string windows_filesystem::translate_path(std::string_view emulated_path) const
+    static int unlink_path(const std::filesystem::path& path)
+    {
+#ifdef _WIN32
+        return _wunlink(path.c_str());
+#else
+        return ::unlink(path.c_str());
+#endif
+    }
+
+    std::optional<std::filesystem::path> windows_filesystem::translate_path(std::string_view emulated_path) const
     {
         try
         {
-            const auto fs_path = this->win_emu_->file_sys.translate(emulated_path);
-            return fs_path.string();
+            return this->win_emu_->file_sys.translate(windows_path{std::u8string(emulated_path.begin(), emulated_path.end())});
         }
         catch (const std::runtime_error&)
         {
-            return {};
+            return std::nullopt;
         }
     }
 
@@ -111,13 +121,18 @@ namespace sogen
         }
 
         const auto real_path = translate_path(file_path);
-        if (real_path.empty())
+        if (!real_path)
         {
             return 0;
         }
 
-        auto stream = std::fstream(real_path, open_mode);
+        auto stream = std::fstream(*real_path, open_mode);
         stream.exceptions(std::fstream::goodbit);
+
+        if (!stream.is_open())
+        {
+            return 0;
+        }
 
         opened_files.emplace(free_index, std::move(stream));
         return free_index++;
@@ -227,12 +242,12 @@ namespace sogen
     int windows_filesystem::unlink(const std::string& file_path)
     {
         const auto real_path = translate_path(file_path);
-        if (real_path.empty())
+        if (!real_path)
         {
             return -1;
         }
 
-        return ::unlink(real_path.c_str());
+        return unlink_path(*real_path);
     }
 
 } // namespace sogen

--- a/src/windows-gdb-stub/windows_filesystem.hpp
+++ b/src/windows-gdb-stub/windows_filesystem.hpp
@@ -5,6 +5,7 @@
 
 #include <fstream>
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 
 namespace sogen
@@ -32,7 +33,7 @@ namespace sogen
         int unlink(const std::string& file_path) override;
 
       private:
-        std::string translate_path(std::string_view emulated_path) const;
+        std::optional<std::filesystem::path> translate_path(std::string_view emulated_path) const;
 
         windows_emulator* win_emu_{};
         std::unordered_map<unsigned, std::fstream> opened_files;


### PR DESCRIPTION
This PR fixes issues related to Unicode characters in filenames and file paths:

* Ensure Unicode characters aren’t lost in arguments or file paths on Windows.
* Correctly account for Unicode filenames in `compat_stat`.
* Ensure `translate_path` doesn’t corrupt Unicode characters.
