### PR TITLE
analyzer: stop -i/--ignore and -m/--module from swallowing the application

### DIFF
--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -865,13 +865,11 @@ namespace sogen
                 ->check(CLI::IsMember({"unicorn", "icicle", "whp", "kvm"}));
 
             std::vector<std::string> tracked_modules{};
-            app.add_option("-m,--module", tracked_modules, "Specify module(s) to track");
+            app.add_option("-m,--module", tracked_modules, "Specify module(s) to track")->allow_extra_args(false);
 
             std::vector<std::string> ignored_functions{};
-            app.add_option("-i,--ignore", ignored_functions, "Comma-separated list of functions to ignore");
+            app.add_option("-i,--ignore", ignored_functions, "Comma-separated list of functions to ignore")->allow_extra_args(false);
 
-            // allow_extra_args(false) makes each occurrence consume exactly the pair (2 tokens) instead of
-            // greedily eating following tokens (which would otherwise swallow the application positional).
             std::vector<std::pair<std::string, std::string>> path_mappings{};
             app.add_option("-p,--path", path_mappings, "Map a Windows path to a host path")->type_name("SRC DST")->allow_extra_args(false);
 


### PR DESCRIPTION
Follow-up to #1105.

`-i`/`--ignore` and `-m`/`--module` are CLI11 vector options, which are configured with `allow_extra_args=true` and therefore greedily consume every following token — including the target executable:

```
analyzer --ignore funcA,funcB app.exe
                   └─ swallows "funcA,funcB" AND "app.exe"  →  "No args provided"
```

This is the same greediness already fixed for `-p`/`--path` and `--env` in #1105; those two options got `allow_extra_args(false)` but `-i`/`-m` were missed. This applies the same one-liner to both.

After the fix each occurrence consumes exactly one value, while remaining repeatable and (for `--ignore`) comma-splitting as before.

## Verification

- `analyzer --ignore funcA,funcB test-sample.exe` → exit 0 (target no longer swallowed; previously `No args provided`).
- Comma-split confirmed: with `--ignore GetLastError,Sleep`, `GetLastError` traced-call lines drop 4 → 0.
- Release build clean.