### PR TITLE
Support newest DXVK build in GPU-bridge

### DIFF
--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -389,6 +389,12 @@ namespace sogen
         LUID AdapterLuid;
         UINT VidPnSourceId;
     };
+
+    struct EMU_D3DKMT_OPENADAPTERFROMLUID
+    {
+        LUID AdapterLuid;
+        UINT32 hAdapter;
+    };
 } // namespace sogen
 
 // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -171,6 +171,8 @@ namespace sogen::gpu_bridge
         // Coalesced vkUpdateDescriptorSets: payload is a concatenation of update_descriptor_sets_request blobs
         // (each a header + its descriptor_write[]), applied in issue order.
         update_descriptor_sets_batch = 0x886,
+        cmd_blit_image = 0x887,
+        reset_descriptor_pool = 0x888,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -188,6 +190,7 @@ namespace sogen::gpu_bridge
         rasterizer_discard_enable = 8,
         depth_bias_enable = 9,
         primitive_restart_enable = 10,
+        depth_clip_enable = 11,
     };
 
     // Discriminator for cmd_set_stencil: which of the three single-value stencil dynamic states to set.
@@ -267,6 +270,7 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_create_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::create_descriptor_pool));
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
+    inline constexpr uint32_t ioctl_reset_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::reset_descriptor_pool));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets_batch = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
     inline constexpr uint32_t ioctl_create_sampler = make_ioctl(static_cast<uint32_t>(command::create_sampler));
@@ -1107,6 +1111,38 @@ namespace sogen::gpu_bridge
     };
     static_assert(sizeof(cmd_copy_image_request) == 104, "wire layout drift");
 
+    struct cmd_blit_image_request
+    {
+        object_id command_buffer;
+        object_id src_image;
+        object_id dst_image;
+        uint32_t src_layout; // VkImageLayout
+        uint32_t dst_layout; // VkImageLayout
+        uint32_t src_aspect_mask;
+        uint32_t src_mip_level;
+        uint32_t src_base_array_layer;
+        uint32_t src_layer_count;
+        int32_t src_offset_x0;
+        int32_t src_offset_y0;
+        int32_t src_offset_z0;
+        int32_t src_offset_x1;
+        int32_t src_offset_y1;
+        int32_t src_offset_z1;
+        uint32_t dst_aspect_mask;
+        uint32_t dst_mip_level;
+        uint32_t dst_base_array_layer;
+        uint32_t dst_layer_count;
+        int32_t dst_offset_x0;
+        int32_t dst_offset_y0;
+        int32_t dst_offset_z0;
+        int32_t dst_offset_x1;
+        int32_t dst_offset_y1;
+        int32_t dst_offset_z1;
+        uint32_t filter; // VkFilter
+        uint32_t reserved;
+    };
+    static_assert(sizeof(cmd_blit_image_request) == 120, "wire layout drift");
+
     // Updates a buffer region inline from data that trails this header in the wire stream (vkCmdUpdateBuffer).
     struct cmd_update_buffer_request
     {
@@ -1822,6 +1858,14 @@ namespace sogen::gpu_bridge
         // object_id sets[count];
     };
 
+    struct reset_descriptor_pool_request
+    {
+        object_id device;
+        object_id descriptor_pool;
+        uint32_t flags; // VkDescriptorPoolResetFlags
+        uint32_t reserved;
+    };
+
     // One descriptor write (trailing-array element of update_descriptor_sets). Models a single buffer or
     // image descriptor per write (descriptor_count == 1). For buffer types the buffer/offset/range fields
     // apply; for image types (combined image sampler) the sampler/image_view/image_layout fields apply.
@@ -1916,6 +1960,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_end_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
     static_assert(sizeof(reset_query_pool_request) == 24, "wire layout drift");
+    static_assert(sizeof(reset_descriptor_pool_request) == 24, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding) == 16, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding2) == 32, "wire layout drift");
     static_assert(sizeof(cmd_bind_vertex_buffers2_request) == 24, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -172,7 +172,6 @@ namespace sogen::gpu_bridge
         // (each a header + its descriptor_write[]), applied in issue order.
         update_descriptor_sets_batch = 0x886,
         cmd_blit_image = 0x887,
-        reset_descriptor_pool = 0x888,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -270,7 +269,6 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_create_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::create_descriptor_pool));
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
-    inline constexpr uint32_t ioctl_reset_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::reset_descriptor_pool));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets_batch = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
     inline constexpr uint32_t ioctl_create_sampler = make_ioctl(static_cast<uint32_t>(command::create_sampler));
@@ -1869,14 +1867,6 @@ namespace sogen::gpu_bridge
         // object_id sets[count];
     };
 
-    struct reset_descriptor_pool_request
-    {
-        object_id device;
-        object_id descriptor_pool;
-        uint32_t flags; // VkDescriptorPoolResetFlags
-        uint32_t reserved;
-    };
-
     // One descriptor write (trailing-array element of update_descriptor_sets). Models a single buffer or
     // image descriptor per write (descriptor_count == 1). For buffer types the buffer/offset/range fields
     // apply; for image types (combined image sampler) the sampler/image_view/image_layout fields apply.
@@ -1971,7 +1961,6 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_end_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
     static_assert(sizeof(reset_query_pool_request) == 24, "wire layout drift");
-    static_assert(sizeof(reset_descriptor_pool_request) == 24, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding) == 16, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding2) == 32, "wire layout drift");
     static_assert(sizeof(cmd_bind_vertex_buffers2_request) == 24, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -367,14 +367,25 @@ namespace sogen::gpu_bridge
     {
         object_id physical_device;
         uint32_t max_count; // capacity (in entries) of the array following the response header
-        uint32_t reserved;
+        uint32_t query_ownership_transfer;
     };
 
-    // ioctl_get_queue_family_properties: out header, followed by `count` raw VkQueueFamilyProperties
+    // ioctl_get_queue_family_properties: out header, followed by queue_family_properties entries
     struct get_queue_family_properties_response
     {
         uint32_t count; // true number of queue families on the device
         uint32_t reserved;
+    };
+
+    struct queue_family_properties
+    {
+        uint32_t queue_flags;
+        uint32_t queue_count;
+        uint32_t timestamp_valid_bits;
+        uint32_t min_image_transfer_granularity_width;
+        uint32_t min_image_transfer_granularity_height;
+        uint32_t min_image_transfer_granularity_depth;
+        uint32_t optimal_image_transfer_to_queue_families;
     };
 
     struct enumerate_device_extension_properties_request
@@ -1985,6 +1996,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_bind_descriptor_sets_request) == 32, "wire layout drift");
     static_assert(sizeof(create_sampler_request) == 64, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_request) == 16, "wire layout drift");
+    static_assert(sizeof(queue_family_properties) == 28, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_response) == 8, "wire layout drift");
     static_assert(sizeof(feature_chain_record) == 8, "wire layout drift");
     static_assert(sizeof(get_physical_device_features2_request) == 16, "wire layout drift");

--- a/src/gpu-bridge-protocol/vk_feature_chain.hpp
+++ b/src/gpu-bridge-protocol/vk_feature_chain.hpp
@@ -83,6 +83,12 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceMaintenance3Properties);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES:
             return sizeof(VkPhysicalDeviceMaintenance4Properties);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance6PropertiesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance7PropertiesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_PROPERTIES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance9PropertiesKHR);
         default:
             return 0;
         }

--- a/src/gpu-bridge-protocol/vk_feature_chain.hpp
+++ b/src/gpu-bridge-protocol/vk_feature_chain.hpp
@@ -32,10 +32,22 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceVulkan12Features);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
             return sizeof(VkPhysicalDeviceVulkan13Features);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+            return sizeof(VkPhysicalDeviceDepthClipEnableFeaturesEXT);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
+            return sizeof(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
             return sizeof(VkPhysicalDeviceRobustness2FeaturesEXT);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR:
             return sizeof(VkPhysicalDeviceMaintenance5FeaturesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance6FeaturesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance7FeaturesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance8FeaturesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR:
+            return sizeof(VkPhysicalDeviceMaintenance9FeaturesKHR);
         default:
             return 0;
         }

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -1807,6 +1807,11 @@ extern "C"
         record_set_dynamic_u32(commandBuffer, gb::dynamic_state_u32::depth_bounds_test_enable, depthBoundsTestEnable);
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable)
+    {
+        record_set_dynamic_u32(commandBuffer, gb::dynamic_state_u32::depth_clip_enable, depthClipEnable);
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable)
     {
         record_set_dynamic_u32(commandBuffer, gb::dynamic_state_u32::stencil_test_enable, stencilTestEnable);
@@ -2463,6 +2468,53 @@ extern "C"
             request.depth = r.extent.depth;
             record_command(request.command_buffer, gb::command::cmd_copy_image, &request, sizeof(request));
         }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo)
+    {
+        if (!pBlitImageInfo)
+        {
+            return;
+        }
+
+        for (uint32_t i = 0; i < pBlitImageInfo->regionCount; ++i)
+        {
+            const VkImageBlit2& r = pBlitImageInfo->pRegions[i];
+            gb::cmd_blit_image_request request{};
+            request.command_buffer = to_object_id(commandBuffer);
+            request.src_image = to_object_id(pBlitImageInfo->srcImage);
+            request.dst_image = to_object_id(pBlitImageInfo->dstImage);
+            request.src_layout = static_cast<uint32_t>(pBlitImageInfo->srcImageLayout);
+            request.dst_layout = static_cast<uint32_t>(pBlitImageInfo->dstImageLayout);
+            request.src_aspect_mask = r.srcSubresource.aspectMask;
+            request.src_mip_level = r.srcSubresource.mipLevel;
+            request.src_base_array_layer = r.srcSubresource.baseArrayLayer;
+            request.src_layer_count = r.srcSubresource.layerCount;
+            request.src_offset_x0 = r.srcOffsets[0].x;
+            request.src_offset_y0 = r.srcOffsets[0].y;
+            request.src_offset_z0 = r.srcOffsets[0].z;
+            request.src_offset_x1 = r.srcOffsets[1].x;
+            request.src_offset_y1 = r.srcOffsets[1].y;
+            request.src_offset_z1 = r.srcOffsets[1].z;
+            request.dst_aspect_mask = r.dstSubresource.aspectMask;
+            request.dst_mip_level = r.dstSubresource.mipLevel;
+            request.dst_base_array_layer = r.dstSubresource.baseArrayLayer;
+            request.dst_layer_count = r.dstSubresource.layerCount;
+            request.dst_offset_x0 = r.dstOffsets[0].x;
+            request.dst_offset_y0 = r.dstOffsets[0].y;
+            request.dst_offset_z0 = r.dstOffsets[0].z;
+            request.dst_offset_x1 = r.dstOffsets[1].x;
+            request.dst_offset_y1 = r.dstOffsets[1].y;
+            request.dst_offset_z1 = r.dstOffsets[1].z;
+            request.filter = static_cast<uint32_t>(pBlitImageInfo->filter);
+            record_command(request.command_buffer, gb::command::cmd_blit_image, &request, sizeof(request));
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage2KHR(VkCommandBuffer commandBuffer,
+                                                                        const VkBlitImageInfo2* pBlitImageInfo)
+    {
+        vkCmdBlitImage2(commandBuffer, pBlitImageInfo);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
@@ -3520,6 +3572,23 @@ extern "C"
         destroy_device_child(gb::ioctl_destroy_descriptor_pool, device, descriptorPool);
     }
 
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
+                                                                               VkDescriptorPoolResetFlags flags)
+    {
+        gb::reset_descriptor_pool_request request{};
+        request.device = to_object_id(device);
+        request.descriptor_pool = to_object_id(descriptorPool);
+        request.flags = static_cast<uint32_t>(flags);
+
+        gb::result_response response{};
+        if (!bridge_call(gb::ioctl_reset_descriptor_pool, &request, sizeof(request), &response, sizeof(response)))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        return static_cast<VkResult>(response.vk_result);
+    }
+
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice device,
                                                                                   const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                   VkDescriptorSet* pDescriptorSets)
@@ -4252,6 +4321,26 @@ extern "C"
         record_command(command_buffer, gb::command::cmd_bind_descriptor_sets, message.data(), message.size());
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
+                                                                                 const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo)
+    {
+        if (!pBindDescriptorSetsInfo)
+        {
+            return;
+        }
+
+        // DXVK uses the maintenance6-style bind info, which replaces the old pipeline bind point with
+        // a stage mask. The bridge still replays the legacy vkCmdBindDescriptorSets call, so collapse
+        // the stage mask back to the matching bind point. DXVK only uses graphics or compute here.
+        const VkPipelineBindPoint bind_point = pBindDescriptorSetsInfo->stageFlags == VK_SHADER_STAGE_COMPUTE_BIT
+                                                   ? VK_PIPELINE_BIND_POINT_COMPUTE
+                                                   : VK_PIPELINE_BIND_POINT_GRAPHICS;
+
+        vkCmdBindDescriptorSets(commandBuffer, bind_point, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+                                pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets,
+                                pBindDescriptorSetsInfo->dynamicOffsetCount, pBindDescriptorSetsInfo->pDynamicOffsets);
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass(VkCommandBuffer commandBuffer)
     {
         gb::cmd_end_render_pass_request request{};
@@ -4347,6 +4436,18 @@ extern "C"
             std::memcpy(message.data() + sizeof(header), pValues, size);
         }
         record_command(header.command_buffer, gb::command::cmd_push_constants, message.data(), message.size());
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
+                                                                            const VkPushConstantsInfo* pPushConstantsInfo)
+    {
+        if (!pPushConstantsInfo)
+        {
+            return;
+        }
+
+        vkCmdPushConstants(commandBuffer, pPushConstantsInfo->layout, pPushConstantsInfo->stageFlags, pPushConstantsInfo->offset,
+                           pPushConstantsInfo->size, pPushConstantsInfo->pValues);
     }
 
     __declspec(dllexport) VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice, const char* pName);
@@ -4561,6 +4662,7 @@ extern "C"
             {.name = "vkDestroyDescriptorSetLayout", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorSetLayout)},
             {.name = "vkCreateDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorPool)},
             {.name = "vkDestroyDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorPool)},
+            {.name = "vkResetDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkResetDescriptorPool)},
             {.name = "vkAllocateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkAllocateDescriptorSets)},
             {.name = "vkUpdateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSets)},
             {.name = "vkCreateDescriptorUpdateTemplate", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorUpdateTemplate)},
@@ -4585,15 +4687,21 @@ extern "C"
             {.name = "vkCmdDraw", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDraw)},
             {.name = "vkCmdDispatch", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDispatch)},
             {.name = "vkCmdDispatchIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDispatchIndirect)},
+            {.name = "vkCmdBlitImage2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBlitImage2)},
+            {.name = "vkCmdBlitImage2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBlitImage2KHR)},
             {.name = "vkCmdBindVertexBuffers", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindVertexBuffers)},
             {.name = "vkCmdBindVertexBuffers2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindVertexBuffers2)},
             {.name = "vkCmdBindVertexBuffers2EXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindVertexBuffers2)},
+            {.name = "vkCmdBindDescriptorSets2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindDescriptorSets2KHR)},
+            {.name = "vkCmdBindDescriptorSets2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindDescriptorSets2KHR)},
             {.name = "vkCmdBindIndexBuffer", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindIndexBuffer)},
             {.name = "vkCmdBindIndexBuffer2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindIndexBuffer2KHR)},
             {.name = "vkCmdBindIndexBuffer2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindIndexBuffer2KHR)},
             {.name = "vkCmdDrawIndexed", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexed)},
             {.name = "vkCmdEndRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndRenderPass)},
             {.name = "vkCmdPushConstants", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants)},
+            {.name = "vkCmdPushConstants2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants2KHR)},
+            {.name = "vkCmdPushConstants2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants2KHR)},
             {.name = "vkCmdSetViewport", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetViewport)},
             {.name = "vkCmdSetViewportWithCount", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetViewportWithCount)},
             {.name = "vkCmdSetViewportWithCountEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetViewportWithCount)},
@@ -4623,6 +4731,7 @@ extern "C"
             {.name = "vkCmdSetDepthCompareOpEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetDepthCompareOp)},
             {.name = "vkCmdSetDepthBoundsTestEnable", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetDepthBoundsTestEnable)},
             {.name = "vkCmdSetDepthBoundsTestEnableEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetDepthBoundsTestEnable)},
+            {.name = "vkCmdSetDepthClipEnableEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetDepthClipEnableEXT)},
             {.name = "vkCmdSetStencilTestEnable", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetStencilTestEnable)},
             {.name = "vkCmdSetStencilTestEnableEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetStencilTestEnable)},
             {.name = "vkCmdSetRasterizerDiscardEnable", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetRasterizerDiscardEnable)},

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -323,7 +323,7 @@ extern "C"
         request.max_count = pProperties ? *pCount : 0;
 
         std::vector<std::byte> buffer(sizeof(gb::get_queue_family_properties_response) +
-                                      static_cast<size_t>(request.max_count) * sizeof(VkQueueFamilyProperties));
+                                      static_cast<size_t>(request.max_count) * sizeof(gb::queue_family_properties));
         if (!bridge_call(gb::ioctl_get_queue_family_properties, &request, sizeof(request), buffer.data(),
                          static_cast<DWORD>(buffer.size())))
         {
@@ -341,10 +341,15 @@ extern "C"
 
         const uint32_t written = (response->count < *pCount) ? response->count : *pCount;
         const auto* families =
-            reinterpret_cast<const VkQueueFamilyProperties*>(buffer.data() + sizeof(gb::get_queue_family_properties_response));
+            reinterpret_cast<const gb::queue_family_properties*>(buffer.data() + sizeof(gb::get_queue_family_properties_response));
         for (uint32_t i = 0; i < written; ++i)
         {
-            pProperties[i] = families[i];
+            pProperties[i] = {.queueFlags = families[i].queue_flags,
+                              .queueCount = families[i].queue_count,
+                              .timestampValidBits = families[i].timestamp_valid_bits,
+                              .minImageTransferGranularity = {.width = families[i].min_image_transfer_granularity_width,
+                                                              .height = families[i].min_image_transfer_granularity_height,
+                                                              .depth = families[i].min_image_transfer_granularity_depth}};
         }
         *pCount = written;
     }
@@ -2826,12 +2831,50 @@ extern "C"
             return;
         }
 
-        std::vector<VkQueueFamilyProperties> families(*pCount);
-        uint32_t count = *pCount;
-        vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &count, families.data());
+        gb::get_queue_family_properties_request request{};
+        request.physical_device = to_object_id(physicalDevice);
+        request.max_count = *pCount;
+        for (uint32_t i = 0; i < *pCount && request.query_ownership_transfer == 0; ++i)
+        {
+            for (const auto* next = reinterpret_cast<const VkBaseOutStructure*>(pProperties[i].pNext); next; next = next->pNext)
+            {
+                if (next->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_OWNERSHIP_TRANSFER_PROPERTIES_KHR)
+                {
+                    request.query_ownership_transfer = 1;
+                    break;
+                }
+            }
+        }
+        std::vector<std::byte> buffer(sizeof(gb::get_queue_family_properties_response) +
+                                      static_cast<size_t>(request.max_count) * sizeof(gb::queue_family_properties));
+        if (!bridge_call(gb::ioctl_get_queue_family_properties, &request, sizeof(request), buffer.data(),
+                         static_cast<DWORD>(buffer.size())))
+        {
+            *pCount = 0;
+            return;
+        }
+
+        const auto* response = reinterpret_cast<const gb::get_queue_family_properties_response*>(buffer.data());
+        const uint32_t count = std::min(response->count, *pCount);
+        const auto* families =
+            reinterpret_cast<const gb::queue_family_properties*>(buffer.data() + sizeof(gb::get_queue_family_properties_response));
         for (uint32_t i = 0; i < count; ++i)
         {
-            pProperties[i].queueFamilyProperties = families[i];
+            pProperties[i].queueFamilyProperties = {
+                .queueFlags = families[i].queue_flags,
+                .queueCount = families[i].queue_count,
+                .timestampValidBits = families[i].timestamp_valid_bits,
+                .minImageTransferGranularity = {.width = families[i].min_image_transfer_granularity_width,
+                                                .height = families[i].min_image_transfer_granularity_height,
+                                                .depth = families[i].min_image_transfer_granularity_depth}};
+            for (auto* next = reinterpret_cast<VkBaseOutStructure*>(pProperties[i].pNext); next; next = next->pNext)
+            {
+                if (next->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_OWNERSHIP_TRANSFER_PROPERTIES_KHR)
+                {
+                    reinterpret_cast<VkQueueFamilyOwnershipTransferPropertiesKHR*>(next)->optimalImageTransferToQueueFamilies =
+                        families[i].optimal_image_transfer_to_queue_families;
+                }
+            }
         }
         *pCount = count;
     }
@@ -4329,16 +4372,19 @@ extern "C"
             return;
         }
 
-        // DXVK uses the maintenance6-style bind info, which replaces the old pipeline bind point with
-        // a stage mask. The bridge still replays the legacy vkCmdBindDescriptorSets call, so collapse
-        // the stage mask back to the matching bind point. DXVK only uses graphics or compute here.
-        const VkPipelineBindPoint bind_point = pBindDescriptorSetsInfo->stageFlags == VK_SHADER_STAGE_COMPUTE_BIT
-                                                   ? VK_PIPELINE_BIND_POINT_COMPUTE
-                                                   : VK_PIPELINE_BIND_POINT_GRAPHICS;
-
-        vkCmdBindDescriptorSets(commandBuffer, bind_point, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
-                                pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets,
-                                pBindDescriptorSetsInfo->dynamicOffsetCount, pBindDescriptorSetsInfo->pDynamicOffsets);
+        const auto bind = [&](const VkPipelineBindPoint bind_point) {
+            vkCmdBindDescriptorSets(commandBuffer, bind_point, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+                                    pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets,
+                                    pBindDescriptorSetsInfo->dynamicOffsetCount, pBindDescriptorSetsInfo->pDynamicOffsets);
+        };
+        if (pBindDescriptorSetsInfo->stageFlags & VK_SHADER_STAGE_ALL_GRAPHICS)
+        {
+            bind(VK_PIPELINE_BIND_POINT_GRAPHICS);
+        }
+        if (pBindDescriptorSetsInfo->stageFlags & VK_SHADER_STAGE_COMPUTE_BIT)
+        {
+            bind(VK_PIPELINE_BIND_POINT_COMPUTE);
+        }
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass(VkCommandBuffer commandBuffer)

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -3615,23 +3615,6 @@ extern "C"
         destroy_device_child(gb::ioctl_destroy_descriptor_pool, device, descriptorPool);
     }
 
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                                               VkDescriptorPoolResetFlags flags)
-    {
-        gb::reset_descriptor_pool_request request{};
-        request.device = to_object_id(device);
-        request.descriptor_pool = to_object_id(descriptorPool);
-        request.flags = static_cast<uint32_t>(flags);
-
-        gb::result_response response{};
-        if (!bridge_call(gb::ioctl_reset_descriptor_pool, &request, sizeof(request), &response, sizeof(response)))
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        return static_cast<VkResult>(response.vk_result);
-    }
-
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice device,
                                                                                   const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                   VkDescriptorSet* pDescriptorSets)
@@ -4708,7 +4691,6 @@ extern "C"
             {.name = "vkDestroyDescriptorSetLayout", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorSetLayout)},
             {.name = "vkCreateDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorPool)},
             {.name = "vkDestroyDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorPool)},
-            {.name = "vkResetDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkResetDescriptorPool)},
             {.name = "vkAllocateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkAllocateDescriptorSets)},
             {.name = "vkUpdateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSets)},
             {.name = "vkCreateDescriptorUpdateTemplate", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorUpdateTemplate)},

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -16,12 +16,15 @@ EXPORTS
     vkCmdBeginRenderPass
     vkCmdBeginRendering
     vkCmdBindDescriptorSets
+    vkCmdBindDescriptorSets2KHR
     vkCmdBindIndexBuffer
     vkCmdBindIndexBuffer2KHR
     vkCmdBindPipeline
     vkCmdBeginDebugUtilsLabelEXT
     vkCmdBindVertexBuffers
     vkCmdBindVertexBuffers2
+    vkCmdBlitImage2
+    vkCmdBlitImage2KHR
     vkCmdClearColorImage
     vkCmdClearDepthStencilImage
     vkCmdBeginQuery
@@ -50,12 +53,14 @@ EXPORTS
     vkCmdInsertDebugUtilsLabelEXT
     vkCmdPipelineBarrier
     vkCmdPushConstants
+    vkCmdPushConstants2KHR
     vkCmdSetBlendConstants
     vkCmdSetCullMode
     vkCmdSetDepthBias
     vkCmdSetDepthBiasEnable
     vkCmdSetDepthBounds
     vkCmdSetDepthBoundsTestEnable
+    vkCmdSetDepthClipEnableEXT
     vkCmdSetDepthCompareOp
     vkCmdSetDepthTestEnable
     vkCmdSetDepthWriteEnable

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -204,8 +204,6 @@ namespace sogen
                     return handle_destroy_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_allocate_descriptor_sets:
                     return handle_allocate_descriptor_sets(win_emu, context);
-                case gpu_bridge::ioctl_reset_descriptor_pool:
-                    return handle_reset_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets:
                     return handle_update_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets_batch:
@@ -2123,18 +2121,6 @@ namespace sogen
                 }
                 set_information(context, static_cast<ULONG>(sizeof(response_t) + written * sizeof(gpu_bridge::object_id)));
                 return STATUS_SUCCESS;
-            }
-
-            NTSTATUS handle_reset_descriptor_pool(windows_emulator& win_emu, const io_device_context& context)
-            {
-                gpu_bridge::reset_descriptor_pool_request request{};
-                if (!read_input(win_emu, context, request))
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-
-                const int32_t result = this->vulkan_.reset_descriptor_pool(request.device, request.descriptor_pool, request.flags);
-                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
 
             // Cap guest-declared descriptor-update payloads so a bogus IOCTL length can't force a huge allocation.

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -446,8 +446,8 @@ namespace sogen
 
                 std::vector<std::byte> properties(array_bytes);
                 uint32_t count = 0;
-                const int32_t result =
-                    this->vulkan_.get_queue_family_properties(request.physical_device, properties.data(), properties.size(), count);
+                const int32_t result = this->vulkan_.get_queue_family_properties(
+                    request.physical_device, request.query_ownership_transfer != 0, properties.data(), properties.size(), count);
                 if (result != 0)
                 {
                     return STATUS_INVALID_PARAMETER;

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -204,6 +204,8 @@ namespace sogen
                     return handle_destroy_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_allocate_descriptor_sets:
                     return handle_allocate_descriptor_sets(win_emu, context);
+                case gpu_bridge::ioctl_reset_descriptor_pool:
+                    return handle_reset_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets:
                     return handle_update_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets_batch:
@@ -2123,6 +2125,18 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            NTSTATUS handle_reset_descriptor_pool(windows_emulator& win_emu, const io_device_context& context)
+            {
+                gpu_bridge::reset_descriptor_pool_request request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const int32_t result = this->vulkan_.reset_descriptor_pool(request.device, request.descriptor_pool, request.flags);
+                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+            }
+
             // Cap guest-declared descriptor-update payloads so a bogus IOCTL length can't force a huge allocation.
             static constexpr size_t max_descriptor_update_input_bytes = size_t{256} * 1024 * 1024;
 
@@ -2765,6 +2779,38 @@ namespace sogen
                         .depth = req.depth,
                     };
                     return this->vulkan_.cmd_copy_image(req.command_buffer, req.src_image, req.src_layout, req.dst_image, req.dst_layout,
+                                                        region);
+                }
+                case gpu_bridge::command::cmd_blit_image: {
+                    gpu_bridge::cmd_blit_image_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    const vulkan_host::image_blit_region region{
+                        .src_aspect_mask = req.src_aspect_mask,
+                        .src_mip_level = req.src_mip_level,
+                        .src_base_array_layer = req.src_base_array_layer,
+                        .src_layer_count = req.src_layer_count,
+                        .src_offset_x0 = req.src_offset_x0,
+                        .src_offset_y0 = req.src_offset_y0,
+                        .src_offset_z0 = req.src_offset_z0,
+                        .src_offset_x1 = req.src_offset_x1,
+                        .src_offset_y1 = req.src_offset_y1,
+                        .src_offset_z1 = req.src_offset_z1,
+                        .dst_aspect_mask = req.dst_aspect_mask,
+                        .dst_mip_level = req.dst_mip_level,
+                        .dst_base_array_layer = req.dst_base_array_layer,
+                        .dst_layer_count = req.dst_layer_count,
+                        .dst_offset_x0 = req.dst_offset_x0,
+                        .dst_offset_y0 = req.dst_offset_y0,
+                        .dst_offset_z0 = req.dst_offset_z0,
+                        .dst_offset_x1 = req.dst_offset_x1,
+                        .dst_offset_y1 = req.dst_offset_y1,
+                        .dst_offset_z1 = req.dst_offset_z1,
+                        .filter = req.filter,
+                    };
+                    return this->vulkan_.cmd_blit_image(req.command_buffer, req.src_image, req.src_layout, req.dst_image, req.dst_layout,
                                                         region);
                 }
                 case gpu_bridge::command::cmd_update_buffer: {

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -236,6 +236,7 @@ namespace sogen
             PFN_vkCmdUpdateBuffer cmd_update_buffer{};
             PFN_vkCmdCopyBufferToImage cmd_copy_buffer_to_image{};
             PFN_vkCmdCopyImage cmd_copy_image{};
+            PFN_vkCmdBlitImage cmd_blit_image{};
             PFN_vkCmdCopyBuffer cmd_copy_buffer{};
             PFN_vkCreateSampler create_sampler{};
             PFN_vkDestroySampler destroy_sampler{};
@@ -263,6 +264,7 @@ namespace sogen
             PFN_vkDestroyDescriptorSetLayout destroy_descriptor_set_layout{};
             PFN_vkCreateDescriptorPool create_descriptor_pool{};
             PFN_vkDestroyDescriptorPool destroy_descriptor_pool{};
+            PFN_vkResetDescriptorPool reset_descriptor_pool{};
             PFN_vkAllocateDescriptorSets allocate_descriptor_sets{};
             PFN_vkUpdateDescriptorSets update_descriptor_sets{};
             PFN_vkCmdBindDescriptorSets cmd_bind_descriptor_sets{};
@@ -302,6 +304,7 @@ namespace sogen
             PFN_vkCmdSetDepthWriteEnable cmd_set_depth_write_enable{};
             PFN_vkCmdSetDepthCompareOp cmd_set_depth_compare_op{};
             PFN_vkCmdSetDepthBoundsTestEnable cmd_set_depth_bounds_test_enable{};
+            PFN_vkCmdSetDepthClipEnableEXT cmd_set_depth_clip_enable{};
             PFN_vkCmdSetStencilTestEnable cmd_set_stencil_test_enable{};
             PFN_vkCmdSetRasterizerDiscardEnable cmd_set_rasterizer_discard_enable{};
             PFN_vkCmdSetDepthBiasEnable cmd_set_depth_bias_enable{};
@@ -1565,6 +1568,7 @@ namespace sogen
             data.cmd_update_buffer = reinterpret_cast<PFN_vkCmdUpdateBuffer>(resolve("vkCmdUpdateBuffer"));
             data.cmd_copy_buffer_to_image = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(resolve("vkCmdCopyBufferToImage"));
             data.cmd_copy_image = reinterpret_cast<PFN_vkCmdCopyImage>(resolve("vkCmdCopyImage"));
+            data.cmd_blit_image = reinterpret_cast<PFN_vkCmdBlitImage>(resolve("vkCmdBlitImage"));
             data.cmd_copy_buffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(resolve("vkCmdCopyBuffer"));
             data.create_sampler = reinterpret_cast<PFN_vkCreateSampler>(resolve("vkCreateSampler"));
             data.destroy_sampler = reinterpret_cast<PFN_vkDestroySampler>(resolve("vkDestroySampler"));
@@ -1593,6 +1597,7 @@ namespace sogen
                 reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(resolve("vkDestroyDescriptorSetLayout"));
             data.create_descriptor_pool = reinterpret_cast<PFN_vkCreateDescriptorPool>(resolve("vkCreateDescriptorPool"));
             data.destroy_descriptor_pool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(resolve("vkDestroyDescriptorPool"));
+            data.reset_descriptor_pool = reinterpret_cast<PFN_vkResetDescriptorPool>(resolve("vkResetDescriptorPool"));
             data.allocate_descriptor_sets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(resolve("vkAllocateDescriptorSets"));
             data.update_descriptor_sets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(resolve("vkUpdateDescriptorSets"));
             data.cmd_bind_descriptor_sets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(resolve("vkCmdBindDescriptorSets"));
@@ -1633,6 +1638,7 @@ namespace sogen
             data.cmd_set_depth_compare_op = reinterpret_cast<PFN_vkCmdSetDepthCompareOp>(resolve("vkCmdSetDepthCompareOp"));
             data.cmd_set_depth_bounds_test_enable =
                 reinterpret_cast<PFN_vkCmdSetDepthBoundsTestEnable>(resolve("vkCmdSetDepthBoundsTestEnable"));
+            data.cmd_set_depth_clip_enable = reinterpret_cast<PFN_vkCmdSetDepthClipEnableEXT>(resolve("vkCmdSetDepthClipEnableEXT"));
             data.cmd_set_stencil_test_enable = reinterpret_cast<PFN_vkCmdSetStencilTestEnable>(resolve("vkCmdSetStencilTestEnable"));
             data.cmd_set_rasterizer_discard_enable =
                 reinterpret_cast<PFN_vkCmdSetRasterizerDiscardEnable>(resolve("vkCmdSetRasterizerDiscardEnable"));
@@ -3089,6 +3095,42 @@ namespace sogen
         return VK_SUCCESS;
     }
 
+    int32_t vulkan_host::cmd_blit_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image,
+                                        uint32_t dst_layout, const image_blit_region& r)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto src = this->impl_->images.find(src_image);
+        const auto dst = this->impl_->images.find(dst_image);
+        if (cb == this->impl_->command_buffers.end() || src == this->impl_->images.end() || dst == this->impl_->images.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_blit_image)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkImageBlit region{};
+        region.srcSubresource = {.aspectMask = r.src_aspect_mask,
+                                 .mipLevel = r.src_mip_level,
+                                 .baseArrayLayer = r.src_base_array_layer,
+                                 .layerCount = r.src_layer_count ? r.src_layer_count : 1};
+        region.srcOffsets[0] = {.x = r.src_offset_x0, .y = r.src_offset_y0, .z = r.src_offset_z0};
+        region.srcOffsets[1] = {.x = r.src_offset_x1, .y = r.src_offset_y1, .z = r.src_offset_z1};
+        region.dstSubresource = {.aspectMask = r.dst_aspect_mask,
+                                 .mipLevel = r.dst_mip_level,
+                                 .baseArrayLayer = r.dst_base_array_layer,
+                                 .layerCount = r.dst_layer_count ? r.dst_layer_count : 1};
+        region.dstOffsets[0] = {.x = r.dst_offset_x0, .y = r.dst_offset_y0, .z = r.dst_offset_z0};
+        region.dstOffsets[1] = {.x = r.dst_offset_x1, .y = r.dst_offset_y1, .z = r.dst_offset_z1};
+
+        dev->second.cmd_blit_image(cb->second.handle, src->second.handle, translate_layout(src_layout), dst->second.handle,
+                                   translate_layout(dst_layout), 1, &region, static_cast<VkFilter>(r.filter));
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::create_sampler(uint64_t device, uint32_t mag_filter, uint32_t min_filter, uint32_t address_mode_u,
                                         uint32_t address_mode_v, uint32_t address_mode_w, uint32_t mipmap_mode, uint32_t compare_enable,
                                         uint32_t compare_op, uint32_t anisotropy_enable, uint32_t border_color, float mip_lod_bias,
@@ -4239,6 +4281,26 @@ namespace sogen
         this->impl_->descriptor_pools.erase(it);
     }
 
+    int32_t vulkan_host::reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags)
+    {
+        const auto dev = this->impl_->devices.find(device);
+        const auto it = this->impl_->descriptor_pools.find(pool);
+        if (dev == this->impl_->devices.end() || it == this->impl_->descriptor_pools.end() || !dev->second.reset_descriptor_pool)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const VkResult result =
+            dev->second.reset_descriptor_pool(dev->second.handle, it->second.handle, static_cast<VkDescriptorPoolResetFlags>(flags));
+        if (result != VK_SUCCESS)
+        {
+            return result;
+        }
+
+        this->impl_->erase_owned(this->impl_->descriptor_sets, [&](const impl::descriptor_set_data& d) { return d.pool_id == pool; });
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,
                                                   std::span<uint64_t> out_sets, uint32_t& out_count)
     {
@@ -5314,6 +5376,13 @@ namespace sogen
                 return VK_ERROR_INITIALIZATION_FAILED;
             }
             dev->second.cmd_set_depth_bounds_test_enable(handle, value);
+            break;
+        case gpu_bridge::dynamic_state_u32::depth_clip_enable:
+            if (!dev->second.cmd_set_depth_clip_enable)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            dev->second.cmd_set_depth_clip_enable(handle, value);
             break;
         case gpu_bridge::dynamic_state_u32::stencil_test_enable:
             if (!dev->second.cmd_set_stencil_test_enable)

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -162,6 +162,7 @@ namespace sogen
             PFN_vkGetPhysicalDeviceFormatProperties get_physical_device_format_properties{};
             PFN_vkGetPhysicalDeviceImageFormatProperties get_physical_device_image_format_properties{};
             PFN_vkGetPhysicalDeviceQueueFamilyProperties get_queue_family_properties{};
+            PFN_vkGetPhysicalDeviceQueueFamilyProperties2 get_queue_family_properties2{};
             PFN_vkGetPhysicalDeviceMemoryProperties get_physical_device_memory_properties{};
             PFN_vkGetPhysicalDeviceMemoryProperties2 get_physical_device_memory_properties2{};
             PFN_vkGetPhysicalDeviceFeatures2 get_physical_device_features2{};
@@ -911,6 +912,8 @@ namespace sogen
             instance, "vkGetPhysicalDeviceImageFormatProperties");
         data.get_queue_family_properties = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(
             instance, "vkGetPhysicalDeviceQueueFamilyProperties");
+        data.get_queue_family_properties2 = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceQueueFamilyProperties2>(
+            instance, "vkGetPhysicalDeviceQueueFamilyProperties2");
         data.get_physical_device_memory_properties =
             this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceMemoryProperties>(instance, "vkGetPhysicalDeviceMemoryProperties");
         data.get_physical_device_memory_properties2 =
@@ -1113,7 +1116,8 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::get_queue_family_properties(uint64_t physical_device, void* out, size_t out_size, uint32_t& out_count)
+    int32_t vulkan_host::get_queue_family_properties(uint64_t physical_device, const bool query_ownership_transfer, void* out,
+                                                     size_t out_size, uint32_t& out_count)
     {
         out_count = 0;
 
@@ -1132,18 +1136,57 @@ namespace sogen
         uint32_t count = 0;
         instance->second.get_queue_family_properties(pd->second.handle, &count, nullptr);
 
-        std::vector<VkQueueFamilyProperties> families(count);
-        if (count > 0)
+        std::vector<gpu_bridge::queue_family_properties> wire_families(count);
+        if (query_ownership_transfer && instance->second.get_queue_family_properties2)
         {
-            instance->second.get_queue_family_properties(pd->second.handle, &count, families.data());
+            std::vector<VkQueueFamilyProperties2> families(count);
+            std::vector<VkQueueFamilyOwnershipTransferPropertiesKHR> ownership(count);
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                families[i].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2;
+                families[i].pNext = &ownership[i];
+                ownership[i].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_OWNERSHIP_TRANSFER_PROPERTIES_KHR;
+            }
+            instance->second.get_queue_family_properties2(pd->second.handle, &count, families.data());
+            wire_families.resize(count);
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                const auto& family = families[i].queueFamilyProperties;
+                wire_families[i] = {.queue_flags = family.queueFlags,
+                                    .queue_count = family.queueCount,
+                                    .timestamp_valid_bits = family.timestampValidBits,
+                                    .min_image_transfer_granularity_width = family.minImageTransferGranularity.width,
+                                    .min_image_transfer_granularity_height = family.minImageTransferGranularity.height,
+                                    .min_image_transfer_granularity_depth = family.minImageTransferGranularity.depth,
+                                    .optimal_image_transfer_to_queue_families = ownership[i].optimalImageTransferToQueueFamilies};
+            }
+        }
+        else
+        {
+            std::vector<VkQueueFamilyProperties> families(count);
+            if (count > 0)
+            {
+                instance->second.get_queue_family_properties(pd->second.handle, &count, families.data());
+            }
+            wire_families.resize(count);
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                const auto& family = families[i];
+                wire_families[i] = {.queue_flags = family.queueFlags,
+                                    .queue_count = family.queueCount,
+                                    .timestamp_valid_bits = family.timestampValidBits,
+                                    .min_image_transfer_granularity_width = family.minImageTransferGranularity.width,
+                                    .min_image_transfer_granularity_height = family.minImageTransferGranularity.height,
+                                    .min_image_transfer_granularity_depth = family.minImageTransferGranularity.depth};
+            }
         }
 
         out_count = count;
 
-        const size_t copy_bytes = std::min(out_size, families.size() * sizeof(VkQueueFamilyProperties));
+        const size_t copy_bytes = std::min(out_size, wire_families.size() * sizeof(gpu_bridge::queue_family_properties));
         if (copy_bytes > 0)
         {
-            std::memcpy(out, families.data(), copy_bytes);
+            std::memcpy(out, wire_families.data(), copy_bytes);
         }
 
         return VK_SUCCESS;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -1176,7 +1176,8 @@ namespace sogen
                                     .timestamp_valid_bits = family.timestampValidBits,
                                     .min_image_transfer_granularity_width = family.minImageTransferGranularity.width,
                                     .min_image_transfer_granularity_height = family.minImageTransferGranularity.height,
-                                    .min_image_transfer_granularity_depth = family.minImageTransferGranularity.depth};
+                                    .min_image_transfer_granularity_depth = family.minImageTransferGranularity.depth,
+                                    .optimal_image_transfer_to_queue_families = 0};
             }
         }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -265,7 +265,6 @@ namespace sogen
             PFN_vkDestroyDescriptorSetLayout destroy_descriptor_set_layout{};
             PFN_vkCreateDescriptorPool create_descriptor_pool{};
             PFN_vkDestroyDescriptorPool destroy_descriptor_pool{};
-            PFN_vkResetDescriptorPool reset_descriptor_pool{};
             PFN_vkAllocateDescriptorSets allocate_descriptor_sets{};
             PFN_vkUpdateDescriptorSets update_descriptor_sets{};
             PFN_vkCmdBindDescriptorSets cmd_bind_descriptor_sets{};
@@ -1640,7 +1639,6 @@ namespace sogen
                 reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(resolve("vkDestroyDescriptorSetLayout"));
             data.create_descriptor_pool = reinterpret_cast<PFN_vkCreateDescriptorPool>(resolve("vkCreateDescriptorPool"));
             data.destroy_descriptor_pool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(resolve("vkDestroyDescriptorPool"));
-            data.reset_descriptor_pool = reinterpret_cast<PFN_vkResetDescriptorPool>(resolve("vkResetDescriptorPool"));
             data.allocate_descriptor_sets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(resolve("vkAllocateDescriptorSets"));
             data.update_descriptor_sets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(resolve("vkUpdateDescriptorSets"));
             data.cmd_bind_descriptor_sets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(resolve("vkCmdBindDescriptorSets"));
@@ -4322,26 +4320,6 @@ namespace sogen
         // Sets allocated from this pool are freed implicitly; drop their ids.
         this->impl_->erase_owned(this->impl_->descriptor_sets, [&](const impl::descriptor_set_data& d) { return d.pool_id == pool; });
         this->impl_->descriptor_pools.erase(it);
-    }
-
-    int32_t vulkan_host::reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags)
-    {
-        const auto dev = this->impl_->devices.find(device);
-        const auto it = this->impl_->descriptor_pools.find(pool);
-        if (dev == this->impl_->devices.end() || it == this->impl_->descriptor_pools.end() || !dev->second.reset_descriptor_pool)
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        const VkResult result =
-            dev->second.reset_descriptor_pool(dev->second.handle, it->second.handle, static_cast<VkDescriptorPoolResetFlags>(flags));
-        if (result != VK_SUCCESS)
-        {
-            return result;
-        }
-
-        this->impl_->erase_owned(this->impl_->descriptor_sets, [&](const impl::descriptor_set_data& d) { return d.pool_id == pool; });
-        return VK_SUCCESS;
     }
 
     int32_t vulkan_host::allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -298,8 +298,34 @@ namespace sogen
             uint32_t height;
             uint32_t depth;
         };
+        struct image_blit_region
+        {
+            uint32_t src_aspect_mask;
+            uint32_t src_mip_level;
+            uint32_t src_base_array_layer;
+            uint32_t src_layer_count;
+            int32_t src_offset_x0;
+            int32_t src_offset_y0;
+            int32_t src_offset_z0;
+            int32_t src_offset_x1;
+            int32_t src_offset_y1;
+            int32_t src_offset_z1;
+            uint32_t dst_aspect_mask;
+            uint32_t dst_mip_level;
+            uint32_t dst_base_array_layer;
+            uint32_t dst_layer_count;
+            int32_t dst_offset_x0;
+            int32_t dst_offset_y0;
+            int32_t dst_offset_z0;
+            int32_t dst_offset_x1;
+            int32_t dst_offset_y1;
+            int32_t dst_offset_z1;
+            uint32_t filter;
+        };
         int32_t cmd_copy_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image, uint32_t dst_layout,
                                const image_copy_region& region);
+        int32_t cmd_blit_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image, uint32_t dst_layout,
+                               const image_blit_region& region);
         // Resolves a multisampled source image into a single-sample destination (full image, mip 0 / layer 0).
         int32_t cmd_resolve_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image, uint32_t dst_layout,
                                   uint32_t width, uint32_t height, uint32_t aspect_mask);
@@ -417,6 +443,7 @@ namespace sogen
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
         int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
         void destroy_descriptor_pool(uint64_t device, uint64_t pool);
+        int32_t reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags);
         // Allocates one set per layout id; writes the allocated set ids into out_sets, out_count gets the
         // true count.
         int32_t allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -62,9 +62,10 @@ namespace sogen
         int32_t get_physical_device_image_format_properties(uint64_t physical_device, uint32_t format, uint32_t type, uint32_t tiling,
                                                             uint32_t usage, uint32_t flags, image_format_properties& out);
 
-        // Writes the device's queue families as raw VkQueueFamilyProperties into out (sized in
-        // bytes). out_count always receives the true family count.
-        int32_t get_queue_family_properties(uint64_t physical_device, void* out, size_t out_size, uint32_t& out_count);
+        // Writes the device's queue families in the bridge wire format into out (sized in bytes).
+        // out_count always receives the true family count.
+        int32_t get_queue_family_properties(uint64_t physical_device, bool query_ownership_transfer, void* out, size_t out_size,
+                                            uint32_t& out_count);
 
         // Writes the device's real VkExtensionProperties array into out (sized in bytes); out_count
         // always receives the true device-extension count.

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -444,7 +444,6 @@ namespace sogen
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
         int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
         void destroy_descriptor_pool(uint64_t device, uint64_t pool);
-        int32_t reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags);
         // Allocates one set per layout id; writes the allocated set ids into out_sets, out_count gets the
         // true count.
         int32_t allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -713,6 +713,8 @@ namespace sogen
                                                     emulator_object<EMU_D3DKMT_DESTROYALLOCATION> destroy_allocation);
         NTSTATUS handle_NtGdiDdDDIDestroyContext();
         NTSTATUS handle_NtGdiDdDDIDestroyDevice();
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromLuid(const syscall_context& c,
+                                                      emulator_object<EMU_D3DKMT_OPENADAPTERFROMLUID> open_adapter);
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter);
 
         // syscalls/trace.cpp:
@@ -1443,6 +1445,7 @@ namespace sogen
         add_handler(NtAllocateLocallyUniqueId);
         add_handler(NtUserAllowSetForegroundWindow);
         add_handler(NtGdiOpenDCW);
+        add_handler(NtGdiDdDDIOpenAdapterFromLuid);
         add_handler(NtGdiDdDDIOpenAdapterFromHdc);
         add_handler(NtGdiSelectFont);
         add_handler(NtUserInitThreadCoreMessagingIocp2);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -3895,6 +3895,21 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtGdiDdDDIOpenAdapterFromLuid(const syscall_context&,
+                                                      const emulator_object<EMU_D3DKMT_OPENADAPTERFROMLUID> open_adapter)
+        {
+            if (!open_adapter)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            open_adapter.access([](EMU_D3DKMT_OPENADAPTERFROMLUID& params) { //
+                params.hAdapter = k_dxgk_adapter_handle;
+            });
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context&,
                                                      const emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter)
         {


### PR DESCRIPTION
This PR implements several GPU-bridge updates needed to run current DXVK builds under Sogen:

- extend feature-chain parsing for newer Vulkan feature structs, including `VK_EXT_depth_clip_enable`, `VK_EXT_extended_dynamic_state3`, and `VK_KHR_maintenance6/7/8/9`
- add support for the `depthClipEnable` dynamic state used by current DXVK
- expose compatibility entry points in the Vulkan shim for:
  - `vkCmdBindDescriptorSets2/KHR`
  - `vkCmdPushConstants2/KHR`
  - `vkCmdBlitImage2/KHR`
  - ~~`vkResetDescriptorPool`~~
- add protocol and host-side replay support for image blits
- add protocol and host-side handling for descriptor-pool resets
- implement `NtGdiDdDDIOpenAdapterFromLuid`, which newer DXVK builds use during adapter discovery