### PR TITLE
ci: ship DXVK + Vulkan shim in the emulation root

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Verify Page Formatting
         run: cd page && npx --yes prettier . --check
 
-  build-apiset-dumper:
-    name: Build API Set Dumper
+  build-root-tools:
+    name: Build Root Tools
     runs-on: windows-latest
     steps:
       - name: Checkout Source
@@ -180,7 +180,7 @@ jobs:
   create-emulation-root:
     name: Create Emulation Root
     runs-on: ${{ matrix.runner }}
-    needs: [build-apiset-dumper]
+    needs: [build-root-tools]
     strategy:
       fail-fast: false
       matrix:
@@ -1138,7 +1138,7 @@ jobs:
         build-python-sdist,
         test-python-sdist,
         clang-tidy,
-        build-apiset-dumper,
+        build-root-tools,
         smoke-test-whp,
         smoke-test-kvm,
         smoke-test-node,

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -166,13 +166,13 @@ jobs:
       - name: Stage Vulkan Shims
         shell: pwsh
         run: |
-          Copy-Item build/release/artifacts/vulkan-shim.dll build/release/artifacts/vulkan-shim-x64.dll -Force
+          Move-Item build/release/artifacts/vulkan-shim.dll build/release/artifacts/vulkan-shim-x64.dll -Force
           Copy-Item shims/vulkan-shim-x86.dll build/release/artifacts/vulkan-shim-x86.dll -Force
 
       - name: Upload Artifacts
         uses: pyTooling/upload-artifact@v7
         with:
-          name: Temp API Set Dumper
+          name: Temp Root Build Tools
           working-directory: build/release/artifacts/
           path: "*"
           retention-days: 1
@@ -208,10 +208,10 @@ jobs:
       - name: Install DirectX Runtime
         run: "cmd /c \"start /wait .\\dxrt\\dxsetup.exe /silent\""
 
-      - name: Download API Set Dumper
+      - name: Download Root Build Tools
         uses: pyTooling/download-artifact@v8
         with:
-          name: Temp API Set Dumper
+          name: Temp Root Build Tools
           path: build/release/artifacts
 
       - name: Create Emulation Root

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -140,11 +140,34 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Enable Developer Command Prompt
+      - name: Enable Developer Command Prompt (x86)
         uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: x86
 
-      - name: CMake Build
-        run: cmake --preset=release && cmake --build --preset=release -t dump-apiset
+      - name: Build 32-bit Vulkan Shim
+        run: cmake --preset=release && cmake --build --preset=release -t vulkan-shim
+
+      - name: Stash 32-bit Vulkan Shim
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path shims -Force | Out-Null
+          Copy-Item build/release/artifacts/vulkan-shim.dll shims/vulkan-shim-x86.dll -Force
+          Remove-Item build/release -Recurse -Force
+
+      - name: Enable Developer Command Prompt (x64)
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: x64
+
+      - name: Build API Set Dumper and 64-bit Vulkan Shim
+        run: cmake --preset=release && cmake --build --preset=release -t dump-apiset vulkan-shim
+
+      - name: Stage Vulkan Shims
+        shell: pwsh
+        run: |
+          Copy-Item build/release/artifacts/vulkan-shim.dll build/release/artifacts/vulkan-shim-x64.dll -Force
+          Copy-Item shims/vulkan-shim-x86.dll build/release/artifacts/vulkan-shim-x86.dll -Force
 
       - name: Upload Artifacts
         uses: pyTooling/upload-artifact@v7
@@ -196,6 +219,12 @@ jobs:
 
       - name: Dump API Set
         run: cd root && ../build/release/artifacts/dump-apiset.exe
+
+      - name: Install DXVK and Vulkan Shim
+        shell: pwsh
+        run: ./src/tools/install-gpu-runtime.ps1 -WindowsDir root/filesys/c/windows -Shim64 build/release/artifacts/vulkan-shim-x64.dll -Shim32 build/release/artifacts/vulkan-shim-x86.dll
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload Artifacts
         uses: pyTooling/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The debugger runs at the emulator level, outside the process, so it stays invisi
 ## Run Games in a Sandbox
 
 Native GUI apps run, with working windows, dialogs and controls.  
-GPU paravirtualization enables 3D acceleration on your real GPU, while the Hyper-V backend runs the code natively on your CPU. Fast enough for games.
+GPU paravirtualization enables 3D acceleration on your real GPU, while the Hyper-V backend runs the code natively on your CPU. Fast enough for games.  
+DirectX titles run through [DXVK](https://github.com/doitsujin/dxvk), which translates Direct3D to Vulkan on top of the GPU bridge.
 
 <img src="https://momo5502.com/sogen/game.png" width="650" alt="A game running inside the Sogen emulator" />
 &nbsp;  

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The debugger runs at the emulator level, outside the process, so it stays invisi
 
 Native GUI apps run, with working windows, dialogs and controls.  
 GPU paravirtualization enables 3D acceleration on your real GPU, while the Hyper-V backend runs the code natively on your CPU. Fast enough for games.  
-DirectX titles run through [DXVK](https://github.com/doitsujin/dxvk), which translates Direct3D to Vulkan on top of the GPU bridge.
+Direct3D 8/9/10/11 titles run through [DXVK](https://github.com/doitsujin/dxvk), which translates Direct3D to Vulkan on top of the GPU bridge.
 
 <img src="https://momo5502.com/sogen/game.png" width="650" alt="A game running inside the Sogen emulator" />
 &nbsp;  

--- a/src/tools/install-gpu-runtime.ps1
+++ b/src/tools/install-gpu-runtime.ps1
@@ -14,11 +14,22 @@ $ErrorActionPreference = 'Stop'
 $system32 = Join-Path $WindowsDir 'system32'
 $syswow64 = Join-Path $WindowsDir 'syswow64'
 
-$headers = @{ 'User-Agent' = 'sogen-ci' }
-if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+# DXVK ships its D3D DLLs under x64/ (64-bit) and x32/ (32-bit); overwrite the bundled DirectX ones.
+function Install-Dxvk([string]$srcDir, [string]$dstDir) {
+    if (-not (Test-Path $srcDir)) { throw "DXVK source directory not found: $srcDir" }
+    Get-ChildItem -Path $srcDir -Filter '*.dll' | ForEach-Object {
+        $dst = Join-Path $dstDir $_.Name
+        Write-Host "DXVK: $($_.Name) -> $dst"
+        Copy-Item -Path $_.FullName -Destination $dst -Force
+    }
+}
+
+# Auth only raises the api.github.com rate limit; it is never sent to the asset CDN below.
+$apiHeaders = @{ 'User-Agent' = 'sogen-ci' }
+if ($env:GITHUB_TOKEN) { $apiHeaders['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
 
 # Resolve the latest DXVK release tarball (skip the *-native Linux build).
-$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/doitsujin/dxvk/releases/latest' -Headers $headers
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/doitsujin/dxvk/releases/latest' -Headers $apiHeaders
 $asset = $release.assets |
     Where-Object { $_.name -like 'dxvk-*.tar.gz' -and $_.name -notlike '*native*' } |
     Select-Object -First 1
@@ -27,27 +38,25 @@ if (-not $asset) { throw "No DXVK release tarball found in $($release.tag_name)"
 Write-Host "Downloading DXVK $($release.tag_name): $($asset.name)"
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ('dxvk-' + [System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $work -Force | Out-Null
-$tarball = Join-Path $work $asset.name
-Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tarball -Headers $headers
+try {
+    $tarball = Join-Path $work $asset.name
+    # browser_download_url redirects to a public CDN; don't forward the API auth header to it.
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tarball
 
-tar -xzf $tarball -C $work
-if ($LASTEXITCODE -ne 0) { throw "Failed to extract $tarball" }
+    tar -xzf $tarball -C $work
+    if ($LASTEXITCODE -ne 0) { throw "Failed to extract $tarball" }
 
-$dxvkRoot = Get-ChildItem -Path $work -Directory | Where-Object { $_.Name -like 'dxvk-*' } | Select-Object -First 1
-if (-not $dxvkRoot) { throw 'Unexpected DXVK archive layout' }
+    $dxvkRoot = Get-ChildItem -Path $work -Directory | Where-Object { $_.Name -like 'dxvk-*' } | Select-Object -First 1
+    if (-not $dxvkRoot) { throw 'Unexpected DXVK archive layout' }
 
-# DXVK ships its D3D DLLs under x64/ (64-bit) and x32/ (32-bit); overwrite the bundled DirectX ones.
-function Install-Dxvk([string]$srcDir, [string]$dstDir) {
-    Get-ChildItem -Path $srcDir -Filter '*.dll' | ForEach-Object {
-        $dst = Join-Path $dstDir $_.Name
-        Write-Host "DXVK: $($_.Name) -> $dst"
-        Copy-Item -Path $_.FullName -Destination $dst -Force
-    }
+    Install-Dxvk (Join-Path $dxvkRoot.FullName 'x64') $system32
+    Install-Dxvk (Join-Path $dxvkRoot.FullName 'x32') $syswow64
+
+    # Install the GPU-bridge Vulkan shim as the system vulkan-1.dll DXVK loads.
+    Copy-Item -Path $Shim64 -Destination (Join-Path $system32 'vulkan-1.dll') -Force
+    Copy-Item -Path $Shim32 -Destination (Join-Path $syswow64 'vulkan-1.dll') -Force
+    Write-Host 'Vulkan shim installed as vulkan-1.dll (system32 + syswow64)'
 }
-Install-Dxvk (Join-Path $dxvkRoot.FullName 'x64') $system32
-Install-Dxvk (Join-Path $dxvkRoot.FullName 'x32') $syswow64
-
-# Install the GPU-bridge Vulkan shim as the system vulkan-1.dll DXVK loads.
-Copy-Item -Path $Shim64 -Destination (Join-Path $system32 'vulkan-1.dll') -Force
-Copy-Item -Path $Shim32 -Destination (Join-Path $syswow64 'vulkan-1.dll') -Force
-Write-Host 'Vulkan shim installed as vulkan-1.dll (system32 + syswow64)'
+finally {
+    Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/src/tools/install-gpu-runtime.ps1
+++ b/src/tools/install-gpu-runtime.ps1
@@ -1,0 +1,53 @@
+# Provisions the guest GPU runtime into an emulation root: drops the latest DXVK
+# D3D->Vulkan translation DLLs over the bundled DirectX ones and installs the GPU-bridge
+# Vulkan shim as vulkan-1.dll. 64-bit files go to system32, 32-bit files to syswow64.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$WindowsDir, # <root>/filesys/c/windows
+    [Parameter(Mandatory)][string]$Shim64,     # 64-bit vulkan-shim.dll
+    [Parameter(Mandatory)][string]$Shim32      # 32-bit vulkan-shim.dll
+)
+
+$ErrorActionPreference = 'Stop'
+
+$system32 = Join-Path $WindowsDir 'system32'
+$syswow64 = Join-Path $WindowsDir 'syswow64'
+
+$headers = @{ 'User-Agent' = 'sogen-ci' }
+if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+
+# Resolve the latest DXVK release tarball (skip the *-native Linux build).
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/doitsujin/dxvk/releases/latest' -Headers $headers
+$asset = $release.assets |
+    Where-Object { $_.name -like 'dxvk-*.tar.gz' -and $_.name -notlike '*native*' } |
+    Select-Object -First 1
+if (-not $asset) { throw "No DXVK release tarball found in $($release.tag_name)" }
+
+Write-Host "Downloading DXVK $($release.tag_name): $($asset.name)"
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ('dxvk-' + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+$tarball = Join-Path $work $asset.name
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tarball -Headers $headers
+
+tar -xzf $tarball -C $work
+if ($LASTEXITCODE -ne 0) { throw "Failed to extract $tarball" }
+
+$dxvkRoot = Get-ChildItem -Path $work -Directory | Where-Object { $_.Name -like 'dxvk-*' } | Select-Object -First 1
+if (-not $dxvkRoot) { throw 'Unexpected DXVK archive layout' }
+
+# DXVK ships its D3D DLLs under x64/ (64-bit) and x32/ (32-bit); overwrite the bundled DirectX ones.
+function Install-Dxvk([string]$srcDir, [string]$dstDir) {
+    Get-ChildItem -Path $srcDir -Filter '*.dll' | ForEach-Object {
+        $dst = Join-Path $dstDir $_.Name
+        Write-Host "DXVK: $($_.Name) -> $dst"
+        Copy-Item -Path $_.FullName -Destination $dst -Force
+    }
+}
+Install-Dxvk (Join-Path $dxvkRoot.FullName 'x64') $system32
+Install-Dxvk (Join-Path $dxvkRoot.FullName 'x32') $syswow64
+
+# Install the GPU-bridge Vulkan shim as the system vulkan-1.dll DXVK loads.
+Copy-Item -Path $Shim64 -Destination (Join-Path $system32 'vulkan-1.dll') -Force
+Copy-Item -Path $Shim32 -Destination (Join-Path $syswow64 'vulkan-1.dll') -Force
+Write-Host 'Vulkan shim installed as vulkan-1.dll (system32 + syswow64)'


### PR DESCRIPTION
## What

Builds the guest `vulkan-1.dll` shim for **both 32- and 64-bit** in CI and provisions the emulation root with **DXVK + the shim**, so the uploaded root (and `root.zip`) can run Direct3D titles through the GPU bridge out of the box.

## Changes

- **`build-apiset-dumper`** now also builds `vulkan-shim`. To get both architectures from a single `release` tree, it builds x86 first, stashes the DLL, wipes the tree, then builds x64 (`dump-apiset` + `vulkan-shim`). Both are uploaded as `vulkan-shim-x64.dll` / `vulkan-shim-x86.dll`.
- **`src/tools/install-gpu-runtime.ps1`** (new) downloads the latest DXVK release, overwrites the bundled `d3d9/d3d10core/d3d11/dxgi` DLLs (`x64`→`system32`, `x32`→`syswow64`), and installs the shim as `vulkan-1.dll` in both directories.
- **`create-emulation-root`** runs that script right after the API-set dump, so every uploaded root ships the GPU runtime.
- **README** credits DXVK, since its binaries are redistributed in `root.zip` (it's not a submodule, so it isn't covered by any in-tree LICENSE).

## Note

This makes DXVK the default D3D path for **every** emulation root produced by CI — D3D9/10/11 now resolve to DXVK and Vulkan routes through the bridge shim. That matches the request ("overwrite the DirectX DLLs"), just flagging the blast radius. Easy to gate behind a flag if you'd rather opt in.
