### PR TITLE
Fix async presentation of static frames in GPU-bridge

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -18,6 +18,18 @@ namespace sogen
         // in snapshots yet; restoring with an open GPU handle is an experimental limitation.
         struct gpu_bridge_device : io_device
         {
+            void work(windows_emulator& win_emu) override
+            {
+                for (auto& frame : this->vulkan_.poll_presented_frames())
+                {
+                    win_emu.ui().present_surface(static_cast<hwnd>(frame.hwnd), ui_surface_desc{.width = static_cast<int>(frame.width),
+                                                                                                .height = static_cast<int>(frame.height),
+                                                                                                .stride = static_cast<int>(frame.width * 4),
+                                                                                                .format = ui_surface_format::bgra8,
+                                                                                                .pixels = frame.pixels.data()});
+                }
+            }
+
             NTSTATUS io_control(windows_emulator& win_emu, const io_device_context& context) override
             {
                 switch (context.io_control_code)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -22,11 +22,7 @@ namespace sogen
             {
                 for (auto& frame : this->vulkan_.poll_presented_frames())
                 {
-                    win_emu.ui().present_surface(static_cast<hwnd>(frame.hwnd), ui_surface_desc{.width = static_cast<int>(frame.width),
-                                                                                                .height = static_cast<int>(frame.height),
-                                                                                                .stride = static_cast<int>(frame.width * 4),
-                                                                                                .format = ui_surface_format::bgra8,
-                                                                                                .pixels = frame.pixels.data()});
+                    present_surface_if_ready(win_emu, frame.hwnd, frame.width, frame.height, frame.pixels);
                 }
             }
 
@@ -261,6 +257,23 @@ namespace sogen
                 {
                     context.io_status_block.access([&](IO_STATUS_BLOCK<EmulatorTraits<Emu64>>& block) { block.Information = bytes; });
                 }
+            }
+
+            static void present_surface_if_ready(windows_emulator& win_emu, const uint64_t hwnd_value, const uint32_t width,
+                                                 const uint32_t height, const std::vector<std::byte>& pixels)
+            {
+                if (hwnd_value == 0 || pixels.empty())
+                {
+                    return;
+                }
+
+                win_emu.ui().present_surface(static_cast<hwnd>(hwnd_value), ui_surface_desc{
+                                                                                .width = static_cast<int>(width),
+                                                                                .height = static_cast<int>(height),
+                                                                                .stride = static_cast<int>(width * 4),
+                                                                                .format = ui_surface_format::bgra8,
+                                                                                .pixels = pixels.data(),
+                                                                            });
             }
 
             // Reads a fixed-size request struct from the guest input buffer.
@@ -1640,15 +1653,9 @@ namespace sogen
 
                 // Hand the freshly read-back pixels to the guest window through the UI backend (the same
                 // seam GDI EndPaint uses). The swapchain is B8G8R8A8, matching bgra8, so no swizzle.
-                if (result == 0 /* VK_SUCCESS */ && hwnd_value != 0 && !pixels.empty())
+                if (result == 0 /* VK_SUCCESS */)
                 {
-                    win_emu.ui().present_surface(static_cast<hwnd>(hwnd_value), ui_surface_desc{
-                                                                                    .width = static_cast<int>(width),
-                                                                                    .height = static_cast<int>(height),
-                                                                                    .stride = static_cast<int>(width * 4),
-                                                                                    .format = ui_surface_format::bgra8,
-                                                                                    .pixels = pixels.data(),
-                                                                                });
+                    present_surface_if_ready(win_emu, hwnd_value, width, height, pixels);
                 }
 
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <unordered_map>
 #include <vector>
+#include <ranges>
 
 #define VK_NO_PROTOTYPES
 #include <vulkan/vulkan_core.h>
@@ -507,6 +508,26 @@ namespace sogen
         std::unordered_map<uint64_t, descriptor_pool_data> descriptor_pools;
         std::unordered_map<uint64_t, descriptor_set_data> descriptor_sets;
         uint64_t next_id{1};
+
+        static bool drain_readback(swapchain_data& sc, device_data& dev, vulkan_host::presented_frame& frame)
+        {
+            const auto readback_size = static_cast<VkDeviceSize>(sc.width) * sc.height * 4;
+            void* mapped = nullptr;
+            if (dev.map_memory(dev.handle, sc.readback_memory, 0, readback_size, 0, &mapped) != VK_SUCCESS || !mapped)
+            {
+                sc.present_in_flight = false;
+                return false;
+            }
+
+            frame.pixels.resize(static_cast<size_t>(readback_size));
+            std::memcpy(frame.pixels.data(), mapped, frame.pixels.size());
+            dev.unmap_memory(dev.handle, sc.readback_memory);
+            frame.width = sc.width;
+            frame.height = sc.height;
+            frame.hwnd = sc.hwnd;
+            sc.present_in_flight = false;
+            return true;
+        }
 
         // Picks the first memory type set in `type_bits` that has all `required` property flags, using
         // the memory properties of the device's physical device. Returns UINT32_MAX if none qualifies.
@@ -3590,8 +3611,6 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        const VkDeviceSize readback_size = static_cast<VkDeviceSize>(sc.width) * sc.height * 4;
-
         // The work loop normally collects completed readbacks. If another present arrives first, reclaim
         // the single readback slot here; waiting is only necessary when the guest outruns the GPU copy.
         if (sc.present_in_flight)
@@ -3601,17 +3620,14 @@ namespace sogen
                 dev.queue_wait_idle(queue_it->second.handle);
             }
 
-            void* mapped = nullptr;
-            if (dev.map_memory(dev.handle, sc.readback_memory, 0, readback_size, 0, &mapped) == VK_SUCCESS && mapped)
+            presented_frame frame{};
+            if (impl::drain_readback(sc, dev, frame))
             {
-                out_pixels.resize(static_cast<size_t>(readback_size));
-                std::memcpy(out_pixels.data(), mapped, out_pixels.size());
-                dev.unmap_memory(dev.handle, sc.readback_memory);
-                out_width = sc.width;
-                out_height = sc.height;
-                out_hwnd = sc.hwnd;
+                out_pixels = std::move(frame.pixels);
+                out_width = frame.width;
+                out_height = frame.height;
+                out_hwnd = frame.hwnd;
             }
-            sc.present_in_flight = false;
         }
 
         // Make the rendered image's writes visible to the copy, then copy it into the readback buffer.
@@ -3673,9 +3689,8 @@ namespace sogen
     {
         std::vector<presented_frame> frames{};
 
-        for (auto& [id, sc] : this->impl_->swapchains)
+        for (auto& sc : this->impl_->swapchains | std::views::values)
         {
-            (void)id;
             if (!sc.present_in_flight)
             {
                 continue;
@@ -3693,22 +3708,12 @@ namespace sogen
                 continue;
             }
 
-            const auto readback_size = static_cast<VkDeviceSize>(sc.width) * sc.height * 4;
-            void* mapped = nullptr;
-            if (dev.map_memory(dev.handle, sc.readback_memory, 0, readback_size, 0, &mapped) != VK_SUCCESS || !mapped)
+            auto& frame = frames.emplace_back();
+            if (!impl::drain_readback(sc, dev, frame))
             {
-                sc.present_in_flight = false;
+                frames.pop_back();
                 continue;
             }
-
-            auto& frame = frames.emplace_back();
-            frame.pixels.resize(static_cast<size_t>(readback_size));
-            std::memcpy(frame.pixels.data(), mapped, frame.pixels.size());
-            dev.unmap_memory(dev.handle, sc.readback_memory);
-            frame.width = sc.width;
-            frame.height = sc.height;
-            frame.hwnd = sc.hwnd;
-            sc.present_in_flight = false;
         }
 
         return frames;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -337,9 +337,8 @@ namespace sogen
             VkCommandBuffer present_cmd{};
             VkFence present_fence{};
             uint32_t next_image{};
-            // Async present: the readback copy of the most recent frame is submitted but not waited on
-            // here; it is drained on the *next* present (by which point the GPU has finished it), so the
-            // host thread never blocks on vkQueueWaitIdle inline. Present is therefore one frame behind.
+            // The device work loop polls this copy so the frame can be displayed without waiting for
+            // another guest present.
             bool present_in_flight{};
         };
 
@@ -3593,12 +3592,8 @@ namespace sogen
 
         const VkDeviceSize readback_size = static_cast<VkDeviceSize>(sc.width) * sc.height * 4;
 
-        // Async present, part 1: drain the copy submitted on the *previous* present and hand its pixels
-        // back to be shown now. A full guest frame has elapsed since it was submitted, so its fence is
-        // essentially always already signalled (the GPU did the copy while the guest rendered the next
-        // frame) -- only fall back to a blocking wait in the unlikely case it is not. The previous
-        // synchronous vkQueueWaitIdle here was ~25% of the emulated frame; deferring keeps it off the
-        // host thread's critical path. Present is therefore one frame behind, which is imperceptible.
+        // The work loop normally collects completed readbacks. If another present arrives first, reclaim
+        // the single readback slot here; waiting is only necessary when the guest outruns the GPU copy.
         if (sc.present_in_flight)
         {
             if (dev.get_fence_status(dev.handle, sc.present_fence) != VK_SUCCESS)
@@ -3619,9 +3614,6 @@ namespace sogen
             sc.present_in_flight = false;
         }
 
-        // Async present, part 2: record + submit the copy for the *current* frame, but do not wait on it.
-        // It runs on the GPU while the guest proceeds; the next present drains it (above). The previous
-        // copy is guaranteed finished here (the drain checked its fence), so reusing present_cmd is safe.
         // Make the rendered image's writes visible to the copy, then copy it into the readback buffer.
         // The guest left the image in PRESENT_SRC, which the bridge mapped to TRANSFER_SRC_OPTIMAL.
         VkCommandBufferBeginInfo begin{};
@@ -3671,9 +3663,55 @@ namespace sogen
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
+        // Do not wait here. gpu_bridge_device::work publishes the frame as soon as this fence signals.
         sc.present_in_flight = true;
 
         return VK_SUCCESS;
+    }
+
+    std::vector<vulkan_host::presented_frame> vulkan_host::poll_presented_frames()
+    {
+        std::vector<presented_frame> frames{};
+
+        for (auto& [id, sc] : this->impl_->swapchains)
+        {
+            (void)id;
+            if (!sc.present_in_flight)
+            {
+                continue;
+            }
+
+            const auto dev_it = this->impl_->devices.find(sc.device_id);
+            if (dev_it == this->impl_->devices.end())
+            {
+                continue;
+            }
+            auto& dev = dev_it->second;
+            if (!dev.get_fence_status || !dev.map_memory || !dev.unmap_memory ||
+                dev.get_fence_status(dev.handle, sc.present_fence) != VK_SUCCESS)
+            {
+                continue;
+            }
+
+            const auto readback_size = static_cast<VkDeviceSize>(sc.width) * sc.height * 4;
+            void* mapped = nullptr;
+            if (dev.map_memory(dev.handle, sc.readback_memory, 0, readback_size, 0, &mapped) != VK_SUCCESS || !mapped)
+            {
+                sc.present_in_flight = false;
+                continue;
+            }
+
+            auto& frame = frames.emplace_back();
+            frame.pixels.resize(static_cast<size_t>(readback_size));
+            std::memcpy(frame.pixels.data(), mapped, frame.pixels.size());
+            dev.unmap_memory(dev.handle, sc.readback_memory);
+            frame.width = sc.width;
+            frame.height = sc.height;
+            frame.hwnd = sc.hwnd;
+            sc.present_in_flight = false;
+        }
+
+        return frames;
     }
 
     int32_t vulkan_host::create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module)

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -367,11 +367,23 @@ namespace sogen
         // render submit that waits on them can proceed (0 = none).
         int32_t acquire_next_image(uint64_t swapchain, uint64_t semaphore, uint64_t fence, uint32_t& out_index);
 
-        // Copies the presented image into the readback buffer (blocking on the queue), then fills
-        // out_pixels (BGRA, width*height*4) and reports the target window/extent so the caller can hand
-        // the pixels to the UI backend.
+        // Submits an asynchronous copy of the presented image into the readback buffer. If the previous
+        // copy has already completed, out_pixels receives that frame immediately; otherwise it is later
+        // returned by poll_presented_frames().
         int32_t queue_present(uint64_t queue, uint64_t swapchain, uint32_t image_index, std::vector<std::byte>& out_pixels,
                               uint32_t& out_width, uint32_t& out_height, uint64_t& out_hwnd);
+
+        struct presented_frame
+        {
+            std::vector<std::byte> pixels{};
+            uint32_t width{};
+            uint32_t height{};
+            uint64_t hwnd{};
+        };
+
+        // Collects readbacks whose GPU fences have completed without waiting. This lets the host UI
+        // display a static final frame even when the guest does not issue another present.
+        std::vector<presented_frame> poll_presented_frames();
 
         // --- graphics pipeline (enough for a render-pass triangle) ---
 


### PR DESCRIPTION
This PR fixes asynchronous presentation by polling for completed GPU readbacks in the device work loop and presenting them immediately, so completed static frames appear without requiring another guest present. This was a particularly noticeable issue in apps that did not re-render until something on the screen changed.