### PR TITLE
GTA San Andreas bringup: file-handle waits + WoW64 CWD path capacity

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -101,6 +101,17 @@ namespace sogen
                 break;
             }
 
+            case handle_types::file: {
+                // File I/O is synchronous in the emulator, so no operation is ever in flight when a
+                // wait is issued -- the file object's built-in event stays signaled.
+                if (h.value.is_pseudo || c.files.get(h))
+                {
+                    return wait_state::signaled;
+                }
+
+                break;
+            }
+
             case handle_types::mutant: {
                 const auto* e = c.mutants.get(h);
                 if (e && e->is_signaled(current_thread_id))
@@ -190,6 +201,15 @@ namespace sogen
                 if (event->type == SynchronizationEvent)
                 {
                     event->signaled = false;
+                }
+
+                return wait_state::signaled;
+            }
+
+            case handle_types::file: {
+                if (!h.value.is_pseudo && !c.files.get(h))
+                {
+                    return std::nullopt;
                 }
 
                 return wait_state::signaled;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -392,7 +392,7 @@ namespace sogen
                     allocator.make_unicode_string(params32.CommandLine, read_unicode_string(emu, params64.CommandLine));
                     allocator.make_unicode_string(params32.DllPath, read_unicode_string(emu, params64.DllPath));
                     allocator.make_unicode_string(params32.CurrentDirectory.DosPath,
-                                                  read_unicode_string(emu, params64.CurrentDirectory.DosPath));
+                                                  read_unicode_string(emu, params64.CurrentDirectory.DosPath), 1024);
                     allocator.make_unicode_string(params32.WindowTitle, read_unicode_string(emu, params64.WindowTitle));
                     allocator.make_unicode_string(params32.DesktopInfo, read_unicode_string(emu, params64.DesktopInfo));
                     allocator.make_unicode_string(params32.ShellInfo, read_unicode_string(emu, params64.ShellInfo));

--- a/src/windows-emulator/syscalls/object.cpp
+++ b/src/windows-emulator/syscalls/object.cpp
@@ -496,6 +496,14 @@ namespace sogen
             case handle_types::process:
                 return h == GUEST_PROCESS_HANDLE ? STATUS_SUCCESS : STATUS_INVALID_HANDLE;
 
+            case handle_types::file:
+                if (h.value.is_pseudo)
+                {
+                    return STATUS_SUCCESS;
+                }
+
+                return validate_handle_in_store(c.proc.files);
+
             case handle_types::event:
                 if (h.value.is_pseudo)
                 {


### PR DESCRIPTION
## Summary

Two fixes that let GTA San Andreas' `Setup.exe` boot past asset loading. The game now runs all the way through model/text loading and exits cleanly (status 0) at the audio-device check ("no audio card installed").

### 1. Support waiting on file handles
`NtWaitForSingleObject`/`NtWaitForMultipleObjects` previously aborted with `Wait handle type not supported: 1` (type 1 = `file`). The game reads `GTA3.IMG` and then waits on the file handle.

File I/O is synchronous in the emulator, so a file object never has an operation in flight when waited on — its built-in event is always signaled. Added the `file` case to `validate_wait_handle`, `observe_object_signal`, and `consume_object_signal`.

### 2. WoW64 current-directory path capacity
After the wait fix, the game crashed with a null-`FILE*` `fread` inside `CText::Load`. Root cause: `SetDir("TEXT")` → `SetCurrentDirectoryA("...\GTA San Andreas\TEXT\")` returned FALSE with `GetLastError = 206` (`ERROR_FILENAME_EXCED_RANGE`).

The 32-bit `RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath` was allocated with `MaximumLength` equal to exactly the initial working-directory length (the 64-bit copy gets `1024`, the 32-bit copy got none). Without spare capacity, guest ntdll's `RtlSetCurrentDirectory_U` rejected any chdir into a longer path with `STATUS_NAME_TOO_LONG`. The game ignored the chdir failure and `fopen`'d `AMERICAN.GXT` at the game root, got null, and `fread` crashed on it.

Gave the 32-bit DosPath the same `1024` capacity as the 64-bit one.

## Testing
- GTA SA `Setup.exe` now boots through asset loading and exits cleanly (verified under both WHP and Unicorn backends — the failures were not backend-specific).
- `analyzer -s test-sample.exe` smoke test passes all tests (including Working Directory) with no regression.
- Built with the `release` preset; `tidy` not yet run.

@claude review