### PR TITLE
Assassin's Creed bring-up: NtQueryDirectoryFile FileId class, NtQuerySecurityPolicy, SystemCodeIntegrityInformation

### DIFF
--- a/src/emulator-platform/platform/file_management.hpp
+++ b/src/emulator-platform/platform/file_management.hpp
@@ -526,6 +526,25 @@ namespace sogen
         char16_t FileName[1];
     } FILE_BOTH_DIR_INFORMATION, *PFILE_BOTH_DIR_INFORMATION;
 
+    typedef struct _FILE_ID_BOTH_DIR_INFORMATION
+    {
+        ULONG NextEntryOffset;
+        ULONG FileIndex;
+        LARGE_INTEGER CreationTime;
+        LARGE_INTEGER LastAccessTime;
+        LARGE_INTEGER LastWriteTime;
+        LARGE_INTEGER ChangeTime;
+        LARGE_INTEGER EndOfFile;
+        LARGE_INTEGER AllocationSize;
+        ULONG FileAttributes;
+        ULONG FileNameLength;
+        ULONG EaSize;
+        char ShortNameLength;
+        char16_t ShortName[12];
+        LARGE_INTEGER FileId;
+        char16_t FileName[1];
+    } FILE_ID_BOTH_DIR_INFORMATION, *PFILE_ID_BOTH_DIR_INFORMATION;
+
     typedef struct _FILE_RENAME_INFORMATION
     {
         BOOLEAN ReplaceIfExists;

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -758,6 +758,12 @@ namespace sogen
         char NumberOfProcessors;
     } SYSTEM_BASIC_INFORMATION64, *PSYSTEM_BASIC_INFORMATION64;
 
+    typedef struct _SYSTEM_CODEINTEGRITY_INFORMATION
+    {
+        ULONG Length;
+        ULONG CodeIntegrityOptions;
+    } SYSTEM_CODEINTEGRITY_INFORMATION, *PSYSTEM_CODEINTEGRITY_INFORMATION;
+
     typedef struct _SYSTEM_DEVICE_INFORMATION
     {
         ULONG NumberOfDisks;

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -429,6 +429,7 @@ namespace sogen
                                                        ULONG number_of_attributes, uint64_t buffer, ULONG buffer_length,
                                                        emulator_object<ULONG> return_length);
         NTSTATUS handle_NtAdjustPrivilegesToken();
+        NTSTATUS handle_NtQuerySecurityPolicy();
         NTSTATUS handle_NtFlushInstructionCache(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
                                                 uint64_t region_size);
 
@@ -1165,6 +1166,7 @@ namespace sogen
         add_handler(NtOpenProcessTokenEx);
         add_handler(NtQuerySecurityAttributesToken);
         add_handler(NtAdjustPrivilegesToken);
+        add_handler(NtQuerySecurityPolicy);
         add_handler(NtQueryLicenseValue);
         add_handler(NtTestAlert);
         add_handler(NtContinue);

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -448,6 +448,12 @@ namespace sogen
                                                                           file_name, f);
             }
 
+            if (info_class == FileIdBothDirectoryInformation)
+            {
+                return handle_file_enumeration<FILE_ID_BOTH_DIR_INFORMATION>(c, io_status_block, file_information, length, query_flags,
+                                                                             file_name, f);
+            }
+
             c.win_emu.log.error("Unsupported query directory file info class: %X\n", info_class);
             c.emu.stop();
 

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -575,6 +575,17 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            case SystemCodeIntegrityInformation: {
+                // Report a normal retail configuration: code integrity (driver signature enforcement) enabled,
+                // test-signing/debug off, so anti-tamper checks observe a non-tampered system.
+                constexpr ULONG CODEINTEGRITY_OPTION_ENABLED = 0x1;
+                return handle_query<SYSTEM_CODEINTEGRITY_INFORMATION>(c.emu, system_information, system_information_length, return_length,
+                                                                      [&](SYSTEM_CODEINTEGRITY_INFORMATION& ci) {
+                                                                          ci.Length = sizeof(ci);
+                                                                          ci.CodeIntegrityOptions = CODEINTEGRITY_OPTION_ENABLED;
+                                                                      });
+            }
+
             default:
                 c.win_emu.log.error("Unsupported system info class: 0x%X\n", info_class);
                 c.emu.stop();

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -492,6 +492,11 @@ namespace sogen
         {
             return STATUS_NOT_SUPPORTED;
         }
+
+        NTSTATUS handle_NtQuerySecurityPolicy()
+        {
+            return STATUS_NOT_SUPPORTED;
+        }
     }
 
 } // namespace sogen


### PR DESCRIPTION
A series of small syscall/feature gaps found while bringing up **Assassin's Creed** (32-bit, WHP backend). Each one was an `emu.stop()` on an unimplemented path; the game now progresses through startup well past all three.

### 1. `NtQueryDirectoryFile`: `FileIdBothDirectoryInformation` (0x25)
Only `FileDirectory`/`FileFullDirectory`/`FileBothDirectory` were handled. Added the `FILE_ID_BOTH_DIR_INFORMATION` struct and routed the class through the existing `handle_file_enumeration<T>` template (extra `ShortName`/`FileId` fields zero-fill, like the other classes).

### 2. `NtQuerySecurityPolicy` — stub
`wldp.dll` calls it during startup. Stubbed to `STATUS_NOT_SUPPORTED` (no lockdown policy configured), matching the existing `NtAdjustPrivilegesToken` stub.

### 3. `NtQuerySystemInformation`: `SystemCodeIntegrityInformation` (0x67)
Returns a `SYSTEM_CODEINTEGRITY_INFORMATION` reporting a normal retail configuration (code integrity enabled, test-signing off) so anti-tamper checks see a non-tampered system.

## Result on Assassin's Creed (WHP)
- Before: stopped at the directory `FileId` query.
- After all three: runs for 45s+ without a hard stop, loading the crypto/networking stack (`rsaenh`, `cryptnet`, `iphlpapi`, `nsi`, …). The next item is a soft, non-fatal `BAD PORT \RPC Control\keysvc` warning (unemulated RPC key-service port), not a crash.

## Verification
- Release build clean.
- Smoke test 26/26 (incl. `Dir I/O`) after each change — no regressions.