### PR TITLE
cmake: embed $ORIGIN/@loader_path rpath so colocated libs load without LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -712,7 +712,6 @@ jobs:
         run: cd build/release/artifacts && chmod +x ./analyzer && ./analyzer -e root c:/test-sample.exe
         env:
           EMULATOR_KVM: "1"
-          LD_LIBRARY_PATH: ${{github.workspace}}/build/release/artifacts
           EMULATOR_ROOT: ${{github.workspace}}/build/release/artifacts/root
           EMULATOR_VERBOSE: ${{ inputs.verbose }}
 

--- a/cmake/compiler-env.cmake
+++ b/cmake/compiler-env.cmake
@@ -124,6 +124,26 @@ if(LINUX OR APPLE)
   endif()
 
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+
+  # Embed an rpath so binaries find their colocated shared libraries without
+  # requiring LD_LIBRARY_PATH / DYLD_LIBRARY_PATH. All sogen artifacts (the
+  # executables and the shared libs they depend on) share one output directory,
+  # so an $ORIGIN/@loader_path rpath lets every binary locate its libraries
+  # relative to itself. CMAKE_BUILD_RPATH adds it on top of the auto-computed
+  # build-tree rpath, which also covers transitive dependencies the linker only
+  # records as (non-transitive) DT_RUNPATH. It keeps working after the output
+  # directory is copied elsewhere.
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+  set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+
+  if(APPLE)
+    set(CMAKE_BUILD_RPATH "@loader_path")
+    set(CMAKE_INSTALL_RPATH "@loader_path")
+  else()
+    set(CMAKE_BUILD_RPATH "$ORIGIN")
+    set(CMAKE_INSTALL_RPATH "$ORIGIN")
+  endif()
 endif()
 
 ##########################################

--- a/src/linux-emulator-test/CMakeLists.txt
+++ b/src/linux-emulator-test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_definitions(linux-emulator-test PRIVATE
 )
 
 add_test(NAME linux-emulator-test
-         COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=." -- "${PYTHON3_EXE}" "${PROJECT_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py" ./linux-emulator-test
+         COMMAND "${PYTHON3_EXE}" "${PROJECT_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py" ./linux-emulator-test
          WORKING_DIRECTORY "$<TARGET_FILE_DIR:linux-emulator-test>")
 
 sogen_targets_set_folder("tests" linux-emulator-test)

--- a/src/windows-emulator-test/CMakeLists.txt
+++ b/src/windows-emulator-test/CMakeLists.txt
@@ -23,7 +23,7 @@ if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif()
 
 add_test(NAME windows-emulator-test
-         COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=." -- "${PYTHON3_EXE}" "${PROJECT_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py" ./windows-emulator-test
+         COMMAND "${PYTHON3_EXE}" "${PROJECT_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py" ./windows-emulator-test
          WORKING_DIRECTORY "$<TARGET_FILE_DIR:windows-emulator-test>")
 
 sogen_targets_set_folder("tests" windows-emulator-test)


### PR DESCRIPTION
## Problem

On Linux (and potentially macOS), running the built binaries fails to locate the `.so`/`.dylib` files unless `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` is set manually.

All sogen artifacts — executables and the shared libraries they depend on — are emitted into a single output directory (`sogen_set_artifact_directory`). Despite that colocation, modern linkers emit a **non-transitive** `DT_RUNPATH`, which only resolves a binary's *direct* dependencies and not dependencies-of-dependencies, so users are forced to fall back to `LD_LIBRARY_PATH`.

## Fix

Embed a relative rpath so every binary searches its own directory for the libraries sitting next to it:

- `$ORIGIN` on Linux, `@loader_path` on macOS
- Set via both `CMAKE_BUILD_RPATH` (build tree) and `CMAKE_INSTALL_RPATH` (after install/relocation)
- `CMAKE_BUILD_RPATH_USE_ORIGIN` keeps the auto-computed build rpath relocatable too

Because the explicit rpath is the binary's own directory, it resolves all colocated libraries regardless of the transitive-`DT_RUNPATH` limitation, both in the build tree and after the output directory is copied elsewhere.

## CI cleanup

With the rpath in place, the `LD_LIBRARY_PATH` workarounds are no longer needed, so this PR also removes them — which doubles as verification that the rpath works, since CI runs the tests/smoke test without them:

- `linux-emulator-test` / `windows-emulator-test` `add_test` runners no longer wrap the command in `cmake -E env LD_LIBRARY_PATH=.`
- The Linux KVM smoke test drops its `LD_LIBRARY_PATH` env var

The **Android** adb smoke test keeps its `export LD_LIBRARY_PATH=.`: the rpath is only configured for `LINUX`/`APPLE`, and Android (`CMAKE_SYSTEM_NAME=Android`) is neither.

https://claude.ai/code/session_01VmjCnTwdddHfYrpGafQ6QK