### PR TITLE
open-iw5 SP bringup: caret/GDI/window syscalls + GPU-bridge vkResetDescriptorPool

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -1965,4 +1965,5 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(reset_command_buffer_request) == 16, "wire layout drift");
     static_assert(sizeof(get_physical_device_image_format_properties_request) == 32, "wire layout drift");
     static_assert(sizeof(get_physical_device_image_format_properties_response) == 40, "wire layout drift");
+    static_assert(sizeof(reset_descriptor_pool_request) == 24, "wire layout drift");
 }

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -171,6 +171,7 @@ namespace sogen::gpu_bridge
         // Coalesced vkUpdateDescriptorSets: payload is a concatenation of update_descriptor_sets_request blobs
         // (each a header + its descriptor_write[]), applied in issue order.
         update_descriptor_sets_batch = 0x886,
+        reset_descriptor_pool = 0x887,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -266,6 +267,7 @@ namespace sogen::gpu_bridge
         make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_set_layout));
     inline constexpr uint32_t ioctl_create_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::create_descriptor_pool));
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
+    inline constexpr uint32_t ioctl_reset_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::reset_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets_batch = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
@@ -1802,6 +1804,15 @@ namespace sogen::gpu_bridge
         uint32_t pool_size_count;
         uint32_t reserved;
         // descriptor_pool_size pool_sizes[pool_size_count];
+    };
+
+    // ioctl_reset_descriptor_pool: out = result_response
+    struct reset_descriptor_pool_request
+    {
+        object_id device;
+        object_id descriptor_pool;
+        uint32_t flags; // VkDescriptorPoolResetFlags (reserved, must be 0)
+        uint32_t reserved;
     };
 
     // ioctl_allocate_descriptor_sets: in header immediately followed by `set_count` object_id set-layout

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -3520,6 +3520,23 @@ extern "C"
         destroy_device_child(gb::ioctl_destroy_descriptor_pool, device, descriptorPool);
     }
 
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
+                                                                               VkDescriptorPoolResetFlags flags)
+    {
+        gb::reset_descriptor_pool_request request{};
+        request.device = to_object_id(device);
+        request.descriptor_pool = to_object_id(descriptorPool);
+        request.flags = flags;
+
+        gb::result_response response{};
+        if (!bridge_call(gb::ioctl_reset_descriptor_pool, &request, sizeof(request), &response, sizeof(response)) ||
+            response.vk_result != VK_SUCCESS)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        return VK_SUCCESS;
+    }
+
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice device,
                                                                                   const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                   VkDescriptorSet* pDescriptorSets)
@@ -4561,6 +4578,7 @@ extern "C"
             {.name = "vkDestroyDescriptorSetLayout", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorSetLayout)},
             {.name = "vkCreateDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorPool)},
             {.name = "vkDestroyDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorPool)},
+            {.name = "vkResetDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkResetDescriptorPool)},
             {.name = "vkAllocateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkAllocateDescriptorSets)},
             {.name = "vkUpdateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSets)},
             {.name = "vkCreateDescriptorUpdateTemplate", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorUpdateTemplate)},

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -163,6 +163,7 @@ EXPORTS
     vkReleaseSwapchainImagesEXT
     vkResetCommandBuffer
     vkResetCommandPool
+    vkResetDescriptorPool
     vkResetQueryPool
     vkResetFences
     vkSubmitDebugUtilsMessageEXT

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -202,6 +202,8 @@ namespace sogen
                     return handle_create_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_destroy_descriptor_pool:
                     return handle_destroy_descriptor_pool(win_emu, context);
+                case gpu_bridge::ioctl_reset_descriptor_pool:
+                    return handle_reset_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_allocate_descriptor_sets:
                     return handle_allocate_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets:
@@ -2081,6 +2083,18 @@ namespace sogen
                 }
                 this->vulkan_.destroy_descriptor_pool(request.device, request.object);
                 return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_reset_descriptor_pool(windows_emulator& win_emu, const io_device_context& context)
+            {
+                gpu_bridge::reset_descriptor_pool_request request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const int32_t result = this->vulkan_.reset_descriptor_pool(request.device, request.descriptor_pool, request.flags);
+                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
 
             NTSTATUS handle_allocate_descriptor_sets(windows_emulator& win_emu, const io_device_context& context)

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -4233,7 +4233,14 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        return dev->second.reset_descriptor_pool(dev->second.handle, it->second.handle, static_cast<VkDescriptorPoolResetFlags>(flags));
+        const int32_t result =
+            dev->second.reset_descriptor_pool(dev->second.handle, it->second.handle, static_cast<VkDescriptorPoolResetFlags>(flags));
+        if (result == VK_SUCCESS)
+        {
+            // The reset implicitly frees every set allocated from this pool; drop their ids.
+            this->impl_->erase_owned(this->impl_->descriptor_sets, [&](const impl::descriptor_set_data& d) { return d.pool_id == pool; });
+        }
+        return result;
     }
 
     void vulkan_host::destroy_descriptor_pool(uint64_t device, uint64_t pool)

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -263,6 +263,7 @@ namespace sogen
             PFN_vkDestroyDescriptorSetLayout destroy_descriptor_set_layout{};
             PFN_vkCreateDescriptorPool create_descriptor_pool{};
             PFN_vkDestroyDescriptorPool destroy_descriptor_pool{};
+            PFN_vkResetDescriptorPool reset_descriptor_pool{};
             PFN_vkAllocateDescriptorSets allocate_descriptor_sets{};
             PFN_vkUpdateDescriptorSets update_descriptor_sets{};
             PFN_vkCmdBindDescriptorSets cmd_bind_descriptor_sets{};
@@ -1593,6 +1594,7 @@ namespace sogen
                 reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(resolve("vkDestroyDescriptorSetLayout"));
             data.create_descriptor_pool = reinterpret_cast<PFN_vkCreateDescriptorPool>(resolve("vkCreateDescriptorPool"));
             data.destroy_descriptor_pool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(resolve("vkDestroyDescriptorPool"));
+            data.reset_descriptor_pool = reinterpret_cast<PFN_vkResetDescriptorPool>(resolve("vkResetDescriptorPool"));
             data.allocate_descriptor_sets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(resolve("vkAllocateDescriptorSets"));
             data.update_descriptor_sets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(resolve("vkUpdateDescriptorSets"));
             data.cmd_bind_descriptor_sets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(resolve("vkCmdBindDescriptorSets"));
@@ -4220,6 +4222,18 @@ namespace sogen
         this->impl_->descriptor_pools.emplace(id, impl::descriptor_pool_data{.handle = pool, .device_id = device});
         out_pool = id;
         return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags)
+    {
+        const auto dev = this->impl_->devices.find(device);
+        const auto it = this->impl_->descriptor_pools.find(pool);
+        if (dev == this->impl_->devices.end() || it == this->impl_->descriptor_pools.end() || !dev->second.reset_descriptor_pool)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        return dev->second.reset_descriptor_pool(dev->second.handle, it->second.handle, static_cast<VkDescriptorPoolResetFlags>(flags));
     }
 
     void vulkan_host::destroy_descriptor_pool(uint64_t device, uint64_t pool)

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -416,6 +416,7 @@ namespace sogen
         int32_t create_descriptor_set_layout(uint64_t device, std::span<const descriptor_binding> bindings, uint64_t& out_layout);
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
         int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
+        int32_t reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags);
         void destroy_descriptor_pool(uint64_t device, uint64_t pool);
         // Allocates one set per layout id; writes the allocated set ids into out_sets, out_count gets the
         // true count.

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -602,6 +602,12 @@ namespace sogen
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
         BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, hwnd hwnd, emulator_pointer data);
         BOOL handle_NtUserCreateCaret();
+        BOOL handle_NtUserSetCaretPos();
+        BOOL handle_NtUserShowCaret();
+        BOOL handle_NtUserHideCaret();
+        BOOL handle_NtUserDestroyCaret();
+        uint64_t handle_NtUserQueryWindow(const syscall_context& c, hwnd window_handle, uint32_t query_type);
+        int handle_NtUserSetScrollInfo();
         BOOL handle_NtUserIsTouchWindow();
         BOOL handle_NtUserGetWindowPlacement();
         BOOL handle_NtUserTrackMouseEvent();
@@ -663,6 +669,8 @@ namespace sogen
                                                             emulator_pointer unknown);
         BOOL handle_NtGdiGetTextExtent(const syscall_context& c, hdc dc, emulator_pointer text, int32_t char_count, emulator_pointer size,
                                        ULONG flags);
+        BOOL handle_NtGdiGetCharWidthW(const syscall_context& c, hdc dc, UINT first_char, UINT char_count, emulator_pointer chars,
+                                       UINT flags, emulator_pointer buffer);
         NTSTATUS handle_NtGdiExtCreateRegion();
         NTSTATUS handle_NtGdiTransparentBlt();
         uint64_t handle_NtGdiCreateRectRgn(const syscall_context& c, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
@@ -1189,6 +1197,7 @@ namespace sogen
         add_handler(NtGdiGetTextMetricsW);
         add_handler(NtGdiGetTextFaceW);
         add_handler(NtGdiGetTextExtent);
+        add_handler(NtGdiGetCharWidthW);
         add_handler(NtGdiGetGlyphOutline);
         add_handler(NtGdiCreateRectRgn);
         add_handler(NtGdiGetRandomRgn);
@@ -1474,6 +1483,12 @@ namespace sogen
         add_handler(NtUserSetWindowCompositionAttribute);
         add_handler(NtUserGetWindowPlacement);
         add_handler(NtUserCreateCaret);
+        add_handler(NtUserSetCaretPos);
+        add_handler(NtUserShowCaret);
+        add_handler(NtUserHideCaret);
+        add_handler(NtUserDestroyCaret);
+        add_handler(NtUserQueryWindow);
+        add_handler(NtUserSetScrollInfo);
         add_handler(NtUserTrackMouseEvent);
         add_handler(NtGdiGetOutlineTextMetricsInternalW);
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2313,6 +2313,19 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtGdiGetCharWidthW(const syscall_context& c, const hdc dc, const UINT /*first_char*/, const UINT char_count,
+                                       const emulator_pointer /*chars*/, const UINT /*flags*/, const emulator_pointer buffer)
+        {
+            if (dc == 0 || buffer == 0)
+            {
+                return FALSE;
+            }
+
+            const std::vector<int32_t> widths(char_count, static_cast<int32_t>(k_default_font_width));
+            c.emu.write_memory(buffer, widths.data(), widths.size() * sizeof(int32_t));
+            return TRUE;
+        }
+
         uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, const hdc dc, const UINT /*character*/, const UINT format,
                                              const emulator_pointer glyph_metrics, const DWORD buffer_size, const emulator_pointer buffer,
                                              const emulator_pointer mat2)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4418,6 +4418,49 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserSetCaretPos()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserShowCaret()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserHideCaret()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserDestroyCaret()
+        {
+            return TRUE;
+        }
+
+        uint64_t handle_NtUserQueryWindow(const syscall_context& c, const hwnd window_handle, const uint32_t query_type)
+        {
+            const auto* win = c.proc.windows.get(window_handle);
+            if (!win)
+            {
+                return 0;
+            }
+
+            // WINDOWINFOCLASS: WindowProcess (0) returns the owning process id; the single emulated process
+            // always has id 1 (see TEB ClientId.UniqueProcess). Everything else resolves to the thread.
+            if (query_type == 0)
+            {
+                return 1;
+            }
+
+            return win->thread_id;
+        }
+
+        int handle_NtUserSetScrollInfo()
+        {
+            return 0;
+        }
+
         BOOL handle_NtUserIsTouchWindow()
         {
             return FALSE;


### PR DESCRIPTION
Brings open-iw5 (Call of Duty MW3) single-player further along under the WHP backend + GPU bridge. Two independent fixes, each found by running `analyzer -ss open-iw5.exe -singleplayer` and resolving the next hard stop.

## 1. win32k syscall stubs (`af5237cc`)
SP boot halted on several known-but-unimplemented win32k syscalls (each stops the emulator via the unimplemented-syscall path). Implemented as stubs mirroring the existing UI handlers:

- `NtUserSetCaretPos` / `NtUserShowCaret` / `NtUserHideCaret` / `NtUserDestroyCaret` — caret lifecycle, return `TRUE` (alongside the existing `NtUserCreateCaret`).
- `NtGdiGetCharWidthW` — fills the width array with the default font width.
- `NtUserQueryWindow` — returns process id `1` for the WindowProcess query, otherwise the window's owning thread id.
- `NtUserSetScrollInfo` — returns 0.

## 2. GPU-bridge `vkResetDescriptorPool` (`5fcf5902`)
DXVK calls `vkResetDescriptorPool` during renderer init — a core Vulkan function it doesn't null-check — but the guest shim lacked it, so the game called a null pointer (`d3d9.dll` → `0x0`) and aborted graphics init. Wired end to end:

- **protocol**: `command::reset_descriptor_pool = 0x887` + `reset_descriptor_pool_request`.
- **shim**: real `vkResetDescriptorPool` export sending the IOCTL (+ `.def` export, proc table).
- **bridge**: dispatch case + `handle_reset_descriptor_pool` → `result_response`.
- **host**: `vulkan_host::reset_descriptor_pool` resolves `PFN_vkResetDescriptorPool` per device and resets the looked-up pool.

## Result
With both, open-iw5 SP passes renderer init and loads a map (verified: graphics init clean, no null-call, reaches map fastfile load — e.g. `mp_paris`). The remaining wall is unrelated (Demonware networking has unimplemented message handlers), out of scope here.