### PR TITLE
Fix CreateDIBSection, Improve UI Key Dispatch, and other improvements

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -201,6 +201,11 @@ namespace sogen
 #define WM_KEYDOWN           0x0100
 #define WM_KEYUP             0x0101
 #define WM_CHAR              0x0102
+#define WM_DEADCHAR          0x0103
+#define WM_SYSKEYDOWN        0x0104
+#define WM_SYSKEYUP          0x0105
+#define WM_SYSCHAR           0x0106
+#define WM_SYSDEADCHAR       0x0107
 #define WM_MOUSEMOVE         0x0200
 #define WM_LBUTTONDOWN       0x0201
 #define WM_LBUTTONUP         0x0202

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -249,6 +249,7 @@ namespace sogen
 #define VK_SHIFT             0x10
 #define VK_CONTROL           0x11
 #define VK_MENU              0x12
+#define VK_PAUSE             0x13
 #define VK_CAPITAL           0x14
 #define VK_SPACE             0x20
 #define VK_PRIOR             0x21
@@ -263,6 +264,23 @@ namespace sogen
 #define VK_DELETE            0x2E
 #define VK_LWIN              0x5B
 #define VK_RWIN              0x5C
+#define VK_APPS              0x5D
+#define VK_NUMPAD0           0x60
+#define VK_NUMPAD1           0x61
+#define VK_NUMPAD2           0x62
+#define VK_NUMPAD3           0x63
+#define VK_NUMPAD4           0x64
+#define VK_NUMPAD5           0x65
+#define VK_NUMPAD6           0x66
+#define VK_NUMPAD7           0x67
+#define VK_NUMPAD8           0x68
+#define VK_NUMPAD9           0x69
+#define VK_MULTIPLY          0x6A
+#define VK_ADD               0x6B
+#define VK_SEPARATOR         0x6C
+#define VK_SUBTRACT          0x6D
+#define VK_DECIMAL           0x6E
+#define VK_DIVIDE            0x6F
 #define VK_F1                0x70
 #define VK_F2                0x71
 #define VK_F3                0x72
@@ -275,6 +293,8 @@ namespace sogen
 #define VK_F10               0x79
 #define VK_F11               0x7A
 #define VK_F12               0x7B
+#define VK_NUMLOCK           0x90
+#define VK_SCROLL            0x91
 #define VK_OEM_1             0xBA
 #define VK_OEM_PLUS          0xBB
 #define VK_OEM_COMMA         0xBC
@@ -286,6 +306,7 @@ namespace sogen
 #define VK_OEM_5             0xDC
 #define VK_OEM_6             0xDD
 #define VK_OEM_7             0xDE
+#define VK_OEM_102           0xE2
 
 #define IDOK                 1
 #define IDCANCEL             2

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -89,11 +89,20 @@ namespace sogen
         uint32_t height{};
         std::vector<uint32_t> pixels{};
 
+        emulator_pointer guest_bits{};
+        uint32_t guest_stride{};
+        bool guest_top_down{};
+        bool guest_owns_memory{};
+
         void serialize(utils::buffer_serializer& buffer) const
         {
             buffer.write(this->width);
             buffer.write(this->height);
             buffer.write_vector(this->pixels);
+            buffer.write(this->guest_bits);
+            buffer.write(this->guest_stride);
+            buffer.write(this->guest_top_down);
+            buffer.write(this->guest_owns_memory);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
@@ -101,6 +110,10 @@ namespace sogen
             buffer.read(this->width);
             buffer.read(this->height);
             buffer.read_vector(this->pixels);
+            buffer.read(this->guest_bits);
+            buffer.read(this->guest_stride);
+            buffer.read(this->guest_top_down);
+            buffer.read(this->guest_owns_memory);
         }
     };
 

--- a/src/windows-emulator/syscall_utils.hpp
+++ b/src/windows-emulator/syscall_utils.hpp
@@ -65,8 +65,8 @@ namespace sogen
 
     inline bool is_named_pipe_path(const std::u16string_view& filename)
     {
-        return filename == u"\\Device\\NamedPipe\\" || filename.starts_with(u"\\Device\\NamedPipe\\") ||
-               filename.starts_with(u"\\??\\pipe\\");
+        return utils::string::starts_with_ignore_case(filename, {u"\\Device\\NamedPipe\\"}) ||
+               utils::string::starts_with_ignore_case(filename, {u"\\??\\Pipe\\"});
     }
 
     inline std::optional<uint32_t> extract_syscall_id(const exported_symbol& symbol, std::span<const std::byte> data)

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -469,6 +469,7 @@ namespace sogen
         hdc handle_NtUserBeginPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
         BOOL handle_NtUserEndPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
         BOOL handle_NtUserGetCursorPos(const syscall_context& c, emulator_pointer point_ptr);
+        BOOL handle_NtUserGetClipCursor(const syscall_context& c, emulator_pointer rect_ptr);
         BOOL handle_NtUserTransformPoint(const syscall_context& c, emulator_pointer point, uint32_t from_dpi, uint32_t to_dpi,
                                          uint32_t flags);
         int32_t handle_NtUserShowCursor(const syscall_context& c, BOOL show);
@@ -523,6 +524,7 @@ namespace sogen
         BOOL handle_NtUserSetProp(const syscall_context& c, hwnd window, uint16_t atom, uint64_t data);
         BOOL handle_NtUserSetProp2(const syscall_context& c, hwnd window, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str,
                                    uint64_t data);
+        uint64_t handle_NtUserGetProp2(const syscall_context& c, hwnd window, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str);
         uint64_t handle_NtUserChangeWindowMessageFilterEx();
         BOOL handle_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
         BOOL completion_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
@@ -631,6 +633,10 @@ namespace sogen
         NTSTATUS handle_NtUserSelectPalette();
         BOOL handle_NtUserSwapMouseButton();
         hwnd handle_NtUserWindowFromPoint(const syscall_context& c, int32_t x, int32_t y);
+        BOOL handle_NtUserGetKeyboardState(const syscall_context& c, emulator_pointer key_state);
+        uint32_t handle_NtUserGetDoubleClickTime();
+        BOOL handle_NtUserModifyWindowTouchCapability();
+        uint32_t handle_NtUserGetClipboardSequenceNumber();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -713,6 +719,7 @@ namespace sogen
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
         BOOL handle_NtGdiGetRealizationInfo(const syscall_context& c, hdc dc, emulator_pointer realization_info, uint64_t font);
         NTSTATUS handle_NtGdiGetEntry(const syscall_context& c, uint32_t handle_value, emulator_pointer entry_ptr);
+        int32_t handle_NtGdiSetIcmMode();
         NTSTATUS handle_NtGdiSetLayout();
         NTSTATUS handle_NtGdiGetDCObject();
         BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
@@ -1334,6 +1341,7 @@ namespace sogen
         add_handler(NtGetNextThread);
         add_handler(NtSetInformationObject);
         add_handler(NtUserGetCursorPos);
+        add_handler(NtUserGetClipCursor);
         add_handler(NtUserTransformPoint);
         add_handler(NtUserShowCursor);
         add_handler(NtUserClipCursor);
@@ -1401,6 +1409,7 @@ namespace sogen
         add_handler(NtUserEnumDisplayMonitors);
         add_handler(NtUserSetProp);
         add_handler(NtUserSetProp2);
+        add_handler(NtUserGetProp2);
         add_handler(NtUserChangeWindowMessageFilterEx);
         add_handler(NtUserDestroyWindow);
         add_handler(NtQueryInformationByName);
@@ -1538,6 +1547,11 @@ namespace sogen
         add_handler(NtUserGetKeyNameText);
         add_handler(NtUserWindowFromPoint);
         add_handler(NtUserSwapMouseButton);
+        add_handler(NtUserGetDoubleClickTime);
+        add_handler(NtGdiSetIcmMode);
+        add_handler(NtUserGetKeyboardState);
+        add_handler(NtUserModifyWindowTouchCapability);
+        add_handler(NtUserGetClipboardSequenceNumber);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -2113,7 +2113,7 @@ namespace sogen
             const auto attributes = object_attributes.read();
             const auto filename = read_unicode_string(c.emu, attributes.ObjectName);
 
-            if (!filename.starts_with(u"\\Device\\NamedPipe"))
+            if (!is_named_pipe_path(filename))
             {
                 return STATUS_NOT_SUPPORTED;
             }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -565,6 +565,56 @@ namespace sogen
                 return surface != nullptr;
             }
 
+            bool sync_surface_from_guest_dib(const syscall_context& c, gdi_bitmap_surface& surface)
+            {
+                if (surface.guest_bits == 0 || surface.guest_stride == 0 || surface.width == 0 || surface.height == 0)
+                {
+                    return false;
+                }
+
+                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
+                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                {
+                    return false;
+                }
+
+                for (uint32_t y = 0; y < surface.height; ++y)
+                {
+                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                    auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                    if (!c.emu.try_read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst,
+                                               row_bytes))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            bool sync_surface_to_guest_dib(const syscall_context& c, const gdi_bitmap_surface& surface)
+            {
+                if (surface.guest_bits == 0 || surface.guest_stride == 0 || surface.width == 0 || surface.height == 0)
+                {
+                    return false;
+                }
+
+                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
+                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                {
+                    return false;
+                }
+
+                for (uint32_t y = 0; y < surface.height; ++y)
+                {
+                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                    const auto* src = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                    c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, src, row_bytes);
+                }
+
+                return true;
+            }
+
             void set_surface_pixel(gdi_bitmap_surface& surface, const int x, const int y, const uint32_t color)
             {
                 if (x < 0 || y < 0 || x >= static_cast<int>(surface.width) || y >= static_cast<int>(surface.height))
@@ -1897,7 +1947,11 @@ namespace sogen
                 return 0;
             }
 
-            // TODO: Tie the allocated memory with the surface.
+            auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
+            surface.guest_bits = guest_bits;
+            surface.guest_stride = stride;
+            surface.guest_top_down = header.biHeight < 0;
+            surface.guest_owns_memory = true;
 
             bits.write(guest_bits);
             return handle_value;
@@ -2247,6 +2301,12 @@ namespace sogen
             if (handle_value == c.proc.gdi_default_dc_handle)
             {
                 c.proc.gdi_default_dc_handle = 0;
+            }
+
+            if (const auto bmp_it = c.proc.gdi_bitmap_surfaces.find(handle_value);
+                bmp_it != c.proc.gdi_bitmap_surfaces.end() && bmp_it->second.guest_owns_memory && bmp_it->second.guest_bits != 0)
+            {
+                c.win_emu.memory.release_memory(bmp_it->second.guest_bits, 0);
             }
 
             c.proc.gdi_dc_states.erase(handle_value);
@@ -2898,6 +2958,8 @@ namespace sogen
                 return FALSE;
             }
 
+            (void)sync_surface_from_guest_dib(c, *dst_surface);
+
             const auto rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
             const bool needs_source = rop3_uses_source(rop3);
 
@@ -2918,6 +2980,8 @@ namespace sogen
                 {
                     return FALSE;
                 }
+
+                (void)sync_surface_from_guest_dib(c, *src_surface);
             }
 
             auto dx = static_cast<int64_t>(x_dst) + dst_origin_x;
@@ -3030,6 +3094,8 @@ namespace sogen
                     dst_row[col] = apply_rop3(rop3, src, dst, pattern) | 0xFF000000u;
                 }
             }
+
+            (void)sync_surface_to_guest_dib(c, *dst_surface);
 
             if (present_handle != 0 && dst_surface->width > 0 && dst_surface->height > 0 && !dst_surface->pixels.empty())
             {
@@ -3255,6 +3321,11 @@ namespace sogen
 
             c.emu.write_memory(entry_ptr, &entry, sizeof(entry));
             return STATUS_SUCCESS;
+        }
+
+        int32_t handle_NtGdiSetIcmMode()
+        {
+            return 0;
         }
 
         NTSTATUS handle_NtGdiSetLayout()

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -462,6 +462,27 @@ namespace sogen
                 return addr != 0;
             }
 
+            void sync_surface_from_guest_dib(const syscall_context& c, gdi_bitmap_surface& surface)
+            {
+                if (surface.guest_bits == 0 || surface.guest_stride == 0 || surface.width == 0 || surface.height == 0)
+                {
+                    return;
+                }
+
+                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
+                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                {
+                    return;
+                }
+
+                for (uint32_t y = 0; y < surface.height; ++y)
+                {
+                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                    auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                    c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst, row_bytes);
+                }
+            }
+
             uint32_t window_surface_fill_color(const syscall_context& c, const window& win);
 
             // Resolves the bitmap surface a DC draws into, plus the offset from DC-local coordinates to surface
@@ -490,6 +511,7 @@ namespace sogen
                     }
 
                     present_handle = static_cast<uint32_t>(dc_state.target_window);
+                    sync_surface_from_guest_dib(c, bmp_it->second);
                     return &bmp_it->second;
                 }
 
@@ -534,6 +556,7 @@ namespace sogen
                 origin_x = off_x;
                 origin_y = off_y;
                 present_handle = top_handle;
+                sync_surface_from_guest_dib(c, surface);
                 return &surface;
             }
 
@@ -565,44 +588,17 @@ namespace sogen
                 return surface != nullptr;
             }
 
-            bool sync_surface_from_guest_dib(const syscall_context& c, gdi_bitmap_surface& surface)
+            void sync_surface_to_guest_dib(const syscall_context& c, const gdi_bitmap_surface& surface)
             {
                 if (surface.guest_bits == 0 || surface.guest_stride == 0 || surface.width == 0 || surface.height == 0)
                 {
-                    return false;
+                    return;
                 }
 
                 const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
                 if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
                 {
-                    return false;
-                }
-
-                for (uint32_t y = 0; y < surface.height; ++y)
-                {
-                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
-                    auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
-                    if (!c.emu.try_read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst,
-                                               row_bytes))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            bool sync_surface_to_guest_dib(const syscall_context& c, const gdi_bitmap_surface& surface)
-            {
-                if (surface.guest_bits == 0 || surface.guest_stride == 0 || surface.width == 0 || surface.height == 0)
-                {
-                    return false;
-                }
-
-                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
-                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
-                {
-                    return false;
+                    return;
                 }
 
                 for (uint32_t y = 0; y < surface.height; ++y)
@@ -611,8 +607,28 @@ namespace sogen
                     const auto* src = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
                     c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, src, row_bytes);
                 }
+            }
 
-                return true;
+            void present_win_surface(const syscall_context& c, uint32_t present_handle, gdi_bitmap_surface* surface)
+            {
+                if (surface == nullptr)
+                {
+                    return;
+                }
+
+                sync_surface_to_guest_dib(c, *surface);
+
+                if (present_handle == 0 || surface->width <= 0 || surface->height <= 0 || surface->pixels.empty())
+                {
+                    return;
+                }
+
+                c.win_emu.ui().present_surface(present_handle,
+                                               ui_surface_desc{.width = static_cast<int>(surface->width),
+                                                               .height = static_cast<int>(surface->height),
+                                                               .stride = static_cast<int>(surface->width * sizeof(uint32_t)),
+                                                               .format = ui_surface_format::bgra8,
+                                                               .pixels = surface->pixels.data()});
             }
 
             void set_surface_pixel(gdi_bitmap_surface& surface, const int x, const int y, const uint32_t color)
@@ -2269,15 +2285,7 @@ namespace sogen
                 }
             }
 
-            if (present_handle != 0 && surface->width > 0 && surface->height > 0 && !surface->pixels.empty())
-            {
-                c.win_emu.ui().present_surface(present_handle,
-                                               ui_surface_desc{.width = static_cast<int>(surface->width),
-                                                               .height = static_cast<int>(surface->height),
-                                                               .stride = static_cast<int>(surface->width * sizeof(uint32_t)),
-                                                               .format = ui_surface_format::bgra8,
-                                                               .pixels = surface->pixels.data()});
-            }
+            present_win_surface(c, present_handle, surface);
 
             return static_cast<int>(img_height);
         }
@@ -2958,8 +2966,6 @@ namespace sogen
                 return FALSE;
             }
 
-            (void)sync_surface_from_guest_dib(c, *dst_surface);
-
             const auto rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
             const bool needs_source = rop3_uses_source(rop3);
 
@@ -2980,8 +2986,6 @@ namespace sogen
                 {
                     return FALSE;
                 }
-
-                (void)sync_surface_from_guest_dib(c, *src_surface);
             }
 
             auto dx = static_cast<int64_t>(x_dst) + dst_origin_x;
@@ -3095,17 +3099,7 @@ namespace sogen
                 }
             }
 
-            (void)sync_surface_to_guest_dib(c, *dst_surface);
-
-            if (present_handle != 0 && dst_surface->width > 0 && dst_surface->height > 0 && !dst_surface->pixels.empty())
-            {
-                c.win_emu.ui().present_surface(present_handle,
-                                               ui_surface_desc{.width = static_cast<int>(dst_surface->width),
-                                                               .height = static_cast<int>(dst_surface->height),
-                                                               .stride = static_cast<int>(dst_surface->width * sizeof(uint32_t)),
-                                                               .format = ui_surface_format::bgra8,
-                                                               .pixels = dst_surface->pixels.data()});
-            }
+            present_win_surface(c, present_handle, dst_surface);
 
             return TRUE;
         }
@@ -4242,16 +4236,7 @@ namespace sogen
 
             const auto bgra = colorref_to_bgra(color);
             set_surface_pixel(*surface, surface_x, surface_y, bgra);
-            if (present_handle != 0 && surface->width > 0 && surface->height > 0 && !surface->pixels.empty())
-            {
-                c.win_emu.ui().present_surface(present_handle, {
-                                                                   .width = static_cast<int32_t>(surface->width),
-                                                                   .height = static_cast<int32_t>(surface->height),
-                                                                   .stride = static_cast<int32_t>(surface->width * sizeof(uint32_t)),
-                                                                   .format = ui_surface_format::bgra8,
-                                                                   .pixels = surface->pixels.data(),
-                                                               });
-            }
+            present_win_surface(c, present_handle, surface);
 
             return bgra_to_colorref(bgra);
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1874,6 +1874,24 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserGetClipCursor(const syscall_context& c, const emulator_pointer rect_ptr)
+        {
+            if (rect_ptr == 0)
+            {
+                return FALSE;
+            }
+
+            RECT rect{0, 0, 1920, 1080};
+            const auto display_info = c.proc.user_handles.get_display_info().read();
+            if (const emulator_object<USER_MONITOR> monitor_obj(c.emu, display_info.pPrimaryMonitor); monitor_obj)
+            {
+                rect = monitor_obj.read().rcMonitor;
+            }
+
+            c.emu.write_memory(rect_ptr, &rect, sizeof(rect));
+            return TRUE;
+        }
+
         // user32 coordinate helpers (ScreenToClient/ClientToScreen/MapWindowPoints) call this to convert a
         // point between per-monitor DPI spaces before applying the window-origin offset they do themselves.
         // The emulated desktop is a single 96-DPI space, so the conversion is the identity: leave the point.
@@ -2741,6 +2759,25 @@ namespace sogen
             win->props[std::move(prop)] = data;
 
             return TRUE;
+        }
+
+        uint64_t handle_NtUserGetProp2(const syscall_context& c, const hwnd window,
+                                       const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str)
+        {
+            const auto* win = c.proc.windows.get(window);
+            if (!win || !str)
+            {
+                return 0;
+            }
+
+            const auto prop = read_unicode_string_or_atom(c, str);
+            if (prop.empty())
+            {
+                return 0;
+            }
+
+            const auto entry = win->props.find(prop);
+            return entry != win->props.end() ? entry->second : 0;
         }
 
         uint64_t handle_NtUserChangeWindowMessageFilterEx()
@@ -4797,6 +4834,36 @@ namespace sogen
             //       screen point, walking child windows in z-order; this stub just returns the
             //       current foreground window.
             return c.proc.foreground_window;
+        }
+
+        BOOL handle_NtUserGetKeyboardState(const syscall_context& c, const emulator_pointer key_state)
+        {
+            if (key_state == 0)
+            {
+                return FALSE;
+            }
+
+            if (!c.win_emu.memory.try_write_memory(key_state, c.proc.key_state.data(), c.proc.key_state.size()))
+            {
+                return FALSE;
+            }
+
+            return TRUE;
+        }
+
+        uint32_t handle_NtUserGetDoubleClickTime()
+        {
+            return 500;
+        }
+
+        BOOL handle_NtUserModifyWindowTouchCapability()
+        {
+            return TRUE;
+        }
+
+        uint32_t handle_NtUserGetClipboardSequenceNumber()
+        {
+            return 0xBEEFC00L;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1881,6 +1881,7 @@ namespace sogen
                 return FALSE;
             }
 
+            // TODO: This should return the clip cursor. For simplicity, we return a best effort derived from the screen size.
             RECT rect{0, 0, 1920, 1080};
             const auto display_info = c.proc.user_handles.get_display_info().read();
             if (const emulator_object<USER_MONITOR> monitor_obj(c.emu, display_info.pPrimaryMonitor); monitor_obj)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4864,7 +4864,7 @@ namespace sogen
 
         uint32_t handle_NtUserGetClipboardSequenceNumber()
         {
-            return 0xBEEFC00L;
+            return 1;
         }
     }
 

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -113,11 +113,585 @@ namespace sogen
                 return VK_OEM_PERIOD;
             case SDLK_SLASH:
                 return VK_OEM_2;
+            case SDLK_KP_0:
+                return VK_NUMPAD0;
+            case SDLK_KP_1:
+                return VK_NUMPAD1;
+            case SDLK_KP_2:
+                return VK_NUMPAD2;
+            case SDLK_KP_3:
+                return VK_NUMPAD3;
+            case SDLK_KP_4:
+                return VK_NUMPAD4;
+            case SDLK_KP_5:
+                return VK_NUMPAD5;
+            case SDLK_KP_6:
+                return VK_NUMPAD6;
+            case SDLK_KP_7:
+                return VK_NUMPAD7;
+            case SDLK_KP_8:
+                return VK_NUMPAD8;
+            case SDLK_KP_9:
+                return VK_NUMPAD9;
+            case SDLK_KP_PERIOD:
+                return VK_DECIMAL;
+            case SDLK_KP_PLUS:
+                return VK_ADD;
+            case SDLK_KP_MINUS:
+                return VK_SUBTRACT;
+            case SDLK_KP_MULTIPLY:
+                return VK_MULTIPLY;
+            case SDLK_KP_DIVIDE:
+                return VK_DIVIDE;
+            case SDLK_KP_ENTER:
+                return VK_RETURN;
             default:
                 if (key >= SDLK_F1 && key <= SDLK_F12)
                 {
                     return VK_F1 + static_cast<uint64_t>(key - SDLK_F1);
                 }
+                return 0;
+            }
+        }
+
+        struct scan_code_context
+        {
+            bool key_up = false;
+            bool was_down = false;
+            bool alt_context = false;
+            uint16_t repeat_count = 1;
+        };
+
+        uint64_t map_sdl_scancode(const SDL_Scancode scancode, const scan_code_context context = {})
+        {
+            struct scan_result
+            {
+                uint8_t scan_code = 0;
+                bool extended = false;
+            };
+
+            const auto scan = [&]() -> scan_result {
+                switch (scancode)
+                {
+                // Letters
+                case SDL_SCANCODE_A:
+                    return {.scan_code = 0x1E};
+                case SDL_SCANCODE_B:
+                    return {.scan_code = 0x30};
+                case SDL_SCANCODE_C:
+                    return {.scan_code = 0x2E};
+                case SDL_SCANCODE_D:
+                    return {.scan_code = 0x20};
+                case SDL_SCANCODE_E:
+                    return {.scan_code = 0x12};
+                case SDL_SCANCODE_F:
+                    return {.scan_code = 0x21};
+                case SDL_SCANCODE_G:
+                    return {.scan_code = 0x22};
+                case SDL_SCANCODE_H:
+                    return {.scan_code = 0x23};
+                case SDL_SCANCODE_I:
+                    return {.scan_code = 0x17};
+                case SDL_SCANCODE_J:
+                    return {.scan_code = 0x24};
+                case SDL_SCANCODE_K:
+                    return {.scan_code = 0x25};
+                case SDL_SCANCODE_L:
+                    return {.scan_code = 0x26};
+                case SDL_SCANCODE_M:
+                    return {.scan_code = 0x32};
+                case SDL_SCANCODE_N:
+                    return {.scan_code = 0x31};
+                case SDL_SCANCODE_O:
+                    return {.scan_code = 0x18};
+                case SDL_SCANCODE_P:
+                    return {.scan_code = 0x19};
+                case SDL_SCANCODE_Q:
+                    return {.scan_code = 0x10};
+                case SDL_SCANCODE_R:
+                    return {.scan_code = 0x13};
+                case SDL_SCANCODE_S:
+                    return {.scan_code = 0x1F};
+                case SDL_SCANCODE_T:
+                    return {.scan_code = 0x14};
+                case SDL_SCANCODE_U:
+                    return {.scan_code = 0x16};
+                case SDL_SCANCODE_V:
+                    return {.scan_code = 0x2F};
+                case SDL_SCANCODE_W:
+                    return {.scan_code = 0x11};
+                case SDL_SCANCODE_X:
+                    return {.scan_code = 0x2D};
+                case SDL_SCANCODE_Y:
+                    return {.scan_code = 0x15};
+                case SDL_SCANCODE_Z:
+                    return {.scan_code = 0x2C};
+
+                // Number row
+                case SDL_SCANCODE_1:
+                    return {.scan_code = 0x02};
+                case SDL_SCANCODE_2:
+                    return {.scan_code = 0x03};
+                case SDL_SCANCODE_3:
+                    return {.scan_code = 0x04};
+                case SDL_SCANCODE_4:
+                    return {.scan_code = 0x05};
+                case SDL_SCANCODE_5:
+                    return {.scan_code = 0x06};
+                case SDL_SCANCODE_6:
+                    return {.scan_code = 0x07};
+                case SDL_SCANCODE_7:
+                    return {.scan_code = 0x08};
+                case SDL_SCANCODE_8:
+                    return {.scan_code = 0x09};
+                case SDL_SCANCODE_9:
+                    return {.scan_code = 0x0A};
+                case SDL_SCANCODE_0:
+                    return {.scan_code = 0x0B};
+
+                // Basic keys
+                case SDL_SCANCODE_ESCAPE:
+                    return {.scan_code = 0x01};
+                case SDL_SCANCODE_BACKSPACE:
+                    return {.scan_code = 0x0E};
+                case SDL_SCANCODE_TAB:
+                    return {.scan_code = 0x0F};
+                case SDL_SCANCODE_RETURN:
+                    return {.scan_code = 0x1C};
+                case SDL_SCANCODE_SPACE:
+                    return {.scan_code = 0x39};
+
+                // Modifiers
+                case SDL_SCANCODE_LSHIFT:
+                    return {.scan_code = 0x2A};
+                case SDL_SCANCODE_RSHIFT:
+                    return {.scan_code = 0x36};
+                case SDL_SCANCODE_LCTRL:
+                    return {.scan_code = 0x1D};
+                case SDL_SCANCODE_RCTRL:
+                    return {.scan_code = 0x1D, .extended = true};
+                case SDL_SCANCODE_LALT:
+                    return {.scan_code = 0x38};
+                case SDL_SCANCODE_RALT:
+                    return {.scan_code = 0x38, .extended = true};
+                case SDL_SCANCODE_LGUI:
+                    return {.scan_code = 0x5B, .extended = true};
+                case SDL_SCANCODE_RGUI:
+                    return {.scan_code = 0x5C, .extended = true};
+                case SDL_SCANCODE_APPLICATION:
+                    return {.scan_code = 0x5D, .extended = true};
+
+                // Navigation cluster: extended
+                case SDL_SCANCODE_INSERT:
+                    return {.scan_code = 0x52, .extended = true};
+                case SDL_SCANCODE_DELETE:
+                    return {.scan_code = 0x53, .extended = true};
+                case SDL_SCANCODE_HOME:
+                    return {.scan_code = 0x47, .extended = true};
+                case SDL_SCANCODE_END:
+                    return {.scan_code = 0x4F, .extended = true};
+                case SDL_SCANCODE_PAGEUP:
+                    return {.scan_code = 0x49, .extended = true};
+                case SDL_SCANCODE_PAGEDOWN:
+                    return {.scan_code = 0x51, .extended = true};
+
+                // Arrow keys: extended
+                case SDL_SCANCODE_LEFT:
+                    return {.scan_code = 0x4B, .extended = true};
+                case SDL_SCANCODE_UP:
+                    return {.scan_code = 0x48, .extended = true};
+                case SDL_SCANCODE_RIGHT:
+                    return {.scan_code = 0x4D, .extended = true};
+                case SDL_SCANCODE_DOWN:
+                    return {.scan_code = 0x50, .extended = true};
+
+                // Locks
+                case SDL_SCANCODE_CAPSLOCK:
+                    return {.scan_code = 0x3A};
+                case SDL_SCANCODE_NUMLOCKCLEAR:
+                    return {.scan_code = 0x45};
+                case SDL_SCANCODE_SCROLLLOCK:
+                    return {.scan_code = 0x46};
+
+                // Punctuation, US keyboard physical positions
+                case SDL_SCANCODE_GRAVE:
+                    return {.scan_code = 0x29};
+                case SDL_SCANCODE_MINUS:
+                    return {.scan_code = 0x0C};
+                case SDL_SCANCODE_EQUALS:
+                    return {.scan_code = 0x0D};
+                case SDL_SCANCODE_LEFTBRACKET:
+                    return {.scan_code = 0x1A};
+                case SDL_SCANCODE_RIGHTBRACKET:
+                    return {.scan_code = 0x1B};
+                case SDL_SCANCODE_BACKSLASH:
+                    return {.scan_code = 0x2B};
+                case SDL_SCANCODE_NONUSHASH:
+                    return {.scan_code = 0x2B};
+                case SDL_SCANCODE_SEMICOLON:
+                    return {.scan_code = 0x27};
+                case SDL_SCANCODE_APOSTROPHE:
+                    return {.scan_code = 0x28};
+                case SDL_SCANCODE_COMMA:
+                    return {.scan_code = 0x33};
+                case SDL_SCANCODE_PERIOD:
+                    return {.scan_code = 0x34};
+                case SDL_SCANCODE_SLASH:
+                    return {.scan_code = 0x35};
+                case SDL_SCANCODE_NONUSBACKSLASH:
+                    return {.scan_code = 0x56};
+
+                // Function keys
+                case SDL_SCANCODE_F1:
+                    return {.scan_code = 0x3B};
+                case SDL_SCANCODE_F2:
+                    return {.scan_code = 0x3C};
+                case SDL_SCANCODE_F3:
+                    return {.scan_code = 0x3D};
+                case SDL_SCANCODE_F4:
+                    return {.scan_code = 0x3E};
+                case SDL_SCANCODE_F5:
+                    return {.scan_code = 0x3F};
+                case SDL_SCANCODE_F6:
+                    return {.scan_code = 0x40};
+                case SDL_SCANCODE_F7:
+                    return {.scan_code = 0x41};
+                case SDL_SCANCODE_F8:
+                    return {.scan_code = 0x42};
+                case SDL_SCANCODE_F9:
+                    return {.scan_code = 0x43};
+                case SDL_SCANCODE_F10:
+                    return {.scan_code = 0x44};
+                case SDL_SCANCODE_F11:
+                    return {.scan_code = 0x57};
+                case SDL_SCANCODE_F12:
+                    return {.scan_code = 0x58};
+
+                // Extended F keys, usually not needed for older Win32 games,
+                // but harmless if something asks for them.
+                case SDL_SCANCODE_F13:
+                    return {.scan_code = 0x64};
+                case SDL_SCANCODE_F14:
+                    return {.scan_code = 0x65};
+                case SDL_SCANCODE_F15:
+                    return {.scan_code = 0x66};
+
+                // Keypad
+                case SDL_SCANCODE_KP_7:
+                    return {.scan_code = 0x47};
+                case SDL_SCANCODE_KP_8:
+                    return {.scan_code = 0x48};
+                case SDL_SCANCODE_KP_9:
+                    return {.scan_code = 0x49};
+                case SDL_SCANCODE_KP_MINUS:
+                    return {.scan_code = 0x4A};
+                case SDL_SCANCODE_KP_4:
+                    return {.scan_code = 0x4B};
+                case SDL_SCANCODE_KP_5:
+                    return {.scan_code = 0x4C};
+                case SDL_SCANCODE_KP_6:
+                    return {.scan_code = 0x4D};
+                case SDL_SCANCODE_KP_PLUS:
+                    return {.scan_code = 0x4E};
+                case SDL_SCANCODE_KP_1:
+                    return {.scan_code = 0x4F};
+                case SDL_SCANCODE_KP_2:
+                    return {.scan_code = 0x50};
+                case SDL_SCANCODE_KP_3:
+                    return {.scan_code = 0x51};
+                case SDL_SCANCODE_KP_0:
+                    return {.scan_code = 0x52};
+                case SDL_SCANCODE_KP_PERIOD:
+                    return {.scan_code = 0x53};
+                case SDL_SCANCODE_KP_MULTIPLY:
+                    return {.scan_code = 0x37};
+                case SDL_SCANCODE_KP_DIVIDE:
+                    return {.scan_code = 0x35, .extended = true};
+                case SDL_SCANCODE_KP_ENTER:
+                    return {.scan_code = 0x1C, .extended = true};
+
+                // Special keys
+                case SDL_SCANCODE_PRINTSCREEN:
+                    return {.scan_code = 0x37, .extended = true};
+                case SDL_SCANCODE_PAUSE:
+                    return {.scan_code = 0x45};
+                case SDL_SCANCODE_MENU:
+                    return {.scan_code = 0x5D, .extended = true};
+
+                default:
+                    return {};
+                }
+            }();
+
+            if (scan.scan_code == 0)
+            {
+                return 0;
+            }
+
+            uint64_t scan_code = 0;
+
+            // bits 0-15: repeat count
+            scan_code |= static_cast<uint64_t>(context.repeat_count == 0 ? 1 : context.repeat_count);
+
+            // bits 16-23: scan code
+            scan_code |= static_cast<uint64_t>(scan.scan_code) << 16;
+
+            // bit 24: extended key
+            if (scan.extended)
+            {
+                scan_code |= 1ull << 24;
+            }
+
+            // bit 29: context code, normally ALT/syskey context
+            if (context.alt_context)
+            {
+                scan_code |= 1ull << 29;
+            }
+
+            // bit 30: previous key state
+            if (context.was_down)
+            {
+                scan_code |= 1ull << 30;
+            }
+
+            // bit 31: transition state, set for key release
+            if (context.key_up)
+            {
+                scan_code |= 1ull << 31;
+            }
+
+            return scan_code;
+        }
+
+        uint64_t map_sdl_scancode_to_vk(const SDL_Scancode scancode)
+        {
+            switch (scancode)
+            {
+            case SDL_SCANCODE_A:
+                return 'A';
+            case SDL_SCANCODE_B:
+                return 'B';
+            case SDL_SCANCODE_C:
+                return 'C';
+            case SDL_SCANCODE_D:
+                return 'D';
+            case SDL_SCANCODE_E:
+                return 'E';
+            case SDL_SCANCODE_F:
+                return 'F';
+            case SDL_SCANCODE_G:
+                return 'G';
+            case SDL_SCANCODE_H:
+                return 'H';
+            case SDL_SCANCODE_I:
+                return 'I';
+            case SDL_SCANCODE_J:
+                return 'J';
+            case SDL_SCANCODE_K:
+                return 'K';
+            case SDL_SCANCODE_L:
+                return 'L';
+            case SDL_SCANCODE_M:
+                return 'M';
+            case SDL_SCANCODE_N:
+                return 'N';
+            case SDL_SCANCODE_O:
+                return 'O';
+            case SDL_SCANCODE_P:
+                return 'P';
+            case SDL_SCANCODE_Q:
+                return 'Q';
+            case SDL_SCANCODE_R:
+                return 'R';
+            case SDL_SCANCODE_S:
+                return 'S';
+            case SDL_SCANCODE_T:
+                return 'T';
+            case SDL_SCANCODE_U:
+                return 'U';
+            case SDL_SCANCODE_V:
+                return 'V';
+            case SDL_SCANCODE_W:
+                return 'W';
+            case SDL_SCANCODE_X:
+                return 'X';
+            case SDL_SCANCODE_Y:
+                return 'Y';
+            case SDL_SCANCODE_Z:
+                return 'Z';
+
+            case SDL_SCANCODE_1:
+                return '1';
+            case SDL_SCANCODE_2:
+                return '2';
+            case SDL_SCANCODE_3:
+                return '3';
+            case SDL_SCANCODE_4:
+                return '4';
+            case SDL_SCANCODE_5:
+                return '5';
+            case SDL_SCANCODE_6:
+                return '6';
+            case SDL_SCANCODE_7:
+                return '7';
+            case SDL_SCANCODE_8:
+                return '8';
+            case SDL_SCANCODE_9:
+                return '9';
+            case SDL_SCANCODE_0:
+                return '0';
+
+            case SDL_SCANCODE_RETURN:
+                return VK_RETURN;
+            case SDL_SCANCODE_ESCAPE:
+                return VK_ESCAPE;
+            case SDL_SCANCODE_BACKSPACE:
+                return VK_BACK;
+            case SDL_SCANCODE_TAB:
+                return VK_TAB;
+            case SDL_SCANCODE_SPACE:
+                return VK_SPACE;
+
+            case SDL_SCANCODE_LSHIFT:
+                return VK_SHIFT;
+            case SDL_SCANCODE_RSHIFT:
+                return VK_SHIFT;
+            case SDL_SCANCODE_LCTRL:
+                return VK_CONTROL;
+            case SDL_SCANCODE_RCTRL:
+                return VK_CONTROL;
+            case SDL_SCANCODE_LALT:
+                return VK_MENU;
+            case SDL_SCANCODE_RALT:
+                return VK_MENU;
+            case SDL_SCANCODE_LGUI:
+                return VK_LWIN;
+            case SDL_SCANCODE_RGUI:
+                return VK_RWIN;
+            case SDL_SCANCODE_APPLICATION:
+                return VK_APPS;
+
+            case SDL_SCANCODE_INSERT:
+                return VK_INSERT;
+            case SDL_SCANCODE_DELETE:
+                return VK_DELETE;
+            case SDL_SCANCODE_HOME:
+                return VK_HOME;
+            case SDL_SCANCODE_END:
+                return VK_END;
+            case SDL_SCANCODE_PAGEUP:
+                return VK_PRIOR;
+            case SDL_SCANCODE_PAGEDOWN:
+                return VK_NEXT;
+            case SDL_SCANCODE_LEFT:
+                return VK_LEFT;
+            case SDL_SCANCODE_UP:
+                return VK_UP;
+            case SDL_SCANCODE_RIGHT:
+                return VK_RIGHT;
+            case SDL_SCANCODE_DOWN:
+                return VK_DOWN;
+
+            case SDL_SCANCODE_CAPSLOCK:
+                return VK_CAPITAL;
+            case SDL_SCANCODE_NUMLOCKCLEAR:
+                return VK_NUMLOCK;
+            case SDL_SCANCODE_SCROLLLOCK:
+                return VK_SCROLL;
+
+            case SDL_SCANCODE_GRAVE:
+                return VK_OEM_3;
+            case SDL_SCANCODE_MINUS:
+                return VK_OEM_MINUS;
+            case SDL_SCANCODE_EQUALS:
+                return VK_OEM_PLUS;
+            case SDL_SCANCODE_LEFTBRACKET:
+                return VK_OEM_4;
+            case SDL_SCANCODE_RIGHTBRACKET:
+                return VK_OEM_6;
+            case SDL_SCANCODE_BACKSLASH:
+                return VK_OEM_5;
+            case SDL_SCANCODE_NONUSHASH:
+                return VK_OEM_5;
+            case SDL_SCANCODE_SEMICOLON:
+                return VK_OEM_1;
+            case SDL_SCANCODE_APOSTROPHE:
+                return VK_OEM_7;
+            case SDL_SCANCODE_COMMA:
+                return VK_OEM_COMMA;
+            case SDL_SCANCODE_PERIOD:
+                return VK_OEM_PERIOD;
+            case SDL_SCANCODE_SLASH:
+                return VK_OEM_2;
+            case SDL_SCANCODE_NONUSBACKSLASH:
+                return VK_OEM_102;
+
+            case SDL_SCANCODE_F1:
+                return VK_F1;
+            case SDL_SCANCODE_F2:
+                return VK_F2;
+            case SDL_SCANCODE_F3:
+                return VK_F3;
+            case SDL_SCANCODE_F4:
+                return VK_F4;
+            case SDL_SCANCODE_F5:
+                return VK_F5;
+            case SDL_SCANCODE_F6:
+                return VK_F6;
+            case SDL_SCANCODE_F7:
+                return VK_F7;
+            case SDL_SCANCODE_F8:
+                return VK_F8;
+            case SDL_SCANCODE_F9:
+                return VK_F9;
+            case SDL_SCANCODE_F10:
+                return VK_F10;
+            case SDL_SCANCODE_F11:
+                return VK_F11;
+            case SDL_SCANCODE_F12:
+                return VK_F12;
+
+            case SDL_SCANCODE_KP_0:
+                return VK_NUMPAD0;
+            case SDL_SCANCODE_KP_1:
+                return VK_NUMPAD1;
+            case SDL_SCANCODE_KP_2:
+                return VK_NUMPAD2;
+            case SDL_SCANCODE_KP_3:
+                return VK_NUMPAD3;
+            case SDL_SCANCODE_KP_4:
+                return VK_NUMPAD4;
+            case SDL_SCANCODE_KP_5:
+                return VK_NUMPAD5;
+            case SDL_SCANCODE_KP_6:
+                return VK_NUMPAD6;
+            case SDL_SCANCODE_KP_7:
+                return VK_NUMPAD7;
+            case SDL_SCANCODE_KP_8:
+                return VK_NUMPAD8;
+            case SDL_SCANCODE_KP_9:
+                return VK_NUMPAD9;
+            case SDL_SCANCODE_KP_PERIOD:
+                return VK_DECIMAL;
+            case SDL_SCANCODE_KP_PLUS:
+                return VK_ADD;
+            case SDL_SCANCODE_KP_MINUS:
+                return VK_SUBTRACT;
+            case SDL_SCANCODE_KP_MULTIPLY:
+                return VK_MULTIPLY;
+            case SDL_SCANCODE_KP_DIVIDE:
+                return VK_DIVIDE;
+            case SDL_SCANCODE_KP_ENTER:
+                return VK_RETURN;
+
+            case SDL_SCANCODE_PRINTSCREEN:
+                return VK_SNAPSHOT;
+            case SDL_SCANCODE_PAUSE:
+                return VK_PAUSE;
+            case SDL_SCANCODE_MENU:
+                return VK_APPS;
+
+            default:
                 return 0;
             }
         }
@@ -150,6 +724,8 @@ namespace sogen
 
                 this->windows_.clear();
                 this->guest_by_window_id_.clear();
+                this->active_window_ = 0;
+                this->key_down_.fill(false);
 
                 if (this->initialized_)
                 {
@@ -199,32 +775,89 @@ namespace sogen
                         this->set_window_active(this->resolve_guest(event.window.windowID), true);
                         break;
 
-                    case SDL_EVENT_WINDOW_FOCUS_LOST:
-                        this->set_window_active(this->resolve_guest(event.window.windowID), false);
+                    case SDL_EVENT_WINDOW_FOCUS_LOST: {
+                        const auto guest = this->resolve_guest(event.window.windowID);
+                        this->release_all_pressed_keys(guest);
+                        this->set_window_active(guest, false);
                         break;
+                    }
 
-                    case SDL_EVENT_KEY_DOWN:
-                        if (!event.key.repeat)
+                    case SDL_EVENT_KEY_DOWN: {
+                        const auto guest = this->resolve_guest(event.key.windowID);
+                        if (guest == 0)
                         {
-                            if (const auto guest = this->resolve_guest(event.key.windowID); guest != 0)
-                            {
-                                if (const auto key = map_sdl_keycode(event.key.key); key != 0)
-                                {
-                                    this->post_event(guest, WM_KEYDOWN, key, 0);
-                                }
-                            }
+                            break;
                         }
-                        break;
 
-                    case SDL_EVENT_KEY_UP:
-                        if (const auto guest = this->resolve_guest(event.key.windowID); guest != 0)
+                        const auto vk = map_sdl_keycode(event.key.key);
+                        const auto scan = map_sdl_scancode(event.key.scancode);
+
+                        if (vk == 0 || scan == 0)
                         {
-                            if (const auto key = map_sdl_keycode(event.key.key); key != 0)
-                            {
-                                this->post_event(guest, wm_keyup, key, 0);
-                            }
+                            break;
                         }
+
+                        const auto scancode_index = static_cast<size_t>(event.key.scancode);
+                        bool was_down = event.key.repeat;
+
+                        if (scancode_index < key_down_.size())
+                        {
+                            was_down = was_down || key_down_[scancode_index];
+                            key_down_[scancode_index] = true;
+                        }
+
+                        const bool is_alt = vk == VK_MENU;
+                        const bool alt_down = (event.key.mod & SDL_KMOD_ALT) != 0;
+                        const bool alt_context = !is_alt && alt_down;
+
+                        scan_code_context context{};
+                        context.key_up = false;
+                        context.was_down = was_down;
+                        context.alt_context = alt_context;
+                        context.repeat_count = 1;
+
+                        const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYDOWN : WM_KEYDOWN;
+
+                        this->post_event(guest, message, vk, map_sdl_scancode(event.key.scancode, context));
                         break;
+                    }
+
+                    case SDL_EVENT_KEY_UP: {
+                        const auto guest = this->resolve_guest(event.key.windowID);
+                        if (guest == 0)
+                        {
+                            break;
+                        }
+
+                        const auto vk = map_sdl_keycode(event.key.key);
+                        const auto scan = map_sdl_scancode(event.key.scancode);
+
+                        if (vk == 0 || scan == 0)
+                        {
+                            break;
+                        }
+
+                        const auto scancode_index = static_cast<size_t>(event.key.scancode);
+                        if (scancode_index < key_down_.size())
+                        {
+                            key_down_[scancode_index] = false;
+                        }
+
+                        const bool is_alt = vk == VK_MENU;
+                        const bool alt_down = (event.key.mod & SDL_KMOD_ALT) != 0;
+                        const bool alt_context = !is_alt && alt_down;
+
+                        scan_code_context context{};
+                        context.key_up = true;
+                        context.was_down = true;
+                        context.alt_context = alt_context;
+                        context.repeat_count = 1;
+
+                        const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYUP : WM_KEYUP;
+
+                        this->post_event(guest, message, vk, map_sdl_scancode(event.key.scancode, context));
+                        break;
+                    }
 
                     case SDL_EVENT_TEXT_INPUT:
                         if (const auto guest = this->resolve_guest(event.text.windowID); guest != 0)
@@ -683,6 +1316,46 @@ namespace sogen
                     this->post_event(window, WM_KILLFOCUS, 0, 0);
                 }
             }
+
+            void release_all_pressed_keys(const hwnd window)
+            {
+                const bool alt_was_down = key_down_[SDL_SCANCODE_LALT] || key_down_[SDL_SCANCODE_RALT];
+
+                if (window == 0)
+                {
+                    this->key_down_.fill(false);
+                    return;
+                }
+
+                for (size_t i = 0; i < this->key_down_.size(); ++i)
+                {
+                    if (!this->key_down_[i])
+                    {
+                        continue;
+                    }
+
+                    this->key_down_[i] = false;
+
+                    const auto scancode = static_cast<SDL_Scancode>(i);
+                    const auto vk = map_sdl_scancode_to_vk(scancode);
+                    if (vk == 0)
+                    {
+                        continue;
+                    }
+
+                    const bool is_alt = vk == VK_MENU;
+                    const bool alt_context = !is_alt && alt_was_down;
+
+                    scan_code_context context{};
+                    context.key_up = true;
+                    context.was_down = true;
+                    context.alt_context = alt_context;
+
+                    const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYUP : wm_keyup;
+
+                    this->post_event(window, message, vk, map_sdl_scancode(scancode, context));
+                }
+            }
 #endif
 
             void post_event(const hwnd window, const uint32_t message, const uint64_t w_param, const uint64_t l_param) const
@@ -697,6 +1370,7 @@ namespace sogen
 #ifdef SOGEN_HAS_SDL3
             bool initialized_{};
             hwnd active_window_{};
+            std::array<bool, SDL_SCANCODE_COUNT> key_down_{};
             std::unordered_map<hwnd, window_state> windows_{};
             std::unordered_map<SDL_WindowID, hwnd> guest_by_window_id_{};
 #endif

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -151,7 +151,7 @@ namespace sogen
             }
         }
 
-        struct scan_code_context
+        struct scancode_context
         {
             bool key_up = false;
             bool was_down = false;
@@ -159,7 +159,7 @@ namespace sogen
             uint16_t repeat_count = 1;
         };
 
-        uint64_t map_sdl_scancode(const SDL_Scancode scancode, const scan_code_context context = {})
+        uint64_t map_sdl_scancode(const SDL_Scancode scancode, const scancode_context context = {})
         {
             struct scan_result
             {
@@ -551,35 +551,39 @@ namespace sogen
                         }
 
                         const auto vk = map_sdl_keycode(event.key.key);
-                        const auto scan = map_sdl_scancode(event.key.scancode);
-
-                        if (vk == 0 || scan == 0)
+                        if (vk == 0)
                         {
                             break;
                         }
 
-                        const auto scancode_index = static_cast<size_t>(event.key.scancode);
                         bool was_down = event.key.repeat;
+                        const auto scancode_index = static_cast<size_t>(event.key.scancode);
 
                         if (scancode_index < key_down_.size())
                         {
                             was_down = was_down || key_down_[scancode_index];
-                            key_down_[scancode_index] = true;
                         }
 
                         const bool is_alt = vk == VK_MENU;
                         const bool alt_down = (event.key.mod & SDL_KMOD_ALT) != 0;
                         const bool alt_context = !is_alt && alt_down;
 
-                        scan_code_context context{};
-                        context.key_up = false;
-                        context.was_down = was_down;
-                        context.alt_context = alt_context;
-                        context.repeat_count = 1; // TODO: Track repeat count
+                        // TODO: Track repeat count
+                        scancode_context context{.was_down = was_down, .alt_context = alt_context};
+                        const auto scan = map_sdl_scancode(event.key.scancode, context);
+                        if (scan == 0)
+                        {
+                            break;
+                        }
+
+                        if (scancode_index < key_down_.size())
+                        {
+                            key_down_[scancode_index] = true;
+                        }
 
                         const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYDOWN : WM_KEYDOWN;
 
-                        this->post_event(guest, message, vk, map_sdl_scancode(event.key.scancode, context));
+                        this->post_event(guest, message, vk, scan);
                         break;
                     }
 
@@ -591,9 +595,18 @@ namespace sogen
                         }
 
                         const auto vk = map_sdl_keycode(event.key.key);
-                        const auto scan = map_sdl_scancode(event.key.scancode);
+                        if (vk == 0)
+                        {
+                            break;
+                        }
 
-                        if (vk == 0 || scan == 0)
+                        const bool is_alt = vk == VK_MENU;
+                        const bool alt_down = (event.key.mod & SDL_KMOD_ALT) != 0;
+                        const bool alt_context = !is_alt && alt_down;
+
+                        scancode_context context{.key_up = true, .was_down = true, .alt_context = alt_context};
+                        const auto scan = map_sdl_scancode(event.key.scancode, context);
+                        if (scan == 0)
                         {
                             break;
                         }
@@ -604,19 +617,9 @@ namespace sogen
                             key_down_[scancode_index] = false;
                         }
 
-                        const bool is_alt = vk == VK_MENU;
-                        const bool alt_down = (event.key.mod & SDL_KMOD_ALT) != 0;
-                        const bool alt_context = !is_alt && alt_down;
-
-                        scan_code_context context{};
-                        context.key_up = true;
-                        context.was_down = true;
-                        context.alt_context = alt_context;
-                        context.repeat_count = 1; // TODO: Track repeat count
-
                         const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYUP : WM_KEYUP;
 
-                        this->post_event(guest, message, vk, map_sdl_scancode(event.key.scancode, context));
+                        this->post_event(guest, message, vk, scan);
                         break;
                     }
 

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -462,239 +462,6 @@ namespace sogen
 
             return scan_code;
         }
-
-        uint64_t map_sdl_scancode_to_vk(const SDL_Scancode scancode)
-        {
-            switch (scancode)
-            {
-            case SDL_SCANCODE_A:
-                return 'A';
-            case SDL_SCANCODE_B:
-                return 'B';
-            case SDL_SCANCODE_C:
-                return 'C';
-            case SDL_SCANCODE_D:
-                return 'D';
-            case SDL_SCANCODE_E:
-                return 'E';
-            case SDL_SCANCODE_F:
-                return 'F';
-            case SDL_SCANCODE_G:
-                return 'G';
-            case SDL_SCANCODE_H:
-                return 'H';
-            case SDL_SCANCODE_I:
-                return 'I';
-            case SDL_SCANCODE_J:
-                return 'J';
-            case SDL_SCANCODE_K:
-                return 'K';
-            case SDL_SCANCODE_L:
-                return 'L';
-            case SDL_SCANCODE_M:
-                return 'M';
-            case SDL_SCANCODE_N:
-                return 'N';
-            case SDL_SCANCODE_O:
-                return 'O';
-            case SDL_SCANCODE_P:
-                return 'P';
-            case SDL_SCANCODE_Q:
-                return 'Q';
-            case SDL_SCANCODE_R:
-                return 'R';
-            case SDL_SCANCODE_S:
-                return 'S';
-            case SDL_SCANCODE_T:
-                return 'T';
-            case SDL_SCANCODE_U:
-                return 'U';
-            case SDL_SCANCODE_V:
-                return 'V';
-            case SDL_SCANCODE_W:
-                return 'W';
-            case SDL_SCANCODE_X:
-                return 'X';
-            case SDL_SCANCODE_Y:
-                return 'Y';
-            case SDL_SCANCODE_Z:
-                return 'Z';
-
-            case SDL_SCANCODE_1:
-                return '1';
-            case SDL_SCANCODE_2:
-                return '2';
-            case SDL_SCANCODE_3:
-                return '3';
-            case SDL_SCANCODE_4:
-                return '4';
-            case SDL_SCANCODE_5:
-                return '5';
-            case SDL_SCANCODE_6:
-                return '6';
-            case SDL_SCANCODE_7:
-                return '7';
-            case SDL_SCANCODE_8:
-                return '8';
-            case SDL_SCANCODE_9:
-                return '9';
-            case SDL_SCANCODE_0:
-                return '0';
-
-            case SDL_SCANCODE_RETURN:
-                return VK_RETURN;
-            case SDL_SCANCODE_ESCAPE:
-                return VK_ESCAPE;
-            case SDL_SCANCODE_BACKSPACE:
-                return VK_BACK;
-            case SDL_SCANCODE_TAB:
-                return VK_TAB;
-            case SDL_SCANCODE_SPACE:
-                return VK_SPACE;
-
-            case SDL_SCANCODE_LSHIFT:
-                return VK_SHIFT;
-            case SDL_SCANCODE_RSHIFT:
-                return VK_SHIFT;
-            case SDL_SCANCODE_LCTRL:
-                return VK_CONTROL;
-            case SDL_SCANCODE_RCTRL:
-                return VK_CONTROL;
-            case SDL_SCANCODE_LALT:
-                return VK_MENU;
-            case SDL_SCANCODE_RALT:
-                return VK_MENU;
-            case SDL_SCANCODE_LGUI:
-                return VK_LWIN;
-            case SDL_SCANCODE_RGUI:
-                return VK_RWIN;
-            case SDL_SCANCODE_APPLICATION:
-                return VK_APPS;
-
-            case SDL_SCANCODE_INSERT:
-                return VK_INSERT;
-            case SDL_SCANCODE_DELETE:
-                return VK_DELETE;
-            case SDL_SCANCODE_HOME:
-                return VK_HOME;
-            case SDL_SCANCODE_END:
-                return VK_END;
-            case SDL_SCANCODE_PAGEUP:
-                return VK_PRIOR;
-            case SDL_SCANCODE_PAGEDOWN:
-                return VK_NEXT;
-            case SDL_SCANCODE_LEFT:
-                return VK_LEFT;
-            case SDL_SCANCODE_UP:
-                return VK_UP;
-            case SDL_SCANCODE_RIGHT:
-                return VK_RIGHT;
-            case SDL_SCANCODE_DOWN:
-                return VK_DOWN;
-
-            case SDL_SCANCODE_CAPSLOCK:
-                return VK_CAPITAL;
-            case SDL_SCANCODE_NUMLOCKCLEAR:
-                return VK_NUMLOCK;
-            case SDL_SCANCODE_SCROLLLOCK:
-                return VK_SCROLL;
-
-            case SDL_SCANCODE_GRAVE:
-                return VK_OEM_3;
-            case SDL_SCANCODE_MINUS:
-                return VK_OEM_MINUS;
-            case SDL_SCANCODE_EQUALS:
-                return VK_OEM_PLUS;
-            case SDL_SCANCODE_LEFTBRACKET:
-                return VK_OEM_4;
-            case SDL_SCANCODE_RIGHTBRACKET:
-                return VK_OEM_6;
-            case SDL_SCANCODE_BACKSLASH:
-                return VK_OEM_5;
-            case SDL_SCANCODE_NONUSHASH:
-                return VK_OEM_5;
-            case SDL_SCANCODE_SEMICOLON:
-                return VK_OEM_1;
-            case SDL_SCANCODE_APOSTROPHE:
-                return VK_OEM_7;
-            case SDL_SCANCODE_COMMA:
-                return VK_OEM_COMMA;
-            case SDL_SCANCODE_PERIOD:
-                return VK_OEM_PERIOD;
-            case SDL_SCANCODE_SLASH:
-                return VK_OEM_2;
-            case SDL_SCANCODE_NONUSBACKSLASH:
-                return VK_OEM_102;
-
-            case SDL_SCANCODE_F1:
-                return VK_F1;
-            case SDL_SCANCODE_F2:
-                return VK_F2;
-            case SDL_SCANCODE_F3:
-                return VK_F3;
-            case SDL_SCANCODE_F4:
-                return VK_F4;
-            case SDL_SCANCODE_F5:
-                return VK_F5;
-            case SDL_SCANCODE_F6:
-                return VK_F6;
-            case SDL_SCANCODE_F7:
-                return VK_F7;
-            case SDL_SCANCODE_F8:
-                return VK_F8;
-            case SDL_SCANCODE_F9:
-                return VK_F9;
-            case SDL_SCANCODE_F10:
-                return VK_F10;
-            case SDL_SCANCODE_F11:
-                return VK_F11;
-            case SDL_SCANCODE_F12:
-                return VK_F12;
-
-            case SDL_SCANCODE_KP_0:
-                return VK_NUMPAD0;
-            case SDL_SCANCODE_KP_1:
-                return VK_NUMPAD1;
-            case SDL_SCANCODE_KP_2:
-                return VK_NUMPAD2;
-            case SDL_SCANCODE_KP_3:
-                return VK_NUMPAD3;
-            case SDL_SCANCODE_KP_4:
-                return VK_NUMPAD4;
-            case SDL_SCANCODE_KP_5:
-                return VK_NUMPAD5;
-            case SDL_SCANCODE_KP_6:
-                return VK_NUMPAD6;
-            case SDL_SCANCODE_KP_7:
-                return VK_NUMPAD7;
-            case SDL_SCANCODE_KP_8:
-                return VK_NUMPAD8;
-            case SDL_SCANCODE_KP_9:
-                return VK_NUMPAD9;
-            case SDL_SCANCODE_KP_PERIOD:
-                return VK_DECIMAL;
-            case SDL_SCANCODE_KP_PLUS:
-                return VK_ADD;
-            case SDL_SCANCODE_KP_MINUS:
-                return VK_SUBTRACT;
-            case SDL_SCANCODE_KP_MULTIPLY:
-                return VK_MULTIPLY;
-            case SDL_SCANCODE_KP_DIVIDE:
-                return VK_DIVIDE;
-            case SDL_SCANCODE_KP_ENTER:
-                return VK_RETURN;
-
-            case SDL_SCANCODE_PRINTSCREEN:
-                return VK_SNAPSHOT;
-            case SDL_SCANCODE_PAUSE:
-                return VK_PAUSE;
-            case SDL_SCANCODE_MENU:
-                return VK_APPS;
-
-            default:
-                return 0;
-            }
-        }
 #endif
 
         class sdl_ui_backend final : public ui_backend
@@ -775,12 +542,9 @@ namespace sogen
                         this->set_window_active(this->resolve_guest(event.window.windowID), true);
                         break;
 
-                    case SDL_EVENT_WINDOW_FOCUS_LOST: {
-                        const auto guest = this->resolve_guest(event.window.windowID);
-                        this->release_all_pressed_keys(guest);
-                        this->set_window_active(guest, false);
+                    case SDL_EVENT_WINDOW_FOCUS_LOST:
+                        this->set_window_active(this->resolve_guest(event.window.windowID), false);
                         break;
-                    }
 
                     case SDL_EVENT_KEY_DOWN: {
                         const auto guest = this->resolve_guest(event.key.windowID);
@@ -814,7 +578,7 @@ namespace sogen
                         context.key_up = false;
                         context.was_down = was_down;
                         context.alt_context = alt_context;
-                        context.repeat_count = 1;
+                        context.repeat_count = 1; // TODO: Track repeat count
 
                         const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYDOWN : WM_KEYDOWN;
 
@@ -851,7 +615,7 @@ namespace sogen
                         context.key_up = true;
                         context.was_down = true;
                         context.alt_context = alt_context;
-                        context.repeat_count = 1;
+                        context.repeat_count = 1; // TODO: Track repeat count
 
                         const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYUP : WM_KEYUP;
 
@@ -1314,46 +1078,6 @@ namespace sogen
                     this->active_window_ = 0;
                     this->post_event(window, WM_ACTIVATE, WA_INACTIVE, 0);
                     this->post_event(window, WM_KILLFOCUS, 0, 0);
-                }
-            }
-
-            void release_all_pressed_keys(const hwnd window)
-            {
-                const bool alt_was_down = key_down_[SDL_SCANCODE_LALT] || key_down_[SDL_SCANCODE_RALT];
-
-                if (window == 0)
-                {
-                    this->key_down_.fill(false);
-                    return;
-                }
-
-                for (size_t i = 0; i < this->key_down_.size(); ++i)
-                {
-                    if (!this->key_down_[i])
-                    {
-                        continue;
-                    }
-
-                    this->key_down_[i] = false;
-
-                    const auto scancode = static_cast<SDL_Scancode>(i);
-                    const auto vk = map_sdl_scancode_to_vk(scancode);
-                    if (vk == 0)
-                    {
-                        continue;
-                    }
-
-                    const bool is_alt = vk == VK_MENU;
-                    const bool alt_context = !is_alt && alt_was_down;
-
-                    scan_code_context context{};
-                    context.key_up = true;
-                    context.was_down = true;
-                    context.alt_context = alt_context;
-
-                    const uint32_t message = (is_alt || vk == VK_F10 || alt_context) ? WM_SYSKEYUP : wm_keyup;
-
-                    this->post_event(window, message, vk, map_sdl_scancode(scancode, context));
                 }
             }
 #endif

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -13,9 +13,6 @@ namespace sogen
     namespace
     {
 #ifdef SOGEN_HAS_SDL3
-        constexpr uint32_t wm_keyup = 0x0101;
-        constexpr uint32_t wm_char = 0x0102;
-
 #ifdef _WIN32
         void apply_application_icon(SDL_Window* window)
         {
@@ -629,7 +626,7 @@ namespace sogen
                             const auto text = u8_to_u16(event.text.text ? std::string_view{event.text.text} : std::string_view{});
                             for (const auto ch : text)
                             {
-                                this->post_event(guest, wm_char, ch, 0);
+                                this->post_event(guest, WM_CHAR, ch, 0);
                             }
                         }
                         break;


### PR DESCRIPTION
This PR makes enough improvements to the emulator for [Sonic3AIR](https://github.com/Eukaryot/sonic3air) to run in Sogen:

* Fixes key dispatch in the UI backend so the message’s `lParam` is filled with the key scancode.
* Fixes `CreateDIBSection` so it is closer to a real implementation.
* Fixes named pipe creation so it accepts `\??\pipe\` paths.
* Adds stubs for `NtGdiSetIcmMode`, `NtUserGetDoubleClickTime`, `NtUserModifyWindowTouchCapability`, and `NtUserGetClipboardSequenceNumber`.
* Implements `NtUserGetKeyboardState`, `NtUserGetProp2`, and `NtUserGetClipCursor`.

With these patches, Sonic3AIR runs quite well in Sogen using software rendering mode (no GPU-bridge necessary!):

<img width="606" height="358" alt="image" src="https://github.com/user-attachments/assets/ebe9166c-2ba0-4baa-82f1-9597105dd537" />