### PR TITLE
WHP: fix FP-exception crash, coalesce memory unmaps; GPU-bridge batching

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1233,11 +1233,15 @@ namespace sogen::whp
                 // an expensive EPT flush, so freeing a large region one page at a time stalls the guest for
                 // seconds. The LIFO GPA free list scatters a region's pages across non-adjacent and reverse-ordered
                 // guest-physical addresses, so sort them to recover every contiguous run before unmapping.
+                //
+                // Free pages high-to-low so released GPA indices land on the LIFO free list in descending order;
+                // the next large allocation then pops them back ascending, keeping remap_pages' contiguous-run
+                // check effective so re-mapping the region stays coalesced too.
                 std::vector<uint64_t> unmap_gpas;
                 bool flushed_virtual_mappings = false;
-                for (size_t offset = 0; offset < size; offset += page_size)
+                for (size_t offset = size; offset > 0; offset -= page_size)
                 {
-                    const auto guest_address = address + offset;
+                    const auto guest_address = address + offset - page_size;
                     this->revoke_mmio_read_grace(guest_address);
 
                     const auto entry = this->mapped_pages_.find(guest_address);

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1228,15 +1228,10 @@ namespace sogen::whp
                     throw std::runtime_error("WHP memory unmappings must be page aligned");
                 }
 
-                // Collect the guest-physical pages backing this region and run the per-page bookkeeping, then drop
-                // them from the partition with as few WHvUnmapGpaRange calls as possible. Each WHvUnmapGpaRange is
-                // an expensive EPT flush, so freeing a large region one page at a time stalls the guest for
-                // seconds. The LIFO GPA free list scatters a region's pages across non-adjacent and reverse-ordered
-                // guest-physical addresses, so sort them to recover every contiguous run before unmapping.
-                //
-                // Free pages high-to-low so released GPA indices land on the LIFO free list in descending order;
-                // the next large allocation then pops them back ascending, keeping remap_pages' contiguous-run
-                // check effective so re-mapping the region stays coalesced too.
+                // Coalesce into one WHvUnmapGpaRange per contiguous guest-physical run: each call is an EPT flush,
+                // so freeing a large region page-by-page stalls the guest for seconds. The LIFO GPA free list
+                // scatters/reverses a region's GPAs, hence the sort. Free high-to-low so the indices pop back
+                // ascending on the next allocation, keeping remap_pages' map-side coalescing effective too.
                 std::vector<uint64_t> unmap_gpas;
                 bool flushed_virtual_mappings = false;
                 for (size_t offset = size; offset > 0; offset -= page_size)
@@ -3378,12 +3373,10 @@ namespace sogen::whp
                 if (exception.ExceptionType == WHvX64ExceptionTypeSimdFloatingPointFault ||
                     exception.ExceptionType == WHvX64ExceptionTypeFloatingPointErrorFault)
                 {
-                    // There is no guest IDT, so an FP exception cannot be vectored by the CPU - it would read
-                    // the null IDT (e.g. IDT[19] = 0x130 for #XM) and fault. The guest reaches here only because
-                    // its MXCSR / x87 control word has the exception masks cleared, which is never the Windows
-                    // user-mode default (0x1F80 / 0x037F = all masked) and is a corrupted state. Restore the
-                    // masked defaults and clear the sticky exception flags, then let the faulting SSE/x87
-                    // instruction re-run; it now completes (producing NaN/inf) exactly as it would on Windows.
+                    // With no guest IDT, an unhandled FP exception faults at IDT[vec] (e.g. 0x130 for #XM). The
+                    // guest only reaches here with its FP exception masks cleared (a corrupted MXCSR/x87 control
+                    // word); restore the masked Windows defaults and re-run the instruction so it completes as it
+                    // would natively.
                     const auto mxcsr = this->reg<uint32_t>(x86_register::mxcsr);
                     this->reg(x86_register::mxcsr, (mxcsr | 0x1F80u) & ~0x3Fu);
                     const auto fpcw = this->reg<uint16_t>(x86_register::fpcw);

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1257,7 +1257,7 @@ namespace sogen::whp
                     this->mapped_pages_.erase(entry);
                 }
 
-                std::sort(unmap_gpas.begin(), unmap_gpas.end());
+                std::ranges::sort(unmap_gpas);
                 for (size_t i = 0; i < unmap_gpas.size();)
                 {
                     size_t j = i;

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -3381,6 +3381,10 @@ namespace sogen::whp
                     this->reg(x86_register::mxcsr, (mxcsr | 0x1F80u) & ~0x3Fu);
                     const auto fpcw = this->reg<uint16_t>(x86_register::fpcw);
                     this->reg(x86_register::fpcw, static_cast<uint16_t>(fpcw | 0x3Fu));
+                    // Also clear the x87 status-word exception flags / summary (ES) bit, or an FWAIT or following
+                    // x87 op would re-raise #MF on the rerun.
+                    const auto fpsw = this->reg<uint16_t>(x86_register::fpsw);
+                    this->reg(x86_register::fpsw, static_cast<uint16_t>(fpsw & ~0x80FFu));
                     return true;
                 }
 

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1228,11 +1228,16 @@ namespace sogen::whp
                     throw std::runtime_error("WHP memory unmappings must be page aligned");
                 }
 
+                // Collect the guest-physical pages backing this region and run the per-page bookkeeping, then drop
+                // them from the partition with as few WHvUnmapGpaRange calls as possible. Each WHvUnmapGpaRange is
+                // an expensive EPT flush, so freeing a large region one page at a time stalls the guest for
+                // seconds. The LIFO GPA free list scatters a region's pages across non-adjacent and reverse-ordered
+                // guest-physical addresses, so sort them to recover every contiguous run before unmapping.
+                std::vector<uint64_t> unmap_gpas;
                 bool flushed_virtual_mappings = false;
-                for (size_t offset = size; offset > 0; offset -= page_size)
+                for (size_t offset = 0; offset < size; offset += page_size)
                 {
-                    const auto guest_address = address + offset - page_size;
-
+                    const auto guest_address = address + offset;
                     this->revoke_mmio_read_grace(guest_address);
 
                     const auto entry = this->mapped_pages_.find(guest_address);
@@ -1243,13 +1248,26 @@ namespace sogen::whp
 
                     if (entry->second->map_flags != 0)
                     {
-                        WHP_CHECK_HR(WHvUnmapGpaRange(this->partition_, entry->second->guest_physical_address, page_size));
+                        unmap_gpas.push_back(entry->second->guest_physical_address);
                     }
 
                     flushed_virtual_mappings = this->clear_virtual_mapping(guest_address) || flushed_virtual_mappings;
                     this->mark_patched_execution_breakpoints_unmapped(guest_address);
                     this->release_guest_physical_page(entry->second->guest_physical_address);
                     this->mapped_pages_.erase(entry);
+                }
+
+                std::sort(unmap_gpas.begin(), unmap_gpas.end());
+                for (size_t i = 0; i < unmap_gpas.size();)
+                {
+                    size_t j = i;
+                    while (j + 1 < unmap_gpas.size() && unmap_gpas[j + 1] == unmap_gpas[j] + page_size)
+                    {
+                        ++j;
+                    }
+
+                    WHP_CHECK_HR(WHvUnmapGpaRange(this->partition_, unmap_gpas[i], (j - i + 1) * page_size));
+                    i = j + 1;
                 }
 
                 if (flushed_virtual_mappings)

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1847,7 +1847,8 @@ namespace sogen::whp
                     WHV_PARTITION_PROPERTY exception_exit_bitmap{};
                     exception_exit_bitmap.ExceptionExitBitmap =
                         (1ull << WHvX64ExceptionTypeDebugTrapOrFault) | (1ull << WHvX64ExceptionTypeBreakpointTrap) |
-                        (1ull << WHvX64ExceptionTypeInvalidOpcodeFault) | (1ull << WHvX64ExceptionTypePageFault);
+                        (1ull << WHvX64ExceptionTypeInvalidOpcodeFault) | (1ull << WHvX64ExceptionTypePageFault) |
+                        (1ull << WHvX64ExceptionTypeFloatingPointErrorFault) | (1ull << WHvX64ExceptionTypeSimdFloatingPointFault);
 
                     WHP_CHECK_HR(WHvSetPartitionProperty(this->partition_, WHvPartitionPropertyCodeExceptionExitBitmap,
                                                          &exception_exit_bitmap, sizeof(exception_exit_bitmap)));
@@ -3350,6 +3351,22 @@ namespace sogen::whp
                     {
                         return true;
                     }
+                }
+
+                if (exception.ExceptionType == WHvX64ExceptionTypeSimdFloatingPointFault ||
+                    exception.ExceptionType == WHvX64ExceptionTypeFloatingPointErrorFault)
+                {
+                    // There is no guest IDT, so an FP exception cannot be vectored by the CPU - it would read
+                    // the null IDT (e.g. IDT[19] = 0x130 for #XM) and fault. The guest reaches here only because
+                    // its MXCSR / x87 control word has the exception masks cleared, which is never the Windows
+                    // user-mode default (0x1F80 / 0x037F = all masked) and is a corrupted state. Restore the
+                    // masked defaults and clear the sticky exception flags, then let the faulting SSE/x87
+                    // instruction re-run; it now completes (producing NaN/inf) exactly as it would on Windows.
+                    const auto mxcsr = this->reg<uint32_t>(x86_register::mxcsr);
+                    this->reg(x86_register::mxcsr, (mxcsr | 0x1F80u) & ~0x3Fu);
+                    const auto fpcw = this->reg<uint16_t>(x86_register::fpcw);
+                    this->reg(x86_register::fpcw, static_cast<uint16_t>(fpcw | 0x3Fu));
+                    return true;
                 }
 
                 for (auto& [_, hook] : this->interrupt_hooks_)

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1233,6 +1233,9 @@ namespace sogen::whp
                 // scatters/reverses a region's GPAs, hence the sort. Free high-to-low so the indices pop back
                 // ascending on the next allocation, keeping remap_pages' map-side coalescing effective too.
                 std::vector<uint64_t> unmap_gpas;
+                // Keep each page's host backing alive until after the unmaps below: erasing the mapped_page drops
+                // its (shared) owned_page, which can free memory the WHP partition still maps by GPA.
+                std::vector<std::shared_ptr<uint8_t>> retired_backings;
                 bool flushed_virtual_mappings = false;
                 for (size_t offset = size; offset > 0; offset -= page_size)
                 {
@@ -1253,6 +1256,7 @@ namespace sogen::whp
                     flushed_virtual_mappings = this->clear_virtual_mapping(guest_address) || flushed_virtual_mappings;
                     this->mark_patched_execution_breakpoints_unmapped(guest_address);
                     this->release_guest_physical_page(entry->second->guest_physical_address);
+                    retired_backings.push_back(std::move(entry->second->owned_page));
                     this->mapped_pages_.erase(entry);
                 }
 

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -168,6 +168,11 @@ namespace sogen::gpu_bridge
         invalidate_mapped_memory_direct = 0x883,
         cmd_copy_image = 0x884,
         get_physical_device_memory_budget = 0x885,
+        // Coalesced vkUpdateDescriptorSets: the payload is a concatenation of one-or-more
+        // update_descriptor_sets_request blobs (each header + its descriptor_write[]). The shim buffers
+        // updates and flushes them in one IOCTL before any other bridge call, preserving issue order while
+        // collapsing the dominant per-frame round-trip count.
+        update_descriptor_sets_batch = 0x886,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -265,6 +270,8 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
+    inline constexpr uint32_t ioctl_update_descriptor_sets_batch =
+        make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
     inline constexpr uint32_t ioctl_create_sampler = make_ioctl(static_cast<uint32_t>(command::create_sampler));
     inline constexpr uint32_t ioctl_destroy_sampler = make_ioctl(static_cast<uint32_t>(command::destroy_sampler));
     inline constexpr uint32_t ioctl_enumerate_device_extension_properties =

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -270,8 +270,7 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
-    inline constexpr uint32_t ioctl_update_descriptor_sets_batch =
-        make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
+    inline constexpr uint32_t ioctl_update_descriptor_sets_batch = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
     inline constexpr uint32_t ioctl_create_sampler = make_ioctl(static_cast<uint32_t>(command::create_sampler));
     inline constexpr uint32_t ioctl_destroy_sampler = make_ioctl(static_cast<uint32_t>(command::destroy_sampler));
     inline constexpr uint32_t ioctl_enumerate_device_extension_properties =

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -168,10 +168,8 @@ namespace sogen::gpu_bridge
         invalidate_mapped_memory_direct = 0x883,
         cmd_copy_image = 0x884,
         get_physical_device_memory_budget = 0x885,
-        // Coalesced vkUpdateDescriptorSets: the payload is a concatenation of one-or-more
-        // update_descriptor_sets_request blobs (each header + its descriptor_write[]). The shim buffers
-        // updates and flushes them in one IOCTL before any other bridge call, preserving issue order while
-        // collapsing the dominant per-frame round-trip count.
+        // Coalesced vkUpdateDescriptorSets: payload is a concatenation of update_descriptor_sets_request blobs
+        // (each a header + its descriptor_write[]), applied in issue order.
         update_descriptor_sets_batch = 0x886,
     };
 

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -148,17 +148,18 @@ namespace
 
     void flush_descriptor_updates()
     {
-        // Swap the batch out under the lock, then release it before the IOCTL so the nested flush-guard and
-        // concurrent appends don't deadlock.
-        std::vector<uint8_t> batch;
+        // Hold the lock across the IOCTL so concurrent flushes stay ordered: releasing it after the swap lets a
+        // preempting thread append + flush and get its batch applied on the host before this (earlier) one. The
+        // batch IOCTL never re-enters flush_descriptor_updates (bridge_call skips the flush for it) and runs
+        // synchronously, so the lock cannot self-deadlock; a preempted appender just waits for this flush.
+        std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);
+        if (g_pending_descriptor_updates.empty())
         {
-            std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);
-            if (g_pending_descriptor_updates.empty())
-            {
-                return;
-            }
-            batch.swap(g_pending_descriptor_updates);
+            return;
         }
+
+        std::vector<uint8_t> batch;
+        batch.swap(g_pending_descriptor_updates);
 
         gb::result_response response{};
         bridge_call(gb::ioctl_update_descriptor_sets_batch, batch.data(), static_cast<DWORD>(batch.size()), &response, sizeof(response));

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -170,8 +170,7 @@ namespace
         }
 
         gb::result_response response{};
-        bridge_call(gb::ioctl_update_descriptor_sets_batch, batch.data(), static_cast<DWORD>(batch.size()), &response,
-                    sizeof(response));
+        bridge_call(gb::ioctl_update_descriptor_sets_batch, batch.data(), static_cast<DWORD>(batch.size()), &response, sizeof(response));
     }
 
     void record_command(gb::object_id command_buffer, gb::command command, const void* payload, size_t size)

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -44,8 +45,20 @@ namespace
         return g_bridge;
     }
 
+    // Flushes any descriptor-set updates the shim has coalesced (see vkUpdateDescriptorSets). Defined
+    // below, but called from bridge_call so every host-observable operation sees prior updates applied.
+    void flush_descriptor_updates();
+
     bool bridge_call(uint32_t code, const void* in, DWORD in_len, void* out, DWORD out_len)
     {
+        // Any bridge call other than the descriptor-update flush itself is a point where the host might
+        // observe descriptor state (command recording, submit, ...), so drain pending updates first. This
+        // keeps the host's descriptor state identical to the un-batched path at every observation point.
+        if (code != gb::ioctl_update_descriptor_sets_batch)
+        {
+            flush_descriptor_updates();
+        }
+
         const HANDLE handle = bridge();
         if (handle == INVALID_HANDLE_VALUE)
         {
@@ -127,6 +140,39 @@ namespace
     // emulated frame time. The shim only runs inside the single-threaded emulator, so the map needs no
     // lock. Each record is a gb::command_record_header followed by that command's request payload.
     std::unordered_map<gb::object_id, std::vector<uint8_t>> g_command_streams;
+
+    // vkUpdateDescriptorSets is by far the most frequent bridge call (DXVK updates descriptors per draw).
+    // Each is void-returning and only mutates host descriptor state, so instead of one IOCTL apiece the
+    // shim appends each update's wire blob here and flushes the lot in a single IOCTL right before the next
+    // host-observable bridge call. Issue order is preserved, so the host sees exactly the same descriptor
+    // state at every observation point as the un-batched path did.
+    //
+    // Unlike the per-command-buffer streams (each externally synchronised to one thread by Vulkan), this is
+    // a single global touched by every DXVK thread. The emulator runs one guest thread at a time, but the
+    // preemptive time-slice can interrupt a thread mid-append, so a second thread's append/flush would
+    // observe a half-mutated vector. The mutex makes append and flush-swap atomic against that.
+    std::vector<uint8_t> g_pending_descriptor_updates;
+    std::mutex g_pending_descriptor_updates_mutex;
+
+    void flush_descriptor_updates()
+    {
+        // Move the buffer out under the lock so the IOCTL (and any concurrent append) operates on a stable
+        // local copy. The lock is released before bridge_call so the nested flush-guard / further appends
+        // don't deadlock.
+        std::vector<uint8_t> batch;
+        {
+            std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);
+            if (g_pending_descriptor_updates.empty())
+            {
+                return;
+            }
+            batch.swap(g_pending_descriptor_updates);
+        }
+
+        gb::result_response response{};
+        bridge_call(gb::ioctl_update_descriptor_sets_batch, batch.data(), static_cast<DWORD>(batch.size()), &response,
+                    sizeof(response));
+    }
 
     void record_command(gb::object_id command_buffer, gb::command command, const void* payload, size_t size)
     {
@@ -3561,15 +3607,18 @@ extern "C"
         header.device = to_object_id(device);
         header.write_count = static_cast<uint32_t>(writes.size());
 
-        std::vector<uint8_t> message(sizeof(header) + writes.size() * sizeof(gb::descriptor_write));
-        std::memcpy(message.data(), &header, sizeof(header));
+        // Append this update's blob (header + writes) to the pending batch instead of issuing an IOCTL now.
+        // flush_descriptor_updates() drains it before the next host-observable bridge call. The lock keeps
+        // the append atomic against a flush/append from another thread that preempts this one mid-insert.
+        const auto* header_bytes = reinterpret_cast<const uint8_t*>(&header);
+        const auto* write_bytes = reinterpret_cast<const uint8_t*>(writes.data());
+        std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);
+        g_pending_descriptor_updates.insert(g_pending_descriptor_updates.end(), header_bytes, header_bytes + sizeof(header));
         if (!writes.empty())
         {
-            std::memcpy(message.data() + sizeof(header), writes.data(), writes.size() * sizeof(gb::descriptor_write));
+            g_pending_descriptor_updates.insert(g_pending_descriptor_updates.end(), write_bytes,
+                                                write_bytes + writes.size() * sizeof(gb::descriptor_write));
         }
-
-        gb::result_response response{};
-        bridge_call(gb::ioctl_update_descriptor_sets, message.data(), static_cast<DWORD>(message.size()), &response, sizeof(response));
     }
 
     // Descriptor update templates are lowered entirely inside the shim: the template definition is kept

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -45,15 +45,13 @@ namespace
         return g_bridge;
     }
 
-    // Flushes any descriptor-set updates the shim has coalesced (see vkUpdateDescriptorSets). Defined
-    // below, but called from bridge_call so every host-observable operation sees prior updates applied.
+    // Flushes the coalesced descriptor-set updates (see vkUpdateDescriptorSets); defined below.
     void flush_descriptor_updates();
 
     bool bridge_call(uint32_t code, const void* in, DWORD in_len, void* out, DWORD out_len)
     {
-        // Any bridge call other than the descriptor-update flush itself is a point where the host might
-        // observe descriptor state (command recording, submit, ...), so drain pending updates first. This
-        // keeps the host's descriptor state identical to the un-batched path at every observation point.
+        // Every other bridge call may make the host observe descriptor state (record, submit, ...), so drain
+        // pending updates first to keep host state identical to the un-batched path.
         if (code != gb::ioctl_update_descriptor_sets_batch)
         {
             flush_descriptor_updates();
@@ -141,24 +139,17 @@ namespace
     // lock. Each record is a gb::command_record_header followed by that command's request payload.
     std::unordered_map<gb::object_id, std::vector<uint8_t>> g_command_streams;
 
-    // vkUpdateDescriptorSets is by far the most frequent bridge call (DXVK updates descriptors per draw).
-    // Each is void-returning and only mutates host descriptor state, so instead of one IOCTL apiece the
-    // shim appends each update's wire blob here and flushes the lot in a single IOCTL right before the next
-    // host-observable bridge call. Issue order is preserved, so the host sees exactly the same descriptor
-    // state at every observation point as the un-batched path did.
-    //
-    // Unlike the per-command-buffer streams (each externally synchronised to one thread by Vulkan), this is
-    // a single global touched by every DXVK thread. The emulator runs one guest thread at a time, but the
-    // preemptive time-slice can interrupt a thread mid-append, so a second thread's append/flush would
-    // observe a half-mutated vector. The mutex makes append and flush-swap atomic against that.
+    // Pending coalesced vkUpdateDescriptorSets blobs (the hottest bridge call - DXVK updates per draw).
+    // Unlike the per-command-buffer streams (each synchronised to one thread by Vulkan), this global is
+    // touched by every DXVK thread, and the preemptive time-slice can interrupt a thread mid-append, so the
+    // mutex makes append and flush-swap atomic.
     std::vector<uint8_t> g_pending_descriptor_updates;
     std::mutex g_pending_descriptor_updates_mutex;
 
     void flush_descriptor_updates()
     {
-        // Move the buffer out under the lock so the IOCTL (and any concurrent append) operates on a stable
-        // local copy. The lock is released before bridge_call so the nested flush-guard / further appends
-        // don't deadlock.
+        // Swap the batch out under the lock, then release it before the IOCTL so the nested flush-guard and
+        // concurrent appends don't deadlock.
         std::vector<uint8_t> batch;
         {
             std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);
@@ -3606,9 +3597,7 @@ extern "C"
         header.device = to_object_id(device);
         header.write_count = static_cast<uint32_t>(writes.size());
 
-        // Append this update's blob (header + writes) to the pending batch instead of issuing an IOCTL now.
-        // flush_descriptor_updates() drains it before the next host-observable bridge call. The lock keeps
-        // the append atomic against a flush/append from another thread that preempts this one mid-insert.
+        // Append to the pending batch instead of issuing an IOCTL now (drained before the next bridge call).
         const auto* header_bytes = reinterpret_cast<const uint8_t*>(&header);
         const auto* write_bytes = reinterpret_cast<const uint8_t*>(writes.data());
         std::lock_guard<std::mutex> lock(g_pending_descriptor_updates_mutex);

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -901,12 +901,10 @@ namespace sogen
                 const auto flags = request.flags;
                 const auto count = request.semaphore_count;
 
-                // Poll once without blocking.
                 const int32_t poll = this->vulkan_.wait_semaphores(device, flags, entries.data(), count, 0);
 
-                // Already signaled, an error, or a finite-timeout wait: handle inline. A finite wait still
-                // blocks the VP for its (bounded) duration, but those are rare -- the hot path is DXVK's
-                // infinite frame waits, handled cooperatively below.
+                // Signaled, errored, or a finite-timeout wait: handle inline. The hot path is DXVK's infinite
+                // frame waits, parked cooperatively below.
                 if (poll != vk_timeout || request.timeout != UINT64_MAX)
                 {
                     const int32_t result =
@@ -914,11 +912,9 @@ namespace sogen
                     return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
                 }
 
-                // Infinite wait, not yet signaled: blocking here would freeze the single VP (and every other
-                // guest thread) for the whole GPU wait. Instead pre-write the success result and park this
-                // thread on a predicate that polls the semaphore; the scheduler runs other guest threads
-                // meanwhile and wakes this one when the GPU signals. An infinite wait never times out, so the
-                // result is always VK_SUCCESS.
+                // Infinite wait, not yet signaled: blocking would freeze the single VP and every guest thread.
+                // Park on a semaphore-polling predicate instead, so the scheduler runs other threads and wakes
+                // this one when the GPU signals.
                 const auto out_status = write_output(win_emu, context, gpu_bridge::result_response{.vk_result = vk_success, .reserved = 0});
                 if (out_status != STATUS_SUCCESS)
                 {
@@ -933,8 +929,7 @@ namespace sogen
                     {
                         return false;
                     }
-                    // Propagate the real result (success, or an error such as device loss), overwriting the
-                    // pre-written success, so error cases reach the guest instead of parking the thread forever.
+                    // Propagate the real result so an error (e.g. device loss) reaches the guest instead of hanging.
                     write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
                     return true;
                 };
@@ -2127,10 +2122,8 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            // Applies one update_descriptor_sets_request blob (header followed by `write_count`
-            // descriptor_write records) from a host-side byte buffer. Shared by the single IOCTL and the
-            // coalesced batch. Returns the VkResult, or VK_ERROR_INITIALIZATION_FAILED on a malformed record,
-            // and advances `offset` past the consumed blob.
+            // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
+            // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.
             int32_t apply_update_descriptor_sets(const std::byte* data, size_t size, size_t& offset)
             {
                 constexpr int32_t vk_error_initialization_failed = -3; // VK_ERROR_INITIALIZATION_FAILED (no vulkan.h here)
@@ -2187,8 +2180,7 @@ namespace sogen
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
 
-            // Coalesced vkUpdateDescriptorSets: the input buffer is a concatenation of update blobs, applied
-            // in order (preserving the guest's issue order). See command::update_descriptor_sets_batch.
+            // Applies a concatenation of update_descriptor_sets blobs in order (see update_descriptor_sets_batch).
             NTSTATUS handle_update_descriptor_sets_batch(windows_emulator& win_emu, const io_device_context& context)
             {
                 if (!context.input_buffer || context.input_buffer_length == 0)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -926,8 +926,17 @@ namespace sogen
                 }
 
                 auto* vulkan = &this->vulkan_;
-                win_emu.current_thread().await_host_condition = [vulkan, device, flags, entries = std::move(entries), count]() {
-                    return vulkan->wait_semaphores(device, flags, entries.data(), count, 0) == 0 /* VK_SUCCESS */;
+                win_emu.current_thread().await_host_condition = [vulkan, &win_emu, context, device, flags, entries = std::move(entries),
+                                                                 count]() {
+                    const int32_t result = vulkan->wait_semaphores(device, flags, entries.data(), count, 0);
+                    if (result == vk_timeout)
+                    {
+                        return false;
+                    }
+                    // Propagate the real result (success, or an error such as device loss), overwriting the
+                    // pre-written success, so error cases reach the guest instead of parking the thread forever.
+                    write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+                    return true;
                 };
                 win_emu.yield_thread(false);
                 return STATUS_SUCCESS;

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -206,6 +206,8 @@ namespace sogen
                     return handle_allocate_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets:
                     return handle_update_descriptor_sets(win_emu, context);
+                case gpu_bridge::ioctl_update_descriptor_sets_batch:
+                    return handle_update_descriptor_sets_batch(win_emu, context);
                 case gpu_bridge::ioctl_create_sampler:
                     return handle_create_sampler(win_emu, context);
                 case gpu_bridge::ioctl_destroy_sampler:
@@ -2082,38 +2084,93 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            NTSTATUS handle_update_descriptor_sets(windows_emulator& win_emu, const io_device_context& context)
+            // Applies one update_descriptor_sets_request blob (header followed by `write_count`
+            // descriptor_write records) from a host-side byte buffer. Shared by the single IOCTL and the
+            // coalesced batch. Returns the VkResult, or VK_ERROR_INITIALIZATION_FAILED on a malformed record,
+            // and advances `offset` past the consumed blob.
+            int32_t apply_update_descriptor_sets(const std::byte* data, size_t size, size_t& offset)
             {
+                constexpr int32_t vk_error_initialization_failed = -3; // VK_ERROR_INITIALIZATION_FAILED (no vulkan.h here)
                 using request_t = gpu_bridge::update_descriptor_sets_request;
 
+                if (size - offset < sizeof(request_t))
+                {
+                    return vk_error_initialization_failed;
+                }
+
                 request_t request{};
-                if (!read_input(win_emu, context, request))
+                std::memcpy(&request, data + offset, sizeof(request));
+                offset += sizeof(request);
+
+                const size_t writes_bytes = static_cast<size_t>(request.write_count) * sizeof(gpu_bridge::descriptor_write);
+                if (size - offset < writes_bytes)
+                {
+                    return vk_error_initialization_failed;
+                }
+
+                std::vector<vulkan_host::descriptor_write> writes(request.write_count);
+                for (size_t i = 0; i < request.write_count; ++i)
+                {
+                    gpu_bridge::descriptor_write w{};
+                    std::memcpy(&w, data + offset + i * sizeof(w), sizeof(w));
+                    writes[i] = {.dst_set = w.dst_set,
+                                 .dst_binding = w.dst_binding,
+                                 .dst_array_element = w.dst_array_element,
+                                 .descriptor_type = w.descriptor_type,
+                                 .buffer = w.buffer,
+                                 .offset = w.offset,
+                                 .range = w.range,
+                                 .sampler = w.sampler,
+                                 .image_view = w.image_view,
+                                 .image_layout = w.image_layout};
+                }
+                offset += writes_bytes;
+
+                return this->vulkan_.update_descriptor_sets(request.device, writes);
+            }
+
+            NTSTATUS handle_update_descriptor_sets(windows_emulator& win_emu, const io_device_context& context)
+            {
+                if (!context.input_buffer || context.input_buffer_length < sizeof(gpu_bridge::update_descriptor_sets_request))
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                std::vector<gpu_bridge::descriptor_write> wire;
-                if (!read_trailing_array(win_emu, context, sizeof(request_t), request.write_count, wire))
+                std::vector<std::byte> buffer(context.input_buffer_length);
+                win_emu.emu().read_memory(context.input_buffer, buffer.data(), buffer.size());
+
+                size_t offset = 0;
+                const int32_t result = this->apply_update_descriptor_sets(buffer.data(), buffer.size(), offset);
+                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+            }
+
+            // Coalesced vkUpdateDescriptorSets: the input buffer is a concatenation of update blobs, applied
+            // in order (preserving the guest's issue order). See command::update_descriptor_sets_batch.
+            NTSTATUS handle_update_descriptor_sets_batch(windows_emulator& win_emu, const io_device_context& context)
+            {
+                if (!context.input_buffer || context.input_buffer_length == 0)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                std::vector<vulkan_host::descriptor_write> writes(wire.size());
-                for (size_t i = 0; i < wire.size(); ++i)
+                std::vector<std::byte> buffer(context.input_buffer_length);
+                win_emu.emu().read_memory(context.input_buffer, buffer.data(), buffer.size());
+
+                int32_t result = 0; // VK_SUCCESS
+                size_t offset = 0;
+                while (offset + sizeof(gpu_bridge::update_descriptor_sets_request) <= buffer.size())
                 {
-                    writes[i] = {.dst_set = wire[i].dst_set,
-                                 .dst_binding = wire[i].dst_binding,
-                                 .dst_array_element = wire[i].dst_array_element,
-                                 .descriptor_type = wire[i].descriptor_type,
-                                 .buffer = wire[i].buffer,
-                                 .offset = wire[i].offset,
-                                 .range = wire[i].range,
-                                 .sampler = wire[i].sampler,
-                                 .image_view = wire[i].image_view,
-                                 .image_layout = wire[i].image_layout};
+                    const int32_t r = this->apply_update_descriptor_sets(buffer.data(), buffer.size(), offset);
+                    if (r != 0 && result == 0)
+                    {
+                        result = r; // report the first failure
+                    }
+                    if (r == -3) // malformed record: stop to avoid spinning on a bad offset
+                    {
+                        break;
+                    }
                 }
 
-                const int32_t result = this->vulkan_.update_descriptor_sets(request.device, writes);
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -894,9 +894,45 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const int32_t result =
-                    this->vulkan_.wait_semaphores(request.device, request.flags, entries.data(), request.semaphore_count, request.timeout);
-                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+                constexpr int32_t vk_success = 0;
+                constexpr int32_t vk_timeout = 2;
+
+                const auto device = request.device;
+                const auto flags = request.flags;
+                const auto count = request.semaphore_count;
+
+                // Poll once without blocking.
+                const int32_t poll = this->vulkan_.wait_semaphores(device, flags, entries.data(), count, 0);
+
+                // Already signaled, an error, or a finite-timeout wait: handle inline. A finite wait still
+                // blocks the VP for its (bounded) duration, but those are rare -- the hot path is DXVK's
+                // infinite frame waits, handled cooperatively below.
+                if (poll != vk_timeout || request.timeout != UINT64_MAX)
+                {
+                    const int32_t result = (poll == vk_timeout)
+                                               ? this->vulkan_.wait_semaphores(device, flags, entries.data(), count, request.timeout)
+                                               : poll;
+                    return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+                }
+
+                // Infinite wait, not yet signaled: blocking here would freeze the single VP (and every other
+                // guest thread) for the whole GPU wait. Instead pre-write the success result and park this
+                // thread on a predicate that polls the semaphore; the scheduler runs other guest threads
+                // meanwhile and wakes this one when the GPU signals. An infinite wait never times out, so the
+                // result is always VK_SUCCESS.
+                const auto out_status =
+                    write_output(win_emu, context, gpu_bridge::result_response{.vk_result = vk_success, .reserved = 0});
+                if (out_status != STATUS_SUCCESS)
+                {
+                    return out_status;
+                }
+
+                auto* vulkan = &this->vulkan_;
+                win_emu.current_thread().await_host_condition = [vulkan, device, flags, entries = std::move(entries), count]() {
+                    return vulkan->wait_semaphores(device, flags, entries.data(), count, 0) == 0 /* VK_SUCCESS */;
+                };
+                win_emu.yield_thread(false);
+                return STATUS_SUCCESS;
             }
 
             NTSTATUS handle_get_buffer_device_address(windows_emulator& win_emu, const io_device_context& context)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2122,6 +2122,9 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            // Cap guest-declared descriptor-update payloads so a bogus IOCTL length can't force a huge allocation.
+            static constexpr size_t max_descriptor_update_input_bytes = size_t{256} * 1024 * 1024;
+
             // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
             // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.
             int32_t apply_update_descriptor_sets(const std::byte* data, size_t size, size_t& offset)
@@ -2167,7 +2170,8 @@ namespace sogen
 
             NTSTATUS handle_update_descriptor_sets(windows_emulator& win_emu, const io_device_context& context)
             {
-                if (!context.input_buffer || context.input_buffer_length < sizeof(gpu_bridge::update_descriptor_sets_request))
+                if (!context.input_buffer || context.input_buffer_length < sizeof(gpu_bridge::update_descriptor_sets_request) ||
+                    context.input_buffer_length > max_descriptor_update_input_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
@@ -2183,7 +2187,8 @@ namespace sogen
             // Applies a concatenation of update_descriptor_sets blobs in order (see update_descriptor_sets_batch).
             NTSTATUS handle_update_descriptor_sets_batch(windows_emulator& win_emu, const io_device_context& context)
             {
-                if (!context.input_buffer || context.input_buffer_length == 0)
+                if (!context.input_buffer || context.input_buffer_length == 0 ||
+                    context.input_buffer_length > max_descriptor_update_input_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -909,9 +909,8 @@ namespace sogen
                 // infinite frame waits, handled cooperatively below.
                 if (poll != vk_timeout || request.timeout != UINT64_MAX)
                 {
-                    const int32_t result = (poll == vk_timeout)
-                                               ? this->vulkan_.wait_semaphores(device, flags, entries.data(), count, request.timeout)
-                                               : poll;
+                    const int32_t result =
+                        (poll == vk_timeout) ? this->vulkan_.wait_semaphores(device, flags, entries.data(), count, request.timeout) : poll;
                     return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
                 }
 
@@ -920,8 +919,7 @@ namespace sogen
                 // thread on a predicate that polls the semaphore; the scheduler runs other guest threads
                 // meanwhile and wakes this one when the GPU signals. An infinite wait never times out, so the
                 // result is always VK_SUCCESS.
-                const auto out_status =
-                    write_output(win_emu, context, gpu_bridge::result_response{.vk_result = vk_success, .reserved = 0});
+                const auto out_status = write_output(win_emu, context, gpu_bridge::result_response{.vk_result = vk_success, .reserved = 0});
                 if (out_status != STATUS_SUCCESS)
                 {
                     return out_status;

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -923,9 +923,8 @@ namespace sogen
 
         if (this->await_host_condition)
         {
-            // GPU-bridge cooperative wait: poll the host predicate (a Vulkan semaphore poll). The wait is
-            // only ever armed with an infinite timeout, so it completes with STATUS_SUCCESS when ready and
-            // otherwise just stays parked (complete_if_timed_out is a no-op without an await_time).
+            // Cooperative host wait (e.g. a GPU-bridge semaphore poll): ready when the predicate signals,
+            // otherwise stay parked.
             if (this->await_host_condition())
             {
                 this->mark_as_ready(STATUS_SUCCESS);

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -580,6 +580,7 @@ namespace sogen
         this->await_msg = {};
         this->await_msg_mask = {};
         this->await_io_completion = {};
+        this->await_host_condition = {};
 
         // TODO: Find out if this is correct
         if (this->waiting_for_alert)
@@ -918,6 +919,20 @@ namespace sogen
         if (this->await_time.has_value())
         {
             return complete_if_timed_out(STATUS_SUCCESS);
+        }
+
+        if (this->await_host_condition)
+        {
+            // GPU-bridge cooperative wait: poll the host predicate (a Vulkan semaphore poll). The wait is
+            // only ever armed with an infinite timeout, so it completes with STATUS_SUCCESS when ready and
+            // otherwise just stays parked (complete_if_timed_out is a no-op without an await_time).
+            if (this->await_host_condition())
+            {
+                this->mark_as_ready(STATUS_SUCCESS);
+                return true;
+            }
+
+            return complete_if_timed_out(STATUS_TIMEOUT);
         }
 
         if (this->await_io_completion.has_value())

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -4,6 +4,8 @@
 #include "emulator_utils.hpp"
 #include "memory_manager.hpp"
 
+#include <functional>
+
 #include <utils/moved_marker.hpp>
 
 namespace sogen
@@ -300,6 +302,12 @@ namespace sogen
         std::optional<pending_msg> await_msg{};
         std::optional<DWORD> await_msg_mask{};
         std::optional<pending_io_completion_wait> await_io_completion{};
+
+        // When set, the thread is parked until this host-side predicate returns true. Used by the GPU
+        // bridge to wait on a Vulkan semaphore cooperatively (other guest threads run while the GPU works)
+        // instead of blocking the single VP. Polled by is_thread_ready and completed via
+        // mark_as_ready(STATUS_SUCCESS). Not serialized: the only user (GPU bridge) is not snapshotable.
+        std::function<bool()> await_host_condition{};
 
         bool apc_alertable{false};
         std::vector<pending_apc> pending_apcs{};

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -571,7 +571,10 @@ namespace sogen
             }
             else
             {
-                std::this_thread::sleep_for(1ms);
+                // Yield rather than sleep: when every thread is parked (e.g. all blocked on a cooperative
+                // GPU wait), the scheduler re-polls readiness each iteration, so a 1ms sleep would cap how
+                // fast a GPU-finished thread can wake. Yielding re-polls the instant the GPU signals.
+                std::this_thread::yield();
             }
 
             if (this->should_stop)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -571,10 +571,29 @@ namespace sogen
             }
             else
             {
-                // Yield rather than sleep: when every thread is parked (e.g. all blocked on a cooperative
-                // GPU wait), the scheduler re-polls readiness each iteration, so a 1ms sleep would cap how
-                // fast a GPU-finished thread can wake. Yielding re-polls the instant the GPU signals.
-                std::this_thread::yield();
+                bool host_wait_pending = false;
+                for (const auto& thread_entry : this->process.threads)
+                {
+                    if (thread_entry.second.await_host_condition)
+                    {
+                        host_wait_pending = true;
+                        break;
+                    }
+                }
+
+                if (host_wait_pending)
+                {
+                    // A cooperative host wait (e.g. a GPU semaphore) is parked: only its host-side predicate can
+                    // make a thread ready, so re-poll immediately rather than sleeping, to wake it with minimal
+                    // latency the instant the GPU signals.
+                    std::this_thread::yield();
+                }
+                else
+                {
+                    // Only timed/object waits are outstanding; nothing host-side can change readiness sooner than
+                    // wall-clock time, so sleep rather than busy-spinning a CPU for the whole guest timeout.
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
             }
 
             if (this->should_stop)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -583,15 +583,12 @@ namespace sogen
 
                 if (host_wait_pending)
                 {
-                    // A cooperative host wait (e.g. a GPU semaphore) is parked: only its host-side predicate can
-                    // make a thread ready, so re-poll immediately rather than sleeping, to wake it with minimal
-                    // latency the instant the GPU signals.
+                    // A host wait (e.g. a GPU semaphore) is parked - re-poll immediately to wake it promptly.
                     std::this_thread::yield();
                 }
                 else
                 {
-                    // Only timed/object waits are outstanding; nothing host-side can change readiness sooner than
-                    // wall-clock time, so sleep rather than busy-spinning a CPU for the whole guest timeout.
+                    // Only timed waits remain; nothing host-side wakes sooner than wall-clock, so don't busy-spin.
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 }
             }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -185,6 +185,19 @@ namespace sogen
             return {.window = top_level, .x = x, .y = y};
         }
 
+        bool has_pending_host_wait(const process_context& process)
+        {
+            for (const auto& thread_entry : process.threads)
+            {
+                if (thread_entry.second.await_host_condition)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         void perform_context_switch_work(windows_emulator& win_emu)
         {
             auto& threads = win_emu.process.threads;
@@ -569,28 +582,15 @@ namespace sogen
             {
                 this->executed_instructions_ += MAX_INSTRUCTIONS_PER_TIME_SLICE;
             }
+            else if (has_pending_host_wait(this->process))
+            {
+                // A host wait (e.g. a GPU semaphore) is parked - re-poll immediately to wake it promptly.
+                std::this_thread::yield();
+            }
             else
             {
-                bool host_wait_pending = false;
-                for (const auto& thread_entry : this->process.threads)
-                {
-                    if (thread_entry.second.await_host_condition)
-                    {
-                        host_wait_pending = true;
-                        break;
-                    }
-                }
-
-                if (host_wait_pending)
-                {
-                    // A host wait (e.g. a GPU semaphore) is parked - re-poll immediately to wake it promptly.
-                    std::this_thread::yield();
-                }
-                else
-                {
-                    // Only timed waits remain; nothing host-side wakes sooner than wall-clock, so don't busy-spin.
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-                }
+                // Only timed waits remain; nothing host-side wakes sooner than wall-clock, so don't busy-spin.
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
 
             if (this->should_stop)


### PR DESCRIPTION
## Summary

Performance and stability work for the WHP backend and the GPU bridge, validated by running iw4x/MW2 in-game under WHP.

### WHP fixes (this session)

**`fix(whp): service guest FP exceptions instead of faulting through the null IDT`**
The WHP backend runs the guest with no IDT, so any CPU exception it doesn't intercept gets vectored by the hardware through the null IDT and faults at `IDT[vector]`. SIMD/x87 FP exceptions weren't intercepted: when the guest MXCSR loses its exception masks (corrupted to `0x20`), an SSE op on a NaN raises `#XM`, the CPU reads `IDT[19] = 0x130`, and it surfaces as a bogus "null-pointer call to 0x130" crash — an intermittent in-game crash in iw4x/MW2. Intercept `#XM`/`#MF` and service them by restoring the masked MXCSR/x87 defaults and re-running the instruction. In-game survival went from ~60-90s to 10+ minutes. The deeper MXCSR-corruption root cause and the need to faithfully deliver every exception vector are tracked in #1069.

**`perf(whp): coalesce guest memory unmaps into contiguous WHvUnmapGpaRange calls`**
`unmap_memory` issued one `WHvUnmapGpaRange` per 4 KiB page — each an EPT flush — so freeing a large region (a fastfile buffer on map load) meant tens of thousands of kernel calls. A single 1.6 GB free was ~412k calls; map loads stalled for 17+ seconds on one free (~22s total). Collect the region's guest-physical pages, sort them (the LIFO GPA free list scatters pages across non-adjacent/reverse-ordered GPAs), and drop each contiguous run with one call. The 1.6 GB free now collapses to a single ~0.3s call; fragmented frees drop ~10x in call count. The map-load freeze is gone.

### GPU-bridge batching (earlier on this branch)

**`perf(gpu-bridge): coalesce vkUpdateDescriptorSets into a batched IOCTL`** — `vkUpdateDescriptorSets` was ~92% of GPU-bridge IOCTLs in-game; batching them lifted MW2 from ~7fps toward 25-30fps.

**`perf(gpu-bridge): wait on Vulkan semaphores cooperatively`** — yield to the scheduler while waiting on host semaphores instead of blocking the vCPU thread.

## Testing

Ran iw4x/MW2 under WHP (`EMULATOR_WHP=1 analyzer -vc -ss iw4x.exe -console -stdout`), loaded maps and played multi-minute sessions. Confirmed: the `0x130` crash no longer occurs, map-load unmap stalls are eliminated, and frame rate is improved.
