### PR TITLE
Preserve image-backed regions as MEM_IMAGE

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -3309,14 +3309,14 @@ namespace sogen::whp
 
                 if (exception.ExceptionType == WHvX64ExceptionTypeBreakpointTrap)
                 {
-                    if (this->handle_patched_execution_breakpoint(exit_context.VpContext.Rip - 1))
+                    const auto rip = exit_context.VpContext.Rip;
+                    if (this->handle_patched_execution_breakpoint(rip - 1) || this->handle_patched_execution_breakpoint(rip))
                     {
                         return true;
                     }
 
                     if (this->syscall_hook_ != nullptr)
                     {
-                        const auto rip = exit_context.VpContext.Rip;
                         if (rip == this->syscall_hook_page_ || rip == (this->syscall_hook_page_ + 1))
                         {
                             return this->handle_syscall_halt();

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -1462,6 +1462,8 @@ namespace sogen::gpu_bridge
         uint32_t attribute_count;                                    // number of vertex_input_attribute entries that follow the bindings
         uint32_t rasterization_samples;                              // VkSampleCountFlagBits the pipeline rasterizes at (1 = no MSAA)
         uint32_t dynamic_state_count;                                // number of uint32 VkDynamicState values that follow the attributes
+        uint32_t primitive_topology;
+        uint32_t primitive_restart_enable;
         // Per-stage specialization constants (DXVK bakes d3d9 render state into the shaders this way).
         uint32_t vs_spec_entry_count;
         uint32_t vs_spec_data_size;

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -3839,6 +3839,17 @@ extern "C"
             request.attribute_count = attribute_count;
             request.rasterization_samples = ci.pMultisampleState ? static_cast<uint32_t>(ci.pMultisampleState->rasterizationSamples) : 1u;
 
+            request.primitive_topology = static_cast<uint32_t>(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
+
+            request.primitive_restart_enable = 0;
+
+            if (ci.pInputAssemblyState)
+            {
+                request.primitive_topology = static_cast<uint32_t>(ci.pInputAssemblyState->topology);
+
+                request.primitive_restart_enable = ci.pInputAssemblyState->primitiveRestartEnable ? 1u : 0u;
+            }
+
             // Forward the dynamic-state list verbatim. DXVK marks vertex-binding stride, cull, topology,
             // depth/stencil etc. dynamic and sets them via vkCmdSet*/vkCmdBindVertexBuffers2; if the host
             // pipeline does not also declare them dynamic it bakes (often wrong) defaults instead.

--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -628,6 +628,11 @@ namespace sogen
 
         emulator_callbacks::continuation handle_syscall(analysis_context& c, const uint32_t syscall_id, const std::string_view syscall_name)
         {
+            if (c.settings->ignored_functions.contains(syscall_name))
+            {
+                return instruction_hook_continuation::run_instruction;
+            }
+
             auto& win_emu = *c.win_emu;
             auto& emu = win_emu.emu();
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1940,7 +1940,8 @@ namespace sogen
                 const int32_t result = this->vulkan_.create_graphics_pipeline(
                     request.device, request.render_pass, request.pipeline_layout, request.vertex_shader, request.fragment_shader,
                     request.width, request.height, bindings, attributes, depth, color_formats, request.depth_format, request.stencil_format,
-                    request.rasterization_samples, dynamic_states, vs_spec, fs_spec, blend_attachments, pipeline);
+                    request.rasterization_samples, request.primitive_topology, request.primitive_restart_enable, dynamic_states, vs_spec,
+                    fs_spec, blend_attachments, pipeline);
                 if (result != 0)
                 {
                     win_emu.log.error(

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -4383,9 +4383,9 @@ namespace sogen
                                                   uint64_t fragment_shader, uint32_t width, uint32_t height,
                                                   std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
                                                   const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
-                                                  uint32_t stencil_format, uint32_t rasterization_samples,
-                                                  std::span<const uint32_t> dynamic_states, const specialization& vs_spec,
-                                                  const specialization& fs_spec,
+                                                  uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
+                                                  uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
+                                                  const specialization& vs_spec, const specialization& fs_spec,
                                                   std::span<const color_blend_attachment> blend_attachments_in, uint64_t& out_pipeline)
     {
         out_pipeline = 0;
@@ -4475,7 +4475,8 @@ namespace sogen
 
         VkPipelineInputAssemblyStateCreateInfo input_assembly{};
         input_assembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-        input_assembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        input_assembly.topology = static_cast<VkPrimitiveTopology>(primitive_topology);
+        input_assembly.primitiveRestartEnable = primitive_restart_enable ? VK_TRUE : VK_FALSE;
 
         VkViewport viewport{};
         viewport.width = static_cast<float>(width);

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -491,7 +491,8 @@ namespace sogen
                                          uint64_t fragment_shader, uint32_t width, uint32_t height,
                                          std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
                                          const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
-                                         uint32_t stencil_format, uint32_t rasterization_samples, std::span<const uint32_t> dynamic_states,
+                                         uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
+                                         uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
                                          const specialization& vs_spec, const specialization& fs_spec,
                                          std::span<const color_blend_attachment> blend_attachments, uint64_t& out_pipeline);
         int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, uint64_t shader_module, uint64_t& out_pipeline);

--- a/src/windows-emulator/memory_manager.cpp
+++ b/src/windows-emulator/memory_manager.cpp
@@ -85,6 +85,7 @@ namespace sogen
         static void serialize(buffer_serializer& buffer, const memory_manager::reserved_region& region)
         {
             buffer.write(region.kind);
+            buffer.write(region.mapped_filename);
             buffer.write(region.initial_permission);
             buffer.write<uint64_t>(region.length);
             buffer.write_map(region.committed_regions);
@@ -93,6 +94,7 @@ namespace sogen
         static void deserialize(buffer_deserializer& buffer, memory_manager::reserved_region& region)
         {
             buffer.read(region.kind);
+            buffer.read(region.mapped_filename);
             buffer.read(region.initial_permission);
             region.length = static_cast<size_t>(buffer.read<uint64_t>());
             buffer.read_map(region.committed_regions);
@@ -572,6 +574,7 @@ namespace sogen
             left_region.length = static_cast<size_t>(aligned_start - reserved_start);
             left_region.initial_permission = region.initial_permission;
             left_region.kind = region.kind;
+            left_region.mapped_filename = region.mapped_filename;
             left_region.committed_regions = std::move(left_committed);
             this->reserved_regions_.try_emplace(reserved_start, std::move(left_region));
         }
@@ -582,6 +585,7 @@ namespace sogen
             right_region.length = static_cast<size_t>(reserved_end - aligned_end);
             right_region.initial_permission = region.initial_permission;
             right_region.kind = region.kind;
+            right_region.mapped_filename = region.mapped_filename;
             right_region.committed_regions = std::move(right_committed);
             this->reserved_regions_.try_emplace(aligned_end, std::move(right_region));
         }
@@ -802,6 +806,39 @@ namespace sogen
         result.length = static_cast<size_t>(committed_end - result.start);
 
         return result;
+    }
+
+    std::optional<std::u16string> memory_manager::get_region_mapped_filename(const uint64_t address) const
+    {
+        if (this->reserved_regions_.empty())
+        {
+            return std::nullopt;
+        }
+
+        auto upper_bound = this->reserved_regions_.upper_bound(address);
+        if (upper_bound == this->reserved_regions_.begin())
+        {
+            return std::nullopt;
+        }
+
+        const auto entry = --upper_bound;
+        if (entry->first + entry->second.length <= address || entry->second.mapped_filename.empty())
+        {
+            return std::nullopt;
+        }
+
+        return entry->second.mapped_filename;
+    }
+
+    void memory_manager::set_region_mapped_filename(const uint64_t address, std::u16string filename)
+    {
+        const auto entry = this->find_reserved_region(address);
+        if (entry == this->reserved_regions_.end())
+        {
+            return;
+        }
+
+        entry->second.mapped_filename = std::move(filename);
     }
 
     memory_manager::reserved_region_map::iterator memory_manager::find_reserved_region(const uint64_t address)

--- a/src/windows-emulator/memory_manager.cpp
+++ b/src/windows-emulator/memory_manager.cpp
@@ -343,13 +343,31 @@ namespace sogen
 
     bool memory_manager::commit_memory(const uint64_t address, const size_t size, const nt_memory_permission permissions)
     {
+        return this->commit_memory(address, size, permissions, false);
+    }
+
+    bool memory_manager::commit_image_memory(const uint64_t address, const size_t size, const nt_memory_permission permissions)
+    {
+        const auto entry = this->find_reserved_region(address);
+        if (entry == this->reserved_regions_.end() || entry->second.kind != memory_region_kind::section_image)
+        {
+            return false;
+        }
+
+        return this->commit_memory(address, size, permissions, true);
+    }
+
+    bool memory_manager::commit_memory(const uint64_t address, const size_t size, const nt_memory_permission permissions,
+                                       const bool allow_image_section)
+    {
         const auto entry = this->find_reserved_region(address);
         if (entry == this->reserved_regions_.end())
         {
             return false;
         }
 
-        if (memory_region_policy::is_section_kind(entry->second.kind))
+        if (memory_region_policy::is_section_kind(entry->second.kind) &&
+            !(allow_image_section && entry->second.kind == memory_region_kind::section_image))
         {
             return false;
         }

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 
 #include "memory_permission_ext.hpp"
 #include "memory_region.hpp"
@@ -73,6 +74,7 @@ namespace sogen
             memory_permission initial_permission{};
             committed_region_map committed_regions{};
             memory_region_kind kind{memory_region_kind::private_allocation};
+            std::u16string mapped_filename{};
         };
 
         using reserved_region_map = std::map<uint64_t, reserved_region>;
@@ -108,6 +110,8 @@ namespace sogen
                                            uint64_t highest_address) const;
 
         region_info get_region_info(uint64_t address);
+        std::optional<std::u16string> get_region_mapped_filename(uint64_t address) const;
+        void set_region_mapped_filename(uint64_t address, std::u16string filename);
 
         reserved_region_map::iterator find_reserved_region(uint64_t address);
 

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -93,6 +93,7 @@ namespace sogen
                              memory_region_kind kind = memory_region_kind::private_allocation);
 
         bool commit_memory(uint64_t address, size_t size, nt_memory_permission permissions);
+        bool commit_image_memory(uint64_t address, size_t size, nt_memory_permission permissions);
         bool decommit_memory(uint64_t address, size_t size);
 
         bool release_memory(uint64_t address, size_t size);
@@ -152,6 +153,7 @@ namespace sogen
         void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) final;
 
         void update_layout_version();
+        bool commit_memory(uint64_t address, size_t size, nt_memory_permission permissions, bool allow_image_section);
     };
 
     namespace memory_region_policy

--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -436,7 +436,7 @@ namespace sogen
                     continue;
                 }
 
-                if (!memory.commit_memory(target_ptr, section_size, memory_permission::read_write))
+                if (!memory.commit_image_memory(target_ptr, section_size, memory_permission::read_write))
                 {
                     return false;
                 }
@@ -511,13 +511,13 @@ namespace sogen
             binary.address_names.clear();
 
             const auto image_size = static_cast<size_t>(binary.size_of_image);
-            if (!memory.allocate_memory(binary.image_base, image_size, memory_permission::all, true))
+            if (!memory.allocate_memory(binary.image_base, image_size, memory_permission::all, true, memory_region_kind::section_image))
             {
                 return false;
             }
 
             const auto headers_size = static_cast<size_t>(page_align_up(optional_header.SizeOfHeaders));
-            if (!memory.commit_memory(binary.image_base, headers_size, memory_permission::read_write))
+            if (!memory.commit_image_memory(binary.image_base, headers_size, memory_permission::read_write))
             {
                 memory.release_memory(binary.image_base, 0);
                 return false;

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -117,6 +117,24 @@ namespace sogen
 
                 return STATUS_SUCCESS;
             }
+
+            std::optional<std::u16string> get_mapped_filename(const syscall_context& c, const uint64_t base_address)
+            {
+                const auto* mod = c.win_emu.mod_manager.find_by_address(base_address);
+                if (!mod || mod->module_path.empty())
+                {
+                    return std::nullopt;
+                }
+
+                try
+                {
+                    return mod->module_path.to_device_path();
+                }
+                catch (const std::exception&)
+                {
+                    return mod->module_path.to_unc_path();
+                }
+            }
         }
 
         NTSTATUS handle_NtQueryVirtualMemory(const syscall_context& c, const handle process_handle, const uint64_t base_address,
@@ -180,6 +198,43 @@ namespace sogen
                     {
                         image_info.Type = memory_region_policy::to_memory_basic_information_type(region_info.kind);
                     }
+                });
+
+                return STATUS_SUCCESS;
+            }
+
+            if (info_class == MemoryMappedFilenameInformation)
+            {
+                const auto mapped_filename = get_mapped_filename(c, base_address);
+                if (!mapped_filename)
+                {
+                    return STATUS_INVALID_ADDRESS;
+                }
+
+                const auto string_bytes = static_cast<uint32_t>(mapped_filename->size() * sizeof(char16_t));
+                const auto required_length =
+                    static_cast<uint32_t>(sizeof(UNICODE_STRING<EmulatorTraits<Emu64>>) + string_bytes + sizeof(char16_t));
+
+                if (return_length)
+                {
+                    return_length.write(required_length);
+                }
+
+                if (memory_information_length < required_length)
+                {
+                    return STATUS_BUFFER_OVERFLOW;
+                }
+
+                const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> info{c.emu, memory_information};
+                info.access([&](UNICODE_STRING<EmulatorTraits<Emu64>>& filename) {
+                    const auto buffer_start = static_cast<uint64_t>(memory_information) + sizeof(UNICODE_STRING<EmulatorTraits<Emu64>>);
+                    filename.Length = static_cast<USHORT>(string_bytes);
+                    filename.MaximumLength = static_cast<USHORT>(string_bytes + sizeof(char16_t));
+                    filename.Buffer = buffer_start;
+
+                    c.emu.write_memory(buffer_start, mapped_filename->data(), string_bytes);
+                    const char16_t terminator = u'\0';
+                    c.emu.write_memory(buffer_start + string_bytes, &terminator, sizeof(terminator));
                 });
 
                 return STATUS_SUCCESS;

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -4,6 +4,7 @@
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../memory_manager.hpp"
+#include "../windows_path.hpp"
 
 namespace sogen
 {
@@ -120,6 +121,18 @@ namespace sogen
 
             std::optional<std::u16string> get_mapped_filename(const syscall_context& c, const uint64_t base_address)
             {
+                if (const auto mapped_filename = c.win_emu.memory.get_region_mapped_filename(base_address))
+                {
+                    try
+                    {
+                        return windows_path(*mapped_filename).to_device_path();
+                    }
+                    catch (const std::exception&)
+                    {
+                        return windows_path(*mapped_filename).to_unc_path();
+                    }
+                }
+
                 const auto* mod = c.win_emu.mod_manager.find_by_address(base_address);
                 if (!mod || mod->module_path.empty())
                 {

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -429,6 +429,7 @@ namespace sogen
             const auto reserve_only = section_entry->allocation_attributes == SEC_RESERVE;
             const auto address =
                 c.win_emu.memory.allocate_memory(aligned_size, protection, reserve_only, 0, memory_region_kind::file_section_view);
+            c.win_emu.memory.set_region_mapped_filename(address, section_entry->file_name);
 
             if (!reserve_only && !file_data.empty())
             {


### PR DESCRIPTION
This PR fixes some issues related to memory region type reporting:

* Ensure normal PE loader mappings are reported as `MEM_IMAGE` instead of `MEM_PRIVATE`.
* Preserve image allocation metadata across `NtProtectVirtualMemory`.
* Add handling for `MemoryMappedFilenameInformation` in `NtQueryVirtualMemory`.

It also includes some additional fixes:

* Fix breakpoint handling in the WHP backend. _(I have no clue why this suddenly stopped working when I’m pretty sure it was working before, but anyway, this should be good now)_
* Forward primitive topology and primitive restart state when creating Vulkan graphics pipelines.
* Respect ignored functions in the analyzer syscall hook.