### PR TITLE
ci: move emulation-root jobs to Windows Server 2025

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -478,8 +478,8 @@ jobs:
           - Unicorn
           - Icicle
         emulation-root:
-          #- Windows 2025
-          - Windows 2022
+          - Windows 2025
+          #- Windows 2022
           #- Windows 2019
         configuration:
           #- Debug
@@ -638,7 +638,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample
@@ -664,7 +664,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample
@@ -724,7 +724,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample
@@ -758,7 +758,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample
@@ -784,7 +784,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample
@@ -810,8 +810,8 @@ jobs:
           - Unicorn
           - Icicle
         emulation-root:
-          #- Windows 2025
-          - Windows 2022
+          - Windows 2025
+          #- Windows 2022
           #- Windows 2019
         configuration:
           #- Debug
@@ -895,7 +895,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Sample
@@ -1050,7 +1050,7 @@ jobs:
       - name: Download Emulation Root
         uses: pyTooling/download-artifact@v8
         with:
-          name: Windows 2022 Emulation Root
+          name: Windows 2025 Emulation Root
           path: build/release/artifacts/root
 
       - name: Copy Test Sample


### PR DESCRIPTION
Windows Server 2022 is deprecated, so shift CI onto the Server 2025 emulation root.

## Changes (`.github/workflows/ci-reusable.yml`)
- **Matrix jobs** `test` and `smoke-test-android` → **2025 only** (2022 commented out).
- **Single-root smoke jobs** (`smoke-test-node`, `-whp`, `-kvm`, `-win32`, `-mingw`, `test-python`) → swapped 2022 → **2025**.
- **`build-page`** → ships the **2025** root in the public web-demo `root.zip`.
- **`win-test`** (Windows isolation matrix) → unchanged, still runs **both** 2025 + 2022.
- **`create-emulation-root`** → unchanged, still builds both roots since `win-test` consumes the 2022 one.

After this, 2022 coverage survives only in the `win-test` isolation matrix; everything else runs on 2025.