### PR TITLE
syscalls: stub clipboard open/close/empty/get/set

### DIFF
--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -638,6 +638,12 @@ namespace sogen
         uint32_t handle_NtUserGetDoubleClickTime();
         BOOL handle_NtUserModifyWindowTouchCapability();
         uint32_t handle_NtUserGetClipboardSequenceNumber();
+        BOOL handle_NtUserOpenClipboard();
+        BOOL handle_NtUserCloseClipboard();
+        BOOL handle_NtUserEmptyClipboard();
+        uint64_t handle_NtUserGetClipboardData();
+        uint64_t handle_NtUserConvertMemHandle();
+        uint64_t handle_NtUserSetClipboardData();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -1554,6 +1560,12 @@ namespace sogen
         add_handler(NtUserGetKeyboardState);
         add_handler(NtUserModifyWindowTouchCapability);
         add_handler(NtUserGetClipboardSequenceNumber);
+        add_handler(NtUserOpenClipboard);
+        add_handler(NtUserCloseClipboard);
+        add_handler(NtUserEmptyClipboard);
+        add_handler(NtUserGetClipboardData);
+        add_handler(NtUserConvertMemHandle);
+        add_handler(NtUserSetClipboardData);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4833,6 +4833,38 @@ namespace sogen
         {
             return 1;
         }
+
+        BOOL handle_NtUserOpenClipboard()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserCloseClipboard()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserEmptyClipboard()
+        {
+            return TRUE;
+        }
+
+        uint64_t handle_NtUserGetClipboardData()
+        {
+            return 0;
+        }
+
+        uint64_t handle_NtUserConvertMemHandle()
+        {
+            // Return a non-null placeholder clipboard handle so SetClipboardData succeeds. The contents are
+            // not stored; reads via NtUserGetClipboardData report an empty clipboard.
+            return 1;
+        }
+
+        uint64_t handle_NtUserSetClipboardData()
+        {
+            return 1;
+        }
     }
 
 } // namespace sogen


### PR DESCRIPTION
The clipboard NtUser syscalls were unimplemented, so any app touching the clipboard during startup stopped emulation. Unreal Tournament III (via wxWidgets) does this on launch — it hit `NtUserOpenClipboard`, then `NtUserConvertMemHandle` (the `SetClipboardData` write path).

Adds minimal stubs alongside the existing `NtUserGetClipboardSequenceNumber`:
- `NtUserOpenClipboard` / `NtUserCloseClipboard` / `NtUserEmptyClipboard` → success
- `NtUserGetClipboardData` → no data (empty clipboard)
- `NtUserConvertMemHandle` / `NtUserSetClipboardData` → non-null placeholder so `SetClipboardData` succeeds

Contents are not stored (reads report an empty clipboard), which is sufficient for apps that only probe or set the clipboard during init. A full implementation would back these with per-process clipboard storage.

## Verification
- Release build clean; smoke test 26/26.
- UT3 (WHP): no longer stops at the clipboard syscalls — it now proceeds well past them (loads OpenAL/PhysX/dbghelp) before hitting an unrelated later issue.