### PR TITLE
Emulator fixes surfaced by CoD MW3 / open-iw5 (IOCP, LSA, win32k, thread enumeration)

### DIFF
--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -1152,6 +1152,65 @@ namespace sogen
         typename Traits::PVOID DefaultBase;
     };
 
+    template <typename Traits>
+    struct SYSTEM_THREAD_INFORMATION
+    {
+        LARGE_INTEGER KernelTime;
+        LARGE_INTEGER UserTime;
+        LARGE_INTEGER CreateTime;
+        ULONG WaitTime;
+        typename Traits::PVOID StartAddress;
+        CLIENT_ID<Traits> ClientId;
+        LONG Priority;
+        LONG BasePriority;
+        ULONG ContextSwitches;
+        ULONG ThreadState;
+        ULONG WaitReason;
+    };
+
+    template <typename Traits>
+    struct SYSTEM_PROCESS_INFORMATION
+    {
+        ULONG NextEntryOffset;
+        ULONG NumberOfThreads;
+        LARGE_INTEGER WorkingSetPrivateSize;
+        ULONG HardFaultCount;
+        ULONG NumberOfThreadsHighWatermark;
+        ULONGLONG CycleTime;
+        LARGE_INTEGER CreateTime;
+        LARGE_INTEGER UserTime;
+        LARGE_INTEGER KernelTime;
+        UNICODE_STRING<Traits> ImageName;
+        LONG BasePriority;
+        typename Traits::HANDLE UniqueProcessId;
+        typename Traits::HANDLE InheritedFromUniqueProcessId;
+        ULONG HandleCount;
+        ULONG SessionId;
+        typename Traits::ULONG_PTR UniqueProcessKey;
+        typename Traits::SIZE_T PeakVirtualSize;
+        typename Traits::SIZE_T VirtualSize;
+        ULONG PageFaultCount;
+        typename Traits::SIZE_T PeakWorkingSetSize;
+        typename Traits::SIZE_T WorkingSetSize;
+        typename Traits::SIZE_T QuotaPeakPagedPoolUsage;
+        typename Traits::SIZE_T QuotaPagedPoolUsage;
+        typename Traits::SIZE_T QuotaPeakNonPagedPoolUsage;
+        typename Traits::SIZE_T QuotaNonPagedPoolUsage;
+        typename Traits::SIZE_T PagefileUsage;
+        typename Traits::SIZE_T PeakPagefileUsage;
+        typename Traits::SIZE_T PrivatePageCount;
+        LARGE_INTEGER ReadOperationCount;
+        LARGE_INTEGER WriteOperationCount;
+        LARGE_INTEGER OtherOperationCount;
+        LARGE_INTEGER ReadTransferCount;
+        LARGE_INTEGER WriteTransferCount;
+        LARGE_INTEGER OtherTransferCount;
+        // Followed by SYSTEM_THREAD_INFORMATION<Traits> Threads[NumberOfThreads]
+    };
+
+    static_assert(sizeof(SYSTEM_THREAD_INFORMATION<EmulatorTraits<Emu64>>) == 0x50);
+    static_assert(sizeof(SYSTEM_PROCESS_INFORMATION<EmulatorTraits<Emu64>>) == 0x100);
+
     struct PROCESS_PRIORITY_CLASS
     {
         BOOLEAN Foreground;

--- a/src/windows-emulator/io_completion_wait.cpp
+++ b/src/windows-emulator/io_completion_wait.cpp
@@ -48,6 +48,39 @@ namespace sogen
                 }
             }
 
+            // Delivering a wait-completion-packet completion is a satisfied wait, so it must consume the
+            // target's signal exactly like NtWaitForSingleObject would: an auto-reset event resets and a
+            // semaphore decrements. Without this, an edge-triggered target stays signaled and floods the
+            // completion port with spurious packets (e.g. a games's async scheduler busy-spins forever).
+            void consume_wait_completion_target(process_context& process, const handle target_object_handle)
+            {
+                switch (target_object_handle.value.type)
+                {
+                case handle_types::event: {
+                    auto* e = process.events.get(target_object_handle);
+                    if (e && e->type == SynchronizationEvent)
+                    {
+                        e->signaled = false;
+                    }
+                    break;
+                }
+
+                case handle_types::semaphore: {
+                    auto* semaphore = process.semaphores.get(target_object_handle);
+                    if (semaphore)
+                    {
+                        (void)semaphore->try_lock();
+                    }
+                    break;
+                }
+
+                default:
+                    // process/thread/timer are level-triggered or terminal; ports and mutants are left
+                    // untouched (a wait packet does not take mutant ownership).
+                    break;
+                }
+            }
+
             void release_wait_packet_association(process_context& process, wait_completion_packet& wait_packet)
             {
                 release_handle_reference(process, wait_packet.io_completion_handle);
@@ -214,6 +247,8 @@ namespace sogen
                 {
                     continue;
                 }
+
+                consume_wait_completion_target(process, wait_packet.target_object_handle);
 
                 enqueue_wait_packet_completion(process, *completion, process.wait_completion_packets.make_handle(packet_id), wait_packet);
                 wait_packet.queued_completion = true;

--- a/src/windows-emulator/ports/lsa_policy_lookup.cpp
+++ b/src/windows-emulator/ports/lsa_policy_lookup.cpp
@@ -137,8 +137,14 @@ namespace sogen
                     return handle_close_policy(win_emu, writer);
                 case 2:
                     return handle_lookup_sids(win_emu, c, writer);
+                case 5:
+                    // The shell's account-lookup path (e.g. SHGetKnownFolderPath, used while the engine sets
+                    // up its crash-report queue) issues this additional lookup. We don't resolve it, but we
+                    // must answer with a well-formed "none mapped" result: returning an RPC error makes the
+                    // runtime raise RPC_S_CALL_FAILED in the caller, whose vectored exception handler then
+                    // re-enters a half-initialized singleton and deadlocks.
+                    return write_lookup_not_mapped_reply(writer);
                 default:
-                    // win_emu.log.warn("Unsupported lsapolicylookup procedure: %u\n", procedure_id);
                     return STATUS_NOT_SUPPORTED;
                 }
             }
@@ -168,6 +174,11 @@ namespace sogen
                     return STATUS_SUCCESS;
                 }
 
+                return write_lookup_not_mapped_reply(writer);
+            }
+
+            static NTSTATUS write_lookup_not_mapped_reply(utils::aligned_binary_writer& writer)
+            {
                 const auto reply_offset = writer.offset();
                 writer.pad(k_lookup_sids_not_mapped_reply_size);
                 writer.write_at(reply_offset + 0x14, k_status_none_mapped);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -458,6 +458,7 @@ namespace sogen
         BOOL handle_NtUserGetOemBitmapSize(const syscall_context& c, uint32_t bitmap_id, emulator_pointer size_ptr);
         BOOL handle_NtUserSetWindowState(const syscall_context& c, hwnd window, uint32_t flags);
         BOOL handle_NtUserClearWindowState(const syscall_context& c, hwnd window, uint32_t flags);
+        BOOL handle_NtUserDisableProcessWindowsGhosting(const syscall_context& c);
         BOOL handle_NtUserBitBltSysBmp(const syscall_context& c, hdc dc, int x, int y, uint32_t bitmap_index);
         BOOL handle_NtUserGetClientRect(const syscall_context& c, hwnd window, emulator_pointer rect_ptr);
         hdc handle_NtUserBeginPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
@@ -1279,6 +1280,7 @@ namespace sogen
         add_handler(NtUserDefSetText);
         add_handler(NtUserSetWindowState);
         add_handler(NtUserClearWindowState);
+        add_handler(NtUserDisableProcessWindowsGhosting);
         add_handler(NtUserBitBltSysBmp);
         add_handler(NtUserGetClientRect);
         add_handler(NtUserBeginPaint);

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -194,15 +194,89 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_system_process_information(const syscall_context& c, const uint64_t system_information,
+                                                   const uint32_t system_information_length, const emulator_object<uint32_t> return_length)
+        {
+            using Traits = EmulatorTraits<Emu64>;
+            using proc_t = SYSTEM_PROCESS_INFORMATION<Traits>;
+            using thread_t = SYSTEM_THREAD_INFORMATION<Traits>;
+
+            uint64_t process_id = 1;
+            uint64_t active_tid = 0;
+            if (c.proc.active_thread && c.proc.active_thread->teb64)
+            {
+                c.proc.active_thread->teb64->access([&](const TEB64& teb) {
+                    process_id = teb.ClientId.UniqueProcess;
+                    active_tid = teb.ClientId.UniqueThread;
+                });
+            }
+
+            std::vector<uint64_t> thread_ids;
+            for (const auto& t : c.proc.threads | std::views::values)
+            {
+                if (t.is_terminated() || !t.teb64)
+                {
+                    continue;
+                }
+                uint64_t tid = 0;
+                t.teb64->access([&](const TEB64& teb) { tid = teb.ClientId.UniqueThread; });
+                thread_ids.push_back(tid);
+            }
+
+            if (thread_ids.empty())
+            {
+                thread_ids.push_back(active_tid);
+            }
+
+            const auto required = static_cast<uint32_t>(sizeof(proc_t) + thread_ids.size() * sizeof(thread_t));
+
+            if (return_length)
+            {
+                return_length.write(required);
+            }
+
+            if (system_information_length < required)
+            {
+                return STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            proc_t proc{};
+            memset(&proc, 0, sizeof(proc));
+            proc.NextEntryOffset = 0; // single process; terminator
+            proc.NumberOfThreads = static_cast<ULONG>(thread_ids.size());
+            proc.BasePriority = 8;
+            proc.UniqueProcessId = process_id;
+            proc.HandleCount = 0;
+            proc.SessionId = 0;
+            c.emu.write_memory(system_information, &proc, sizeof(proc));
+
+            for (size_t i = 0; i < thread_ids.size(); ++i)
+            {
+                thread_t info{};
+                memset(&info, 0, sizeof(info));
+                info.ClientId.UniqueProcess = process_id;
+                info.ClientId.UniqueThread = thread_ids[i];
+                info.Priority = 8;
+                info.BasePriority = 8;
+                info.ThreadState = 5; // Waiting
+                info.WaitReason = 6;  // WrQueue
+                c.emu.write_memory(system_information + sizeof(proc_t) + i * sizeof(thread_t), &info, sizeof(info));
+            }
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtQuerySystemInformationEx(const syscall_context& c, const uint32_t info_class, const uint64_t input_buffer,
                                                    const uint32_t input_buffer_length, const uint64_t system_information,
                                                    const uint32_t system_information_length, const emulator_object<uint32_t> return_length)
         {
             switch (info_class)
             {
+            case SystemProcessInformation:
+                return handle_system_process_information(c, system_information, system_information_length, return_length);
+
             case 250: // Build 27744
             case SystemFlushInformation:
-            case SystemProcessInformation:
             case SystemMemoryUsageInformation:
             case SystemCodeIntegrityPolicyInformation:
             case SystemHypervisorSharedPageInformation:

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1746,6 +1746,13 @@ namespace sogen
             return apply_window_state(c, window, flags, false);
         }
 
+        BOOL handle_NtUserDisableProcessWindowsGhosting(const syscall_context& /*c*/)
+        {
+            // Window ghosting is a desktop-compositor feature with no meaning in the emulator; accept the
+            // request so callers (e.g. game engine startup) proceed.
+            return TRUE;
+        }
+
         BOOL handle_NtUserBitBltSysBmp(const syscall_context& c, const hdc dc, const int x, const int y, const uint32_t bitmap_index)
         {
             (void)handle_NtGdiFlush(c);


### PR DESCRIPTION
Four independent emulator-side fixes surfaced while bringing up Call of Duty: Modern Warfare 3 (via open-iw5) under the emulator.

## io-completion: consume target signal when delivering a wait packet
Delivering a wait-completion-packet completion is a satisfied wait, so it must consume the target's signal exactly like `NtWaitForSingleObject` (auto-reset event resets, semaphore decrements). Without this an edge-triggered target stays signaled and floods the completion port with spurious packets — the game's async scheduler busy-spins forever.

## lsa-policy-lookup: answer opnum 5 instead of failing the RPC
The shell's account-lookup path (`SHGetKnownFolderPath`, hit while the engine sets up its crash-report queue) issues an additional LsaLookup call (opnum 5). We can't resolve it, but returning an RPC error makes the runtime raise `RPC_S_CALL_FAILED`, whose vectored handler re-enters a half-initialized singleton and deadlocks. Answer with a well-formed "none mapped" reply instead.

## win32k: stub NtUserDisableProcessWindowsGhosting
Window ghosting is a desktop-compositor feature with no meaning in the emulator; accept the request so engine startup proceeds.

## system-process-info: implement SystemProcessInformation for thread enumeration
`NtQuerySystemInformation(SystemProcessInformation)` returned `STATUS_NOT_SUPPORTED`, which breaks `CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD)`. MinHook freezes all other threads before patching and enumerates them through that snapshot; when it fails, `MH_EnableHook` returns `MH_ERROR_MEMORY_ALLOC` and the detour is never written — so **every MinHook-based detour silently no-ops** under the emulator. For open-iw5 this left the GSC builtin dispatch table empty, crashing on the first script builtin (`spawnstruct`) during map load. Return the current process and its live threads so the snapshot succeeds and MinHook can install its detours.

## Testing
- `analyzer.exe -s test-sample.exe` passes.
- MW3 (open-iw5) now loads multiplayer maps in the emulator.