### PR TITLE
client-ids: 4-aligned process and thread ids like Windows

### DIFF
--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -352,7 +352,7 @@ namespace sogen
                 // https://github.com/momo5502/emulator/issues/128
                 reinterpret_cast<uint8_t*>(&teb_obj)[0x179C] = 1;
 
-                teb_obj.ClientId.UniqueProcess = 1ul;
+                teb_obj.ClientId.UniqueProcess = process_context::process_id;
                 teb_obj.ClientId.UniqueThread = static_cast<uint64_t>(this->id);
                 teb_obj.DeallocationStack = this->stack_base;
                 teb_obj.NtTib.StackLimit = this->stack_base;
@@ -423,7 +423,7 @@ namespace sogen
             // https://github.com/momo5502/emulator/issues/128
             reinterpret_cast<uint8_t*>(&teb_obj)[0x179C] = 1;
 
-            teb_obj.ClientId.UniqueProcess = 1ul;
+            teb_obj.ClientId.UniqueProcess = process_context::process_id;
             teb_obj.ClientId.UniqueThread = static_cast<uint64_t>(this->id);
 
             // Native 64-bit stack
@@ -490,7 +490,7 @@ namespace sogen
             teb32_obj.NtTib.ArbitraryUserPointer = static_cast<uint32_t>(0x0);
 
             // Set ClientId for 32-bit TEB
-            teb32_obj.ClientId.UniqueProcess = 1;
+            teb32_obj.ClientId.UniqueProcess = process_context::process_id;
             teb32_obj.ClientId.UniqueThread = this->id;
 
             // Set 32-bit PEB pointer

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -863,7 +863,9 @@ namespace sogen
     handle process_context::create_thread(memory_manager& memory, const uint64_t start_address, const uint64_t argument,
                                           const uint64_t stack_size, const uint32_t create_flags, const bool initial_thread)
     {
-        emulator_thread t{memory, *this, start_address, argument, stack_size, create_flags, ++this->spawned_thread_count, initial_thread};
+        // Thread ids are 8, 12, 16, ... (the process keeps id 4); all 4-aligned like real Windows.
+        const uint32_t thread_id = (++this->spawned_thread_count + 1) * 4;
+        emulator_thread t{memory, *this, start_address, argument, stack_size, create_flags, thread_id, initial_thread};
         auto [h, thr] = this->threads.store_and_get(std::move(t));
         this->thread_handles_by_id[thr->id] = h;
         this->callbacks_->on_thread_create(h, *thr);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -436,6 +436,10 @@ namespace sogen
 
         std::vector<std::byte> default_register_set{};
 
+        // Process and thread ids mimic Windows' PspCidTable: a single space of distinct multiples of 4.
+        // The process keeps id 4; threads take 8, 12, 16, ... Real Windows never hands out tiny or
+        // non-4-aligned ids, and some code (e.g. CEG-style anti-tamper) relies on that.
+        static constexpr uint32_t process_id = 4;
         uint32_t spawned_thread_count{0};
         handle_store<handle_types::thread, emulator_thread> threads{};
         emulator_thread* active_thread{nullptr};

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -132,7 +132,7 @@ namespace sogen
             case ProcessBasicInformation: {
                 const auto init_basic_info = [&](PROCESS_BASIC_INFORMATION64& basic_info) {
                     basic_info.PebBaseAddress = c.proc.peb64.value();
-                    basic_info.UniqueProcessId = 1;
+                    basic_info.UniqueProcessId = process_context::process_id;
                 };
 
                 switch (process_information_length)

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -201,7 +201,7 @@ namespace sogen
             using proc_t = SYSTEM_PROCESS_INFORMATION<Traits>;
             using thread_t = SYSTEM_THREAD_INFORMATION<Traits>;
 
-            uint64_t process_id = 1;
+            uint64_t process_id = process_context::process_id;
             uint64_t active_tid = 0;
             if (c.proc.active_thread && c.proc.active_thread->teb64)
             {


### PR DESCRIPTION
## What

Process and thread ids handed to the guest are now distinct multiples of 4, matching Windows:
- **Process id** is `4` (canonical `process_context::process_id`), replacing the literal `1` that was hardcoded in five places.
- **Thread ids** are `8, 12, 16, ...` (were `1, 2, 3, ...`).

## Why

Real Windows allocates process/thread ids from a single table (PspCidTable) as distinct, 4-aligned, non-trivial values — the low two bits are always zero. Some guest code relies on this (e.g. anti-tamper that packs flags into the low bits, or uses thread ids as 4-aligned table keys). Returning `1, 2, 3` from `GetCurrentThreadId` / `GetCurrentProcessId` is unrealistic and can break such code.

## Notes

- `process_context::process_id` is now the single source of truth for the PID (was duplicated as `1` across `emulator_thread.cpp`, `process.cpp`, `system.cpp`).
- IDs are kept distinct (process keeps `4`, threads start at `8`) so nothing comparing PID vs TID collides.