### PR TITLE
Implement window restoration when loading snapshots

### DIFF
--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -661,6 +661,15 @@ export function attachSogenUiHost(
       return;
     }
 
+    if (message.command === "reset") {
+      windows.clear();
+      focusedWindow = 0;
+      viewportPinnedByUser = false;
+      notifyWindowCount();
+      composite();
+      return;
+    }
+
     const hwnd = message.hwnd ?? 0;
     if (!hwnd) {
       return;

--- a/src/emulator-platform/platform/ui_backend.hpp
+++ b/src/emulator-platform/platform/ui_backend.hpp
@@ -68,6 +68,9 @@ namespace sogen
 
         virtual void set_event_sink(event_sink sink) = 0;
         virtual void pump_events() = 0;
+        virtual void reset()
+        {
+        }
 
         virtual void create_window(const ui_window_desc& /*desc*/)
         {
@@ -108,6 +111,9 @@ namespace sogen
         {
         }
         void pump_events() override
+        {
+        }
+        void reset() override
         {
         }
     };

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -152,39 +152,6 @@ namespace sogen
             return name;
         }
 
-        std::u16string_view normalize_builtin_window_class_name(const std::u16string_view class_name)
-        {
-            if (class_name == u"#1" || class_name == u"BUTTON" || class_name == u"Button")
-            {
-                return u"Button";
-            }
-            if (class_name == u"#2" || class_name == u"EDIT" || class_name == u"Edit")
-            {
-                return u"Edit";
-            }
-            // Build-specific integer atoms for the control classes are resolved to their canonical names
-            // earlier, via SERVERINFO.atomSysClass (see resolve_builtin_class_atom), so only the literal
-            // class names and the stable ordinal aliases need to be handled here.
-            if (class_name == u"#3" || class_name == u"STATIC" || class_name == u"Static")
-            {
-                return u"Static";
-            }
-            if (class_name == u"#4" || class_name == u"LISTBOX" || class_name == u"ListBox")
-            {
-                return u"ListBox";
-            }
-            if (class_name == u"#5" || class_name == u"SCROLLBAR" || class_name == u"ScrollBar")
-            {
-                return u"ScrollBar";
-            }
-            if (class_name == u"#6" || class_name == u"COMBOBOX" || class_name == u"ComboBox")
-            {
-                return u"ComboBox";
-            }
-
-            return class_name;
-        }
-
         bool is_builtin_window_class_name(const std::u16string_view class_name)
         {
             const auto normalized = normalize_builtin_window_class_name(class_name);

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -142,6 +142,18 @@ namespace sogen
             ~sdl_ui_backend() override
             {
 #ifdef SOGEN_HAS_SDL3
+                this->reset();
+
+                if (this->initialized_)
+                {
+                    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                }
+#endif
+            }
+
+            void reset() override
+            {
+#ifdef SOGEN_HAS_SDL3
                 for (auto& [guest, state] : this->windows_)
                 {
                     (void)guest;
@@ -153,7 +165,7 @@ namespace sogen
 
                 if (this->initialized_)
                 {
-                    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                    SDL_FlushEvents(SDL_EVENT_FIRST, SDL_EVENT_LAST);
                 }
 #endif
             }
@@ -481,6 +493,7 @@ namespace sogen
             {
                 if (!this->initialized_)
                 {
+                    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
                     this->initialized_ = SDL_InitSubSystem(SDL_INIT_VIDEO);
                 }
 

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -271,6 +271,15 @@ namespace sogen
                 this->drain_events();
             }
 
+            void reset() override
+            {
+                {
+                    std::scoped_lock lock{g_web_ui_event_mutex};
+                    g_web_ui_events.clear();
+                }
+                post_ui_message("reset", 0);
+            }
+
             void deliver_external_event(const ui_event& event)
             {
                 // Always enqueue. Browser 'message' callbacks fire during emscripten_sleep(0), i.e. on the

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1326,6 +1326,113 @@ namespace sogen
         this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
         this->process.deserialize(buffer);
+        this->restore_ui_backend();
+    }
+
+    void windows_emulator::restore_ui_backend()
+    {
+        this->ui().reset();
+
+        std::vector<const window*> pending{};
+        pending.reserve(this->process.windows.size());
+        for (const auto& [index, win] : this->process.windows)
+        {
+            (void)index;
+            if (win.host_surface_window)
+            {
+                pending.push_back(&win);
+            }
+        }
+
+        std::unordered_set<hwnd> created{};
+        const auto dependency_ready = [&](const hwnd handle) {
+            if (handle == 0)
+            {
+                return true;
+            }
+
+            const auto* dependency = this->process.windows.get(handle);
+            return !dependency || !dependency->host_surface_window || created.contains(handle);
+        };
+
+        const auto create_window = [&](const window& win) {
+            const auto child = (win.style & WS_CHILD) != 0;
+            uint32_t control_id = 0;
+            if (child)
+            {
+                if (const auto guest_window = win.guest.try_read())
+                {
+                    control_id = static_cast<uint32_t>(guest_window->wID);
+                }
+            }
+
+            this->ui().create_window(ui_window_desc{
+                .handle = win.handle,
+                .parent = child ? win.parent_handle : 0,
+                .owner = child ? 0 : win.owner_handle,
+                .rect = {.left = win.x, .top = win.y, .right = win.x + win.width, .bottom = win.y + win.height},
+                .client_insets = {},
+                .class_name = std::u16string{normalize_builtin_window_class_name(win.class_name)},
+                .title = win.name,
+                .style = win.style,
+                .ex_style = win.ex_style,
+                .control_id = control_id,
+                .visible = (win.style & WS_VISIBLE) != 0,
+                .enabled = (win.style & WS_DISABLED) == 0,
+                .top_level = !child,
+            });
+            created.insert(win.handle);
+        };
+
+        while (!pending.empty())
+        {
+            bool made_progress = false;
+            for (auto it = pending.begin(); it != pending.end();)
+            {
+                const auto& win = **it;
+                if (dependency_ready(win.parent_handle) && dependency_ready(win.owner_handle))
+                {
+                    create_window(win);
+                    it = pending.erase(it);
+                    made_progress = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+
+            if (!made_progress)
+            {
+                create_window(*pending.front());
+                pending.erase(pending.begin());
+            }
+        }
+
+        for (const auto& [index, win] : this->process.windows)
+        {
+            (void)index;
+            if (!win.host_surface_window || (win.style & WS_CHILD) != 0)
+            {
+                continue;
+            }
+
+            const auto surface = this->process.gdi_window_surfaces.find(static_cast<uint32_t>(win.handle));
+            if (surface == this->process.gdi_window_surfaces.end() || surface->second.width == 0 || surface->second.height == 0 ||
+                surface->second.pixels.empty())
+            {
+                continue;
+            }
+
+            const auto& restored = surface->second;
+            this->ui().present_surface(win.handle, ui_surface_desc{
+                                                       .width = static_cast<int>(restored.width),
+                                                       .height = static_cast<int>(restored.height),
+                                                       .stride = static_cast<int>(restored.width * sizeof(uint32_t)),
+                                                       .format = ui_surface_format::bgra8,
+                                                       .pixels = restored.pixels.data(),
+                                                   });
+        }
     }
 
     void windows_emulator::save_snapshot()
@@ -1377,6 +1484,7 @@ namespace sogen
         this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
         this->process.deserialize(buffer);
+        this->restore_ui_backend();
     }
 
 } // namespace sogen

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -325,6 +325,7 @@ namespace sogen
         void install_section_first_execution_hook(const mapped_module& mod, size_t section_index);
         void install_section_first_execution_hooks();
         void track_section_first_execution(uint64_t address);
+        void restore_ui_backend();
 
         void register_factories(utils::buffer_deserializer& buffer);
     };

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -77,6 +77,36 @@ namespace sogen
     // resolved through SERVERINFO.atomSysClass), so matching this canonical name is portable.
     inline constexpr std::u16string_view builtin_dialog_class_name = u"#32770";
 
+    inline std::u16string_view normalize_builtin_window_class_name(const std::u16string_view class_name)
+    {
+        if (class_name == u"#1" || class_name == u"BUTTON" || class_name == u"Button")
+        {
+            return u"Button";
+        }
+        if (class_name == u"#2" || class_name == u"EDIT" || class_name == u"Edit")
+        {
+            return u"Edit";
+        }
+        if (class_name == u"#3" || class_name == u"STATIC" || class_name == u"Static")
+        {
+            return u"Static";
+        }
+        if (class_name == u"#4" || class_name == u"LISTBOX" || class_name == u"ListBox")
+        {
+            return u"ListBox";
+        }
+        if (class_name == u"#5" || class_name == u"SCROLLBAR" || class_name == u"ScrollBar")
+        {
+            return u"ScrollBar";
+        }
+        if (class_name == u"#6" || class_name == u"COMBOBOX" || class_name == u"ComboBox")
+        {
+            return u"ComboBox";
+        }
+
+        return class_name;
+    }
+
     struct window : user_object<USER_WINDOW>
     {
         uint32_t thread_id{};


### PR DESCRIPTION
This PR restores windows that were open when an emulator snapshot was created. Not many changes were necessary, since we already serialize everything :D

After these changes, apps that create windows are restored correctly, and you can even restore software-rendered games:

https://github.com/user-attachments/assets/e9e9b58f-5fa1-4769-ac52-d5b6809b0163

One future objective could be to make these "save states" work for games that use the GPU as well, though that would require saving and restoring GPU state.