### PR TITLE
analyzer: parse the command line with CLI11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 	path = deps/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
 	shallow = true
+[submodule "deps/CLI11"]
+	path = deps/CLI11
+	url = https://github.com/CLIUtils/CLI11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,4 @@
 [submodule "deps/CLI11"]
 	path = deps/CLI11
 	url = https://github.com/CLIUtils/CLI11.git
+	shallow = true

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -38,6 +38,20 @@ target_include_directories(vulkan-headers INTERFACE
 
 ##########################################
 
+add_library(cli11 INTERFACE)
+target_include_directories(cli11 INTERFACE
+  "${CMAKE_CURRENT_LIST_DIR}/CLI11/include"
+)
+
+if(NOT WIN)
+  # CLI11's codecvt conversion path uses the deprecated std::wstring_convert, which fails under
+  # -Werror on non-Windows toolchains (e.g. Emscripten). It is only needed for the Windows wide
+  # command line, so use CLI11's locale-based fallback everywhere else.
+  target_compile_definitions(cli11 INTERFACE CLI11_HAS_CODECVT=0)
+endif()
+
+##########################################
+
 if(SOGEN_ENABLE_SDL3 AND NOT EMSCRIPTEN)
   # Prefer a system-installed SDL3 (find_package) when allowed and present;
   # otherwise build the vendored submodule. Emscripten uses the web UI backend

--- a/page/src/settings.ts
+++ b/page/src/settings.ts
@@ -81,16 +81,16 @@ export function translateSettings(settings: Settings): TranslatedSettings {
   } else {
     switch (settings.logging) {
       case "verbose":
-        switches.push("-v");
+        switches.push("--verbose");
         break;
       case "silent":
-        switches.push("-s");
+        switches.push("--silent");
         break;
       case "concise":
-        switches.push("-c");
+        switches.push("--concise");
         break;
       case "very-concise":
-        switches.push("-vc");
+        switches.push("--very-concise");
         break;
 
       default:
@@ -98,28 +98,28 @@ export function translateSettings(settings: Settings): TranslatedSettings {
     }
 
     if (settings.bufferStdout) {
-      switches.push("-b");
+      switches.push("--buffer");
     }
 
     if (settings.execAccess) {
-      switches.push("-x");
+      switches.push("--exec");
     }
 
     if (settings.foreignAccess) {
-      switches.push("-f");
+      switches.push("--foreign");
     }
 
     if (settings.instructionSummary) {
-      switches.push("-is");
+      switches.push("--inst-summary");
     }
 
     settings.ignoredFunctions.forEach((f) => {
-      switches.push("-i");
+      switches.push("--ignore");
       switches.push(f);
     });
 
     settings.interestingModules.forEach((m) => {
-      switches.push("-m");
+      switches.push("--module");
       switches.push(m);
     });
   }

--- a/src/analyzer/CMakeLists.txt
+++ b/src/analyzer/CMakeLists.txt
@@ -2,7 +2,6 @@ add_executable(analyzer main.cpp)
 
 if(WIN)
   target_sources(analyzer PRIVATE resource.rc)
-  target_link_libraries(analyzer PRIVATE shell32)
 endif()
 
 sogen_assign_source_group(main.cpp)

--- a/src/analyzer/main.cpp
+++ b/src/analyzer/main.cpp
@@ -1,13 +1,4 @@
 #include <cstdlib>
-#include <string>
-#include <vector>
-
-#ifdef _WIN32
-#include <windows.h>
-#include <shellapi.h>
-#endif
-
-#include <emulator-platform/platform/platform.hpp>
 
 namespace sogen
 {
@@ -24,52 +15,7 @@ namespace
     }
 }
 
-#ifdef _WIN32
-int dispatch_wmain(int argc, wchar_t** wargv)
-{
-    std::vector<std::string> utf8_storage;
-    utf8_storage.reserve(argc);
-
-    for (int i = 0; i < argc; ++i)
-    {
-        utf8_storage.push_back(sogen::w_to_u8(wargv[i]));
-    }
-
-    std::vector<char*> argv_utf8;
-    argv_utf8.reserve(argc + 1);
-
-    for (auto& arg : utf8_storage)
-    {
-        argv_utf8.push_back(arg.data());
-    }
-
-    argv_utf8.push_back(nullptr);
-
-    if (should_use_linux_analyzer())
-    {
-        return sogen::linux_main(argc, argv_utf8.data());
-    }
-
-    return sogen::windows_main(argc, argv_utf8.data());
-}
-
-int dispatch_current_command_line()
-{
-    int argc = 0;
-    auto** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    if (!argv)
-    {
-        return 1;
-    }
-
-    const auto result = dispatch_wmain(argc, argv);
-    LocalFree(argv);
-    return result;
-}
-#endif
-
-#ifndef _WIN32
-int dispatch_main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     if (should_use_linux_analyzer())
     {
@@ -78,22 +24,3 @@ int dispatch_main(int argc, char** argv)
 
     return sogen::windows_main(argc, argv);
 }
-#endif
-
-int main(int argc, char** argv)
-{
-#ifdef _WIN32
-    (void)argc;
-    (void)argv;
-    return dispatch_current_command_line();
-#else
-    return dispatch_main(argc, argv);
-#endif
-}
-
-#ifdef _WIN32
-int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
-{
-    return dispatch_current_command_line();
-}
-#endif

--- a/src/linux-analyzer/CMakeLists.txt
+++ b/src/linux-analyzer/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(linux-analyzer STATIC ${SRC_FILES})
 
 sogen_assign_source_group(${SRC_FILES})
 
-target_link_libraries(linux-analyzer PRIVATE linux-emulator linux-gdb-stub linux-debugger backend-selection)
+target_link_libraries(linux-analyzer PRIVATE linux-emulator linux-gdb-stub linux-debugger backend-selection cli11)

--- a/src/linux-analyzer/main.cpp
+++ b/src/linux-analyzer/main.cpp
@@ -11,6 +11,8 @@
 #include <network/address.hpp>
 #include <backend_selection.hpp>
 
+#include <CLI/CLI.hpp>
+
 #if defined(OS_EMSCRIPTEN) && !defined(SOGEN_EMSCRIPTEN_SUPPORT_NODEJS)
 #include <linux_event_handler.hpp>
 #include <utils/finally.hpp>
@@ -31,90 +33,38 @@ namespace sogen
             bool pause_before_start{false};
         };
 
-        void print_usage(const char* program)
-        {
-            fprintf(stderr, "Usage: %s [options] <executable> [args...]\n", program);
-            fprintf(stderr, "\nOptions:\n");
-            fprintf(stderr, "  --root <path>    Set emulation root directory\n");
-            fprintf(stderr, "  --verbose        Enable verbose logging\n");
-            fprintf(stderr, "  --gdb, -d        Wait for GDB connection on 127.0.0.1:28960\n");
-            fprintf(stderr, "  --break-start     Pause before executing the first instruction\n");
-            fprintf(stderr, "  --help           Show this help message\n");
-        }
-
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
-        cli_options parse_args(const int argc, char** argv)
-        {
-            cli_options opts{};
-
-            // Default environment
-            opts.envp.emplace_back("PATH=/usr/bin:/bin");
-            opts.envp.emplace_back("HOME=/root");
-            opts.envp.emplace_back("TERM=xterm");
-
-            int i = 1;
-            while (i < argc)
-            {
-                const std::string arg = argv[i];
-
-                if (arg == "--root" && i + 1 < argc)
-                {
-                    opts.emulation_root = argv[++i];
-                }
-                else if (arg == "--verbose")
-                {
-                    opts.verbose = true;
-                }
-                else if (arg == "--gdb" || arg == "-d")
-                {
-                    opts.use_gdb = true;
-                }
-                else if (arg == "--help" || arg == "-h")
-                {
-                    print_usage(argv[0]);
-                    exit(0);
-                }
-                else if (arg == "--break-start")
-                {
-                    opts.pause_before_start = true;
-                }
-                else if (arg[0] == '-')
-                {
-                    fprintf(stderr, "Unknown option: %s\n", arg.c_str());
-                    print_usage(argv[0]);
-                    exit(1);
-                }
-                else
-                {
-                    // First non-option argument is the executable
-                    opts.executable = arg;
-                    opts.argv.push_back(arg);
-
-                    // Remaining arguments are passed to the emulated program
-                    for (int j = i + 1; j < argc; ++j)
-                    {
-                        opts.argv.emplace_back(argv[j]);
-                    }
-                    break;
-                }
-
-                ++i;
-            }
-
-            return opts;
-        }
     }
 
-    int run_main(const int argc, char** argv)
+    int run_main(int argc, char** argv)
     {
-        auto opts = parse_args(argc, argv);
+        CLI::App app{"Sogen Linux Analyzer"};
 
-        if (opts.executable.empty())
+        // On Windows this resolves the UTF-8 arguments from the wide command line; elsewhere it is a no-op.
+        argv = app.ensure_utf8(argv);
+
+        // Stop parsing at the first positional (the executable) and forward everything after it to the emulated program.
+        app.prefix_command();
+
+        cli_options opts{};
+        opts.envp = {"PATH=/usr/bin:/bin", "HOME=/root", "TERM=xterm"};
+
+        app.add_option("--root", opts.emulation_root, "Set emulation root directory");
+        app.add_flag("--verbose", opts.verbose, "Enable verbose logging");
+        app.add_flag("-d,--gdb", opts.use_gdb, "Wait for GDB connection on 127.0.0.1:28960");
+        app.add_flag("--break-start", opts.pause_before_start, "Pause before executing the first instruction");
+
+        CLI11_PARSE(app, argc, argv);
+
+        const auto application = app.remaining();
+        if (application.empty())
         {
             fprintf(stderr, "Error: No executable specified\n");
-            print_usage(argv[0]);
+            fputs(app.help().c_str(), stderr);
             return 1;
         }
+
+        opts.executable = application.front();
+        opts.argv.assign(application.begin(), application.end());
 
         if (!std::filesystem::exists(opts.executable))
         {

--- a/src/tools/sandbox/CMakeLists.txt
+++ b/src/tools/sandbox/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(sandbox PRIVATE
   windows-emulator
   whp-emulator
   emulator-common
+  cli11
   shell32
 )
 

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -4,7 +4,7 @@
 #include <utils/interupt_handler.hpp>
 #include <utils/win.hpp>
 
-#include <shellapi.h>
+#include <CLI/CLI.hpp>
 
 #include <array>
 #include <atomic>
@@ -45,11 +45,6 @@ namespace sogen::sandbox
             }
 
             return wide_args;
-        }
-
-        void print_help()
-        {
-            printf("Usage: sandbox <application> [args...]\n");
         }
 
         int run(const std::span<const std::string_view> args)
@@ -94,29 +89,29 @@ namespace sogen::sandbox
             return static_cast<int>(*exit_status);
         }
 
-        int run_main(const int argc, wchar_t** wargv)
+        int run_main(int argc, char** argv)
         {
+            CLI::App app{"Sogen Sandbox"};
+
+            // On Windows this resolves the UTF-8 arguments from the wide command line.
+            argv = app.ensure_utf8(argv);
+
+            // Stop parsing at the first positional (the application) and forward everything after it to the
+            // emulated program.
+            app.prefix_command();
+
+            CLI11_PARSE(app, argc, argv);
+
             try
             {
-                std::vector<std::string> args{};
-                for (int i = 1; i < argc; ++i)
+                const auto application = app.remaining();
+                if (application.empty())
                 {
-                    args.emplace_back(w_to_u8(wargv[i]));
-                }
-
-                std::vector<std::string_view> views{};
-                views.reserve(args.size());
-                for (const auto& str : args)
-                {
-                    views.push_back(str);
-                }
-
-                if (args.empty())
-                {
-                    print_help();
+                    puts(app.help().c_str());
                     return 1;
                 }
 
+                const std::vector<std::string_view> views{application.begin(), application.end()};
                 return run(views);
             }
             catch (const std::exception& e)
@@ -130,31 +125,10 @@ namespace sogen::sandbox
 
             return 1;
         }
-
-        int run_current_command_line()
-        {
-            int argc = 0;
-            auto** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-            if (!argv)
-            {
-                return 1;
-            }
-
-            const auto result = run_main(argc, argv);
-            LocalFree(argv);
-            return result;
-        }
     }
 }
 
-int wmain(const int argc, wchar_t** argv)
+int main(int argc, char** argv)
 {
-    (void)argc;
-    (void)argv;
-    return sogen::sandbox::run_current_command_line();
-}
-
-int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR, int)
-{
-    return sogen::sandbox::run_current_command_line();
+    return sogen::sandbox::run_main(argc, argv);
 }

--- a/src/windows-analyzer/CMakeLists.txt
+++ b/src/windows-analyzer/CMakeLists.txt
@@ -21,7 +21,21 @@ target_link_libraries(windows-analyzer PRIVATE
   windows-emulator
   windows-gdb-stub
   backend-selection
+  cli11
 )
+
+if(WIN)
+  # CLI11's ensure_utf8() resolves the UTF-8 command line through CommandLineToArgvW (shell32).
+  target_link_libraries(windows-analyzer PRIVATE shell32)
+endif()
+
+# main.cpp is a large translation unit (CLI11 plus the analysis code) that exceeds the COFF section
+# limit in Debug builds without the large-object format.
+if(MSVC)
+  target_compile_options(windows-analyzer PRIVATE /bigobj)
+elseif(MINGW)
+  target_compile_options(windows-analyzer PRIVATE -Wa,-mbig-obj)
+endif()
 
 if(SOGEN_ENABLE_REFLECTION)
   target_link_libraries(windows-analyzer PRIVATE

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -1,5 +1,7 @@
 #include "std_include.hpp"
 
+#include <CLI/CLI.hpp>
+
 #include <windows_emulator.hpp>
 #include <backend_selection.hpp>
 #include <win_x86_64_gdb_stub_handler.hpp>
@@ -473,31 +475,6 @@ namespace sogen
             };
         }
 
-        backend_type parse_backend_type(const std::string_view name)
-        {
-            if (name == "unicorn")
-            {
-                return backend_type::unicorn;
-            }
-
-            if (name == "icicle")
-            {
-                return backend_type::icicle;
-            }
-
-            if (name == "whp")
-            {
-                return backend_type::whp;
-            }
-
-            if (name == "kvm")
-            {
-                return backend_type::kvm;
-            }
-
-            throw std::runtime_error("Unknown backend '" + std::string(name) + "' (supported: unicorn, icicle, whp, kvm)");
-        }
-
         hook_interface::memory_execution_hook_mode parse_memory_execution_hook_mode(const std::string_view mode)
         {
             if (mode == "auto")
@@ -511,26 +488,6 @@ namespace sogen
             }
 
             throw std::runtime_error("WHP memory execution hook mode must be auto or int3");
-        }
-
-        uint64_t parse_u64_argument(const std::string_view value, const std::string_view option_name)
-        {
-            if (value.empty())
-            {
-                throw std::runtime_error("Bad value for " + std::string(option_name));
-            }
-
-            uint64_t parsed{};
-            const auto* const begin = value.data();
-            const auto* const end = begin + value.size();
-            const auto result = std::from_chars(begin, end, parsed, 10);
-
-            if (result.ec != std::errc{} || result.ptr != end)
-            {
-                throw std::runtime_error("Bad value for " + std::string(option_name));
-            }
-
-            return parsed;
         }
 
         std::unique_ptr<x86_64_emulator> create_configured_backend(const analysis_options& options)
@@ -840,342 +797,130 @@ namespace sogen
             return run_emulation(context, options);
         }
 
-        std::vector<std::string_view> bundle_arguments(const int argc, char** argv)
-        {
-            std::vector<std::string_view> args{};
-
-            for (int i = 1; i < argc; ++i)
-            {
-                args.emplace_back(argv[i]);
-            }
-
-            return args;
-        }
-
-        void print_help()
-        {
-            printf("Usage: analyzer [options] [application] [args...]\n\n");
-            printf("Options:\n");
-            printf("  -h, --help                 Show this help message\n");
-            printf("  -d, --debug                Enable GDB debugging mode\n");
-            printf("  --bind <ip>                IP or hostname to bind to in GDB mode (default: 127.0.0.1)\n");
-            printf("  --port <port>              Port to listen to in GDB mode (default: 28960)\n");
-            printf("  -s, --silent               Silent mode\n");
-            printf("  -v, --verbose              Verbose logging\n");
-            printf("  -b, --buffer               Buffer stdout\n");
-            printf("  -f, --foreign              Log read access to foreign modules\n");
-            printf("  -c, --concise              Concise logging\n");
-            printf("  -vc, --very-concise        Very concise logging\n");
-            printf("  -x, --exec                 Log r/w access to executable memory\n");
-            printf("  -m, --module <module>      Specify module to track\n");
-            printf("  -e, --emulation <path>     Set emulation root path\n");
-            printf("  -a, --snapshot <path>      Load snapshot dump from path\n");
-            printf("  --minidump <path>          Load minidump from path\n");
-            printf("  --report <path>            Write machine-readable analysis events to a file\n");
-            printf("  --report-format <format>   Report format (supported: jsonl)\n");
-            printf("  --whp-exec-hook <mode>     WHP memory execution hook mode: auto or int3 (default: auto)\n");
-            printf("  --backend <name>           Select CPU backend: unicorn, icicle, whp or kvm (overrides env)\n");
-            printf("  -nip, --no-inst-precision  Disable per-instruction precision (faster, less precise)\n");
-            printf("  --call-count               Prefix function and syscall lines with a traced-call count\n");
-            printf("  -t, --tenet-trace          Enable Tenet tracer\n");
-            printf("  -i, --ignore <funcs>       Comma-separated list of functions to ignore\n");
-            printf("  -p, --path <src> <dst>     Map Windows path to host path\n");
-            printf("  -r, --registry <path>      Set registry path (default: ./registry)\n\n");
-            printf("  -fx, --first-exec          Print first executions of sections\n");
-            printf("  -is, --inst-summary        Print a summary of executed instructions of the analyzed modules\n");
-            printf("  -ss, --skip-syscalls       Skip the logging of regular syscalls\n");
-            printf("  -rep, --reproducible       Stub clocks and other mechanisms to make executions reproducible\n");
-            printf("  --env <var> <value>        Set environment variable\n");
-#if defined(OS_EMSCRIPTEN) && !defined(SOGEN_EMSCRIPTEN_SUPPORT_NODEJS)
-            printf("  --break-start             Pause before executing the first instruction\n");
-#endif
-            printf("  -bc, --break-call <count>  In GDB mode, stop before the specified traced function/syscall call\n");
-            printf("Examples:\n");
-            printf("  analyzer -v -e path/to/root myapp.exe\n");
-            printf("  analyzer --report run.jsonl test-sample.exe\n");
-            printf("  analyzer -e path/to/root -p c:/analysis-sample.exe /path/to/sample.exe c:/analysis-sample.exe\n");
-        }
-
-        analysis_options parse_options(std::vector<std::string_view>& args)
-        {
-            analysis_options options{};
-            std::optional<std::string_view> require_debug_option{};
-
-            while (!args.empty())
-            {
-                auto arg_it = args.begin();
-                const auto& arg = *arg_it;
-
-                if (arg == "-h" || arg == "--help")
-                {
-                    print_help();
-                    std::exit(0);
-                }
-
-                if (arg == "-d" || arg == "--debug")
-                {
-                    options.use_gdb = true;
-                }
-                else if (arg == "--bind")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No IP provided after --bind");
-                    }
-
-                    arg_it = args.erase(arg_it);
-                    options.gdb_host = args[0];
-                    require_debug_option = arg;
-                }
-                else if (arg == "--port")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No port number provided after --port");
-                    }
-
-                    arg_it = args.erase(arg_it);
-
-                    const auto port = parse_u64_argument(args[0], arg);
-
-                    if (port > 65535)
-                    {
-                        throw std::runtime_error("Port number should be in range 0-65535");
-                    }
-
-                    options.gdb_port = static_cast<uint16_t>(port);
-                    require_debug_option = arg;
-                }
-                else if (arg == "-s" || arg == "--silent")
-                {
-                    options.silent = true;
-                }
-                else if (arg == "-v" || arg == "--verbose")
-                {
-                    options.verbose_logging = true;
-                }
-                else if (arg == "-b" || arg == "--buffer")
-                {
-                    options.buffer_stdout = true;
-                }
-                else if (arg == "-x" || arg == "--exec")
-                {
-                    options.log_executable_access = true;
-                }
-                else if (arg == "-f" || arg == "--foreign")
-                {
-                    options.log_foreign_module_access = true;
-                }
-                else if (arg == "-c" || arg == "--concise")
-                {
-                    options.concise_logging = true;
-                }
-                else if (arg == "-vc" || arg == "--very-concise")
-                {
-                    options.concise_logging = true;
-                    options.skip_syscalls = true;
-                    options.skip_generic_activity = true;
-                }
-                else if (arg == "-t" || arg == "--tenet-trace")
-                {
-                    options.tenet_trace = true;
-                }
-                else if (arg == "-fx" || arg == "--first-exec")
-                {
-                    options.log_first_section_execution = true;
-                }
-                else if (arg == "-is" || arg == "--inst-summary")
-                {
-                    options.instruction_summary = true;
-                }
-                else if (arg == "-ss" || arg == "--skip-syscalls")
-                {
-                    options.skip_syscalls = true;
-                }
-                else if (arg == "-rep" || arg == "--reproducible")
-                {
-                    options.reproducible = true;
-                }
-                else if (arg == "-m" || arg == "--module")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No module provided after -m/--module");
-                    }
-
-                    arg_it = args.erase(arg_it);
-                    options.modules.insert(std::string(args[0]));
-                }
-                else if (arg == "-e" || arg == "--emulation")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No emulation root path provided after -e/--emulation");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.emulation_root = args[0];
-                }
-                else if (arg == "-a" || arg == "--snapshot")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No dump path provided after -a/--snapshot");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.dump = args[0];
-                }
-                else if (arg == "--minidump")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No minidump path provided after --minidump");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.minidump_path = args[0];
-                }
-                else if (arg == "--report")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No report path provided after --report");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.report_path = args[0];
-                }
-                else if (arg == "--report-format")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No report format provided after --report-format");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.report_format = std::string(args[0]);
-                }
-                else if (arg == "--whp-exec-hook")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No WHP memory execution hook mode provided after --whp-exec-hook");
-                    }
-
-                    arg_it = args.erase(arg_it);
-                    options.whp_execution_hook_mode = std::string(args[0]);
-                    if (options.whp_execution_hook_mode != "auto" && options.whp_execution_hook_mode != "int3")
-                    {
-                        throw std::runtime_error("WHP memory execution hook mode must be auto or int3");
-                    }
-                }
-                else if (arg == "--backend")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No backend provided after --backend");
-                    }
-
-                    arg_it = args.erase(arg_it);
-                    options.backend = parse_backend_type(args[0]);
-                }
-                else if (arg == "-nip" || arg == "--no-inst-precision")
-                {
-                    options.disable_instruction_precision = true;
-                }
-                else if (arg == "-i" || arg == "--ignore")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No ignored function(s) provided after -i/--ignore");
-                    }
-                    arg_it = args.erase(arg_it);
-                    split_and_insert(options.ignored_functions, args[0]);
-                }
-                else if (arg == "-p" || arg == "--path")
-                {
-                    if (args.size() < 3)
-                    {
-                        throw std::runtime_error("No path mapping provided after -p/--path");
-                    }
-                    arg_it = args.erase(arg_it);
-                    windows_path source = args[0];
-                    arg_it = args.erase(arg_it);
-                    std::filesystem::path target = std::filesystem::absolute(args[0]);
-
-                    options.path_mappings[std::move(source)] = std::move(target);
-                }
-                else if (arg == "-r" || arg == "--registry")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No registry path provided after -r/--registry");
-                    }
-                    arg_it = args.erase(arg_it);
-                    options.registry_path = args[0];
-                }
-                else if (arg == "--env")
-                {
-                    if (args.size() < 3)
-                    {
-                        throw std::runtime_error("No environment variable provided after --env");
-                    }
-                    arg_it = args.erase(arg_it);
-                    auto env_var = std::u16string(args[0].begin(), args[0].end());
-                    arg_it = args.erase(arg_it);
-                    auto env_value = std::u16string(args[0].begin(), args[0].end());
-
-                    options.environment[std::move(env_var)] = std::move(env_value);
-                }
-                else if (arg == "--call-count")
-                {
-                    options.prepend_call_count = true;
-                }
-#if defined(OS_EMSCRIPTEN) && !defined(SOGEN_EMSCRIPTEN_SUPPORT_NODEJS)
-                else if (arg == "--break-start")
-                {
-                    options.pause_before_start = true;
-                }
-#endif
-                else if (arg == "-bc" || arg == "--break-call")
-                {
-                    if (args.size() < 2)
-                    {
-                        throw std::runtime_error("No call count provided after -bc/--break-call");
-                    }
-
-                    arg_it = args.erase(arg_it);
-                    options.break_call = parse_u64_argument(args[0], arg);
-                    require_debug_option = arg;
-                }
-                else
-                {
-                    break;
-                }
-
-                args.erase(arg_it);
-            }
-
-            if (require_debug_option && !options.use_gdb)
-            {
-                throw std::runtime_error(std::string(*require_debug_option) + " option used without -d");
-            }
-
-            return options;
-        }
-
-        int run_main(const int argc, char** argv)
+        int run_main(int argc, char** argv)
         {
 #ifndef _WIN32
             signal(SIGPIPE, SIG_IGN);
 #endif
 
+            CLI::App app{"Sogen Windows Analyzer"};
+
+            // On Windows this resolves the UTF-8 arguments from the wide command line; elsewhere it is a no-op.
+            argv = app.ensure_utf8(argv);
+
+            // Stop parsing at the first positional (the application to analyze) and forward everything after it
+            // verbatim to the emulated program.
+            app.prefix_command();
+            app.footer("Examples:\n"
+                       "  analyzer -v -e path/to/root myapp.exe\n"
+                       "  analyzer --report run.jsonl test-sample.exe\n"
+                       "  analyzer -e path/to/root -p c:/analysis-sample.exe /path/to/sample.exe c:/analysis-sample.exe");
+
+            analysis_options options{};
+
+            auto* const debug_option = app.add_flag("-d,--debug", options.use_gdb, "Enable GDB debugging mode");
+            app.add_option("--bind", options.gdb_host, "IP or hostname to bind to in GDB mode")->capture_default_str()->needs(debug_option);
+            app.add_option("--port", options.gdb_port, "Port to listen to in GDB mode")->capture_default_str()->needs(debug_option);
+            app.add_option("--break-call", options.break_call, "In GDB mode, stop before the specified traced function/syscall call")
+                ->needs(debug_option);
+
+            app.add_flag("-s,--silent", options.silent, "Silent mode");
+            app.add_flag("-v,--verbose", options.verbose_logging, "Verbose logging");
+            app.add_flag("-b,--buffer", options.buffer_stdout, "Buffer stdout");
+            app.add_flag("-f,--foreign", options.log_foreign_module_access, "Log read access to foreign modules");
+            app.add_flag("-c,--concise", options.concise_logging, "Concise logging");
+            app.add_flag_callback(
+                "--very-concise",
+                [&] {
+                    options.concise_logging = true;
+                    options.skip_syscalls = true;
+                    options.skip_generic_activity = true;
+                },
+                "Very concise logging");
+            app.add_flag("-x,--exec", options.log_executable_access, "Log r/w access to executable memory");
+            app.add_flag("-t,--tenet-trace", options.tenet_trace, "Enable Tenet tracer");
+            app.add_flag("--first-exec", options.log_first_section_execution, "Print first executions of sections");
+            app.add_flag("--inst-summary", options.instruction_summary, "Print a summary of executed instructions of the analyzed modules");
+            app.add_flag("--skip-syscalls", options.skip_syscalls, "Skip the logging of regular syscalls");
+            app.add_flag("--reproducible", options.reproducible, "Stub clocks and other mechanisms to make executions reproducible");
+            app.add_flag("--no-inst-precision", options.disable_instruction_precision,
+                         "Disable per-instruction precision (faster, less precise)");
+            app.add_flag("--call-count", options.prepend_call_count, "Prefix function and syscall lines with a traced-call count");
+#if defined(OS_EMSCRIPTEN) && !defined(SOGEN_EMSCRIPTEN_SUPPORT_NODEJS)
+            app.add_flag("--break-start", options.pause_before_start, "Pause before executing the first instruction");
+#endif
+
+            app.add_option("-e,--emulation", options.emulation_root, "Set emulation root path");
+            app.add_option("-a,--snapshot", options.dump, "Load snapshot dump from path");
+            app.add_option("--minidump", options.minidump_path, "Load minidump from path");
+            app.add_option("--report", options.report_path, "Write machine-readable analysis events to a file");
+            app.add_option("--report-format", options.report_format, "Report format (supported: jsonl)")->capture_default_str();
+            app.add_option("--whp-exec-hook", options.whp_execution_hook_mode, "WHP memory execution hook mode")
+                ->capture_default_str()
+                ->check(CLI::IsMember({"auto", "int3"}));
+            app.add_option("-r,--registry", options.registry_path, "Set registry path");
+
+            std::string backend_name{};
+            app.add_option("--backend", backend_name, "Select CPU backend: unicorn, icicle, whp or kvm (overrides env)")
+                ->check(CLI::IsMember({"unicorn", "icicle", "whp", "kvm"}));
+
+            std::vector<std::string> tracked_modules{};
+            app.add_option("-m,--module", tracked_modules, "Specify module(s) to track");
+
+            std::vector<std::string> ignored_functions{};
+            app.add_option("-i,--ignore", ignored_functions, "Comma-separated list of functions to ignore");
+
+            // allow_extra_args(false) makes each occurrence consume exactly the pair (2 tokens) instead of
+            // greedily eating following tokens (which would otherwise swallow the application positional).
+            std::vector<std::pair<std::string, std::string>> path_mappings{};
+            app.add_option("-p,--path", path_mappings, "Map a Windows path to a host path")->type_name("SRC DST")->allow_extra_args(false);
+
+            std::vector<std::pair<std::string, std::string>> environment{};
+            app.add_option("--env", environment, "Set an environment variable")->type_name("NAME VALUE")->allow_extra_args(false);
+
+            CLI11_PARSE(app, argc, argv);
+
+            if (argc <= 1)
+            {
+                puts(app.help().c_str());
+                return 1;
+            }
+
             try
             {
-                auto args = bundle_arguments(argc, argv);
-                if (args.empty())
+                if (!backend_name.empty())
                 {
-                    print_help();
-                    return 1;
+                    static const std::map<std::string, backend_type> backends{
+                        {"unicorn", backend_type::unicorn},
+                        {"icicle", backend_type::icicle},
+                        {"whp", backend_type::whp},
+                        {"kvm", backend_type::kvm},
+                    };
+                    options.backend = backends.at(backend_name);
                 }
 
-                const auto options = parse_options(args);
+                for (auto& module_name : tracked_modules)
+                {
+                    options.modules.insert(std::move(module_name));
+                }
+
+                for (const auto& functions : ignored_functions)
+                {
+                    split_and_insert(options.ignored_functions, functions);
+                }
+
+                for (const auto& [source, target] : path_mappings)
+                {
+                    options.path_mappings[windows_path(source)] = std::filesystem::absolute(target);
+                }
+
+                for (const auto& [name, value] : environment)
+                {
+                    options.environment[std::u16string(name.begin(), name.end())] = std::u16string(value.begin(), value.end());
+                }
+
+                const auto application = app.remaining();
+                const std::vector<std::string_view> args{application.begin(), application.end()};
 
                 bool result{};
 


### PR DESCRIPTION
Replaces the hand-rolled argument parsing in the **analyzer**, **windows-analyzer**, **linux-analyzer** and **sandbox** with [CLI11](https://github.com/CLIUtils/CLI11) (added as a submodule at v2.5.0, header-only, BSD-3 → GPLv2-compatible).

## Why

- **Unicode/UTF-8 on Windows** — `App::ensure_utf8()` resolves the UTF-8 arguments from the wide command line directly, so the awkward `CommandLineToArgvW` + `wchar_t`→UTF-8 conversion in `analyzer/main.cpp` and `sandbox/main.cpp` is gone. The dispatcher is now a plain `int main(int, char**)`.
- **Trailing-argument passthrough** — `prefix_command()` stops parsing at the first positional (the application to analyze) and forwards everything after it verbatim to the emulated program, including guest flags like `-console -stdout`.
- **CMake** — one-line submodule integration via an interface target (`cli11`).

## Breaking change

The non-standard multi-character *single-dash* options are removed in favor of their long names. CLI11 (like every getopt-style parser) combines single-dash short flags, so `-vc` would mean `-v -c`; keeping both was impossible.

| Removed | Use instead |
|---|---|
| `-vc` | `--very-concise` |
| `-ss` | `--skip-syscalls` |
| `-rep` | `--reproducible` |
| `-fx` | `--first-exec` |
| `-is` | `--inst-summary` |
| `-bc` | `--break-call` |
| `-nip` | `--no-inst-precision` |

All single-character short options (`-d -s -v -b -x -f -c -m -e -a -t -i -p -r`) are unchanged. `page/src/settings.ts` now emits long forms for every switch.

## Verification

- Release build clean; net −390 lines.
- Smoke test (`analyzer -s test-sample.exe`): 26/26 pass.
- Passthrough: `analyzer --very-concise test-sample.exe -console -stdout` forwards `-console -stdout` to the guest with zero parse errors.
- Backend selection intact: `--backend whp`/`unicorn` select the expected engine; invalid value errors with `--backend: bogus not in {unicorn,icicle,whp,kvm}`.
- `-p src dst` / `--env name value` pairs parse without swallowing the target positional.
- `sandbox test-sample.exe` runs.

Builds on #1104 (merged).

https://claude.ai/code/session_01EK8LEh461LrzTUwgZctt84