### PR TITLE
Fix OOB read/write sandbox escape in Vulkan host

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1178,7 +1178,10 @@ namespace sogen
 
                 std::vector<std::byte> bytes(static_cast<size_t>(copy_bytes));
                 const auto direct = this->direct_mappings_.find(request.memory);
-                if (direct != this->direct_mappings_.end() && direct->second.host_ptr && request.offset + copy_bytes <= direct->second.size)
+                // The alias only covers whole-page allocations, so direct->second.size is the real allocation
+                // size; bound the copy against it without overflowing on a hostile offset.
+                if (direct != this->direct_mappings_.end() && direct->second.host_ptr && request.offset <= direct->second.size &&
+                    copy_bytes <= direct->second.size - request.offset)
                 {
                     std::memcpy(bytes.data(), static_cast<const std::byte*>(direct->second.host_ptr) + request.offset,
                                 static_cast<size_t>(copy_bytes));
@@ -1226,7 +1229,9 @@ namespace sogen
 
             // Maps the host VkDeviceMemory and aliases it straight into the guest address space, so the guest
             // accesses it coherently with no staging copy. Returns guest_address = 0 if it can't be aliased
-            // (e.g. an unaligned host pointer), in which case the shim falls back to the staging path.
+            // (e.g. an unaligned host pointer, or an allocation whose size is not a whole number of pages --
+            // aliasing the page-rounded tail would expose host memory past the allocation to the guest), in
+            // which case the shim falls back to the (bounds-checked) staging path.
             NTSTATUS handle_map_memory_direct(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::map_memory_direct_request request{};
@@ -1251,7 +1256,8 @@ namespace sogen
                 response.vk_result = this->vulkan_.map_memory(request.device, request.memory, host_ptr, host_size);
 
                 constexpr uint64_t page = 0x1000;
-                if (response.vk_result != 0 || !host_ptr || host_size == 0 || (reinterpret_cast<uintptr_t>(host_ptr) % page) != 0)
+                if (response.vk_result != 0 || !host_ptr || host_size == 0 || (reinterpret_cast<uintptr_t>(host_ptr) % page) != 0 ||
+                    (host_size % page) != 0)
                 {
                     if (host_ptr)
                     {

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1228,10 +1228,10 @@ namespace sogen
             }
 
             // Maps the host VkDeviceMemory and aliases it straight into the guest address space, so the guest
-            // accesses it coherently with no staging copy. Returns guest_address = 0 if it can't be aliased
-            // (e.g. an unaligned host pointer, or an allocation whose size is not a whole number of pages --
-            // aliasing the page-rounded tail would expose host memory past the allocation to the guest), in
-            // which case the shim falls back to the (bounds-checked) staging path.
+            // accesses it coherently with no staging copy. Allocations are page-rounded at allocation time, so
+            // the page-granular alias never covers memory beyond the allocation. Returns guest_address = 0 if it
+            // still can't be aliased (e.g. an unaligned host pointer, or -- as a safety net -- a non-page-sized
+            // allocation), in which case the shim falls back to the (bounds-checked) staging path.
             NTSTATUS handle_map_memory_direct(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::map_memory_direct_request request{};

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -2367,9 +2367,16 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        // Round the allocation up to a whole number of guest pages. The map-direct path aliases the host
+        // mapping straight into the guest, which can only be done at page granularity; rounding the actual
+        // allocation up means the page-aligned alias never covers anything beyond this allocation, so the
+        // tail of the final page is the guest's own (slack) memory rather than leaked host memory.
+        constexpr uint64_t page_size = 0x1000;
+        const uint64_t aligned_size = (size > UINT64_MAX - (page_size - 1)) ? size : ((size + page_size - 1) & ~(page_size - 1));
+
         VkMemoryAllocateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        info.allocationSize = size;
+        info.allocationSize = aligned_size;
         info.memoryTypeIndex = memory_type_index;
 
         VkDeviceMemory memory{};
@@ -2380,7 +2387,7 @@ namespace sogen
         }
 
         const uint64_t id = this->impl_->next_id++;
-        this->impl_->memories.emplace(id, impl::memory_data{.handle = memory, .device_id = device, .allocation_size = size});
+        this->impl_->memories.emplace(id, impl::memory_data{.handle = memory, .device_id = device, .allocation_size = aligned_size});
         out_memory = id;
         return VK_SUCCESS;
     }

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -1,5 +1,7 @@
 #include "vulkan_host.hpp"
 
+#include <address_utils.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -2372,7 +2374,7 @@ namespace sogen
         // allocation up means the page-aligned alias never covers anything beyond this allocation, so the
         // tail of the final page is the guest's own (slack) memory rather than leaked host memory.
         constexpr uint64_t page_size = 0x1000;
-        const uint64_t aligned_size = (size > UINT64_MAX - (page_size - 1)) ? size : ((size + page_size - 1) & ~(page_size - 1));
+        const uint64_t aligned_size = (size > UINT64_MAX - (page_size - 1)) ? size : page_align_up(size, page_size);
 
         VkMemoryAllocateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -74,6 +74,24 @@ namespace sogen
 #endif
 #endif
 
+        // Validates a guest-controlled [offset, offset + size) range against an allocation size without
+        // overflowing. VK_WHOLE_SIZE is only accepted where the Vulkan API itself permits it (flush /
+        // invalidate of mapped ranges), in which case it covers the rest of the allocation from offset.
+        bool is_memory_range_valid(const uint64_t allocation_size, const uint64_t offset, const uint64_t size, const bool allow_whole_size)
+        {
+            if (offset > allocation_size)
+            {
+                return false;
+            }
+
+            if (allow_whole_size && size == VK_WHOLE_SIZE)
+            {
+                return true;
+            }
+
+            return size <= allocation_size - offset;
+        }
+
         // VkPhysicalDeviceProperties crosses the 32/64-bit ABI boundary unchanged except for
         // VkPhysicalDeviceLimits::minMemoryMapAlignment, the struct's only size_t (8 bytes on the
         // 64-bit host, 4 bytes on the 32-bit WoW64 guest). Members before it are ABI-identical;
@@ -2497,6 +2515,11 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        if (!is_memory_range_valid(mem->second.allocation_size, offset, size, false))
+        {
+            return VK_ERROR_MEMORY_MAP_FAILED;
+        }
+
         const size_t copy_bytes = std::min(static_cast<size_t>(size), out_size);
 
         void* mapped = nullptr;
@@ -2518,6 +2541,11 @@ namespace sogen
         if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.map_memory || !dev->second.unmap_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        if (!is_memory_range_valid(mem->second.allocation_size, offset, size, false))
+        {
+            return VK_ERROR_MEMORY_MAP_FAILED;
         }
 
         const size_t copy_bytes = std::min(static_cast<size_t>(size), data_size);
@@ -2543,6 +2571,11 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        if (!is_memory_range_valid(mem->second.allocation_size, offset, size, true))
+        {
+            return VK_ERROR_MEMORY_MAP_FAILED;
+        }
+
         VkMappedMemoryRange range{};
         range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
         range.memory = mem->second.handle;
@@ -2558,6 +2591,11 @@ namespace sogen
         if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.invalidate_mapped_memory_ranges)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        if (!is_memory_range_valid(mem->second.allocation_size, offset, size, true))
+        {
+            return VK_ERROR_MEMORY_MAP_FAILED;
         }
 
         VkMappedMemoryRange range{};


### PR DESCRIPTION
## Summary

Fixes #1055 — a sandbox escape via an arbitrary read/write primitive in the Vulkan host.

`vulkan_host::upload_memory`, `download_memory`, `flush_mapped_memory_range`, and `invalidate_mapped_memory_range` forwarded the **guest-controlled** `offset`/`size` straight to `vkMapMemory(offset, size)` without validating them against the allocation's `allocation_size`. Since the host maps `base + offset` and the copy length is also guest-controlled, the guest could pick `offset = target - base` to read/write any host address — an arbitrary R/W in the analyzer's address space.

## Fix

Added an overflow-safe range check (`is_memory_range_valid`) that rejects any `[offset, offset + size)` range exceeding the allocation size before the memory is mapped. `VK_WHOLE_SIZE` is permitted only on the flush/invalidate paths, where the Vulkan API itself allows it.

## Testing

- `cmake --build --preset=release` — builds cleanly
- `analyzer.exe -s test-sample.exe` — all smoke tests pass

Credit to @ioncodes for reporting the issue and the PoC.
