### PR TITLE
windows-emulator: preempt non-thread-safe backends via basic-block hook

### DIFF
--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -533,6 +533,11 @@ namespace sogen::icicle
             return true;
         }
 
+        bool is_stop_thread_safe() const override
+        {
+            return true;
+        }
+
         std::string get_name() const override
         {
             return "icicle-emu";

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -851,6 +851,12 @@ namespace sogen::kvm
             {
                 return false;
             }
+
+            bool is_stop_thread_safe() const override
+            {
+                return true;
+            }
+
             std::string get_name() const override
             {
                 return "Linux KVM";

--- a/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
+++ b/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
@@ -716,6 +716,11 @@ namespace sogen::unicorn
                 return true;
             }
 
+            bool is_stop_thread_safe() const override
+            {
+                return false;
+            }
+
             std::string get_name() const override
             {
                 return "Unicorn Engine";

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1734,6 +1734,11 @@ namespace sogen::whp
                 return false;
             }
 
+            bool is_stop_thread_safe() const override
+            {
+                return true;
+            }
+
             bool supports_global_memory_execution_hooks() const override
             {
                 return false;

--- a/src/emulator/cpu_interface.hpp
+++ b/src/emulator/cpu_interface.hpp
@@ -33,6 +33,11 @@ namespace sogen
         virtual bool has_violation() const = 0;
 
         virtual bool supports_instruction_counting() const = 0;
+
+        // Whether stop() may be safely called from a different thread while the CPU is executing.
+        // Hypervisor-backed backends can cancel execution from any thread; the JIT/interpreter
+        // backends cannot, so they must be preempted cooperatively from the CPU thread instead.
+        virtual bool is_stop_thread_safe() const = 0;
     };
 
 } // namespace sogen

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -282,6 +282,7 @@ namespace sogen
         uint64_t start_address{};
         uint64_t argument{};
         uint64_t executed_instructions{0};
+        uint64_t executed_blocks{0};
         bool setup_done{false};
 
         uint32_t id{};
@@ -410,6 +411,7 @@ namespace sogen
             buffer.write(this->start_address);
             buffer.write(this->argument);
             buffer.write(this->executed_instructions);
+            buffer.write(this->executed_blocks);
             buffer.write(this->setup_done);
             buffer.write(this->id);
             buffer.write(this->current_ip);
@@ -478,6 +480,7 @@ namespace sogen
             buffer.read(this->start_address);
             buffer.read(this->argument);
             buffer.read(this->executed_instructions);
+            buffer.read(this->executed_blocks);
             buffer.read(this->setup_done);
             buffer.read(this->id);
             buffer.read(this->current_ip);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -18,6 +18,7 @@
 namespace sogen
 {
     constexpr auto MAX_INSTRUCTIONS_PER_TIME_SLICE = 0x20000;
+    constexpr auto MAX_BASIC_BLOCKS_PER_TIME_SLICE = 0x8000;
 
     namespace
     {
@@ -989,6 +990,30 @@ namespace sogen
                 this->on_instruction_execution(address); //
             });
         }
+        else if (!this->emu().is_stop_thread_safe())
+        {
+            // The backend cannot be stopped safely from another thread, so the interrupt thread in start()
+            // is not available for time-slicing. Preempt cooperatively from the CPU thread via a basic-block
+            // hook instead.
+            this->emu().hook_basic_block([&](const basic_block& block) {
+                this->on_basic_block_execution(block); //
+            });
+        }
+    }
+
+    void windows_emulator::on_basic_block_execution(const basic_block&)
+    {
+        auto& thread = this->current_thread();
+
+        // This path deliberately trades instruction precision for speed (one callback per block instead of
+        // one per instruction), so we cannot account for individual instructions. Time-slice on a fixed number
+        // of executed blocks instead.
+        ++this->executed_instructions_;
+
+        if (++thread.executed_blocks % MAX_BASIC_BLOCKS_PER_TIME_SLICE == 0)
+        {
+            this->yield_thread();
+        }
     }
 
     void windows_emulator::start(size_t count)
@@ -1020,7 +1045,7 @@ namespace sogen
             }
         });
 
-        if (!this->uses_instruction_precision())
+        if (!this->uses_instruction_precision() && this->emu().is_stop_thread_safe())
         {
             interrupt_thread = std::thread([&] {
                 while (!this->should_stop)

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -319,6 +319,7 @@ namespace sogen
         void setup_hooks();
         void setup_process();
         void on_instruction_execution(uint64_t address);
+        void on_basic_block_execution(const basic_block& block);
 
         bool uses_section_first_execution_hooks() const;
         void clear_section_first_execution_hooks();


### PR DESCRIPTION
## Problem

Disabling instruction precision (`use_instruction_precision = false`) moved time-slicing onto an interrupt thread that calls `stop()` from another thread. Unicorn's `stop()` is **not** thread-safe — the cross-thread stop races with CPU-thread engine state mutated inside syscall hooks (Unicorn's own `break_translation_loop` carries a `// TODO: make this atomic somehow?` over the `cpu_exit` path), causing random crashes (`C0000005`, heap corruption, `UC_ERR_WRITE_UNMAPPED` at varying addresses).

Installing any per-instruction hook "fixed" it only because it flips the emulator back to cooperative scheduling — never a timing effect. WHP is immune because its `stop()` is a thread-safe hypervisor cancel.

## Change

- Expose `is_stop_thread_safe()` on the CPU interface — `false` for Unicorn, `true` for WHP and icicle.
- When precision is off and the backend's `stop()` is **not** thread-safe, preempt cooperatively from the CPU thread via a basic-block hook instead of spawning the interrupt thread.
- The basic-block path time-slices on a **fixed block count** (`MAX_BASIC_BLOCKS_PER_TIME_SLICE`) via a per-thread `executed_blocks` counter, dropping the previous `block.size / 3` instruction estimate (Unicorn's `UC_HOOK_BLOCK` only reports address + size, never an instruction count).
- The cross-thread interrupt thread is now used only for backends whose `stop()` is thread-safe.

Basic-block hooks are also cheaper than per-instruction `UC_HOOK_CODE` (the Unicorn FAQ recommends `UC_HOOK_BLOCK` for speed), so the speed win is retained without the crash.

## Verification

- Release build clean.
- Smoke test (`analyzer -s test-sample.exe`): all Success — the default exercises the new block-hook path on Unicorn, including the threading-heavy APC / Message Queue / User Timer / Socket tests.
- iw4x sample: 5 runs (1×30s + 4×15s) at full CPU, 0 crashes (previously intermittent).

https://claude.ai/code/session_01EK8LEh461LrzTUwgZctt84