### PR TITLE
Witcher 3 / DXVK bringup: syscall stubs and descriptor-update fix

### DIFF
--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -4428,6 +4428,7 @@ namespace sogen
 
             const bool is_image =
                 (w.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER || w.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+                 w.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE || w.descriptor_type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT ||
                  w.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER);
             if (is_image)
             {

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -70,6 +70,10 @@ namespace sogen
                                     uint64_t /*apc_context*/, emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
                                     uint64_t buffer, ULONG length, emulator_object<LARGE_INTEGER> /*byte_offset*/,
                                     emulator_object<ULONG> /*key*/);
+        NTSTATUS handle_NtCopyFileChunk(const syscall_context& c, handle source_handle, handle destination_handle, handle event_handle,
+                                        emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block, ULONG length,
+                                        emulator_object<LARGE_INTEGER> source_offset, emulator_object<LARGE_INTEGER> destination_offset,
+                                        emulator_object<ULONG> source_key, emulator_object<ULONG> destination_key, ULONG flags);
         NTSTATUS handle_NtLockFile(const syscall_context& c, handle file_handle, handle event_handle, uint64_t apc_routine,
                                    uint64_t apc_context, emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
                                    emulator_object<LARGE_INTEGER> byte_offset, emulator_object<LARGE_INTEGER> length, ULONG key,
@@ -1151,6 +1155,7 @@ namespace sogen
         add_handler(NtTerminateProcess);
         add_handler(NtFlushProcessWriteBuffers);
         add_handler(NtWriteFile);
+        add_handler(NtCopyFileChunk);
         add_handler(NtLockFile);
         add_handler(NtUnlockFile);
         add_handler(NtRaiseHardError);

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1357,6 +1357,56 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtCopyFileChunk(const syscall_context& c, const handle source_handle, const handle destination_handle,
+                                        const handle /*event_handle*/,
+                                        const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block, const ULONG length,
+                                        const emulator_object<LARGE_INTEGER> source_offset,
+                                        const emulator_object<LARGE_INTEGER> destination_offset,
+                                        const emulator_object<ULONG> /*source_key*/, const emulator_object<ULONG> /*destination_key*/,
+                                        const ULONG /*flags*/)
+        {
+            const auto* source = c.proc.files.get(source_handle);
+            const auto* destination = c.proc.files.get(destination_handle);
+            if (!source || !destination || !source->handle || !destination->handle)
+            {
+                return STATUS_INVALID_HANDLE;
+            }
+
+            if (source_offset)
+            {
+                const auto offset = source_offset.read();
+                if (offset.QuadPart < 0 || !source->handle.seek_to(offset.QuadPart))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+            }
+
+            std::string temp_buffer{};
+            temp_buffer.resize(length);
+            const auto bytes_read = fread(temp_buffer.data(), 1, temp_buffer.size(), source->handle);
+
+            if (destination_offset)
+            {
+                const auto offset = destination_offset.read();
+                if (offset.QuadPart < 0 || !destination->handle.seek_to(offset.QuadPart))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+            }
+
+            const auto bytes_written = fwrite(temp_buffer.data(), 1, bytes_read, destination->handle);
+            (void)fflush(destination->handle);
+
+            if (io_status_block)
+            {
+                IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
+                block.Information = bytes_written;
+                io_status_block.write(block);
+            }
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtLockFile(const syscall_context& c, const handle file_handle, const handle /*event_handle*/,
                                    const uint64_t /*apc_routine*/, const uint64_t /*apc_context*/,
                                    const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -265,6 +265,7 @@ namespace sogen
                 || info_class == ProcessDynamicFunctionTableInformation      //
                 || info_class == ProcessPriorityBoost                        //
                 || info_class == ProcessPriorityClassEx                      //
+                || info_class == ProcessQuotaLimits                          //
                 || info_class == ProcessPriorityClass || info_class == ProcessAffinityMask)
             {
                 return STATUS_SUCCESS;

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -256,6 +256,21 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            if (token_information_class == TokenElevationType)
+            {
+                constexpr auto required_size = sizeof(ULONG);
+                return_length.write(required_size);
+
+                if (required_size > token_information_length)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                // TokenElevationTypeDefault: no UAC split token (matches the non-elevated TokenElevation above).
+                emulator_object<ULONG>{c.emu, token_information}.write(1);
+                return STATUS_SUCCESS;
+            }
+
             if (token_information_class == TokenIsAppContainer)
             {
                 constexpr auto required_size = sizeof(ULONG);


### PR DESCRIPTION
Advances The Witcher 3 under WHP from an early-init halt all the way to a live DXVK render loop. Four independent fixes:

- **`NtSetInformationProcess` / `ProcessQuotaLimits`** — treated as a benign no-op (it's used by `SetProcessWorkingSetSize`) instead of stopping emulation.
- **`NtCopyFileChunk`** — implemented the Win11 file-copy syscall by copying the requested chunk between the source and destination file handles.
- **`NtQueryInformationToken` / `TokenElevationType`** — returns `TokenElevationTypeDefault` (consistent with the non-elevated `TokenElevation`).
- **`vulkan_host` `update_descriptor_sets`** — route `STORAGE_IMAGE` and `INPUT_ATTACHMENT` through `pImageInfo`. They were falling into the buffer branch, so the host driver dereferenced a null `pImageInfo` and faulted, breaking every descriptor update (and thus all rendering).

Smoke tests pass (26/0). With these, the game boots, initializes DXVK (device + shader-compiler threads), and reaches its render loop; remaining blockers are audio/COM-init related and out of scope here.