### PR TITLE
Fix gaps in posted messages

### DIFF
--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -29,12 +29,12 @@ namespace sogen
 
             virtual ~clock() = default;
 
-            virtual system_time_point system_now()
+            virtual system_time_point system_now() const
             {
                 return std::chrono::system_clock::now();
             }
 
-            virtual steady_time_point steady_now()
+            virtual steady_time_point steady_now() const
             {
                 return std::chrono::steady_clock::now();
             }
@@ -66,12 +66,12 @@ namespace sogen
                 }
             }
 
-            system_time_point system_now() override
+            system_time_point system_now() const override
             {
                 return this->now(this->system_start_);
             }
 
-            steady_time_point steady_now() override
+            steady_time_point steady_now() const override
             {
                 return this->now(this->steady_start_);
             }
@@ -81,7 +81,7 @@ namespace sogen
                 return this->ticks();
             }
 
-            virtual uint64_t ticks() = 0;
+            virtual uint64_t ticks() const = 0;
 
             uint64_t get_frequency() const
             {
@@ -94,7 +94,7 @@ namespace sogen
             steady_time_point steady_start_{};
 
             template <typename TimePoint>
-            TimePoint now(const TimePoint start)
+            TimePoint now(const TimePoint start) const
             {
                 using duration = typename TimePoint::duration;
 

--- a/src/common/utils/time.hpp
+++ b/src/common/utils/time.hpp
@@ -29,12 +29,12 @@ namespace sogen
 
             virtual ~clock() = default;
 
-            virtual system_time_point system_now() const
+            virtual system_time_point system_now()
             {
                 return std::chrono::system_clock::now();
             }
 
-            virtual steady_time_point steady_now() const
+            virtual steady_time_point steady_now()
             {
                 return std::chrono::steady_clock::now();
             }
@@ -66,12 +66,12 @@ namespace sogen
                 }
             }
 
-            system_time_point system_now() const override
+            system_time_point system_now() override
             {
                 return this->now(this->system_start_);
             }
 
-            steady_time_point steady_now() const override
+            steady_time_point steady_now() override
             {
                 return this->now(this->steady_start_);
             }
@@ -81,7 +81,7 @@ namespace sogen
                 return this->ticks();
             }
 
-            virtual uint64_t ticks() const = 0;
+            virtual uint64_t ticks() = 0;
 
             uint64_t get_frequency() const
             {
@@ -94,7 +94,7 @@ namespace sogen
             steady_time_point steady_start_{};
 
             template <typename TimePoint>
-            TimePoint now(const TimePoint start) const
+            TimePoint now(const TimePoint start)
             {
                 using duration = typename TimePoint::duration;
 

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -214,6 +214,7 @@ namespace sogen
 #define WM_NCDESTROY         0x0082
 #define WM_NCCALCSIZE        0x0083
 #define WM_NCACTIVATE        0x0086
+#define WM_NCMOUSEMOVE       0x00A0
 #define WM_INPUT             0x00FF
 
 #define RID_INPUT            0x10000003

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -72,10 +72,10 @@ namespace sogen
         UINT message;
         wparam wParam;
         lparam lParam;
-        DWORD time;
-        POINT pt;
+        DWORD time{};
+        POINT pt{};
 #ifdef _MAC
-        DWORD lPrivate;
+        DWORD lPrivate{};
 #endif
     };
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -860,7 +860,7 @@ namespace sogen
     void emulator_thread::post_message(const windows_emulator& win_emu, msg msg, const bool try_coalesce)
     {
         msg.time = get_current_message_time(win_emu.clock());
-        msg.pt = {win_emu.process.cursor_x, win_emu.process.cursor_y};
+        msg.pt = {.x = win_emu.process.cursor_x, .y = win_emu.process.cursor_y};
 
         if (try_coalesce && this->can_coalesce_message(msg))
         {

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -317,6 +317,13 @@ namespace sogen
                 mask &= ~bit;
             }
         }
+
+        DWORD get_current_message_time(const utils::clock& clock)
+        {
+            const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(clock.steady_now().time_since_epoch()).count();
+            return static_cast<DWORD>(now_ms);
+        }
+
     }
 
     emulator_thread::emulator_thread(memory_manager& memory, const process_context& context, const uint64_t start_address,
@@ -697,10 +704,10 @@ namespace sogen
         return true;
     }
 
-    bool emulator_thread::synthesize_due_user_timer(utils::clock& clock, const hwnd hwnd_filter, const UINT filter_min,
+    bool emulator_thread::synthesize_due_user_timer(const windows_emulator& win_emu, const hwnd hwnd_filter, const UINT filter_min,
                                                     const UINT filter_max)
     {
-        const auto now = clock.steady_now();
+        const auto now = win_emu.clock().steady_now();
         for (auto& user_timer : this->user_timers | std::views::values)
         {
             if (!user_timer.due_time.has_value() || user_timer.due_time.value() > now)
@@ -729,7 +736,7 @@ namespace sogen
                 continue;
             }
 
-            this->post_message(timer_message);
+            this->post_message(win_emu, timer_message, true);
             user_timer.due_time = now + user_timer.interval;
             return true;
         }
@@ -737,11 +744,11 @@ namespace sogen
         return false;
     }
 
-    uint32_t emulator_thread::get_message_queue_status(utils::clock& clock)
+    uint32_t emulator_thread::get_message_queue_status(const windows_emulator& win_emu)
     {
         if (this->await_msg_mask && (*this->await_msg_mask & QS_TIMER) != 0)
         {
-            (void)this->synthesize_due_user_timer(clock);
+            (void)this->synthesize_due_user_timer(win_emu);
         }
 
         return this->message_queue_status_bits;
@@ -774,10 +781,10 @@ namespace sogen
         }
     }
 
-    std::optional<msg> emulator_thread::peek_pending_message(const process_context& process, utils::clock& clock, hwnd hwnd_filter,
-                                                             UINT filter_min, UINT filter_max, bool remove)
+    std::optional<msg> emulator_thread::peek_pending_message(const windows_emulator& win_emu, hwnd hwnd_filter, UINT filter_min,
+                                                             UINT filter_max, bool remove)
     {
-        (void)this->synthesize_due_user_timer(clock, hwnd_filter, filter_min, filter_max);
+        (void)this->synthesize_due_user_timer(win_emu, hwnd_filter, filter_min, filter_max);
 
         for (auto it = message_queue.begin(); it != message_queue.end(); ++it)
         {
@@ -788,7 +795,7 @@ namespace sogen
                     continue;
                 }
             }
-            else if (hwnd_filter != 0 && !window_matches_filter(process, it->window, hwnd_filter))
+            else if (hwnd_filter != 0 && !window_matches_filter(win_emu.process, it->window, hwnd_filter))
             {
                 continue;
             }
@@ -823,8 +830,44 @@ namespace sogen
         return std::nullopt;
     }
 
-    void emulator_thread::post_message(const msg& msg)
+    bool emulator_thread::can_coalesce_message(const msg& msg) const
     {
+        if (message_queue.empty())
+        {
+            return false;
+        }
+
+        const auto& tail_msg = message_queue.back();
+        if (tail_msg.message != msg.message || tail_msg.window != msg.window)
+        {
+            return false;
+        }
+
+        switch (msg.message)
+        {
+        case WM_MOUSEMOVE:
+        case WM_NCMOUSEMOVE:
+            return true;
+
+        case WM_TIMER:
+            return tail_msg.wParam == msg.wParam && tail_msg.lParam == msg.lParam;
+
+        default:
+            return false;
+        }
+    }
+
+    void emulator_thread::post_message(const windows_emulator& win_emu, msg msg, const bool try_coalesce)
+    {
+        msg.time = get_current_message_time(win_emu.clock());
+        msg.pt = {win_emu.process.cursor_x, win_emu.process.cursor_y};
+
+        if (try_coalesce && this->can_coalesce_message(msg))
+        {
+            message_queue.back() = msg;
+            return;
+        }
+
         const auto bits = get_message_queue_status_bits(msg);
 
         for_each_queue_status_bit(bits, [this](const uint32_t /*bit*/, const size_t index) { //
@@ -841,12 +884,15 @@ namespace sogen
         return this->exit_status.has_value();
     }
 
-    bool emulator_thread::is_thread_ready(process_context& process, utils::clock& clock)
+    bool emulator_thread::is_thread_ready(windows_emulator& win_emu)
     {
         if (this->is_terminated() || this->suspended > 0)
         {
             return false;
         }
+
+        auto& process = win_emu.process;
+        auto& clock = win_emu.clock();
 
         const auto complete_if_timed_out = [&](const NTSTATUS status) {
             if (!this->is_await_time_over(clock) || this->has_pending_alertable_apc())
@@ -912,7 +958,7 @@ namespace sogen
             bool message_ready = false;
             if (this->await_msg_mask.has_value())
             {
-                const auto current_message_bits = this->get_message_queue_status(clock);
+                const auto current_message_bits = this->get_message_queue_status(win_emu);
                 message_ready = (current_message_bits & *this->await_msg_mask) != 0;
             }
 
@@ -1025,10 +1071,11 @@ namespace sogen
 
         if (this->await_msg.has_value())
         {
-            if (const auto m = this->peek_pending_message(process, clock, this->await_msg->hwnd_filter, this->await_msg->filter_min,
+            if (const auto m = this->peek_pending_message(win_emu, this->await_msg->hwnd_filter, this->await_msg->filter_min,
                                                           this->await_msg->filter_max, true))
             {
                 this->await_msg->message.write(*m);
+                this->current_message_time = m->time;
 
                 uint64_t active_handle = 0;
                 uint64_t active_window_ptr = 0;

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -318,12 +318,12 @@ namespace sogen
             }
         }
 
-        DWORD get_current_message_time(const utils::clock& clock)
+        DWORD get_current_message_time(utils::clock& clock)
         {
-            const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(clock.steady_now().time_since_epoch()).count();
+            const auto now = clock.steady_now().time_since_epoch();
+            const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
             return static_cast<DWORD>(now_ms);
         }
-
     }
 
     emulator_thread::emulator_thread(memory_manager& memory, const process_context& context, const uint64_t start_address,
@@ -704,7 +704,7 @@ namespace sogen
         return true;
     }
 
-    bool emulator_thread::synthesize_due_user_timer(const windows_emulator& win_emu, const hwnd hwnd_filter, const UINT filter_min,
+    bool emulator_thread::synthesize_due_user_timer(windows_emulator& win_emu, const hwnd hwnd_filter, const UINT filter_min,
                                                     const UINT filter_max)
     {
         const auto now = win_emu.clock().steady_now();
@@ -744,7 +744,7 @@ namespace sogen
         return false;
     }
 
-    uint32_t emulator_thread::get_message_queue_status(const windows_emulator& win_emu)
+    uint32_t emulator_thread::get_message_queue_status(windows_emulator& win_emu)
     {
         if (this->await_msg_mask && (*this->await_msg_mask & QS_TIMER) != 0)
         {
@@ -781,8 +781,8 @@ namespace sogen
         }
     }
 
-    std::optional<msg> emulator_thread::peek_pending_message(const windows_emulator& win_emu, hwnd hwnd_filter, UINT filter_min,
-                                                             UINT filter_max, bool remove)
+    std::optional<msg> emulator_thread::peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
+                                                             bool remove)
     {
         (void)this->synthesize_due_user_timer(win_emu, hwnd_filter, filter_min, filter_max);
 
@@ -857,18 +857,18 @@ namespace sogen
         }
     }
 
-    void emulator_thread::post_message(const windows_emulator& win_emu, msg msg, const bool try_coalesce)
+    void emulator_thread::post_message(windows_emulator& win_emu, msg msg, const bool try_coalesce)
     {
         msg.time = get_current_message_time(win_emu.clock());
         msg.pt = {.x = win_emu.process.cursor_x, .y = win_emu.process.cursor_y};
+        const auto bits = get_message_queue_status_bits(msg);
 
         if (try_coalesce && this->can_coalesce_message(msg))
         {
+            this->queue_status_changed_bits |= bits;
             message_queue.back() = msg;
             return;
         }
-
-        const auto bits = get_message_queue_status_bits(msg);
 
         for_each_queue_status_bit(bits, [this](const uint32_t /*bit*/, const size_t index) { //
             ++this->message_queue_status_bit_counts[index];

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -337,6 +337,7 @@ namespace sogen
         std::map<user_timer_key, user_timer> user_timers{};
         uint64_t next_user_timer_id{1};
         std::vector<msg> message_queue;
+        DWORD current_message_time{};
         std::array<uint32_t, 32> message_queue_status_bit_counts{};
         uint32_t message_queue_status_bits{};
         uint32_t queue_status_changed_bits{};
@@ -358,16 +359,16 @@ namespace sogen
         user_timer& create_user_timer(process_context& process, hwnd hwnd, uint64_t timer_id, uint64_t timer_proc,
                                       std::chrono::milliseconds interval, std::chrono::steady_clock::time_point now);
         bool delete_user_timer(hwnd hwnd, uint64_t timer_id);
-        bool synthesize_due_user_timer(utils::clock& clock, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
+        bool synthesize_due_user_timer(const windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
 
-        uint32_t get_message_queue_status(utils::clock& clock);
-        std::optional<msg> peek_pending_message(const process_context& process, utils::clock& clock, hwnd hwnd_filter = 0,
-                                                UINT filter_min = 0, UINT filter_max = 0, bool remove = false);
-        void post_message(const msg& msg);
+        uint32_t get_message_queue_status(const windows_emulator& win_emu);
+        std::optional<msg> peek_pending_message(const windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0,
+                                                UINT filter_max = 0, bool remove = false);
+        void post_message(const windows_emulator& win_emu, msg msg, bool try_coalesce = false);
 
         bool is_terminated() const;
 
-        bool is_thread_ready(process_context& process, utils::clock& clock);
+        bool is_thread_ready(windows_emulator& win_emu);
 
         void save(x86_64_emulator& emu)
         {
@@ -457,6 +458,7 @@ namespace sogen
             buffer.write_map(this->user_timers);
             buffer.write(this->next_user_timer_id);
             buffer.write_vector(this->message_queue);
+            buffer.write(this->current_message_time);
             buffer.write(this->message_queue_status_bit_counts);
             buffer.write(this->message_queue_status_bits);
             buffer.write(this->queue_status_changed_bits);
@@ -524,6 +526,7 @@ namespace sogen
             buffer.read_map(this->user_timers);
             buffer.read(this->next_user_timer_id);
             buffer.read_vector(this->message_queue);
+            buffer.read(this->current_message_time);
             buffer.read(this->message_queue_status_bit_counts);
             buffer.read(this->message_queue_status_bits);
             buffer.read(this->queue_status_changed_bits);
@@ -540,6 +543,8 @@ namespace sogen
         }
 
       private:
+        bool can_coalesce_message(const msg& msg) const;
+
         void setup_registers(x86_64_emulator& emu, const process_context& context) const;
         void refresh_execution_context(x86_64_emulator& emu) const;
 

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -359,12 +359,12 @@ namespace sogen
         user_timer& create_user_timer(process_context& process, hwnd hwnd, uint64_t timer_id, uint64_t timer_proc,
                                       std::chrono::milliseconds interval, std::chrono::steady_clock::time_point now);
         bool delete_user_timer(hwnd hwnd, uint64_t timer_id);
-        bool synthesize_due_user_timer(const windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
+        bool synthesize_due_user_timer(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
 
-        uint32_t get_message_queue_status(const windows_emulator& win_emu);
-        std::optional<msg> peek_pending_message(const windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0,
-                                                UINT filter_max = 0, bool remove = false);
-        void post_message(const windows_emulator& win_emu, msg msg, bool try_coalesce = false);
+        uint32_t get_message_queue_status(windows_emulator& win_emu);
+        std::optional<msg> peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0,
+                                                bool remove = false);
+        void post_message(windows_emulator& win_emu, msg msg, bool try_coalesce = false);
 
         bool is_terminated() const;
 

--- a/src/windows-emulator/syscalls/event.cpp
+++ b/src/windows-emulator/syscalls/event.cpp
@@ -60,7 +60,7 @@ namespace sogen
             {
                 if (std::ranges::find(thread.await_objects, event_handle) != thread.await_objects.end())
                 {
-                    (void)thread.is_thread_ready(c.proc, c.win_emu.clock());
+                    (void)thread.is_thread_ready(c.win_emu);
                 }
             }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -17,6 +17,7 @@ namespace sogen
     {
         constexpr ULONG k_thread_state_win32_thread_info = 0xE;
         constexpr ULONG k_thread_state_dialog_state = 0xA;
+        constexpr ULONG k_thread_state_message_time = 0x9;
         constexpr size_t k_win32_thread_info_slab_size = 0x2000;
         constexpr uint64_t k_win32_thread_info_bias = 0x800;
         constexpr uint32_t k_client_setup_callback_id = 0x54;
@@ -423,7 +424,8 @@ namespace sogen
 
             if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
             {
-                thread->post_message(msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0, .time = 0, .pt = {}});
+                thread->post_message(c.win_emu,
+                                     msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0, .time = 0, .pt = {}});
                 win.paint_message_posted = true;
             }
         }
@@ -1345,6 +1347,11 @@ namespace sogen
 
         uint64_t handle_NtUserGetThreadState(const syscall_context& c, const ULONG routine)
         {
+            if (routine == k_thread_state_message_time)
+            {
+                return c.proc.active_thread ? c.proc.active_thread->current_message_time : 0;
+            }
+
             if (routine == k_thread_state_dialog_state)
             {
                 return c.proc.active_thread ? c.proc.active_thread->win32k_thread_state : 0;
@@ -2840,7 +2847,7 @@ namespace sogen
                         queued_message.message = msg;
                         queued_message.wParam = w_param;
                         queued_message.lParam = l_param;
-                        t->post_message(queued_message);
+                        t->post_message(c.win_emu, queued_message);
                         return TRUE;
                     }
                 }
@@ -2975,6 +2982,8 @@ namespace sogen
                 return 0;
             }
 
+            c.proc.active_thread->current_message_time = m.time;
+
             if (m.message == WM_TIMER && m.lParam != 0)
             {
                 set_thread_window_context(c, m.window, win ? win->guest.value() : 0);
@@ -3016,9 +3025,10 @@ namespace sogen
         {
             auto& t = c.win_emu.current_thread();
 
-            if (auto pending_msg = t.peek_pending_message(c.proc, c.win_emu.clock(), hwnd, msg_filter_min, msg_filter_max, true))
+            if (auto pending_msg = t.peek_pending_message(c.win_emu, hwnd, msg_filter_min, msg_filter_max, true))
             {
                 message.write(*pending_msg);
+                t.current_message_time = pending_msg->time;
                 set_thread_window_context(c, pending_msg->window);
                 return pending_msg->message != WM_QUIT ? TRUE : FALSE;
             }
@@ -3035,12 +3045,12 @@ namespace sogen
             auto& t = c.win_emu.current_thread();
 
             const bool should_remove = (remove_message & PM_REMOVE) != 0;
-            std::optional<msg> pending_msg =
-                t.peek_pending_message(c.proc, c.win_emu.clock(), hwnd, msg_filter_min, msg_filter_max, should_remove);
+            std::optional<msg> pending_msg = t.peek_pending_message(c.win_emu, hwnd, msg_filter_min, msg_filter_max, should_remove);
 
             if (pending_msg)
             {
                 message.write(*pending_msg);
+                t.current_message_time = pending_msg->time;
                 set_thread_window_context(c, pending_msg->window);
                 return TRUE;
             }
@@ -3051,7 +3061,7 @@ namespace sogen
         BOOL handle_NtUserWaitMessage(const syscall_context& c)
         {
             auto& t = c.win_emu.current_thread();
-            if (t.peek_pending_message(c.proc, c.win_emu.clock()))
+            if (t.peek_pending_message(c.win_emu))
             {
                 return TRUE;
             }
@@ -3125,7 +3135,7 @@ namespace sogen
                 qmsg.wParam = wParam;
                 qmsg.lParam = lParam;
 
-                thread->post_message(qmsg);
+                thread->post_message(c.win_emu, qmsg);
                 return TRUE;
             }
 
@@ -3142,7 +3152,7 @@ namespace sogen
                 qmsg.wParam = wParam;
                 qmsg.lParam = lParam;
 
-                thread->post_message(qmsg);
+                thread->post_message(c.win_emu, qmsg);
                 return TRUE;
             }
 
@@ -3155,7 +3165,7 @@ namespace sogen
             qmsg.message = WM_QUIT;
             qmsg.wParam = exit_code;
 
-            c.proc.active_thread->post_message(qmsg);
+            c.proc.active_thread->post_message(c.win_emu, qmsg);
             return TRUE;
         }
 
@@ -4284,7 +4294,7 @@ namespace sogen
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, const UINT flags)
         {
             auto* thread = c.proc.active_thread;
-            const auto current_bits = thread->get_message_queue_status(c.win_emu.clock()) & flags;
+            const auto current_bits = thread->get_message_queue_status(c.win_emu) & flags;
             const auto changed_bits = thread->queue_status_changed_bits & flags;
             return current_bits | (changed_bits << 16);
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -424,8 +424,7 @@ namespace sogen
 
             if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
             {
-                thread->post_message(c.win_emu,
-                                     msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0, .time = 0, .pt = {}});
+                thread->post_message(c.win_emu, msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0});
                 win.paint_message_posted = true;
             }
         }
@@ -2981,8 +2980,6 @@ namespace sogen
             {
                 return 0;
             }
-
-            c.proc.active_thread->current_message_time = m.time;
 
             if (m.message == WM_TIMER && m.lParam != 0)
             {

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -416,7 +416,7 @@ namespace sogen
             {
             }
 
-            uint64_t ticks() const override
+            uint64_t ticks() override
             {
                 return *this->instructions_;
             }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -321,7 +321,7 @@ namespace sogen
             auto& emu = win_emu.emu();
             auto& context = win_emu.process;
 
-            const auto is_ready = thread.is_thread_ready(context, win_emu.clock());
+            const auto is_ready = thread.is_thread_ready(win_emu);
             const auto has_pending_status = thread.pending_status.has_value();
             const auto can_dispatch_apcs = thread.apc_alertable && !thread.pending_apcs.empty();
 
@@ -416,7 +416,7 @@ namespace sogen
             {
             }
 
-            uint64_t ticks() override
+            uint64_t ticks() const override
             {
                 return *this->instructions_;
             }
@@ -976,7 +976,7 @@ namespace sogen
         while (!this->should_stop)
         {
             this->ui_backend_->pump_events();
-            if (this->switch_thread_ || !this->current_thread().is_thread_ready(this->process, this->clock()))
+            if (this->switch_thread_ || !this->current_thread().is_thread_ready(*this))
             {
                 if (!this->perform_thread_switch())
                 {
@@ -1039,7 +1039,7 @@ namespace sogen
         m.message = WM_INPUT;
         m.wParam = RIM_INPUT;
         m.lParam = token;
-        thread->post_message(m);
+        thread->post_message(*this, m);
     }
 
     void windows_emulator::handle_ui_event(const ui_event& event)
@@ -1137,7 +1137,7 @@ namespace sogen
             break;
         }
 
-        thread->post_message(m);
+        thread->post_message(*this, m, true);
 
         if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN || event.message == WM_LBUTTONDOWN ||
             event.message == WM_LBUTTONUP)


### PR DESCRIPTION
The other day, I was trying to fix an issue in a game running on Sogen, and one of my suspicions was that the missing values for the `pt` and `time` fields in messages that Sogen posts to the guest were the cause... Well, the issue was ultimately caused by #1084, but these were still good changes anyway, so I'm making this PR.

This PR also includes one other change: message coalescing, mostly for `WM_MOUSEMOVE` messages. According to the docs, this appears to be something Windows does as well.