### PR TITLE
Skyrim bringup: child-window present, vkCmdClearAttachments, raw mouse/keyboard input

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -169,6 +169,17 @@ namespace sogen
     };
     static_assert(sizeof(RAWMOUSE32) == 0x18);
 
+    struct RAWKEYBOARD32
+    {
+        uint16_t MakeCode;
+        uint16_t Flags;
+        uint16_t Reserved;
+        uint16_t VKey;
+        uint32_t Message;
+        uint32_t ExtraInformation;
+    };
+    static_assert(sizeof(RAWKEYBOARD32) == 0x10);
+
     enum USER_HANDLETYPE : uint8_t
     {
         TYPE_FREE = 0,

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -173,6 +173,7 @@ namespace sogen::gpu_bridge
         update_descriptor_sets_batch = 0x886,
         cmd_blit_image = 0x887,
         reset_descriptor_pool = 0x888,
+        cmd_clear_attachments = 0x889,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -1679,6 +1680,16 @@ namespace sogen::gpu_bridge
         uint32_t reserved;
     };
 
+    // record payload (command::cmd_clear_attachments): header followed by `attachment_count` raw
+    // VkClearAttachment structs, then `rect_count` raw VkClearRect structs (both forwarded verbatim;
+    // no object ids are involved, so the host reinterprets the trailing bytes directly).
+    struct cmd_clear_attachments_request
+    {
+        object_id command_buffer;
+        uint32_t attachment_count;
+        uint32_t rect_count;
+    };
+
     // One VkViewport. Trails cmd_set_viewport_request `count` times.
     struct viewport_entry
     {
@@ -1981,6 +1992,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(allocate_command_buffer_request) == 24, "wire layout drift");
     static_assert(sizeof(begin_command_buffer_request) == 40, "wire layout drift");
     static_assert(sizeof(cmd_execute_commands_request) == 16, "wire layout drift");
+    static_assert(sizeof(cmd_clear_attachments_request) == 16, "wire layout drift");
     static_assert(sizeof(viewport_entry) == 24, "wire layout drift");
     static_assert(sizeof(cmd_set_viewport_request) == 24, "wire layout drift");
     static_assert(sizeof(scissor_entry) == 16, "wire layout drift");

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -182,6 +182,7 @@ namespace
         std::fputs(message, stdout);
         std::fflush(stdout);
     }
+
 }
 
 extern "C"
@@ -2261,6 +2262,31 @@ extern "C"
             request.color_a = pColor->float32[3];
             record_command(request.command_buffer, gb::command::cmd_clear_color_image, &request, sizeof(request));
         }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
+                                                                           const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                                           const VkClearRect* pRects)
+    {
+        const gb::object_id command_buffer = to_object_id(commandBuffer);
+        const size_t attach_bytes = static_cast<size_t>(attachmentCount) * sizeof(VkClearAttachment);
+        const size_t rect_bytes = static_cast<size_t>(rectCount) * sizeof(VkClearRect);
+
+        std::vector<uint8_t> message(sizeof(gb::cmd_clear_attachments_request) + attach_bytes + rect_bytes);
+        gb::cmd_clear_attachments_request header{};
+        header.command_buffer = command_buffer;
+        header.attachment_count = attachmentCount;
+        header.rect_count = rectCount;
+        std::memcpy(message.data(), &header, sizeof(header));
+        if (attach_bytes)
+        {
+            std::memcpy(message.data() + sizeof(header), pAttachments, attach_bytes);
+        }
+        if (rect_bytes)
+        {
+            std::memcpy(message.data() + sizeof(header) + attach_bytes, pRects, rect_bytes);
+        }
+        record_command(command_buffer, gb::command::cmd_clear_attachments, message.data(), message.size());
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image,
@@ -4693,6 +4719,7 @@ extern "C"
             {.name = "vkCmdPipelineBarrier2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPipelineBarrier2)},
             {.name = "vkCmdPipelineBarrier2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPipelineBarrier2)},
             {.name = "vkCmdClearColorImage", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdClearColorImage)},
+            {.name = "vkCmdClearAttachments", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdClearAttachments)},
             {.name = "vkCmdClearDepthStencilImage", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdClearDepthStencilImage)},
             {.name = "vkCmdCopyImageToBuffer", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdCopyImageToBuffer)},
             {.name = "vkCmdCopyImageToBuffer2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdCopyImageToBuffer2)},

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2722,6 +2722,15 @@ namespace sogen
                     return this->vulkan_.cmd_clear_color_image(req.command_buffer, req.image, req.image_layout, req.color_r, req.color_g,
                                                                req.color_b, req.color_a, to_host_range(req.subresource));
                 }
+                case gpu_bridge::command::cmd_clear_attachments: {
+                    gpu_bridge::cmd_clear_attachments_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_clear_attachments(req.command_buffer, req.attachment_count, req.rect_count, payload + sizeof(req),
+                                                               size - sizeof(req));
+                }
                 case gpu_bridge::command::cmd_clear_depth_stencil_image: {
                     gpu_bridge::cmd_clear_depth_stencil_image_request req{};
                     if (!read(req))

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2728,8 +2728,8 @@ namespace sogen
                     {
                         return vk_error_initialization_failed;
                     }
-                    return this->vulkan_.cmd_clear_attachments(req.command_buffer, req.attachment_count, req.rect_count, payload + sizeof(req),
-                                                               size - sizeof(req));
+                    return this->vulkan_.cmd_clear_attachments(req.command_buffer, req.attachment_count, req.rect_count,
+                                                               payload + sizeof(req), size - sizeof(req));
                 }
                 case gpu_bridge::command::cmd_clear_depth_stencil_image: {
                     gpu_bridge::cmd_clear_depth_stencil_image_request req{};

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -232,6 +232,7 @@ namespace sogen
             PFN_vkBindImageMemory bind_image_memory{};
             PFN_vkCmdPipelineBarrier cmd_pipeline_barrier{};
             PFN_vkCmdClearColorImage cmd_clear_color_image{};
+            PFN_vkCmdClearAttachments cmd_clear_attachments{};
             PFN_vkCmdClearDepthStencilImage cmd_clear_depth_stencil_image{};
             PFN_vkCmdCopyImageToBuffer cmd_copy_image_to_buffer{};
             PFN_vkCmdResolveImage cmd_resolve_image{};
@@ -1626,6 +1627,7 @@ namespace sogen
             data.bind_image_memory = reinterpret_cast<PFN_vkBindImageMemory>(resolve("vkBindImageMemory"));
             data.cmd_pipeline_barrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(resolve("vkCmdPipelineBarrier"));
             data.cmd_clear_color_image = reinterpret_cast<PFN_vkCmdClearColorImage>(resolve("vkCmdClearColorImage"));
+            data.cmd_clear_attachments = reinterpret_cast<PFN_vkCmdClearAttachments>(resolve("vkCmdClearAttachments"));
             data.cmd_clear_depth_stencil_image = reinterpret_cast<PFN_vkCmdClearDepthStencilImage>(resolve("vkCmdClearDepthStencilImage"));
             data.cmd_copy_image_to_buffer = reinterpret_cast<PFN_vkCmdCopyImageToBuffer>(resolve("vkCmdCopyImageToBuffer"));
             data.cmd_resolve_image = reinterpret_cast<PFN_vkCmdResolveImage>(resolve("vkCmdResolveImage"));
@@ -2981,6 +2983,35 @@ namespace sogen
 
         const VkImageSubresourceRange vk_range = to_vk_range(range);
         dev->second.cmd_clear_color_image(cb->second.handle, img->second.handle, translate_layout(image_layout), &clear, 1, &vk_range);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_clear_attachments(uint64_t command_buffer, uint32_t attachment_count, uint32_t rect_count, const void* data,
+                                               size_t data_size)
+    {
+        const size_t attach_bytes = static_cast<size_t>(attachment_count) * sizeof(VkClearAttachment);
+        const size_t rect_bytes = static_cast<size_t>(rect_count) * sizeof(VkClearRect);
+        if (attach_bytes + rect_bytes > data_size)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        if (cb == this->impl_->command_buffers.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_clear_attachments)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        // VkClearAttachment / VkClearRect carry no object handles, so the guest blob is forwarded verbatim.
+        const auto* attachments = reinterpret_cast<const VkClearAttachment*>(data);
+        const auto* rects = reinterpret_cast<const VkClearRect*>(static_cast<const uint8_t*>(data) + attach_bytes);
+        dev->second.cmd_clear_attachments(cb->second.handle, attachment_count, attachment_count ? attachments : nullptr, rect_count,
+                                          rect_count ? rects : nullptr);
         return VK_SUCCESS;
     }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -2991,7 +2991,7 @@ namespace sogen
     {
         const size_t attach_bytes = static_cast<size_t>(attachment_count) * sizeof(VkClearAttachment);
         const size_t rect_bytes = static_cast<size_t>(rect_count) * sizeof(VkClearRect);
-        if (attach_bytes + rect_bytes > data_size)
+        if (data_size < attach_bytes || data_size - attach_bytes < rect_bytes)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -251,6 +251,8 @@ namespace sogen
         // Records vkCmdClearColorImage with an RGBA float clear color.
         int32_t cmd_clear_color_image(uint64_t command_buffer, uint64_t image, uint32_t image_layout, float r, float g, float b, float a,
                                       const subresource_range& range);
+        int32_t cmd_clear_attachments(uint64_t command_buffer, uint32_t attachment_count, uint32_t rect_count, const void* data,
+                                      size_t data_size);
         int32_t cmd_clear_depth_stencil_image(uint64_t command_buffer, uint64_t image, uint32_t image_layout, float depth, uint32_t stencil,
                                               const subresource_range& range);
         // Copies mip 0 / layer 0 of the image (tightly packed) into the buffer at offset 0.

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -601,6 +601,8 @@ namespace sogen
         buffer.write(this->key_state);
         buffer.write(this->raw_mouse_registered);
         buffer.write(this->raw_mouse_target);
+        buffer.write(this->raw_keyboard_registered);
+        buffer.write(this->raw_keyboard_target);
         buffer.write_map(this->raw_inputs);
         buffer.write(this->next_raw_input_token);
 
@@ -685,6 +687,8 @@ namespace sogen
         buffer.read(this->key_state);
         buffer.read(this->raw_mouse_registered);
         buffer.read(this->raw_mouse_target);
+        buffer.read(this->raw_keyboard_registered);
+        buffer.read(this->raw_keyboard_target);
         buffer.read_map(this->raw_inputs);
         buffer.read(this->next_raw_input_token);
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -395,9 +395,22 @@ namespace sogen
         // window), resolved at delivery time so a registration done before any window is foreground still works.
         bool raw_mouse_registered{};
         hwnd raw_mouse_target{};
-        // Pending raw-input payloads keyed by the HRAWINPUT token posted in WM_INPUT's lParam; consumed by
-        // NtUserGetRawInputData. Stores the relative {dx, dy} the motion produced.
-        std::map<uint32_t, std::array<int32_t, 2>> raw_inputs{};
+        // Keyboard raw input registration (HID usage page 0x01, usage 0x06), mirroring the mouse fields above.
+        bool raw_keyboard_registered{};
+        hwnd raw_keyboard_target{};
+        // One pending raw-input payload (mouse motion + buttons, or a keyboard make/break) keyed by the
+        // HRAWINPUT token posted in WM_INPUT's lParam; consumed by NtUserGetRawInputData.
+        struct raw_input_payload
+        {
+            bool keyboard{};          // false = mouse, true = keyboard
+            int32_t dx{};             // mouse relative motion
+            int32_t dy{};             //
+            uint16_t mouse_buttons{}; // RI_MOUSE_* button transition flags
+            uint16_t vkey{};          // keyboard virtual key
+            uint16_t scan_code{};     // keyboard scan code
+            uint16_t key_release{};   // 0 = key down (RI_KEY_MAKE), 1 = key up (RI_KEY_BREAK)
+        };
+        std::map<uint32_t, raw_input_payload> raw_inputs{};
         uint32_t next_raw_input_token{1};
 
         // For WOW64 processes

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1597,23 +1597,26 @@ namespace sogen
 
                 constexpr uint16_t hid_usage_page_generic = 0x01;
                 constexpr uint16_t hid_usage_generic_mouse = 0x02;
-                if (device.usUsagePage != hid_usage_page_generic || device.usUsage != hid_usage_generic_mouse)
+                constexpr uint16_t hid_usage_generic_keyboard = 0x06;
+                if (device.usUsagePage != hid_usage_page_generic ||
+                    (device.usUsage != hid_usage_generic_mouse && device.usUsage != hid_usage_generic_keyboard))
                 {
                     continue;
                 }
 
-                if (device.dwFlags & RIDEV_REMOVE)
+                // hwndTarget == 0 is the valid "follow keyboard focus" mode; keep it as-is and resolve the
+                // destination at delivery time rather than freezing whatever window is foreground right now
+                // (registration often happens at startup before any window has become foreground).
+                const bool remove = (device.dwFlags & RIDEV_REMOVE) != 0;
+                if (device.usUsage == hid_usage_generic_mouse)
                 {
-                    c.proc.raw_mouse_registered = false;
-                    c.proc.raw_mouse_target = 0;
+                    c.proc.raw_mouse_registered = !remove;
+                    c.proc.raw_mouse_target = remove ? hwnd{} : device.hwndTarget;
                 }
                 else
                 {
-                    // hwndTarget == 0 is the valid "follow keyboard focus" mode; keep it as-is and resolve the
-                    // destination at delivery time rather than freezing whatever window is foreground right now
-                    // (registration often happens at startup before any window has become foreground).
-                    c.proc.raw_mouse_registered = true;
-                    c.proc.raw_mouse_target = device.hwndTarget;
+                    c.proc.raw_keyboard_registered = !remove;
+                    c.proc.raw_keyboard_target = remove ? hwnd{} : device.hwndTarget;
                 }
             }
 
@@ -1648,12 +1651,13 @@ namespace sogen
                 return failure;
             }
 
-            RAWMOUSE32 mouse{};
-            mouse.usFlags = MOUSE_MOVE_RELATIVE;
-            mouse.lLastX = entry->second[0];
-            mouse.lLastY = entry->second[1];
+            const auto& payload = entry->second;
 
-            const uint32_t total = header_size + sizeof(RAWMOUSE32);
+            // The body is a RAWKEYBOARD or RAWMOUSE depending on what the token carried.
+            const uint32_t body_size = payload.keyboard ? sizeof(RAWKEYBOARD32) : sizeof(RAWMOUSE32);
+            const uint32_t dw_type = payload.keyboard ? RIM_TYPEKEYBOARD : RIM_TYPEMOUSE;
+
+            const uint32_t total = header_size + body_size;
             const uint32_t required = (command == RID_HEADER) ? header_size : total;
 
             if (data == 0)
@@ -1668,15 +1672,31 @@ namespace sogen
             }
 
             // dwType @0 and dwSize @4 are identical across header layouts; hDevice/wParam stay zeroed, so only
-            // the overall header size (which shifts the mouse body) matters.
+            // the overall header size (which shifts the body) matters.
             std::array<uint8_t, max_header_size + sizeof(RAWMOUSE32)> buffer{};
-            const uint32_t dw_type = RIM_TYPEMOUSE;
             const uint32_t dw_size = total;
             std::memcpy(buffer.data() + 0, &dw_type, sizeof(dw_type));
             std::memcpy(buffer.data() + 4, &dw_size, sizeof(dw_size));
             if (command != RID_HEADER)
             {
-                std::memcpy(buffer.data() + header_size, &mouse, sizeof(mouse));
+                if (payload.keyboard)
+                {
+                    RAWKEYBOARD32 keyboard{};
+                    keyboard.MakeCode = payload.scan_code;
+                    keyboard.Flags = payload.key_release; // RI_KEY_MAKE (0) / RI_KEY_BREAK (1)
+                    keyboard.VKey = payload.vkey;
+                    keyboard.Message = payload.key_release ? WM_KEYUP : WM_KEYDOWN;
+                    std::memcpy(buffer.data() + header_size, &keyboard, sizeof(keyboard));
+                }
+                else
+                {
+                    RAWMOUSE32 mouse{};
+                    mouse.usFlags = MOUSE_MOVE_RELATIVE;
+                    mouse.ulButtons = payload.mouse_buttons; // low 16 bits == usButtonFlags
+                    mouse.lLastX = payload.dx;
+                    mouse.lLastY = payload.dy;
+                    std::memcpy(buffer.data() + header_size, &mouse, sizeof(mouse));
+                }
                 c.proc.raw_inputs.erase(entry);
             }
 

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -344,8 +344,12 @@ namespace sogen
 #ifdef SOGEN_HAS_SDL3
                 if (const auto it = this->windows_.find(window); it != this->windows_.end())
                 {
-                    SDL_StopTextInput(it->second.window);
-                    this->guest_by_window_id_.erase(SDL_GetWindowID(it->second.window));
+                    // Child (non-top-level) windows have no SDL window; only top-level windows do.
+                    if (it->second.window)
+                    {
+                        SDL_StopTextInput(it->second.window);
+                        this->guest_by_window_id_.erase(SDL_GetWindowID(it->second.window));
+                    }
                     destroy_window_resources(it->second);
                     this->windows_.erase(it);
                 }
@@ -497,7 +501,9 @@ namespace sogen
 
             hwnd get_top_level_ancestor(hwnd window) const
             {
-                while (true)
+                // Bound the walk so a malformed parent chain (stale handles, a cycle) can't loop forever.
+                constexpr auto max_depth = 32;
+                for (auto depth = 0; depth < max_depth; ++depth)
                 {
                     const auto* state = this->resolve_window(window);
                     if (!state)
@@ -510,6 +516,8 @@ namespace sogen
                     }
                     window = state->desc.parent;
                 }
+
+                return window;
             }
 
             void redraw_related(const hwnd window)

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -434,7 +434,15 @@ namespace sogen
             void present_surface(const hwnd window, const ui_surface_desc& surface) override
             {
 #ifdef SOGEN_HAS_SDL3
-                if (auto* state = this->resolve_window(window))
+                // The render target is frequently a child window (e.g. a D3D/Vulkan swap-chain child),
+                // which has no SDL renderer of its own. Composite its surface onto the top-level
+                // ancestor -- the window that actually owns the on-screen SDL window and renderer.
+                auto* state = this->resolve_window(window);
+                if (state && !state->renderer)
+                {
+                    state = this->resolve_window(this->get_top_level_ancestor(window));
+                }
+                if (state && state->renderer)
                 {
                     update_surface_texture(*state, surface);
                     render_window(*state);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -134,6 +134,72 @@ namespace sogen
                    message == WM_RBUTTONUP;
         }
 
+        // Window button message -> RAWMOUSE usButtonFlags transition bit (winuser.h RI_MOUSE_* values).
+        uint16_t raw_mouse_button_flags(const uint32_t message)
+        {
+            switch (message)
+            {
+            case WM_LBUTTONDOWN:
+                return 0x0001; // RI_MOUSE_LEFT_BUTTON_DOWN
+            case WM_LBUTTONUP:
+                return 0x0002; // RI_MOUSE_LEFT_BUTTON_UP
+            case WM_RBUTTONDOWN:
+                return 0x0004; // RI_MOUSE_RIGHT_BUTTON_DOWN
+            case WM_RBUTTONUP:
+                return 0x0008; // RI_MOUSE_RIGHT_BUTTON_UP
+            default:
+                return 0;
+            }
+        }
+
+        // Best-effort US-layout virtual-key -> PS/2 set-1 scan code for the RAWKEYBOARD MakeCode field
+        // (games that bind by scan code need it; the VKey is delivered too for those that use it).
+        uint16_t vk_to_scan_code(const uint16_t vk)
+        {
+            switch (vk)
+            {
+            case VK_ESCAPE:
+                return 0x01;
+            case VK_RETURN:
+                return 0x1C;
+            case VK_SPACE:
+                return 0x39;
+            case VK_TAB:
+                return 0x0F;
+            case VK_BACK:
+                return 0x0E;
+            case VK_SHIFT:
+                return 0x2A;
+            case VK_CONTROL:
+                return 0x1D;
+            case VK_UP:
+                return 0x48;
+            case VK_DOWN:
+                return 0x50;
+            case VK_LEFT:
+                return 0x4B;
+            case VK_RIGHT:
+                return 0x4D;
+            default:
+                if (vk >= 'A' && vk <= 'Z')
+                {
+                    static constexpr uint8_t letter_scan[26] = {0x1E, 0x30, 0x2E, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17,
+                                                                0x24, 0x25, 0x26, 0x32, 0x31, 0x18, 0x19, 0x10, 0x13,
+                                                                0x1F, 0x14, 0x16, 0x2F, 0x11, 0x2D, 0x15, 0x2C};
+                    return letter_scan[vk - 'A'];
+                }
+                if (vk >= '1' && vk <= '9')
+                {
+                    return static_cast<uint16_t>(0x02 + (vk - '1'));
+                }
+                if (vk == '0')
+                {
+                    return 0x0B;
+                }
+                return 0;
+            }
+        }
+
         uint64_t pack_point(const int x, const int y)
         {
             return static_cast<uint16_t>(x) | (static_cast<uint64_t>(static_cast<uint16_t>(y)) << 16);
@@ -1005,12 +1071,12 @@ namespace sogen
         }
     }
 
-    void windows_emulator::deliver_raw_mouse_input(const int32_t dx, const int32_t dy)
+    void windows_emulator::deliver_raw_input(const process_context::raw_input_payload& payload, const hwnd explicit_target)
     {
         // Resolve the destination at delivery time: an explicit hwndTarget, else the foreground window
         // (raw input registered with a NULL target follows keyboard focus). If neither resolves to a live
         // window right now there is nowhere to deliver to, so skip without dropping the registration.
-        const auto target = this->process.raw_mouse_target != 0 ? this->process.raw_mouse_target : this->process.foreground_window;
+        const auto target = explicit_target != 0 ? explicit_target : this->process.foreground_window;
         auto* raw_win = this->process.windows.get(target);
         if (!raw_win)
         {
@@ -1024,7 +1090,7 @@ namespace sogen
         }
 
         const auto token = this->process.next_raw_input_token++;
-        this->process.raw_inputs[token] = {dx, dy};
+        this->process.raw_inputs[token] = payload;
 
         // Bound the pending set: WM_INPUT is normally consumed at once by GetRawInputData, but if the guest
         // stops pumping, drop the oldest tokens so the map can't grow without limit.
@@ -1040,6 +1106,18 @@ namespace sogen
         m.wParam = RIM_INPUT;
         m.lParam = token;
         thread->post_message(m);
+    }
+
+    void windows_emulator::deliver_raw_mouse_input(const int32_t dx, const int32_t dy, const uint16_t button_flags)
+    {
+        this->deliver_raw_input({.keyboard = false, .dx = dx, .dy = dy, .mouse_buttons = button_flags}, this->process.raw_mouse_target);
+    }
+
+    void windows_emulator::deliver_raw_keyboard_input(const uint16_t vkey, const uint16_t scan_code, const bool release)
+    {
+        this->deliver_raw_input(
+            {.keyboard = true, .vkey = vkey, .scan_code = scan_code, .key_release = static_cast<uint16_t>(release ? 1 : 0)},
+            this->process.raw_keyboard_target);
     }
 
     void windows_emulator::handle_ui_event(const ui_event& event)
@@ -1078,13 +1156,21 @@ namespace sogen
             // Synthesize that delta from the change in tracked cursor position before updating it. A
             // SetCursorPos recenter pre-updates cursor_x/y, so the warp-echo motion event yields a zero
             // delta -- no spurious look -- while genuine motion between recenters produces the real delta.
-            if (event.message == WM_MOUSEMOVE && this->process.raw_mouse_registered)
+            if (this->process.raw_mouse_registered)
             {
-                const int32_t dx = new_cursor_x - this->process.cursor_x;
-                const int32_t dy = new_cursor_y - this->process.cursor_y;
-                if (dx != 0 || dy != 0)
+                if (event.message == WM_MOUSEMOVE)
                 {
-                    this->deliver_raw_mouse_input(dx, dy);
+                    const int32_t dx = new_cursor_x - this->process.cursor_x;
+                    const int32_t dy = new_cursor_y - this->process.cursor_y;
+                    if (dx != 0 || dy != 0)
+                    {
+                        this->deliver_raw_mouse_input(dx, dy, 0);
+                    }
+                }
+                else if (const uint16_t buttons = raw_mouse_button_flags(event.message); buttons != 0)
+                {
+                    // Raw-input games read button transitions from WM_INPUT, not WM_LBUTTONDOWN/UP.
+                    this->deliver_raw_mouse_input(0, 0, buttons);
                 }
             }
 
@@ -1135,6 +1221,13 @@ namespace sogen
             break;
         default:
             break;
+        }
+
+        // Raw-input games (e.g. Skyrim) read the keyboard via WM_INPUT/GetRawInputData, not WM_KEYDOWN.
+        if (this->process.raw_keyboard_registered && (event.message == WM_KEYDOWN || event.message == WM_KEYUP))
+        {
+            const auto vk = static_cast<uint16_t>(event.wParam & 0xFFFF);
+            this->deliver_raw_keyboard_input(vk, vk_to_scan_code(vk), event.message == WM_KEYUP);
         }
 
         thread->post_message(m);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -183,10 +183,10 @@ namespace sogen
             default:
                 if (vk >= 'A' && vk <= 'Z')
                 {
-                    static constexpr uint8_t letter_scan[26] = {0x1E, 0x30, 0x2E, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17,
-                                                                0x24, 0x25, 0x26, 0x32, 0x31, 0x18, 0x19, 0x10, 0x13,
-                                                                0x1F, 0x14, 0x16, 0x2F, 0x11, 0x2D, 0x15, 0x2C};
-                    return letter_scan[vk - 'A'];
+                    static constexpr std::array<uint8_t, 26> letter_scan = {0x1E, 0x30, 0x2E, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17,
+                                                                            0x24, 0x25, 0x26, 0x32, 0x31, 0x18, 0x19, 0x10, 0x13,
+                                                                            0x1F, 0x14, 0x16, 0x2F, 0x11, 0x2D, 0x15, 0x2C};
+                    return letter_scan[static_cast<size_t>(vk - 'A')];
                 }
                 if (vk >= '1' && vk <= '9')
                 {

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -203,7 +203,9 @@ namespace sogen
         }
 
         void handle_ui_event(const ui_event& event);
-        void deliver_raw_mouse_input(int32_t dx, int32_t dy);
+        void deliver_raw_input(const process_context::raw_input_payload& payload, hwnd explicit_target);
+        void deliver_raw_mouse_input(int32_t dx, int32_t dy, uint16_t button_flags);
+        void deliver_raw_keyboard_input(uint16_t vkey, uint16_t scan_code, bool release);
 
         emulator_thread& current_thread() const
         {


### PR DESCRIPTION
Three fixes from Skyrim (TESV.exe, 32-bit WoW64, DXVK D3D9) bringup.

## Changes

- **ui/sdl: composite child render windows onto their top-level ancestor.** Skyrim renders to a `WS_CHILD` render window whose parent is the visible top-level. The SDL backend only gives top-level windows a renderer, so `present_surface` on the child dropped every frame and the top-level showed its gray empty-surface fallback. Present now redirects to the top-level ancestor.

- **gpu-bridge: implement `vkCmdClearAttachments`.** Was the missing shim function (guest shim record → protocol command → host replay → `vulkan_host`), without which DXVK's render pass recording failed.

- **input: deliver raw mouse buttons and keyboard via `WM_INPUT`.** Extends the existing raw mouse-motion path: `RegisterRawInputDevices` now also accepts keyboard registrations (HID usage 0x06), and `GetRawInputData` returns a `RAWKEYBOARD` or `RAWMOUSE` body depending on the pending token — including mouse button transitions (`RI_MOUSE_*` in `usButtonFlags`) and key make/break with a best-effort US scan code. Games such as Skyrim read buttons/keystrokes through `WM_INPUT` rather than window messages.

## Testing

- Release build + smoke test (`analyzer -s test-sample.exe`) pass.
- With the present + clear-attachments fixes, Skyrim's main menu renders.
- The raw-input change is not yet exercisable in-game (a separate timing-induced deadlock stalls Skyrim before input is read); it is additive and gated on raw-input registration.