### PR TITLE
Implement Menu syscalls and some GDI syscalls

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -279,6 +279,49 @@ namespace sogen
     };
     static_assert(sizeof(USER_WINDOW) == 328);
 
+    struct USER_MENU
+    {
+        uint64_t hMenu;
+        uint64_t self;
+        uint8_t pad_10[0x10];
+        uint64_t rgItems;
+        uint32_t flags;
+        uint32_t cItems;
+    };
+    static_assert(offsetof(USER_MENU, hMenu) == 0x0);
+    static_assert(offsetof(USER_MENU, self) == 0x8);
+    static_assert(offsetof(USER_MENU, rgItems) == 0x20);
+    static_assert(offsetof(USER_MENU, flags) == 0x28);
+    static_assert(offsetof(USER_MENU, cItems) == 0x2C);
+
+    struct USER_MENU_ITEM
+    {
+        uint32_t type;
+        uint32_t state;
+        uint32_t id;
+        uint8_t pad_0C[4];
+        uint64_t submenu;
+        uint64_t hbmpChecked;
+        uint64_t hbmpUnchecked;
+        uint64_t text;
+        uint32_t cch;
+        uint8_t pad_34[4];
+        uint64_t data;
+        uint8_t pad_40[0x20];
+        uint64_t hbmpItem;
+        uint8_t pad_68[8];
+    };
+    static_assert(offsetof(USER_MENU_ITEM, state) == 0x4);
+    static_assert(offsetof(USER_MENU_ITEM, id) == 0x8);
+    static_assert(offsetof(USER_MENU_ITEM, submenu) == 0x10);
+    static_assert(offsetof(USER_MENU_ITEM, hbmpChecked) == 0x18);
+    static_assert(offsetof(USER_MENU_ITEM, hbmpUnchecked) == 0x20);
+    static_assert(offsetof(USER_MENU_ITEM, text) == 0x28);
+    static_assert(offsetof(USER_MENU_ITEM, cch) == 0x30);
+    static_assert(offsetof(USER_MENU_ITEM, data) == 0x38);
+    static_assert(offsetof(USER_MENU_ITEM, hbmpItem) == 0x60);
+    static_assert(sizeof(USER_MENU_ITEM) == 0x70);
+
     struct USER_DESKTOPINFO
     {
         uint8_t unknown0[0x8];

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -282,14 +282,14 @@ namespace sogen
     struct USER_MENU
     {
         uint64_t hMenu;
-        uint64_t self;
+        uint64_t ptrBase;
         uint8_t pad_10[0x10];
         uint64_t rgItems;
         uint32_t flags;
         uint32_t cItems;
     };
     static_assert(offsetof(USER_MENU, hMenu) == 0x0);
-    static_assert(offsetof(USER_MENU, self) == 0x8);
+    static_assert(offsetof(USER_MENU, ptrBase) == 0x8);
     static_assert(offsetof(USER_MENU, rgItems) == 0x20);
     static_assert(offsetof(USER_MENU, flags) == 0x28);
     static_assert(offsetof(USER_MENU, cItems) == 0x2C);
@@ -299,17 +299,17 @@ namespace sogen
         uint32_t type;
         uint32_t state;
         uint32_t id;
-        uint8_t pad_0C[4];
+        uint8_t pad_0C[4]{};
         uint64_t submenu;
         uint64_t hbmpChecked;
         uint64_t hbmpUnchecked;
         uint64_t text;
         uint32_t cch;
-        uint8_t pad_34[4];
+        uint8_t pad_34[4]{};
         uint64_t data;
-        uint8_t pad_40[0x20];
+        uint8_t pad_40[0x20]{};
         uint64_t hbmpItem;
-        uint8_t pad_68[8];
+        uint8_t pad_68[8]{};
     };
     static_assert(offsetof(USER_MENU_ITEM, state) == 0x4);
     static_assert(offsetof(USER_MENU_ITEM, id) == 0x8);

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -52,6 +52,7 @@ namespace sogen
     using hicon = pointer;
     using hcursor = pointer;
     using hbrush = pointer;
+    using hbitmap = pointer;
 
     struct msg
     {
@@ -133,6 +134,22 @@ namespace sogen
         BOOL fRestore;
         BOOL fIncUpdate;
         uint8_t rgbReserved[32];
+    };
+
+    struct EMU_MENUITEMINFO
+    {
+        UINT cbSize;
+        UINT fMask;
+        UINT fType;
+        UINT fState;
+        UINT wID;
+        hmenu hSubMenu;
+        hbitmap hbmpChecked;
+        hbitmap hbmpUnchecked;
+        uint64_t dwItemData;
+        uint64_t dwTypeData;
+        UINT cch;
+        hbitmap hbmpItem;
     };
 
 #define EMU_HWND_MESSAGE ((hwnd) - 3)
@@ -303,6 +320,25 @@ namespace sogen
 #define GWLP_HWNDPARENT      (-8)
 #define GWLP_USERDATA        (-21)
 #define GWLP_ID              (-12)
+
+#define MIIM_STATE           0x0001
+#define MIIM_ID              0x0002
+#define MIIM_SUBMENU         0x0004
+#define MIIM_CHECKMARKS      0x0008
+#define MIIM_TYPE            0x0010
+#define MIIM_DATA            0x0020
+#define MIIM_STRING          0x0040
+#define MIIM_BITMAP          0x0080
+#define MIIM_FTYPE           0x0100
+
+#define MF_INSERT            0x0000
+#define MF_CHANGE            0x0080
+#define MF_APPEND            0x0100
+#define MF_DELETE            0x0200
+#define MF_REMOVE            0x1000
+
+#define MF_BYCOMMAND         0x0000
+#define MF_BYPOSITION        0x0400
 #endif
 
 #define WM_UAHDESTROYWINDOW 0x0090

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -25,6 +25,18 @@ namespace sogen
         LONG y;
     } POINTL;
 
+    typedef struct _FIXED
+    {
+        uint16_t fract;
+        int16_t value;
+    } FIXED;
+
+    typedef struct tagPOINTFX
+    {
+        FIXED x;
+        FIXED y;
+    } POINTFX;
+
     typedef struct tagSIZE
     {
         LONG cx;

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -25,6 +25,7 @@ namespace sogen
             mutant,
             token,
             window,
+            menu,
             timer,
             user_timer,
             monitor,

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -423,6 +423,7 @@ namespace sogen
         handle default_desktop{};
         handle_store<handle_types::desktop, desktop> desktops{};
         user_handle_store<handle_types::window, window> windows{user_handles};
+        user_handle_store<handle_types::type::menu, menu> menus{user_handles};
         handle_store<handle_types::timer, timer> timers{};
         handle_store<handle_types::registry, registry_key, 2> registry_keys{};
         std::map<uint32_t, handle> thread_handles_by_id{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -589,6 +589,24 @@ namespace sogen
         BOOL handle_NtUserValidateTimerCallback(const syscall_context& c, uint64_t timer_proc);
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, UINT flags);
         uint32_t handle_NtUserGetQueueStatus(const syscall_context& c, UINT flags);
+        NTSTATUS handle_NtUserCreateAcceleratorTable();
+        hmenu handle_NtUserCreateMenu(const syscall_context& c);
+        BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, hmenu menu, UINT position, BOOL by_position, BOOL insert,
+                                              emulator_object<MENUITEMINFOW> item_info,
+                                              emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text);
+        hmenu handle_NtUserCreatePopupMenu(const syscall_context& c);
+        BOOL handle_NtUserSetMenu();
+        BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
+        BOOL handle_NtUserDestroyMenu(const syscall_context& c, hmenu menu);
+        BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
+        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, hwnd hwnd, emulator_pointer data);
+        BOOL handle_NtUserCreateCaret();
+        BOOL handle_NtUserIsTouchWindow();
+        BOOL handle_NtUserGetWindowPlacement();
+        BOOL handle_NtUserTrackMouseEvent();
+        BOOL handle_NtUserSetWindowRgn();
+        BOOL handle_NtUserAlterWindowStyle();
+        BOOL handle_NtUserSetActiveWindow();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -638,8 +656,14 @@ namespace sogen
         uint32_t handle_NtGdiQueryFontAssocInfo(const syscall_context& c, hdc dc);
         uint32_t handle_NtGdiGetTextMetricsW(const syscall_context& c, hdc dc, emulator_pointer ptm, uint32_t cj);
         int32_t handle_NtGdiGetTextFaceW(const syscall_context& c, hdc dc, int32_t count, emulator_pointer face_name, BOOL alias_name);
+        uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, hdc dc, UINT character, UINT format, emulator_pointer glyph_metrics,
+                                             DWORD buffer_size, emulator_pointer buffer, emulator_pointer mat2);
+        uint32_t handle_NtGdiGetOutlineTextMetricsInternalW(const syscall_context& c, hdc dc, uint32_t cj_copy, emulator_pointer metrics,
+                                                            emulator_pointer unknown);
         BOOL handle_NtGdiGetTextExtent(const syscall_context& c, hdc dc, emulator_pointer text, int32_t char_count, emulator_pointer size,
                                        ULONG flags);
+        NTSTATUS handle_NtGdiExtCreateRegion();
+        NTSTATUS handle_NtGdiTransparentBlt();
         uint64_t handle_NtGdiCreateRectRgn(const syscall_context& c, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
         int32_t handle_NtGdiGetRandomRgn(const syscall_context& c, hdc dc, uint64_t region, LONG index);
         int32_t handle_NtGdiIntersectClipRect(const syscall_context& c, hdc dc, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
@@ -648,11 +672,15 @@ namespace sogen
         BOOL handle_NtGdiLineTo(const syscall_context& c, hdc dc, LONG x_end, LONG y_end);
         BOOL handle_NtGdiRectangle(const syscall_context& c, hdc dc, LONG left, LONG top, LONG right, LONG bottom);
         BOOL handle_NtGdiPatBlt(const syscall_context& c, hdc dc, LONG x, LONG y, LONG width, LONG height, DWORD rop);
+        BOOL handle_NtGdiBitBlt(const syscall_context& c, hdc dst_dc, int x_dst, int y_dst, int width, int height, hdc src_dc, int x_src,
+                                int y_src, DWORD rop, DWORD cr_back_color, FLONG fl);
         BOOL handle_NtGdiPolyPatBlt(const syscall_context& c, hdc dc, DWORD rop, emulator_pointer poly, DWORD count, DWORD mode);
         BOOL handle_NtGdiExtTextOutW(const syscall_context& c, hdc dc, LONG x, LONG y, UINT options, emulator_pointer rect,
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
         BOOL handle_NtGdiGetRealizationInfo(const syscall_context& c, hdc dc, emulator_pointer realization_info, uint64_t font);
         NTSTATUS handle_NtGdiGetEntry(const syscall_context& c, uint32_t handle_value, emulator_pointer entry_ptr);
+        NTSTATUS handle_NtGdiSetLayout();
+        NTSTATUS handle_NtGdiGetDCObject();
         BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
         uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
         uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
@@ -1160,6 +1188,7 @@ namespace sogen
         add_handler(NtGdiGetTextMetricsW);
         add_handler(NtGdiGetTextFaceW);
         add_handler(NtGdiGetTextExtent);
+        add_handler(NtGdiGetGlyphOutline);
         add_handler(NtGdiCreateRectRgn);
         add_handler(NtGdiGetRandomRgn);
         add_handler(NtGdiIntersectClipRect);
@@ -1168,6 +1197,7 @@ namespace sogen
         add_handler(NtGdiLineTo);
         add_handler(NtGdiRectangle);
         add_handler(NtGdiPatBlt);
+        add_handler(NtGdiBitBlt);
         add_handler(NtGdiPolyPatBlt);
         add_handler(NtGdiExtTextOutW);
         add_handler(NtGdiGetRealizationInfo);
@@ -1423,6 +1453,27 @@ namespace sogen
         add_handler(NtUserGetQueueStatusReadonly);
         add_handler(NtUserGetQueueStatus);
         add_handler(NtUserScheduleDispatchNotification);
+        add_handler(NtGdiExtCreateRegion);
+        add_handler(NtUserSetWindowRgn);
+        add_handler(NtUserAlterWindowStyle);
+        add_handler(NtUserSetActiveWindow);
+        add_handler(NtGdiTransparentBlt);
+        add_handler(NtUserCreateAcceleratorTable);
+        add_handler(NtGdiSetLayout);
+        add_handler(NtGdiGetDCObject);
+        add_handler(NtUserCreateMenu);
+        add_handler(NtUserThunkedMenuItemInfo);
+        add_handler(NtUserIsTouchWindow);
+        add_handler(NtUserCreatePopupMenu);
+        add_handler(NtUserSetMenu);
+        add_handler(NtUserRemoveMenu);
+        add_handler(NtUserDestroyMenu);
+        add_handler(NtUserDrawMenuBar);
+        add_handler(NtUserSetWindowCompositionAttribute);
+        add_handler(NtUserGetWindowPlacement);
+        add_handler(NtUserCreateCaret);
+        add_handler(NtUserTrackMouseEvent);
+        add_handler(NtGdiGetOutlineTextMetricsInternalW);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -592,7 +592,7 @@ namespace sogen
         NTSTATUS handle_NtUserCreateAcceleratorTable();
         hmenu handle_NtUserCreateMenu(const syscall_context& c);
         BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, hmenu menu, UINT position, BOOL by_position, BOOL insert,
-                                              emulator_object<MENUITEMINFOW> item_info,
+                                              emulator_object<EMU_MENUITEMINFO> item_info,
                                               emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text);
         hmenu handle_NtUserCreatePopupMenu(const syscall_context& c);
         BOOL handle_NtUserSetMenu();

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -167,6 +167,21 @@ namespace sogen
                 std::array<gdi_batch_pat_rect, 1> rects{};
             };
 
+            struct emu_ttpolygonheader
+            {
+                uint32_t cb{};
+                uint32_t dwType{};
+                POINTFX pfxStart{};
+            };
+            static_assert(sizeof(emu_ttpolygonheader) == 16);
+
+            struct emu_ttpolycurve_header
+            {
+                uint16_t wType{};
+                uint16_t cpfx{};
+            };
+            static_assert(sizeof(emu_ttpolycurve_header) == 4);
+
             constexpr uint32_t k_dxgk_adapter_count = 1;
             constexpr uint32_t k_dxgk_adapter_handle = 0x4000;
             constexpr uint32_t k_dxgk_device_handle = 0x5000;
@@ -2342,6 +2357,43 @@ namespace sogen
                 return 0;
             }
 
+            const auto make_pointfx = [](const int16_t x, const int16_t y) {
+                return POINTFX{
+                    .x = {.fract = 0, .value = x},
+                    .y = {.fract = 0, .value = y},
+                };
+            };
+            const auto append_outline = []<typename T>(std::vector<uint8_t>& outline, const T& value) {
+                const auto* const bytes = reinterpret_cast<const uint8_t*>(&value);
+                outline.insert(outline.end(), bytes, bytes + sizeof(value));
+            };
+            const auto make_native_outline = [&]() {
+                std::vector<uint8_t> outline;
+                const std::array<POINTFX, 4> points{
+                    make_pointfx(static_cast<int16_t>(glyph_width), 0),
+                    make_pointfx(static_cast<int16_t>(glyph_width), static_cast<int16_t>(glyph_height)),
+                    make_pointfx(0, static_cast<int16_t>(glyph_height)),
+                    make_pointfx(0, 0),
+                };
+
+                const emu_ttpolycurve_header curve{
+                    .wType = 1,
+                    .cpfx = static_cast<uint16_t>(points.size()),
+                };
+                const emu_ttpolygonheader header{
+                    .cb = static_cast<uint32_t>(sizeof(emu_ttpolygonheader) + sizeof(emu_ttpolycurve_header) + sizeof(points)),
+                    .dwType = 24,
+                    .pfxStart = make_pointfx(0, 0),
+                };
+
+                outline.reserve(header.cb);
+                append_outline(outline, header);
+                append_outline(outline, curve);
+                append_outline(outline, points);
+                return outline;
+            };
+
+            std::vector<uint8_t> native_outline;
             uint32_t required_size = 0;
             switch (glyph_format)
             {
@@ -2354,13 +2406,14 @@ namespace sogen
                 required_size = glyph_width * glyph_height;
                 break;
             case ggo_native:
-                required_size = 0;
+                native_outline = make_native_outline();
+                required_size = static_cast<uint32_t>(native_outline.size());
                 break;
             default:
                 return gdi_error;
             }
 
-            if (buffer == 0 || buffer_size == 0 || required_size == 0)
+            if (buffer == 0 || buffer_size == 0)
             {
                 return required_size;
             }
@@ -2370,8 +2423,15 @@ namespace sogen
                 return gdi_error;
             }
 
-            std::vector<uint8_t> zeroed(required_size);
-            c.emu.write_memory(buffer, zeroed.data(), zeroed.size());
+            if (glyph_format == ggo_native)
+            {
+                c.emu.write_memory(buffer, native_outline.data(), native_outline.size());
+            }
+            else
+            {
+                std::vector<uint8_t> zeroed(required_size);
+                c.emu.write_memory(buffer, zeroed.data(), zeroed.size());
+            }
             return required_size;
         }
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2393,14 +2393,12 @@ namespace sogen
             const auto string_bytes = [](const std::u16string_view str) {
                 return static_cast<uint32_t>((str.size() + 1) * sizeof(char16_t));
             };
-            const auto ansi_string_bytes = [](const std::u16string_view str) {
-                return static_cast<uint32_t>(str.size() + 1);
-            };
+            const auto ansi_string_bytes = [](const std::u16string_view str) { return static_cast<uint32_t>(str.size() + 1); };
 
             const auto required_size = k_outline_text_metric_fixed_size + string_bytes(k_family_name) + string_bytes(k_face_name) +
                                        string_bytes(k_style_name) + string_bytes(k_full_name);
-            const auto required_size_a = k_outline_text_metric_fixed_size + ansi_string_bytes(k_family_name) + ansi_string_bytes(k_face_name) +
-                                         ansi_string_bytes(k_style_name) + ansi_string_bytes(k_full_name);
+            const auto required_size_a = k_outline_text_metric_fixed_size + ansi_string_bytes(k_family_name) +
+                                         ansi_string_bytes(k_face_name) + ansi_string_bytes(k_style_name) + ansi_string_bytes(k_full_name);
 
             if (unknown != 0)
             {

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2612,16 +2612,16 @@ namespace sogen
                 return FALSE;
             }
 
-            const uint8_t rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
+            const auto rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
             const bool needs_source = rop3_uses_source(rop3);
 
             int32_t src_origin_x = 0;
             int32_t src_origin_y = 0;
-            uint32_t unused_present_handle = 0;
             gdi_bitmap_surface* src_surface = nullptr;
 
             if (needs_source)
             {
+                uint32_t unused_present_handle = 0;
                 if (src_dc == 0)
                 {
                     return FALSE;
@@ -2634,10 +2634,10 @@ namespace sogen
                 }
             }
 
-            int64_t dx = static_cast<int64_t>(x_dst) + dst_origin_x;
-            int64_t dy = static_cast<int64_t>(y_dst) + dst_origin_y;
-            int64_t sx = static_cast<int64_t>(x_src) + src_origin_x;
-            int64_t sy = static_cast<int64_t>(y_src) + src_origin_y;
+            auto dx = static_cast<int64_t>(x_dst) + dst_origin_x;
+            auto dy = static_cast<int64_t>(y_dst) + dst_origin_y;
+            auto sx = static_cast<int64_t>(x_src) + src_origin_x;
+            auto sy = static_cast<int64_t>(y_src) + src_origin_y;
             int64_t w = width;
             int64_t h = height;
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2387,19 +2387,25 @@ namespace sogen
             static constexpr uint32_t k_outline_text_metric_text_metric_offset = 0x04;
             static constexpr std::u16string_view k_family_name = u"Segoe UI";
             static constexpr std::u16string_view k_face_name = u"Segoe UI";
-            static constexpr std::u16string_view k_style_name = u"Regular";
-            static constexpr std::u16string_view k_full_name = u"Segoe UI";
+            static constexpr std::u16string_view k_style_name = u"Normal";
+            static constexpr std::u16string_view k_full_name = u"Segoe UI Regular";
 
             const auto string_bytes = [](const std::u16string_view str) {
                 return static_cast<uint32_t>((str.size() + 1) * sizeof(char16_t));
             };
+            const auto ansi_string_bytes = [](const std::u16string_view str) {
+                return static_cast<uint32_t>(str.size() + 1);
+            };
+
             const auto required_size = k_outline_text_metric_fixed_size + string_bytes(k_family_name) + string_bytes(k_face_name) +
                                        string_bytes(k_style_name) + string_bytes(k_full_name);
+            const auto required_size_a = k_outline_text_metric_fixed_size + ansi_string_bytes(k_family_name) + ansi_string_bytes(k_face_name) +
+                                         ansi_string_bytes(k_style_name) + ansi_string_bytes(k_full_name);
 
             if (unknown != 0)
             {
-                constexpr uint64_t zero = 0;
-                c.emu.write_memory(unknown, &zero, sizeof(zero));
+                const auto required_size_a64 = static_cast<uint64_t>(required_size_a);
+                c.emu.write_memory(unknown, &required_size_a64, sizeof(required_size_a64));
             }
 
             if (metrics == 0 || cj_copy == 0)
@@ -2427,8 +2433,9 @@ namespace sogen
             const auto write_u8 = [&](const uint32_t offset, const uint8_t value) {
                 c.emu.write_memory(metrics + offset, &value, sizeof(value));
             };
-            const auto write_ptr = [&](const uint32_t offset, const emulator_pointer value) {
-                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            const auto write_offset = [&](const uint32_t pointer_offset, const uint32_t string_offset_value) {
+                const auto value64 = static_cast<uint64_t>(string_offset_value);
+                c.emu.write_memory(metrics + pointer_offset, &value64, sizeof(value64));
             };
 
             write_u32(0x00, required_size);
@@ -2476,10 +2483,10 @@ namespace sogen
             auto string_offset = k_outline_text_metric_fixed_size;
             const auto write_string = [&](const uint32_t pointer_offset, const std::u16string_view str) {
                 const auto string_ptr = metrics + string_offset;
-                write_ptr(pointer_offset, string_ptr);
+                write_offset(pointer_offset, string_offset);
                 c.emu.write_memory(string_ptr, str.data(), str.size() * sizeof(char16_t));
 
-                constexpr char16_t terminator = 0;
+                constexpr char16_t terminator = u'\0';
                 c.emu.write_memory(string_ptr + str.size() * sizeof(char16_t), &terminator, sizeof(terminator));
                 string_offset += string_bytes(str);
             };

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1340,6 +1340,49 @@ namespace sogen
 
                 return status;
             }
+
+            bool rop3_uses_source(const uint8_t rop3)
+            {
+                // ROP3 truth-table index: bit0=D, bit1=S, bit2=P.
+                // If changing S can change the output for any D/P pair, the source DC is required.
+                for (uint32_t p = 0; p <= 1; ++p)
+                {
+                    for (uint32_t d = 0; d <= 1; ++d)
+                    {
+                        const uint32_t i0 = (p << 2) | d;
+                        const uint32_t i1 = (p << 2) | 0x02u | d;
+                        if (((rop3 >> i0) & 1u) != ((rop3 >> i1) & 1u))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            uint32_t apply_rop3(const uint8_t rop3, const uint32_t src, const uint32_t dst, const uint32_t pat)
+            {
+                uint32_t out = 0;
+
+                // Each bit of rop3 selects the output for one D/S/P boolean combination.
+                // Index layout matches Win32 ROP3 encoding:
+                //   bit0 = D, bit1 = S, bit2 = P
+                for (uint32_t i = 0; i < 8; ++i)
+                {
+                    if (((rop3 >> i) & 1u) == 0)
+                    {
+                        continue;
+                    }
+
+                    uint32_t mask = (i & 0x01u) ? dst : ~dst;
+                    mask &= (i & 0x02u) ? src : ~src;
+                    mask &= (i & 0x04u) ? pat : ~pat;
+                    out |= mask;
+                }
+
+                return out;
+            }
         }
 
         // Returns the surface a paint DC should be presented to, and (via present_handle) the host window handle it
@@ -1902,7 +1945,13 @@ namespace sogen
             c.emu.read_memory(info + 16, &compression, sizeof(compression));
 
             constexpr uint32_t bi_rgb = 0;
-            if (bit_count != 32 || compression != bi_rgb || bi_width <= 0)
+
+            uint32_t bi_size = 0;
+            uint32_t clr_used = 0;
+            c.emu.read_memory(info + 0, &bi_size, sizeof(bi_size));
+            c.emu.read_memory(info + 32, &clr_used, sizeof(clr_used)); // BITMAPINFOHEADER.biClrUsed
+
+            if ((bit_count != 4 && bit_count != 32) || compression != bi_rgb || bi_width <= 0 || bi_height == 0)
             {
                 c.win_emu.log.warn("NtGdiStretchDIBitsInternal: unsupported DIB (bpp=%u compression=%u width=%d)\n", bit_count, compression,
                                    bi_width);
@@ -1912,7 +1961,31 @@ namespace sogen
             const bool top_down = bi_height < 0;
             const auto img_width = static_cast<uint32_t>(bi_width);
             const auto img_height = static_cast<uint32_t>(top_down ? -bi_height : bi_height);
-            const size_t stride = static_cast<size_t>(img_width) * sizeof(uint32_t);
+
+            // DIB scanlines are DWORD-aligned, not tightly packed.
+            const size_t stride = ((static_cast<size_t>(img_width) * bit_count + 31u) / 32u) * 4u;
+
+            std::array<uint32_t, 16> palette{};
+            if (bit_count == 4)
+            {
+                const uint32_t palette_entries = clr_used != 0 ? std::min<uint32_t>(clr_used, 16) : 16;
+                const uint64_t palette_ptr = info + bi_size;
+
+                for (uint32_t i = 0; i < palette_entries; ++i)
+                {
+                    struct
+                    {
+                        uint8_t blue;
+                        uint8_t green;
+                        uint8_t red;
+                        uint8_t reserved;
+                    } rgb{};
+
+                    c.emu.read_memory(palette_ptr + static_cast<uint64_t>(i) * sizeof(rgb), &rgb, sizeof(rgb));
+                    palette[i] = 0xFF000000u | (static_cast<uint32_t>(rgb.red) << 16) | (static_cast<uint32_t>(rgb.green) << 8) |
+                                 static_cast<uint32_t>(rgb.blue);
+                }
+            }
 
             std::vector<uint8_t> data(stride * img_height);
             if (data.empty())
@@ -1957,10 +2030,26 @@ namespace sogen
                     {
                         continue;
                     }
+
                     uint32_t pixel = 0;
-                    std::memcpy(&pixel, row + static_cast<size_t>(img_x) * sizeof(uint32_t), sizeof(pixel));
+
+                    if (bit_count == 32)
+                    {
+                        std::memcpy(&pixel, row + static_cast<size_t>(img_x) * sizeof(uint32_t), sizeof(pixel));
+                        pixel |= 0xFF000000u;
+                    }
+                    else // 4bpp BI_RGB
+                    {
+                        const uint8_t packed = row[static_cast<size_t>(img_x) / 2u];
+
+                        // In 4bpp DIBs, the left pixel is the high nibble.
+                        const uint8_t index = (img_x & 1u) == 0 ? static_cast<uint8_t>(packed >> 4) : static_cast<uint8_t>(packed & 0x0Fu);
+
+                        pixel = palette[index];
+                    }
+
                     const int out_x = x_dst + origin_x + (flip_x ? (dst_w - 1 - dx) : dx);
-                    set_surface_pixel(*surface, out_x, out_y, pixel | 0xFF000000u);
+                    set_surface_pixel(*surface, out_x, out_y, pixel);
                 }
             }
 
@@ -2209,6 +2298,210 @@ namespace sogen
             return TRUE;
         }
 
+        uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, const hdc dc, const UINT /*character*/, const UINT format,
+                                             const emulator_pointer glyph_metrics, const DWORD buffer_size, const emulator_pointer buffer,
+                                             const emulator_pointer mat2)
+        {
+            static constexpr uint32_t gdi_error = 0xFFFFFFFF;
+            static constexpr uint32_t ggo_metrics = 0;
+            static constexpr uint32_t ggo_bitmap = 1;
+            static constexpr uint32_t ggo_native = 2;
+            static constexpr uint32_t ggo_gray2_bitmap = 4;
+            static constexpr uint32_t ggo_gray4_bitmap = 5;
+            static constexpr uint32_t ggo_gray8_bitmap = 6;
+            static constexpr uint32_t format_mask = 0x7;
+            static constexpr uint32_t glyph_width = 8;
+            static constexpr uint32_t glyph_height = 16;
+            static constexpr int32_t glyph_ascent = 12;
+
+            if (dc == 0 || glyph_metrics == 0 || mat2 == 0)
+            {
+                return gdi_error;
+            }
+
+            const auto write_u32 = [&](const uint32_t offset, const uint32_t value) {
+                c.emu.write_memory(glyph_metrics + offset, &value, sizeof(value));
+            };
+            const auto write_i32 = [&](const uint32_t offset, const int32_t value) {
+                c.emu.write_memory(glyph_metrics + offset, &value, sizeof(value));
+            };
+            const auto write_i16 = [&](const uint32_t offset, const int16_t value) {
+                c.emu.write_memory(glyph_metrics + offset, &value, sizeof(value));
+            };
+
+            write_u32(0x00, glyph_width);
+            write_u32(0x04, glyph_height);
+            write_i32(0x08, 0);
+            write_i32(0x0C, glyph_ascent);
+            write_i16(0x10, static_cast<int16_t>(glyph_width));
+            write_i16(0x12, 0);
+
+            const auto glyph_format = format & format_mask;
+            if (glyph_format == ggo_metrics)
+            {
+                return 0;
+            }
+
+            uint32_t required_size = 0;
+            switch (glyph_format)
+            {
+            case ggo_bitmap:
+                required_size = ((glyph_width + 31) / 32) * 4 * glyph_height;
+                break;
+            case ggo_gray2_bitmap:
+            case ggo_gray4_bitmap:
+            case ggo_gray8_bitmap:
+                required_size = glyph_width * glyph_height;
+                break;
+            case ggo_native:
+                required_size = 0;
+                break;
+            default:
+                return gdi_error;
+            }
+
+            if (buffer == 0 || buffer_size == 0 || required_size == 0)
+            {
+                return required_size;
+            }
+
+            if (buffer_size < required_size)
+            {
+                return gdi_error;
+            }
+
+            std::vector<uint8_t> zeroed(required_size);
+            c.emu.write_memory(buffer, zeroed.data(), zeroed.size());
+            return required_size;
+        }
+
+        uint32_t handle_NtGdiGetOutlineTextMetricsInternalW(const syscall_context& c, const hdc dc, const uint32_t cj_copy,
+                                                            const emulator_pointer metrics, const emulator_pointer unknown)
+        {
+            if (dc == 0)
+            {
+                return 0;
+            }
+
+            static constexpr uint32_t k_outline_text_metric_fixed_size = 0xE8;
+            static constexpr uint32_t k_outline_text_metric_text_metric_offset = 0x04;
+            static constexpr std::u16string_view k_family_name = u"Segoe UI";
+            static constexpr std::u16string_view k_face_name = u"Segoe UI";
+            static constexpr std::u16string_view k_style_name = u"Regular";
+            static constexpr std::u16string_view k_full_name = u"Segoe UI";
+
+            const auto string_bytes = [](const std::u16string_view str) {
+                return static_cast<uint32_t>((str.size() + 1) * sizeof(char16_t));
+            };
+            const auto required_size = k_outline_text_metric_fixed_size + string_bytes(k_family_name) + string_bytes(k_face_name) +
+                                       string_bytes(k_style_name) + string_bytes(k_full_name);
+
+            if (unknown != 0)
+            {
+                constexpr uint64_t zero = 0;
+                c.emu.write_memory(unknown, &zero, sizeof(zero));
+            }
+
+            if (metrics == 0 || cj_copy == 0)
+            {
+                return required_size;
+            }
+
+            if (cj_copy < required_size)
+            {
+                return 0;
+            }
+
+            std::vector<uint8_t> zeroed(required_size);
+            c.emu.write_memory(metrics, zeroed.data(), zeroed.size());
+
+            const auto write_u32 = [&](const uint32_t offset, const uint32_t value) {
+                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            };
+            const auto write_i32 = [&](const uint32_t offset, const int32_t value) {
+                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            };
+            const auto write_u16 = [&](const uint32_t offset, const uint16_t value) {
+                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            };
+            const auto write_u8 = [&](const uint32_t offset, const uint8_t value) {
+                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            };
+            const auto write_ptr = [&](const uint32_t offset, const emulator_pointer value) {
+                c.emu.write_memory(metrics + offset, &value, sizeof(value));
+            };
+
+            write_u32(0x00, required_size);
+
+            const auto tm = k_outline_text_metric_text_metric_offset;
+            write_u32(tm + 0x00, k_default_font_height);
+            write_u32(tm + 0x04, k_default_font_ascent);
+            write_u32(tm + 0x08, k_default_font_descent);
+            write_u32(tm + 0x14, k_default_font_width);
+            write_u32(tm + 0x18, k_default_font_width);
+            write_u32(tm + 0x1C, k_default_font_weight);
+            write_u16(tm + 0x2C, 0x20);
+            write_u16(tm + 0x2E, 0x7E);
+            write_u16(tm + 0x30, 0x3F);
+            write_u16(tm + 0x32, 0x20);
+            write_u8(tm + 0x38, 0x01);
+
+            write_u32(0x60, 2048);
+            write_i32(0x64, k_default_font_ascent);
+            write_i32(0x68, -static_cast<int32_t>(k_default_font_descent));
+            write_u32(0x6C, 0);
+            write_u32(0x70, k_default_font_ascent);
+            write_u32(0x74, k_default_font_height / 2);
+            write_i32(0x78, 0);
+            write_i32(0x7C, -static_cast<int32_t>(k_default_font_descent));
+            write_i32(0x80, k_default_font_width);
+            write_i32(0x84, k_default_font_ascent);
+            write_i32(0x88, k_default_font_ascent);
+            write_i32(0x8C, -static_cast<int32_t>(k_default_font_descent));
+            write_u32(0x90, 0);
+            write_u32(0x94, 8);
+            write_i32(0x98, k_default_font_width / 2);
+            write_i32(0x9C, k_default_font_height / 2);
+            write_i32(0xA0, 0);
+            write_i32(0xA4, -static_cast<int32_t>(k_default_font_descent / 2));
+            write_i32(0xA8, k_default_font_width / 2);
+            write_i32(0xAC, k_default_font_height / 2);
+            write_i32(0xB0, 0);
+            write_i32(0xB4, k_default_font_ascent / 2);
+            write_u32(0xB8, 1);
+            write_i32(0xBC, k_default_font_height / 3);
+            write_i32(0xC0, 1);
+            write_i32(0xC4, -1);
+
+            auto string_offset = k_outline_text_metric_fixed_size;
+            const auto write_string = [&](const uint32_t pointer_offset, const std::u16string_view str) {
+                const auto string_ptr = metrics + string_offset;
+                write_ptr(pointer_offset, string_ptr);
+                c.emu.write_memory(string_ptr, str.data(), str.size() * sizeof(char16_t));
+
+                constexpr char16_t terminator = 0;
+                c.emu.write_memory(string_ptr + str.size() * sizeof(char16_t), &terminator, sizeof(terminator));
+                string_offset += string_bytes(str);
+            };
+
+            write_string(0xC8, k_family_name);
+            write_string(0xD0, k_face_name);
+            write_string(0xD8, k_style_name);
+            write_string(0xE0, k_full_name);
+
+            return required_size;
+        }
+
+        NTSTATUS handle_NtGdiExtCreateRegion()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiTransparentBlt()
+        {
+            return STATUS_SUCCESS;
+        }
+
         uint64_t handle_NtGdiCreateRectRgn(const syscall_context& c, const LONG /*x_left*/, const LONG /*y_top*/, const LONG /*x_right*/,
                                            const LONG /*y_bottom*/)
         {
@@ -2296,6 +2589,173 @@ namespace sogen
                 return FALSE;
             }
             return handle_NtGdiLineTo(c, dc, left, top);
+        }
+
+        BOOL handle_NtGdiBitBlt(const syscall_context& c, const hdc dst_dc, const int x_dst, const int y_dst, const int width,
+                                const int height, const hdc src_dc, const int x_src, const int y_src, const DWORD rop,
+                                const DWORD /*cr_back_color*/, const FLONG /*fl*/)
+        {
+            if (dst_dc == 0 || width <= 0 || height <= 0)
+            {
+                return FALSE;
+            }
+
+            // Make pending batched GDI output visible before using either DC as source/destination.
+            (void)handle_NtGdiFlush(c);
+
+            int32_t dst_origin_x = 0;
+            int32_t dst_origin_y = 0;
+            uint32_t present_handle = 0;
+            gdi_bitmap_surface* dst_surface = resolve_dc_surface(c, dst_dc, dst_origin_x, dst_origin_y, present_handle);
+            if (!dst_surface || dst_surface->width == 0 || dst_surface->height == 0 || dst_surface->pixels.empty())
+            {
+                return FALSE;
+            }
+
+            const uint8_t rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
+            const bool needs_source = rop3_uses_source(rop3);
+
+            int32_t src_origin_x = 0;
+            int32_t src_origin_y = 0;
+            uint32_t unused_present_handle = 0;
+            gdi_bitmap_surface* src_surface = nullptr;
+
+            if (needs_source)
+            {
+                if (src_dc == 0)
+                {
+                    return FALSE;
+                }
+
+                src_surface = resolve_dc_surface(c, src_dc, src_origin_x, src_origin_y, unused_present_handle);
+                if (!src_surface || src_surface->width == 0 || src_surface->height == 0 || src_surface->pixels.empty())
+                {
+                    return FALSE;
+                }
+            }
+
+            int64_t dx = static_cast<int64_t>(x_dst) + dst_origin_x;
+            int64_t dy = static_cast<int64_t>(y_dst) + dst_origin_y;
+            int64_t sx = static_cast<int64_t>(x_src) + src_origin_x;
+            int64_t sy = static_cast<int64_t>(y_src) + src_origin_y;
+            int64_t w = width;
+            int64_t h = height;
+
+            // Clip to destination surface.
+            if (dx < 0)
+            {
+                const int64_t delta = -dx;
+                dx = 0;
+                sx += delta;
+                w -= delta;
+            }
+            if (dy < 0)
+            {
+                const int64_t delta = -dy;
+                dy = 0;
+                sy += delta;
+                h -= delta;
+            }
+            if (dx + w > static_cast<int64_t>(dst_surface->width))
+            {
+                w = static_cast<int64_t>(dst_surface->width) - dx;
+            }
+            if (dy + h > static_cast<int64_t>(dst_surface->height))
+            {
+                h = static_cast<int64_t>(dst_surface->height) - dy;
+            }
+
+            // Clip to source surface only when the ROP actually depends on S.
+            if (needs_source)
+            {
+                if (sx < 0)
+                {
+                    const int64_t delta = -sx;
+                    sx = 0;
+                    dx += delta;
+                    w -= delta;
+                }
+                if (sy < 0)
+                {
+                    const int64_t delta = -sy;
+                    sy = 0;
+                    dy += delta;
+                    h -= delta;
+                }
+                if (sx + w > static_cast<int64_t>(src_surface->width))
+                {
+                    w = static_cast<int64_t>(src_surface->width) - sx;
+                }
+                if (sy + h > static_cast<int64_t>(src_surface->height))
+                {
+                    h = static_cast<int64_t>(src_surface->height) - sy;
+                }
+            }
+
+            if (w <= 0 || h <= 0)
+            {
+                return TRUE;
+            }
+
+            const auto blt_width = static_cast<size_t>(w);
+            const auto blt_height = static_cast<size_t>(h);
+            const auto pixel_count = blt_width * blt_height;
+
+            if (blt_width != 0 && pixel_count / blt_width != blt_height)
+            {
+                return FALSE;
+            }
+
+            std::vector<uint32_t> dst_snapshot(pixel_count);
+            std::vector<uint32_t> src_snapshot;
+            if (needs_source)
+            {
+                src_snapshot.resize(pixel_count);
+            }
+
+            // Snapshot first. This avoids corrupting overlapping source/destination blits.
+            for (size_t row = 0; row < blt_height; ++row)
+            {
+                const auto dst_index = (static_cast<size_t>(dy) + row) * dst_surface->width + static_cast<size_t>(dx);
+                std::memcpy(dst_snapshot.data() + row * blt_width, dst_surface->pixels.data() + dst_index, blt_width * sizeof(uint32_t));
+
+                if (needs_source)
+                {
+                    const auto src_index = (static_cast<size_t>(sy) + row) * src_surface->width + static_cast<size_t>(sx);
+                    std::memcpy(src_snapshot.data() + row * blt_width, src_surface->pixels.data() + src_index,
+                                blt_width * sizeof(uint32_t));
+                }
+            }
+
+            const uint32_t pattern = get_dc_brush_color(c, dst_dc);
+
+            for (size_t row = 0; row < blt_height; ++row)
+            {
+                auto* dst_row = dst_surface->pixels.data() + (static_cast<size_t>(dy) + row) * dst_surface->width + static_cast<size_t>(dx);
+
+                for (size_t col = 0; col < blt_width; ++col)
+                {
+                    const size_t i = row * blt_width + col;
+                    const uint32_t src = needs_source ? src_snapshot[i] : 0;
+                    const uint32_t dst = dst_snapshot[i];
+
+                    // Your renderer presents BGRA8 surfaces. Keeping alpha opaque matches the rest of this file's
+                    // DIB-to-surface paths. Remove the OR if you later model real alpha-carrying 32-bpp DIB sections.
+                    dst_row[col] = apply_rop3(rop3, src, dst, pattern) | 0xFF000000u;
+                }
+            }
+
+            if (present_handle != 0 && dst_surface->width > 0 && dst_surface->height > 0 && !dst_surface->pixels.empty())
+            {
+                c.win_emu.ui().present_surface(present_handle,
+                                               ui_surface_desc{.width = static_cast<int>(dst_surface->width),
+                                                               .height = static_cast<int>(dst_surface->height),
+                                                               .stride = static_cast<int>(dst_surface->width * sizeof(uint32_t)),
+                                                               .format = ui_surface_format::bgra8,
+                                                               .pixels = dst_surface->pixels.data()});
+            }
+
+            return TRUE;
         }
 
         BOOL handle_NtGdiPatBlt(const syscall_context& c, const hdc dc, const LONG x, const LONG y, const LONG width, const LONG height,
@@ -2508,6 +2968,16 @@ namespace sogen
             }
 
             c.emu.write_memory(entry_ptr, &entry, sizeof(entry));
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiSetLayout()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiGetDCObject()
+        {
             return STATUS_SUCCESS;
         }
 

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -1,4 +1,4 @@
-#include "../std_include.hpp"
+﻿#include "../std_include.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 
@@ -14,6 +14,43 @@ namespace sogen
                                                                     const uint32_t system_information_length,
                                                                     const emulator_object<uint32_t> return_length)
             {
+                constexpr auto group_root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, Group);
+                constexpr auto group_size = group_root_size + sizeof(EMU_GROUP_RELATIONSHIP64);
+                constexpr auto numa_root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, NumaNode);
+                constexpr auto numa_size = numa_root_size + sizeof(EMU_NUMA_NODE_RELATIONSHIP64);
+
+                const auto write_group = [&](const uint64_t output_buffer) {
+                    EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
+                    proc_info.Size = group_size;
+                    proc_info.Relationship = RelationGroup;
+
+                    c.emu.write_memory(output_buffer, &proc_info, group_root_size);
+
+                    EMU_GROUP_RELATIONSHIP64 group{};
+                    group.ActiveGroupCount = 1;
+                    group.MaximumGroupCount = 1;
+
+                    auto& group_info = group.GroupInfo[0];
+                    group_info.ActiveProcessorCount = static_cast<uint8_t>(c.proc.kusd.get().ActiveProcessorCount);
+                    group_info.ActiveProcessorMask = (1ULL << group_info.ActiveProcessorCount) - 1;
+                    group_info.MaximumProcessorCount = group_info.ActiveProcessorCount;
+
+                    c.emu.write_memory(output_buffer + group_root_size, group);
+                };
+
+                const auto write_numa = [&](const uint64_t output_buffer) {
+                    EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
+                    proc_info.Size = numa_size;
+                    proc_info.Relationship = RelationNumaNode;
+
+                    c.emu.write_memory(output_buffer, &proc_info, numa_root_size);
+
+                    EMU_NUMA_NODE_RELATIONSHIP64 numa_node{};
+                    memset(&numa_node, 0, sizeof(numa_node));
+
+                    c.emu.write_memory(output_buffer + numa_root_size, numa_node);
+                };
+
                 if (input_buffer_length != sizeof(LOGICAL_PROCESSOR_RELATIONSHIP))
                 {
                     return STATUS_INVALID_PARAMETER;
@@ -23,13 +60,7 @@ namespace sogen
 
                 if (request == RelationAll)
                 {
-                    return STATUS_NOT_SUPPORTED;
-                }
-
-                if (request == RelationGroup)
-                {
-                    constexpr auto root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, Group);
-                    constexpr auto required_size = root_size + sizeof(EMU_GROUP_RELATIONSHIP64);
+                    constexpr auto required_size = group_size + numa_size;
 
                     if (return_length)
                     {
@@ -41,50 +72,40 @@ namespace sogen
                         return STATUS_INFO_LENGTH_MISMATCH;
                     }
 
-                    EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
-                    proc_info.Size = required_size;
-                    proc_info.Relationship = RelationGroup;
+                    write_group(system_information);
+                    write_numa(system_information + group_size);
+                    return STATUS_SUCCESS;
+                }
 
-                    c.emu.write_memory(system_information, &proc_info, root_size);
+                if (request == RelationGroup)
+                {
+                    if (return_length)
+                    {
+                        return_length.write(group_size);
+                    }
 
-                    EMU_GROUP_RELATIONSHIP64 group{};
-                    group.ActiveGroupCount = 1;
-                    group.MaximumGroupCount = 1;
+                    if (system_information_length < group_size)
+                    {
+                        return STATUS_INFO_LENGTH_MISMATCH;
+                    }
 
-                    auto& group_info = group.GroupInfo[0];
-                    group_info.ActiveProcessorCount = static_cast<uint8_t>(c.proc.kusd.get().ActiveProcessorCount);
-                    group_info.ActiveProcessorMask = (1 << group_info.ActiveProcessorCount) - 1;
-                    group_info.MaximumProcessorCount = group_info.ActiveProcessorCount;
-
-                    c.emu.write_memory(system_information + root_size, group);
+                    write_group(system_information);
                     return STATUS_SUCCESS;
                 }
 
                 if (request == RelationNumaNode || request == RelationNumaNodeEx)
                 {
-                    constexpr auto root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, NumaNode);
-                    constexpr auto required_size = root_size + sizeof(EMU_NUMA_NODE_RELATIONSHIP64);
-
                     if (return_length)
                     {
-                        return_length.write(required_size);
+                        return_length.write(numa_size);
                     }
 
-                    if (system_information_length < required_size)
+                    if (system_information_length < numa_size)
                     {
                         return STATUS_INFO_LENGTH_MISMATCH;
                     }
 
-                    EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
-                    proc_info.Size = required_size;
-                    proc_info.Relationship = RelationNumaNode;
-
-                    c.emu.write_memory(system_information, &proc_info, root_size);
-
-                    EMU_NUMA_NODE_RELATIONSHIP64 numa_node{};
-                    memset(&numa_node, 0, sizeof(numa_node));
-
-                    c.emu.write_memory(system_information + root_size, numa_node);
+                    write_numa(system_information);
                     return STATUS_SUCCESS;
                 }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -428,17 +428,21 @@ namespace sogen
             }
         }
 
-        bool empty_rect(const RECT& r)
-        {
-            return r.left >= r.right || r.top >= r.bottom;
-        }
-
         RECT union_update_rect(const RECT& a, const RECT& b)
         {
+            const auto empty_rect = [](const RECT& r) { //
+                return r.left >= r.right || r.top >= r.bottom;
+            };
+
             if (empty_rect(a))
+            {
                 return b;
+            }
+
             if (empty_rect(b))
+            {
                 return a;
+            }
 
             return RECT{
                 .left = std::min(a.left, b.left),
@@ -1224,7 +1228,7 @@ namespace sogen
             auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
             menu_obj.handle = handle.bits;
             menu_obj.popup = popup;
-            menu_obj.sync_guest(c.win_emu.memory);
+            menu_obj.init_guest();
             return handle.bits;
         }
 
@@ -1247,7 +1251,7 @@ namespace sogen
             return menu;
         }
 
-        std::u16string read_menu_item_text(const syscall_context& c, const MENUITEMINFOW& mi,
+        std::u16string read_menu_item_text(const syscall_context& c, const EMU_MENUITEMINFO& mi,
                                            const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
         {
             if (item_text)
@@ -1263,11 +1267,11 @@ namespace sogen
                 }
             }
 
-            if (mi.dwTypeData != nullptr && mi.cch != 0)
+            if (mi.dwTypeData != 0 && mi.cch != 0)
             {
                 std::u16string result(mi.cch, u'\0');
                 const auto bytes = result.size() * sizeof(char16_t);
-                if (c.win_emu.memory.try_read_memory(reinterpret_cast<emulator_pointer>(mi.dwTypeData), result.data(), bytes))
+                if (c.win_emu.memory.try_read_memory(mi.dwTypeData, result.data(), bytes))
                 {
                     const auto terminator = result.find(u'\0');
                     if (terminator != std::u16string::npos)
@@ -1281,7 +1285,7 @@ namespace sogen
             return {};
         }
 
-        void update_menu_item(const syscall_context& c, menu_item& item, const MENUITEMINFOW& mi,
+        void update_menu_item(const syscall_context& c, menu_item& item, const EMU_MENUITEMINFO& mi,
                               const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
         {
             if ((mi.fMask & MIIM_ID) != 0)
@@ -1290,7 +1294,7 @@ namespace sogen
             }
             if ((mi.fMask & MIIM_SUBMENU) != 0)
             {
-                item.submenu = reinterpret_cast<hmenu>(mi.hSubMenu);
+                item.submenu = mi.hSubMenu;
                 if (const auto* submenu = c.proc.menus.get(item.submenu))
                 {
                     item.submenu_ptr = submenu->guest.value();
@@ -1310,16 +1314,16 @@ namespace sogen
             }
             if ((mi.fMask & MIIM_DATA) != 0)
             {
-                item.data = static_cast<uint64_t>(mi.dwItemData);
+                item.data = mi.dwItemData;
             }
             if ((mi.fMask & MIIM_CHECKMARKS) != 0)
             {
-                item.hbmp_checked = reinterpret_cast<uint64_t>(mi.hbmpChecked);
-                item.hbmp_unchecked = reinterpret_cast<uint64_t>(mi.hbmpUnchecked);
+                item.hbmp_checked = mi.hbmpChecked;
+                item.hbmp_unchecked = mi.hbmpUnchecked;
             }
             if ((mi.fMask & MIIM_BITMAP) != 0)
             {
-                item.hbmp_item = reinterpret_cast<uint64_t>(mi.hbmpItem);
+                item.hbmp_item = mi.hbmpItem;
             }
             if ((mi.fMask & MIIM_STRING) != 0)
             {
@@ -3798,7 +3802,7 @@ namespace sogen
                 if (auto* menu = c.proc.menus.get(win->system_menu_ptr))
                 {
                     menu->items.clear();
-                    menu->sync_guest(c.win_emu.memory);
+                    menu->sync_guest_items(c.win_emu.memory);
                 }
             }
 
@@ -4239,7 +4243,7 @@ namespace sogen
         }
 
         BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, const hmenu menu, const UINT position, const BOOL by_position,
-                                              const BOOL insert, const emulator_object<MENUITEMINFOW> item_info,
+                                              const BOOL insert, const emulator_object<EMU_MENUITEMINFO> item_info,
                                               const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
         {
             auto* m = c.proc.menus.get(menu);
@@ -4253,7 +4257,7 @@ namespace sogen
                 return FALSE;
             }
 
-            MENUITEMINFOW mi{};
+            EMU_MENUITEMINFO mi{};
             if (!c.win_emu.memory.try_read_memory(item_info.value(), &mi, sizeof(mi)))
             {
                 return FALSE;
@@ -4274,7 +4278,7 @@ namespace sogen
                     m->items.push_back(menu_item);
                 }
 
-                m->sync_guest(c.win_emu.memory);
+                m->sync_guest_items(c.win_emu.memory);
                 return TRUE;
             }
 
@@ -4290,8 +4294,16 @@ namespace sogen
                     return FALSE;
                 }
 
+                const auto old_text_size = m->items[position].text.size();
                 update_menu_item(c, m->items[position], mi, item_text);
-                m->sync_guest(c.win_emu.memory);
+                if ((mi.fMask & MIIM_STRING) != 0 && m->items[position].text.size() > old_text_size)
+                {
+                    m->sync_guest_items(c.win_emu.memory);
+                }
+                else
+                {
+                    m->sync_guest_item(c.win_emu.memory, position);
+                }
                 return TRUE;
             }
 
@@ -4301,8 +4313,17 @@ namespace sogen
                 return TRUE;
             }
 
+            const auto index = static_cast<size_t>(std::distance(m->items.begin(), it));
+            const auto old_text_size = it->text.size();
             update_menu_item(c, *it, mi, item_text);
-            m->sync_guest(c.win_emu.memory);
+            if ((mi.fMask & MIIM_STRING) != 0 && it->text.size() > old_text_size)
+            {
+                m->sync_guest_items(c.win_emu.memory);
+            }
+            else
+            {
+                m->sync_guest_item(c.win_emu.memory, index);
+            }
             return TRUE;
         }
 
@@ -4337,7 +4358,7 @@ namespace sogen
                 }
 
                 m->items.erase(m->items.begin() + static_cast<ptrdiff_t>(position));
-                m->sync_guest(c.win_emu.memory);
+                m->sync_guest_items(c.win_emu.memory);
                 return TRUE;
             }
 
@@ -4348,7 +4369,7 @@ namespace sogen
             }
 
             m->items.erase(it);
-            m->sync_guest(c.win_emu.memory);
+            m->sync_guest_items(c.win_emu.memory);
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -428,12 +428,42 @@ namespace sogen
             }
         }
 
+        bool empty_rect(const RECT& r)
+        {
+            return r.left >= r.right || r.top >= r.bottom;
+        }
+
+        RECT union_update_rect(const RECT& a, const RECT& b)
+        {
+            if (empty_rect(a))
+                return b;
+            if (empty_rect(b))
+                return a;
+
+            return RECT{
+                .left = std::min(a.left, b.left),
+                .top = std::min(a.top, b.top),
+                .right = std::max(a.right, b.right),
+                .bottom = std::max(a.bottom, b.bottom),
+            };
+        }
+
         void invalidate_window(const syscall_context& c, window& win, const std::optional<RECT>& update_rect = std::nullopt,
                                bool erase = false)
         {
-            win.update_pending = true;
+            const RECT new_rect = update_rect.value_or(get_client_rect(win));
+
             win.erase_pending = win.erase_pending || erase;
-            win.update_rect = update_rect.value_or(get_client_rect(win));
+
+            if (!win.update_pending)
+            {
+                win.update_rect = new_rect;
+                win.update_pending = true;
+            }
+            else
+            {
+                win.update_rect = union_update_rect(win.update_rect, new_rect);
+            }
 
             if (win.host_surface_window)
             {
@@ -1187,6 +1217,114 @@ namespace sogen
             }
 
             return read_large_string(window_name);
+        }
+
+        hmenu create_menu_object(const syscall_context& c, const bool popup)
+        {
+            auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
+            menu_obj.handle = handle.bits;
+            menu_obj.popup = popup;
+            menu_obj.sync_guest(c.win_emu.memory);
+            return handle.bits;
+        }
+
+        hmenu ensure_system_menu(const syscall_context& c, window& win)
+        {
+            if (win.system_menu_ptr != 0 && c.proc.menus.get(win.system_menu_ptr))
+            {
+                return win.system_menu_ptr;
+            }
+
+            const auto menu = create_menu_object(c, false);
+            win.system_menu_ptr = menu;
+
+            if (win.guest.value() != 0)
+            {
+                const auto spmenu_addr = win.guest.value() + offsetof(USER_WINDOW, spmenu);
+                c.win_emu.memory.write_memory(spmenu_addr, &menu, sizeof(menu));
+            }
+
+            return menu;
+        }
+
+        std::u16string read_menu_item_text(const syscall_context& c, const MENUITEMINFOW& mi,
+                                           const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
+        {
+            if (item_text)
+            {
+                const auto str = item_text.try_read();
+                if (str && str->Buffer != 0 && str->Length != 0)
+                {
+                    std::u16string result(str->Length / sizeof(char16_t), u'\0');
+                    if (c.win_emu.memory.try_read_memory(str->Buffer, result.data(), str->Length))
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            if (mi.dwTypeData != nullptr && mi.cch != 0)
+            {
+                std::u16string result(mi.cch, u'\0');
+                const auto bytes = result.size() * sizeof(char16_t);
+                if (c.win_emu.memory.try_read_memory(reinterpret_cast<emulator_pointer>(mi.dwTypeData), result.data(), bytes))
+                {
+                    const auto terminator = result.find(u'\0');
+                    if (terminator != std::u16string::npos)
+                    {
+                        result.resize(terminator);
+                    }
+                    return result;
+                }
+            }
+
+            return {};
+        }
+
+        void update_menu_item(const syscall_context& c, menu_item& item, const MENUITEMINFOW& mi,
+                              const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
+        {
+            if ((mi.fMask & MIIM_ID) != 0)
+            {
+                item.id = mi.wID;
+            }
+            if ((mi.fMask & MIIM_SUBMENU) != 0)
+            {
+                item.submenu = reinterpret_cast<hmenu>(mi.hSubMenu);
+                if (const auto* submenu = c.proc.menus.get(item.submenu))
+                {
+                    item.submenu_ptr = submenu->guest.value();
+                }
+                else
+                {
+                    item.submenu_ptr = 0;
+                }
+            }
+            if ((mi.fMask & MIIM_FTYPE) != 0)
+            {
+                item.type = mi.fType;
+            }
+            if ((mi.fMask & MIIM_STATE) != 0)
+            {
+                item.state = mi.fState;
+            }
+            if ((mi.fMask & MIIM_DATA) != 0)
+            {
+                item.data = static_cast<uint64_t>(mi.dwItemData);
+            }
+            if ((mi.fMask & MIIM_CHECKMARKS) != 0)
+            {
+                item.hbmp_checked = reinterpret_cast<uint64_t>(mi.hbmpChecked);
+                item.hbmp_unchecked = reinterpret_cast<uint64_t>(mi.hbmpUnchecked);
+            }
+            if ((mi.fMask & MIIM_BITMAP) != 0)
+            {
+                item.hbmp_item = reinterpret_cast<uint64_t>(mi.hbmpItem);
+            }
+            if ((mi.fMask & MIIM_STRING) != 0)
+            {
+                item.text = read_menu_item_text(c, mi, item_text);
+            }
         }
     }
 
@@ -1968,7 +2106,7 @@ namespace sogen
 
         uint64_t handle_NtUserGetProcessWindowStation()
         {
-            return 0;
+            return 1;
         }
 
         uint64_t handle_NtUserCallHwndParam(const syscall_context& c, const hwnd hwnd, const uint64_t param, const uint32_t code)
@@ -3592,17 +3730,7 @@ namespace sogen
                 return FALSE;
             }
 
-            if (win->system_menu_ptr == 0)
-            {
-                win->system_menu_ptr = c.win_emu.memory.allocate_memory(0x1000, memory_permission::read_write);
-            }
-
-            if (win->guest.value() != 0)
-            {
-                const auto spmenu_addr = win->guest.value() + offsetof(USER_WINDOW, spmenu);
-                c.win_emu.memory.write_memory(spmenu_addr, &win->system_menu_ptr, sizeof(win->system_menu_ptr));
-            }
-
+            (void)ensure_system_menu(c, *win);
             return TRUE;
         }
 
@@ -3657,15 +3785,24 @@ namespace sogen
             return TRUE;
         }
 
-        uint64_t handle_NtUserGetSystemMenu(const syscall_context& c, const hwnd hwnd, const BOOL /*revert*/)
+        uint64_t handle_NtUserGetSystemMenu(const syscall_context& c, const hwnd hwnd, const BOOL revert)
         {
-            const auto* win = c.proc.windows.get(hwnd);
+            auto* win = c.proc.windows.get(hwnd);
             if (!win)
             {
                 return 0;
             }
 
-            return win->system_menu_ptr;
+            if (revert != FALSE && win->system_menu_ptr != 0)
+            {
+                if (auto* menu = c.proc.menus.get(win->system_menu_ptr))
+                {
+                    menu->items.clear();
+                    menu->sync_guest(c.win_emu.memory);
+                }
+            }
+
+            return ensure_system_menu(c, *win);
         }
 
         BOOL handle_NtUserAllowSetForegroundWindow()
@@ -4089,6 +4226,197 @@ namespace sogen
             const auto result = handle_NtUserGetQueueStatusReadonly(c, flags);
             c.proc.active_thread->queue_status_changed_bits &= ~flags;
             return result;
+        }
+
+        NTSTATUS handle_NtUserCreateAcceleratorTable()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        hmenu handle_NtUserCreateMenu(const syscall_context& c)
+        {
+            return create_menu_object(c, false);
+        }
+
+        BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, const hmenu menu, const UINT position, const BOOL by_position,
+                                              const BOOL insert, const emulator_object<MENUITEMINFOW> item_info,
+                                              const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text)
+        {
+            auto* m = c.proc.menus.get(menu);
+            if (!m)
+            {
+                return FALSE;
+            }
+
+            if (!item_info)
+            {
+                return FALSE;
+            }
+
+            MENUITEMINFOW mi{};
+            if (!c.win_emu.memory.try_read_memory(item_info.value(), &mi, sizeof(mi)))
+            {
+                return FALSE;
+            }
+
+            if (insert)
+            {
+                menu_item menu_item{};
+                update_menu_item(c, menu_item, mi, item_text);
+
+                if (by_position)
+                {
+                    const auto insert_at = std::min<size_t>(position, m->items.size());
+                    m->items.insert(m->items.begin() + static_cast<ptrdiff_t>(insert_at), menu_item);
+                }
+                else
+                {
+                    m->items.push_back(menu_item);
+                }
+
+                m->sync_guest(c.win_emu.memory);
+                return TRUE;
+            }
+
+            if (m->items.empty())
+            {
+                return FALSE;
+            }
+
+            if (by_position)
+            {
+                if (position >= m->items.size())
+                {
+                    return FALSE;
+                }
+
+                update_menu_item(c, m->items[position], mi, item_text);
+                m->sync_guest(c.win_emu.memory);
+                return TRUE;
+            }
+
+            const auto it = std::ranges::find_if(m->items, [&](const auto& item) { return item.id == position; });
+            if (it == m->items.end())
+            {
+                return TRUE;
+            }
+
+            update_menu_item(c, *it, mi, item_text);
+            m->sync_guest(c.win_emu.memory);
+            return TRUE;
+        }
+
+        hmenu handle_NtUserCreatePopupMenu(const syscall_context& c)
+        {
+            return create_menu_object(c, true);
+        }
+
+        BOOL handle_NtUserSetMenu()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserRemoveMenu(const syscall_context& c, const hmenu menu, const UINT position, const UINT flags)
+        {
+            auto* m = c.proc.menus.get(menu);
+            if (!m)
+            {
+                return FALSE;
+            }
+
+            if (m->items.empty())
+            {
+                return FALSE;
+            }
+
+            if ((flags & MF_BYPOSITION) != 0)
+            {
+                if (position >= m->items.size())
+                {
+                    return FALSE;
+                }
+
+                m->items.erase(m->items.begin() + static_cast<ptrdiff_t>(position));
+                m->sync_guest(c.win_emu.memory);
+                return TRUE;
+            }
+
+            const auto it = std::ranges::find_if(m->items, [&](const auto& item) { return item.id == position; });
+            if (it == m->items.end())
+            {
+                return FALSE;
+            }
+
+            m->items.erase(it);
+            m->sync_guest(c.win_emu.memory);
+            return TRUE;
+        }
+
+        BOOL handle_NtUserDestroyMenu(const syscall_context& c, const hmenu menu)
+        {
+            auto* m = c.proc.menus.get(menu);
+            if (!m)
+            {
+                return FALSE;
+            }
+
+            m->release_guest_backing(c.win_emu.memory);
+            return c.proc.menus.erase(menu) ? TRUE : FALSE;
+        }
+
+        BOOL handle_NtUserDrawMenuBar(const syscall_context& c, const hwnd hwnd)
+        {
+            if (hwnd != 0 && !c.proc.windows.get(hwnd))
+            {
+                return FALSE;
+            }
+
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, const hwnd hwnd, const emulator_pointer /*data*/)
+        {
+            if (hwnd != 0 && !c.proc.windows.get(hwnd))
+            {
+                return FALSE;
+            }
+
+            return TRUE;
+        }
+
+        BOOL handle_NtUserCreateCaret()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserIsTouchWindow()
+        {
+            return FALSE;
+        }
+
+        BOOL handle_NtUserGetWindowPlacement()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserTrackMouseEvent()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetWindowRgn()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserAlterWindowStyle()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetActiveWindow()
+        {
+            return TRUE;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1223,32 +1223,24 @@ namespace sogen
             return read_large_string(window_name);
         }
 
-        hmenu create_menu_object(const syscall_context& c, const bool popup)
-        {
-            auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
-            menu_obj.handle = handle.bits;
-            menu_obj.popup = popup;
-            menu_obj.init_guest();
-            return handle.bits;
-        }
-
         hmenu ensure_system_menu(const syscall_context& c, window& win)
         {
-            if (win.system_menu_ptr != 0 && c.proc.menus.get(win.system_menu_ptr))
+            if (win.system_menu_handle != 0 && c.proc.menus.get(win.system_menu_handle) != nullptr)
             {
-                return win.system_menu_ptr;
+                return win.system_menu_handle;
             }
 
-            const auto menu = create_menu_object(c, false);
-            win.system_menu_ptr = menu;
+            auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
+            menu_obj.handle = handle.bits;
+            menu_obj.popup = false;
+            menu_obj.init_guest();
 
-            if (win.guest.value() != 0)
-            {
-                const auto spmenu_addr = win.guest.value() + offsetof(USER_WINDOW, spmenu);
-                c.win_emu.memory.write_memory(spmenu_addr, &menu, sizeof(menu));
-            }
+            win.system_menu_handle = menu_obj.handle;
+            win.guest.access([&](USER_WINDOW& guest_win) { //
+                guest_win.spmenu = menu_obj.guest.value();
+            });
 
-            return menu;
+            return handle.bits;
         }
 
         std::u16string read_menu_item_text(const syscall_context& c, const EMU_MENUITEMINFO& mi,
@@ -3797,9 +3789,9 @@ namespace sogen
                 return 0;
             }
 
-            if (revert != FALSE && win->system_menu_ptr != 0)
+            if (revert != FALSE && win->system_menu_handle != 0)
             {
-                if (auto* menu = c.proc.menus.get(win->system_menu_ptr))
+                if (auto* menu = c.proc.menus.get(win->system_menu_handle))
                 {
                     menu->items.clear();
                     menu->sync_guest_items(c.win_emu.memory);
@@ -4239,7 +4231,11 @@ namespace sogen
 
         hmenu handle_NtUserCreateMenu(const syscall_context& c)
         {
-            return create_menu_object(c, false);
+            auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
+            menu_obj.handle = handle.bits;
+            menu_obj.popup = false;
+            menu_obj.init_guest();
+            return handle.bits;
         }
 
         BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, const hmenu menu, const UINT position, const BOOL by_position,
@@ -4275,7 +4271,8 @@ namespace sogen
                 }
                 else
                 {
-                    m->items.push_back(menu_item);
+                    const auto it = std::ranges::find_if(m->items, [&](const auto& item) { return item.id == position; });
+                    m->items.insert(it, menu_item);
                 }
 
                 m->sync_guest_items(c.win_emu.memory);
@@ -4329,7 +4326,11 @@ namespace sogen
 
         hmenu handle_NtUserCreatePopupMenu(const syscall_context& c)
         {
-            return create_menu_object(c, true);
+            auto [handle, menu_obj] = c.proc.menus.create(c.win_emu.memory);
+            menu_obj.handle = handle.bits;
+            menu_obj.popup = true;
+            menu_obj.init_guest();
+            return handle.bits;
         }
 
         BOOL handle_NtUserSetMenu()

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -280,6 +280,8 @@ namespace sogen
             {
             case handle_types::type::window:
                 return TYPE_WINDOW;
+            case handle_types::type::menu:
+                return TYPE_MENU;
             case handle_types::type::monitor:
                 return TYPE_MONITOR;
             default:

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -172,9 +172,9 @@ namespace sogen
         uint32_t type{};
         uint32_t state{};
         uint64_t data{};
-        uint64_t hbmp_checked{};
-        uint64_t hbmp_unchecked{};
-        uint64_t hbmp_item{};
+        hbitmap hbmp_checked{};
+        hbitmap hbmp_unchecked{};
+        hbitmap hbmp_item{};
         std::u16string text{};
 
         void serialize(utils::buffer_serializer& buffer) const
@@ -220,7 +220,18 @@ namespace sogen
         {
         }
 
-        void sync_guest(memory_manager& memory)
+        void init_guest() const
+        {
+            this->guest.access([&](USER_MENU& m) {
+                m.hMenu = this->handle;
+                m.ptrBase = this->guest.value();
+                m.rgItems = this->item_storage;
+                m.flags = 0;
+                m.cItems = this->item_count;
+            });
+        }
+
+        void sync_guest_items(memory_manager& memory)
         {
             this->release_backing(memory);
             this->item_count = static_cast<uint32_t>(this->items.size());
@@ -234,48 +245,46 @@ namespace sogen
             if (!this->items.empty())
             {
                 const auto item_bytes = sizeof(USER_MENU_ITEM) * this->items.size();
-                this->item_storage =
-                    memory.allocate_memory(static_cast<size_t>(page_align_up(item_bytes)), memory_permission::read);
+                this->item_storage = memory.allocate_memory(static_cast<size_t>(page_align_up(item_bytes)), memory_permission::read);
             }
 
             auto next_text = this->text_storage;
             for (size_t i = 0; i < this->items.size(); ++i)
             {
                 const auto& item = this->items[i];
-                USER_MENU_ITEM guest_item{
-                    .type = item.type,
-                    .state = item.state,
-                    .id = item.id,
-                    .submenu = item.submenu_ptr,
-                    .hbmpChecked = item.hbmp_checked,
-                    .hbmpUnchecked = item.hbmp_unchecked,
-                    .data = item.data,
-                    .hbmpItem = item.hbmp_item,
-                };
+                const auto text_ptr = !item.text.empty() ? next_text : 0;
+                const auto guest_item = make_guest_item(item, text_ptr);
+                write_guest_item_text(memory, item, text_ptr);
 
-                if (!item.text.empty() && next_text != 0)
+                if (text_ptr != 0)
                 {
-                    const auto bytes = item.text.size() * sizeof(char16_t);
-                    memory.write_memory(next_text, item.text.data(), bytes);
-
-                    constexpr char16_t terminator = 0;
-                    memory.write_memory(next_text + bytes, &terminator, sizeof(terminator));
-
-                    guest_item.text = next_text;
-                    guest_item.cch = static_cast<uint32_t>(item.text.size());
-                    next_text += bytes + sizeof(terminator);
+                    next_text += (item.text.size() + 1) * sizeof(char16_t);
                 }
 
                 memory.write_memory(this->item_storage + i * sizeof(USER_MENU_ITEM), &guest_item, sizeof(guest_item));
             }
 
             this->guest.access([&](USER_MENU& m) {
-                m.hMenu = this->handle;
-                m.self = this->guest.value();
                 m.rgItems = this->item_storage;
-                m.flags = 0;
                 m.cItems = this->item_count;
             });
+        }
+
+        void sync_guest_item(memory_manager& memory, const size_t index)
+        {
+            // TODO: This method is very naive and smartly reserving memory could avoid lots of reallocations.
+            if (this->item_storage == 0 || static_cast<size_t>(this->item_count) != this->items.size() || index >= this->items.size())
+            {
+                this->sync_guest_items(memory);
+                return;
+            }
+
+            const auto& item = this->items[index];
+            const auto text_ptr = this->get_guest_text_ptr(index);
+            const auto guest_item = make_guest_item(item, text_ptr);
+            write_guest_item_text(memory, item, text_ptr);
+
+            memory.write_memory(this->item_storage + index * sizeof(USER_MENU_ITEM), &guest_item, sizeof(guest_item));
         }
 
         void release_guest_backing(memory_manager& memory)
@@ -306,6 +315,34 @@ namespace sogen
         }
 
       private:
+        static USER_MENU_ITEM make_guest_item(const menu_item& item, const emulator_pointer text_ptr)
+        {
+            return USER_MENU_ITEM{
+                .type = item.type,
+                .state = item.state,
+                .id = item.id,
+                .submenu = item.submenu_ptr,
+                .hbmpChecked = item.hbmp_checked,
+                .hbmpUnchecked = item.hbmp_unchecked,
+                .text = text_ptr,
+                .cch = static_cast<uint32_t>(item.text.size()),
+                .data = item.data,
+                .hbmpItem = item.hbmp_item,
+            };
+        }
+
+        static void write_guest_item_text(memory_manager& memory, const menu_item& item, const emulator_pointer text_ptr)
+        {
+            if (!item.text.empty() && text_ptr != 0)
+            {
+                const auto bytes = item.text.size() * sizeof(char16_t);
+                memory.write_memory(text_ptr, item.text.data(), bytes);
+
+                constexpr char16_t terminator = 0;
+                memory.write_memory(text_ptr + bytes, &terminator, sizeof(terminator));
+            }
+        }
+
         void release_backing(memory_manager& memory)
         {
             if (this->item_storage != 0)
@@ -319,6 +356,25 @@ namespace sogen
                 memory.release_memory(this->text_storage, 0);
                 this->text_storage = 0;
             }
+        }
+
+        emulator_pointer get_guest_text_ptr(const size_t index) const
+        {
+            if (this->text_storage == 0 || index >= this->items.size())
+            {
+                return 0;
+            }
+
+            auto text_ptr = this->text_storage;
+            for (size_t i = 0; i < index; ++i)
+            {
+                if (!this->items[i].text.empty())
+                {
+                    text_ptr += (this->items[i].text.size() + 1) * sizeof(char16_t);
+                }
+            }
+
+            return this->items[index].text.empty() ? 0 : text_ptr;
         }
 
         size_t text_storage_size() const

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "handles.hpp"
+#include "memory_manager.hpp"
 
 #include <algorithm>
 #include <string_view>
@@ -160,6 +161,178 @@ namespace sogen
             buffer.read(this->system_menu_ptr);
             buffer.read(this->host_surface_window);
             buffer.read(this->unicode_proc);
+        }
+    };
+
+    struct menu_item
+    {
+        uint32_t id{};
+        hmenu submenu{};
+        emulator_pointer submenu_ptr{};
+        uint32_t type{};
+        uint32_t state{};
+        uint64_t data{};
+        uint64_t hbmp_checked{};
+        uint64_t hbmp_unchecked{};
+        uint64_t hbmp_item{};
+        std::u16string text{};
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(this->id);
+            buffer.write(this->submenu);
+            buffer.write(this->submenu_ptr);
+            buffer.write(this->type);
+            buffer.write(this->state);
+            buffer.write(this->data);
+            buffer.write(this->hbmp_checked);
+            buffer.write(this->hbmp_unchecked);
+            buffer.write(this->hbmp_item);
+            buffer.write(this->text);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(this->id);
+            buffer.read(this->submenu);
+            buffer.read(this->submenu_ptr);
+            buffer.read(this->type);
+            buffer.read(this->state);
+            buffer.read(this->data);
+            buffer.read(this->hbmp_checked);
+            buffer.read(this->hbmp_unchecked);
+            buffer.read(this->hbmp_item);
+            buffer.read(this->text);
+        }
+    };
+
+    struct menu : user_object<USER_MENU>
+    {
+        hmenu handle{};
+        uint32_t item_count{};
+        bool popup{};
+        std::vector<menu_item> items{};
+        emulator_pointer item_storage{};
+        emulator_pointer text_storage{};
+
+        menu(memory_interface& memory)
+            : user_object(memory)
+        {
+        }
+
+        void sync_guest(memory_manager& memory)
+        {
+            this->release_backing(memory);
+            this->item_count = static_cast<uint32_t>(this->items.size());
+
+            const auto text_bytes = this->text_storage_size();
+            if (text_bytes != 0)
+            {
+                this->text_storage = memory.allocate_memory(static_cast<size_t>(page_align_up(text_bytes)), memory_permission::read);
+            }
+
+            if (!this->items.empty())
+            {
+                const auto item_bytes = sizeof(USER_MENU_ITEM) * this->items.size();
+                this->item_storage =
+                    memory.allocate_memory(static_cast<size_t>(page_align_up(item_bytes)), memory_permission::read);
+            }
+
+            auto next_text = this->text_storage;
+            for (size_t i = 0; i < this->items.size(); ++i)
+            {
+                const auto& item = this->items[i];
+                USER_MENU_ITEM guest_item{
+                    .type = item.type,
+                    .state = item.state,
+                    .id = item.id,
+                    .submenu = item.submenu_ptr,
+                    .hbmpChecked = item.hbmp_checked,
+                    .hbmpUnchecked = item.hbmp_unchecked,
+                    .data = item.data,
+                    .hbmpItem = item.hbmp_item,
+                };
+
+                if (!item.text.empty() && next_text != 0)
+                {
+                    const auto bytes = item.text.size() * sizeof(char16_t);
+                    memory.write_memory(next_text, item.text.data(), bytes);
+
+                    constexpr char16_t terminator = 0;
+                    memory.write_memory(next_text + bytes, &terminator, sizeof(terminator));
+
+                    guest_item.text = next_text;
+                    guest_item.cch = static_cast<uint32_t>(item.text.size());
+                    next_text += bytes + sizeof(terminator);
+                }
+
+                memory.write_memory(this->item_storage + i * sizeof(USER_MENU_ITEM), &guest_item, sizeof(guest_item));
+            }
+
+            this->guest.access([&](USER_MENU& m) {
+                m.hMenu = this->handle;
+                m.self = this->guest.value();
+                m.rgItems = this->item_storage;
+                m.flags = 0;
+                m.cItems = this->item_count;
+            });
+        }
+
+        void release_guest_backing(memory_manager& memory)
+        {
+            this->release_backing(memory);
+        }
+
+        void serialize_object(utils::buffer_serializer& buffer) const override
+        {
+            user_object::serialize_object(buffer);
+            buffer.write(this->handle);
+            buffer.write(this->item_count);
+            buffer.write(this->popup);
+            buffer.write_vector(this->items);
+            buffer.write(this->item_storage);
+            buffer.write(this->text_storage);
+        }
+
+        void deserialize_object(utils::buffer_deserializer& buffer) override
+        {
+            user_object::deserialize_object(buffer);
+            buffer.read(this->handle);
+            buffer.read(this->item_count);
+            buffer.read(this->popup);
+            buffer.read_vector(this->items);
+            buffer.read(this->item_storage);
+            buffer.read(this->text_storage);
+        }
+
+      private:
+        void release_backing(memory_manager& memory)
+        {
+            if (this->item_storage != 0)
+            {
+                memory.release_memory(this->item_storage, 0);
+                this->item_storage = 0;
+            }
+
+            if (this->text_storage != 0)
+            {
+                memory.release_memory(this->text_storage, 0);
+                this->text_storage = 0;
+            }
+        }
+
+        size_t text_storage_size() const
+        {
+            size_t bytes = 0;
+            for (const auto& item : this->items)
+            {
+                if (!item.text.empty())
+                {
+                    bytes += (item.text.size() + 1) * sizeof(char16_t);
+                }
+            }
+
+            return bytes;
         }
     };
 

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -97,7 +97,7 @@ namespace sogen
         bool erase_pending{};
         std::map<std::u16string, uint64_t> props{};
         emulator_pointer wnd_proc{};
-        emulator_pointer system_menu_ptr{};
+        hmenu system_menu_handle{};
         bool host_surface_window{};
         bool unicode_proc{};
 
@@ -132,7 +132,7 @@ namespace sogen
             buffer.write(this->erase_pending);
             buffer.write_map(this->props);
             buffer.write(this->wnd_proc);
-            buffer.write(this->system_menu_ptr);
+            buffer.write(this->system_menu_handle);
             buffer.write(this->host_surface_window);
             buffer.write(this->unicode_proc);
         }
@@ -158,7 +158,7 @@ namespace sogen
             buffer.read(this->erase_pending);
             buffer.read_map(this->props);
             buffer.read(this->wnd_proc);
-            buffer.read(this->system_menu_ptr);
+            buffer.read(this->system_menu_handle);
             buffer.read(this->host_surface_window);
             buffer.read(this->unicode_proc);
         }


### PR DESCRIPTION
This PR makes the following changes:

- Implements most of the Menu syscalls.
- Adds several syscall stubs.
- Implements `NtGdiGetGlyphOutline`, `NtGdiGetOutlineTextMetricsInternalW`, and `NtGdiBitBlt`.
- Improves `NtGdiStretchDIBitsInternal` so it supports the format used by winemine.
- Improves `NtQuerySystemInformationEx` so `RelationAll` returns group and NUMA processor information.
- Fixes a bug in `invalidate_window` that was overwriting the invalidation area incorrectly.

After these changes (mostly the GDI implementations and the `invalidate_window` bug fix), winemine works in sogen!

<img width="167" height="224" alt="image" src="https://github.com/user-attachments/assets/dea42c24-1c90-45e7-9a7d-6ddc9b24463c" />