### PR TITLE
deps: require both Wayland and X11 SDL backends on Linux

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -55,6 +55,15 @@ if(SOGEN_ENABLE_SDL3 AND NOT EMSCRIPTEN)
     set(SDL_TESTS OFF CACHE BOOL "" FORCE)
     set(SDL_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(SDL_INSTALL OFF CACHE BOOL "" FORCE)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT SDL_UNIX_CONSOLE_BUILD)
+      # Require both display backends on Linux: Wayland for desktop sessions, and X11 for environments
+      # that only expose Xwayland (e.g. the Steam Deck's Gaming Mode under gamescope, which does not set
+      # WAYLAND_DISPLAY). Forcing them on turns a missing dev package into a hard configure error instead
+      # of a silently dropped backend that leaves the app with no window at runtime. The Python wheel build
+      # opts out via SDL_UNIX_CONSOLE_BUILD, since it intentionally builds without these dev libraries.
+      set(SDL_WAYLAND ON CACHE BOOL "" FORCE)
+      set(SDL_X11 ON CACHE BOOL "" FORCE)
+    endif()
     add_subdirectory(SDL)
     message(STATUS "Using vendored SDL3 submodule (deps/SDL)")
   endif()


### PR DESCRIPTION
Fixes the emulator window never appearing in the Steam Deck's **Gaming Mode**.

## Problem

The vendored SDL3 auto-detects its video backends from the dev libraries present at configure time. When only the Wayland libraries are installed, it silently builds **Wayland-only**. That works in Desktop Mode (KWin sets `WAYLAND_DISPLAY`), but in Gaming Mode gamescope sets `DISPLAY=:1` (Xwayland) and **not** `WAYLAND_DISPLAY` — so SDL falls back to a non-existent X11 backend, `SDL_CreateWindow` fails, and no window ever appears.

This was traced step by step: forcing `SDL_VIDEODRIVER=x11` produced *zero* window-creation in any mode (no X11 backend compiled in), while a `CMakeCache` check confirmed `SDL_X11:BOOL=OFF`. Building SDL with X11 enabled makes the window appear in Gaming Mode via gamescope's Xwayland — the same path every Steam game uses.

## Fix

Force `SDL_WAYLAND` and `SDL_X11` on for normal Linux builds, so a missing dev package becomes a hard configure error instead of a silently dropped backend that leaves the app with no window at runtime. The Python wheel build, which intentionally builds SDL without these libraries, opts out through the existing `SDL_UNIX_CONSOLE_BUILD` flag.

CI already installs the full X11 + Wayland dev set, so official builds were already X11-capable; this change makes the requirement explicit and prevents future silent regressions.

@claude review

https://claude.ai/code/session_01LVXkDJBCzLbfn5dxVBVPtF