### PR TITLE
Fix open-iw5 (MW3) single-player shutdown freeze

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -148,7 +148,9 @@ namespace sogen
 
             case handle_types::thread: {
                 const auto* t = c.threads.get(h);
-                if (t && t->is_terminated())
+                // A reaped thread is gone from the store, but its handle stays signaled (it terminated),
+                // so a missing thread counts the same as a terminated one.
+                if (!t || t->is_terminated())
                 {
                     return wait_state::signaled;
                 }
@@ -247,7 +249,9 @@ namespace sogen
 
             case handle_types::thread: {
                 const auto* thread = c.threads.get(h);
-                if (!thread || !thread->is_terminated())
+                // A missing (reaped) thread counts as terminated; its signal is sticky, so consuming it
+                // is a no-op.
+                if (thread && !thread->is_terminated())
                 {
                     return std::nullopt;
                 }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -606,6 +606,7 @@ namespace sogen
         BOOL handle_NtUserShowCaret();
         BOOL handle_NtUserHideCaret();
         BOOL handle_NtUserDestroyCaret();
+        BOOL handle_NtUserGetObjectInformation();
         uint64_t handle_NtUserQueryWindow(const syscall_context& c, hwnd window_handle, uint32_t query_type);
         int handle_NtUserSetScrollInfo();
         BOOL handle_NtUserIsTouchWindow();
@@ -1490,6 +1491,7 @@ namespace sogen
         add_handler(NtUserShowCaret);
         add_handler(NtUserHideCaret);
         add_handler(NtUserDestroyCaret);
+        add_handler(NtUserGetObjectInformation);
         add_handler(NtUserQueryWindow);
         add_handler(NtUserSetScrollInfo);
         add_handler(NtUserTrackMouseEvent);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4438,6 +4438,11 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserGetObjectInformation()
+        {
+            return FALSE;
+        }
+
         uint64_t handle_NtUserQueryWindow(const syscall_context& c, const hwnd window_handle, const uint32_t query_type)
         {
             const auto* win = c.proc.windows.get(window_handle);


### PR DESCRIPTION
Closing open-iw5 (MW3) single-player froze the emulator deterministically — a guest thread waited on a wakeup that never fired, so the cooperative scheduler idled forever. Two fixes, found by dumping the guest thread wait-states at the hang.

## 1. Wait on a reaped thread handle never completes (`767c6f28`)
The shutdown thread does `WaitForSingleObject` on a worker thread's handle (a join). Once that worker had terminated **and been reaped** from the thread store, `observe_object_signal` / `consume_object_signal` looked the thread up, found nothing, and reported **not-signaled** — so the join hung forever.

On Windows a terminated thread's handle stays **signaled**, even after the object is gone. Treat a missing (reaped) thread the same as a terminated one in both `observe_object_signal` and `consume_object_signal`. With this, the join completes and the shutdown thread proceeds to `NtTerminateProcess(NULL)` to tear down the rest.

## 2. `NtUserGetObjectInformation` stub (`34efaf21`)
After the join was fixed, shutdown reached `NtUserGetObjectInformation` (called during cleanup), which was a known-but-unimplemented syscall and halted the emulator. Stubbed to fail (`FALSE`) for the USER objects the emulator does not model, consistent with the other UI stubs.

## Result
open-iw5 SP now shuts down cleanly on close (`Emulation terminated with status: 3`, the game's own exit code) instead of hanging. Verified end-to-end: launch → load a map → close → prompt clean exit.

Diagnostic instrumentation used to find this (a deadlock watchdog that dumps thread wait-states) is intentionally **not** included.