### PR TITLE
cmake: fix _FORTIFY_SOURCE redefinition on hardened toolchains

### DIFF
--- a/cmake/compiler-env.cmake
+++ b/cmake/compiler-env.cmake
@@ -118,9 +118,23 @@ if(LINUX OR APPLE)
   )
 
   if(NOT SOGEN_ENABLE_SANITIZER)
-    add_compile_definitions(
-      _FORTIFY_SOURCE=2
-    )
+    # Hardened toolchains (e.g. Gentoo hardened) predefine _FORTIFY_SOURCE via
+    # their spec files. Redefining it triggers a -Werror "redefined" failure, so
+    # only set it when the compiler hasn't already done so. This also lets users
+    # keep their own (often stronger) level.
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles([[
+#ifdef _FORTIFY_SOURCE
+#error _FORTIFY_SOURCE already defined
+#endif
+int main() { return 0; }
+]] SOGEN_FORTIFY_SOURCE_UNSET)
+
+    if(SOGEN_FORTIFY_SOURCE_UNSET)
+      add_compile_definitions(
+        _FORTIFY_SOURCE=2
+      )
+    endif()
   endif()
 
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")


### PR DESCRIPTION
## Problem

Builds fail on hardened systems (e.g. Gentoo hardened) with:

```
<command-line>: error: '_FORTIFY_SOURCE' redefined [-Werror]
<built-in>: note: this is the location of the previous definition
```

`cmake/compiler-env.cmake` unconditionally injects `-D_FORTIFY_SOURCE=2` on Linux/macOS. Hardened toolchains already predefine `_FORTIFY_SOURCE` as a `<built-in>` macro via their spec files, so the second definition collides and `-Werror` turns it into a hard failure. This is independent of `CFLAGS`/`CXXFLAGS`, which is why clearing them didn't help.

## Fix

Gate the definition behind a `check_cxx_source_compiles` test so `_FORTIFY_SOURCE=2` is only added when the compiler hasn't already defined it. This:

- Fixes the hardened build (no redefinition / `-Werror` failure).
- Keeps hardening on normal toolchains.
- Respects the user's existing (often stronger, e.g. level 3) setting rather than downgrading it.

Fixes #1096

https://claude.ai/code/session_01VmjCnTwdddHfYrpGafQ6QK