### PR TITLE
kvm: fix GPU buffer cache coherency and shutdown segfault for host-aliased memory

### DIFF
--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -11,7 +11,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#include <emmintrin.h>
+#include <immintrin.h>
 
 #include <algorithm>
 #include <array>
@@ -60,6 +60,52 @@ namespace sogen::kvm
         constexpr uint32_t vp_index = 0;
         constexpr uint32_t breakpoint_interrupt = 3;
         constexpr int invalid_opcode_interrupt = 6;
+
+        constexpr uintptr_t cache_line_size = 64;
+
+        // clflushopt is unordered, so consecutive evictions pipeline instead of serializing like clflush does
+        // on every line; for the bulk flushes the GPU bridge issues before each submit that is a meaningful
+        // win. It needs a target attribute to compile on a generic x86-64 build and is only selected when the
+        // CPU advertises it at runtime. Both variants leave ordering to the caller's sfence.
+        __attribute__((target("clflushopt"))) void flush_cache_lines_clflushopt(uintptr_t first, uintptr_t last)
+        {
+            for (auto line = first; line < last; line += cache_line_size)
+            {
+                _mm_clflushopt(reinterpret_cast<void*>(line));
+            }
+        }
+
+        void flush_cache_lines_clflush(uintptr_t first, uintptr_t last)
+        {
+            for (auto line = first; line < last; line += cache_line_size)
+            {
+                _mm_clflush(reinterpret_cast<const void*>(line));
+            }
+        }
+
+        // Evict the CPU cache for [base, base + size) and order the evictions before subsequent device access.
+        void flush_cache_line_range(const void* base, size_t size)
+        {
+            if (base == nullptr || size == 0)
+            {
+                return;
+            }
+
+            const auto first = reinterpret_cast<uintptr_t>(base) & ~(cache_line_size - 1);
+            const auto last = reinterpret_cast<uintptr_t>(base) + size;
+
+            static const bool has_clflushopt = __builtin_cpu_supports("clflushopt");
+            if (has_clflushopt)
+            {
+                flush_cache_lines_clflushopt(first, last);
+            }
+            else
+            {
+                flush_cache_lines_clflush(first, last);
+            }
+
+            _mm_sfence();
+        }
 
         // Synthetic exception delivery: guest exceptions are routed through an internal IDT whose
         // gates point at single-HLT stubs running at CPL0. The HLT exit identifies the vector, and
@@ -1091,19 +1137,7 @@ namespace sogen::kvm
             }
             void flush_host_memory_cache(const void* host_pointer, size_t size) override
             {
-                if (host_pointer == nullptr || size == 0)
-                {
-                    return;
-                }
-
-                constexpr uintptr_t cache_line = 64;
-                const auto first = reinterpret_cast<uintptr_t>(host_pointer);
-                const auto last = first + size;
-                for (auto line = first & ~(cache_line - 1); line < last; line += cache_line)
-                {
-                    _mm_clflush(reinterpret_cast<const void*>(line));
-                }
-                _mm_sfence();
+                flush_cache_line_range(host_pointer, size);
             }
             void unmap_memory(uint64_t address, size_t size) override
             {

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -11,6 +11,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <emmintrin.h>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -1079,6 +1081,29 @@ namespace sogen::kvm
                 }
 
                 this->rebuild_mappings();
+            }
+            bool host_memory_aliasing_is_coherent() const override
+            {
+                // KVM aliases the host pages into the guest as write-back cacheable, but a device sharing the
+                // same physical memory (e.g. a GPU reading a DXVK buffer) may map it write-combined. The
+                // guest's cached writes are therefore not guaranteed visible without an explicit flush.
+                return false;
+            }
+            void flush_host_memory_cache(const void* host_pointer, size_t size) override
+            {
+                if (host_pointer == nullptr || size == 0)
+                {
+                    return;
+                }
+
+                constexpr uintptr_t cache_line = 64;
+                const auto first = reinterpret_cast<uintptr_t>(host_pointer);
+                const auto last = first + size;
+                for (auto line = first & ~(cache_line - 1); line < last; line += cache_line)
+                {
+                    _mm_clflush(reinterpret_cast<const void*>(line));
+                }
+                _mm_sfence();
             }
             void unmap_memory(uint64_t address, size_t size) override
             {

--- a/src/emulator/memory_interface.hpp
+++ b/src/emulator/memory_interface.hpp
@@ -42,6 +42,24 @@ namespace sogen
 
         virtual void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) = 0;
 
+        // Appended after the existing virtuals so no vtable slot of a pre-existing method moves.
+        //
+        // Whether memory aliased via map_host_memory is cache-coherent with external devices (e.g. a GPU)
+        // without explicit cache maintenance. KVM aliases host memory write-back into the guest while the GPU
+        // may read the same physical pages through a write-combined mapping, so it reports false and callers
+        // must flush the CPU cache (flush_host_memory_cache) for an aliased range before device access.
+        virtual bool host_memory_aliasing_is_coherent() const
+        {
+            return true;
+        }
+
+        // Evicts the CPU cache for a host range previously passed to map_host_memory, making the guest's
+        // pending writes visible to a device that reads the same physical memory non-coherently. No-op when
+        // aliasing is already coherent.
+        virtual void flush_host_memory_cache(const void* /*host_pointer*/, size_t /*size*/)
+        {
+        }
+
       public:
         template <typename T>
         T read_memory(const uint64_t address) const

--- a/src/emulator/memory_interface.hpp
+++ b/src/emulator/memory_interface.hpp
@@ -42,7 +42,9 @@ namespace sogen
 
         virtual void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) = 0;
 
-        // Appended after the existing virtuals so no vtable slot of a pre-existing method moves.
+        // Add new virtuals at the end of the class so the vtable slots of existing methods never move; this
+        // keeps separately built backends (e.g. the dynamically loaded KVM/unicorn backends) ABI-compatible
+        // with the analyzer that calls through this interface.
         //
         // Whether memory aliased via map_host_memory is cache-coherent with external devices (e.g. a GPU)
         // without explicit cache maintenance. KVM aliases host memory write-back into the guest while the GPU

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -251,6 +251,26 @@ namespace sogen
             };
             std::unordered_map<uint64_t, direct_mapping> direct_mappings_{};
 
+            // Before the host GPU reads guest-produced data, make the guest's writes to every directly-aliased
+            // buffer visible. On backends that alias host memory non-coherently (KVM: guest writes are
+            // write-back cached while the GPU may read write-combined memory) this evicts the CPU cache for the
+            // aliased ranges; on coherent backends it is a no-op skipped by the capability check.
+            void flush_aliased_memory_for_device(windows_emulator& win_emu) const
+            {
+                if (win_emu.memory.host_memory_aliasing_is_coherent())
+                {
+                    return;
+                }
+
+                for (const auto& [id, mapping] : this->direct_mappings_)
+                {
+                    if (mapping.host_ptr != nullptr && mapping.size != 0)
+                    {
+                        win_emu.memory.flush_host_memory_cache(mapping.host_ptr, static_cast<size_t>(mapping.size));
+                    }
+                }
+            }
+
             static void set_information(const io_device_context& context, const ULONG bytes)
             {
                 if (context.io_status_block)
@@ -1017,6 +1037,8 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                this->flush_aliased_memory_for_device(win_emu);
+
                 const int32_t result =
                     this->vulkan_.queue_submit2(request.queue, request.fence, waits.data(), request.wait_count, command_buffers.data(),
                                                 request.command_buffer_count, signals.data(), request.signal_count);
@@ -1069,6 +1091,8 @@ namespace sogen
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
+
+                this->flush_aliased_memory_for_device(win_emu);
 
                 const int32_t result = this->vulkan_.queue_submit(request.queue, request.command_buffer, request.fence);
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1218,6 +1218,7 @@ namespace sogen
                 if (const auto it = this->direct_mappings_.find(request.memory); it != this->direct_mappings_.end())
                 {
                     win_emu.memory.release_memory(it->second.guest_address, static_cast<size_t>(it->second.size));
+                    this->vulkan_.unmap_memory(it->second.device, request.memory);
                     this->direct_mappings_.erase(it);
                 }
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1211,6 +1211,16 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                // If this allocation was aliased into the guest, tear the alias down and forget the host
+                // pointer before vkFreeMemory invalidates it. Otherwise the guest keeps a stale alias of freed
+                // memory and direct_mappings_ retains a dangling pointer that the pre-submit cache flush would
+                // dereference (e.g. while DXVK frees buffers during shutdown).
+                if (const auto it = this->direct_mappings_.find(request.memory); it != this->direct_mappings_.end())
+                {
+                    win_emu.memory.release_memory(it->second.guest_address, static_cast<size_t>(it->second.size));
+                    this->direct_mappings_.erase(it);
+                }
+
                 this->vulkan_.free_memory(request.device, request.memory);
                 return STATUS_SUCCESS;
             }

--- a/src/windows-emulator/memory_manager.cpp
+++ b/src/windows-emulator/memory_manager.cpp
@@ -947,6 +947,16 @@ namespace sogen
         this->memory_->map_host_memory(address, size, host_pointer, permissions);
     }
 
+    bool memory_manager::host_memory_aliasing_is_coherent() const
+    {
+        return this->memory_->host_memory_aliasing_is_coherent();
+    }
+
+    void memory_manager::flush_host_memory_cache(const void* host_pointer, const size_t size)
+    {
+        this->memory_->flush_host_memory_cache(host_pointer, size);
+    }
+
     void memory_manager::unmap_memory(const uint64_t address, const size_t size)
     {
         this->memory_->unmap_memory(address, size);

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -95,8 +95,8 @@ namespace sogen
         // Backend coherency hooks for host-aliased memory (see memory_interface). Device emulation such as
         // the GPU bridge uses these to make guest writes visible to the host GPU on backends (e.g. KVM) that
         // alias host memory into the guest non-coherently.
-        bool host_memory_aliasing_is_coherent() const;
-        void flush_host_memory_cache(const void* host_pointer, size_t size);
+        bool host_memory_aliasing_is_coherent() const override;
+        void flush_host_memory_cache(const void* host_pointer, size_t size) override;
         bool allocate_memory(uint64_t address, size_t size, nt_memory_permission permissions, bool reserve_only = false,
                              memory_region_kind kind = memory_region_kind::private_allocation);
 

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -91,6 +91,12 @@ namespace sogen
         // Reserves the range and aliases it onto caller-owned host memory (e.g. a host Vulkan mapping) so the
         // guest accesses it coherently. The region is treated like MMIO: not serialized, host_pointer not owned.
         bool allocate_host_memory(uint64_t address, size_t size, void* host_pointer, nt_memory_permission permissions);
+
+        // Backend coherency hooks for host-aliased memory (see memory_interface). Device emulation such as
+        // the GPU bridge uses these to make guest writes visible to the host GPU on backends (e.g. KVM) that
+        // alias host memory into the guest non-coherently.
+        bool host_memory_aliasing_is_coherent() const;
+        void flush_host_memory_cache(const void* host_pointer, size_t size);
         bool allocate_memory(uint64_t address, size_t size, nt_memory_permission permissions, bool reserve_only = false,
                              memory_region_kind kind = memory_region_kind::private_allocation);
 


### PR DESCRIPTION
Two KVM-backend fixes for the GPU paravirtualization path, found running Call of Duty: MW3 (open-iw5) under KVM on a Steam Deck (AMD Van Gogh / RADV).

## 1. Cache coherency for host-aliased GPU buffers

DXVK allocates `HOST_VISIBLE | HOST_COHERENT` memory that RADV backs with **write-combined** memory, while the KVM backend aliases those physical pages into the guest as **write-back cacheable**. The mismatched cache attributes mean the guest's cached vertex/texture writes are not guaranteed visible to the GPU until they happen to evict, which corrupted streamed geometry — intermittent jumbled glyphs and vertex noise in the menus, worse during asset streaming, fine once in-game. WHP is unaffected because Windows aliases the host memory coherently.

Fix: add a coherency capability to `memory_interface` — backends report whether host-memory aliasing is coherent with external devices and expose a cache-flush hook. The KVM backend reports non-coherent aliasing and flushes the aliased ranges via `clflush`; the GPU bridge flushes every directly-aliased buffer before each queue submit. Other backends keep the coherent default and skip the work entirely (no cost on WHP/unicorn).

An alternative considered was promoting the host allocation to a `HOST_CACHED` (write-back) sibling type, but DXVK's main streaming allocations are `DEVICE_LOCAL | HOST_VISIBLE` (heap with no cached sibling on the APU), so a flush is the only approach that covers all aliased memory regardless of type.

## 2. Use-after-free / segfault on shutdown

`handle_free_memory` freed the `VkDeviceMemory` without releasing the guest alias or erasing the `direct_mappings_` entry. After the guest freed a directly-aliased allocation it kept a stale alias of freed memory, and the bridge retained a dangling host pointer that the pre-submit cache flush then dereferenced — segfaulting while DXVK frees buffers during shutdown. Fix mirrors `handle_unmap_memory_direct`: tear the alias down and forget the host pointer before `vkFreeMemory`.

## Testing
- Verified on the Steam Deck: menu renders cleanly, closing the game no longer crashes.
- Windows release smoke suite (`analyzer -s test-sample.exe`): all 26 tests pass — confirms the shared `memory_interface` change doesn't affect the WHP/unicorn paths.

@claude review