### PR TITLE
windows-emulator: 24bpp DIB blits + clipboard syscall stubs

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -175,6 +175,13 @@ namespace sogen
 #define WS_DISABLED          0x08000000L
 #define WS_CLIPSIBLINGS      0x04000000L
 #define WS_CLIPCHILDREN      0x02000000L
+#define WS_CAPTION           0x00C00000L
+#define WS_BORDER            0x00800000L
+#define WS_DLGFRAME          0x00400000L
+#define WS_SYSMENU           0x00080000L
+#define WS_THICKFRAME        0x00040000L
+#define WS_MINIMIZEBOX       0x00020000L
+#define WS_MAXIMIZEBOX       0x00010000L
 
 #define SWP_NOSIZE           0x0001
 #define SWP_NOMOVE           0x0002

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -184,6 +184,7 @@ namespace sogen
         NtUserDestroyWindow,
         NtUserShowWindow,
         NtUserMessageCall,
+        NtUserUpdateWindow,
         NtUserEnumDisplayMonitors,
     };
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -91,6 +91,7 @@ namespace sogen
 
         emulator_pointer guest_bits{};
         uint32_t guest_stride{};
+        uint32_t guest_bpp{32};
         bool guest_top_down{};
         bool guest_owns_memory{};
 
@@ -101,6 +102,7 @@ namespace sogen
             buffer.write_vector(this->pixels);
             buffer.write(this->guest_bits);
             buffer.write(this->guest_stride);
+            buffer.write(this->guest_bpp);
             buffer.write(this->guest_top_down);
             buffer.write(this->guest_owns_memory);
         }
@@ -112,6 +114,7 @@ namespace sogen
             buffer.read_vector(this->pixels);
             buffer.read(this->guest_bits);
             buffer.read(this->guest_stride);
+            buffer.read(this->guest_bpp);
             buffer.read(this->guest_top_down);
             buffer.read(this->guest_owns_memory);
         }

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -173,6 +173,23 @@ namespace sogen
         }
     };
 
+    struct window_update_state : completion_state
+    {
+        // Window handles still to be painted (WM_PAINT), back() is dispatched next.
+        std::vector<uint64_t> pending{};
+
+      private:
+        void serialize_object(utils::buffer_serializer& buffer) const override
+        {
+            buffer.write_vector(this->pending);
+        }
+
+        void deserialize_object(utils::buffer_deserializer& buffer) override
+        {
+            buffer.read_vector(this->pending);
+        }
+    };
+
     class windows_emulator;
 
     class syscall_dispatcher

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -543,6 +543,7 @@ namespace sogen
         BOOL handle_NtUserInvalidateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect, BOOL erase);
         BOOL handle_NtUserValidateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect);
         BOOL handle_NtUserUpdateWindow(const syscall_context& c, hwnd hwnd);
+        BOOL completion_NtUserUpdateWindow(const syscall_context& c, hwnd hwnd);
         int32_t handle_NtUserGetKeyNameText(const syscall_context& c, int32_t l_param, emulator_pointer buffer, int32_t character_count);
         BOOL handle_NtUserPostMessage(const syscall_context& c, hwnd hwnd, UINT msg, uint64_t wParam, uint64_t lParam);
         BOOL handle_NtUserPostThreadMessage(const syscall_context& c, DWORD id_thread, UINT msg, uint64_t wParam, uint64_t lParam);
@@ -721,6 +722,8 @@ namespace sogen
         COLORREF handle_NtGdiGetPixel(const syscall_context& c, hdc dc, int x, int y);
         BOOL handle_NtGdiBitBlt(const syscall_context& c, hdc dst_dc, int x_dst, int y_dst, int width, int height, hdc src_dc, int x_src,
                                 int y_src, DWORD rop, DWORD cr_back_color, FLONG fl);
+        BOOL handle_NtGdiStretchBlt(const syscall_context& c, hdc dst_dc, int x_dst, int y_dst, int dst_width, int dst_height, hdc src_dc,
+                                    int x_src, int y_src, int src_width, int src_height, DWORD rop, DWORD cr_back_color);
         BOOL handle_NtGdiPolyPatBlt(const syscall_context& c, hdc dc, DWORD rop, emulator_pointer poly, DWORD count, DWORD mode);
         BOOL handle_NtGdiExtTextOutW(const syscall_context& c, hdc dc, LONG x, LONG y, UINT options, emulator_pointer rect,
                                      emulator_pointer text, UINT count, emulator_pointer dx, DWORD code_page);
@@ -1252,6 +1255,7 @@ namespace sogen
         add_handler(NtGdiRectangle);
         add_handler(NtGdiPatBlt);
         add_handler(NtGdiBitBlt);
+        add_handler(NtGdiStretchBlt);
         add_handler(NtGdiPolyPatBlt);
         add_handler(NtGdiExtTextOutW);
         add_handler(NtGdiGetRealizationInfo);
@@ -1590,6 +1594,7 @@ namespace sogen
         add_callback(NtUserDestroyWindow, window_destroy_state);
         add_callback(NtUserShowWindow, window_show_state);
         add_callback(NtUserMessageCall, message_call_state);
+        add_callback(NtUserUpdateWindow, window_update_state);
         add_stateless_callback(NtUserEnumDisplayMonitors);
 
 #undef add_callback

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -638,6 +638,12 @@ namespace sogen
         uint32_t handle_NtUserGetDoubleClickTime();
         BOOL handle_NtUserModifyWindowTouchCapability();
         uint32_t handle_NtUserGetClipboardSequenceNumber();
+        BOOL handle_NtUserOpenClipboard();
+        BOOL handle_NtUserCloseClipboard();
+        BOOL handle_NtUserEmptyClipboard();
+        uint64_t handle_NtUserGetClipboardData();
+        uint64_t handle_NtUserConvertMemHandle();
+        uint64_t handle_NtUserSetClipboardData();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -1554,6 +1560,12 @@ namespace sogen
         add_handler(NtUserGetKeyboardState);
         add_handler(NtUserModifyWindowTouchCapability);
         add_handler(NtUserGetClipboardSequenceNumber);
+        add_handler(NtUserOpenClipboard);
+        add_handler(NtUserCloseClipboard);
+        add_handler(NtUserEmptyClipboard);
+        add_handler(NtUserGetClipboardData);
+        add_handler(NtUserConvertMemHandle);
+        add_handler(NtUserSetClipboardData);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2084,7 +2084,7 @@ namespace sogen
             c.emu.read_memory(info + 16, &compression, sizeof(compression));
 
             constexpr uint32_t bi_rgb = 0;
-            if (bit_count != 32 || compression != bi_rgb || bi_width <= 0)
+            if ((bit_count != 32 && bit_count != 24) || compression != bi_rgb || bi_width <= 0)
             {
                 c.win_emu.log.warn("NtGdiSetDIBitsToDeviceInternal: unsupported DIB (bpp=%u compression=%u width=%d)\n", bit_count,
                                    compression, bi_width);
@@ -2095,7 +2095,9 @@ namespace sogen
             const auto src_width = static_cast<uint32_t>(bi_width);
             const auto src_height = static_cast<uint32_t>(top_down ? -bi_height : bi_height);
             const auto stored_rows = std::min(scan_lines, src_height);
-            const size_t stride = static_cast<size_t>(src_width) * sizeof(uint32_t);
+            const size_t bytes_per_pixel = bit_count / 8;
+            // DIB scanlines are DWORD-aligned, not tightly packed.
+            const size_t stride = ((static_cast<size_t>(src_width) * bit_count + 31u) / 32u) * 4u;
 
             std::vector<uint8_t> data(stride * stored_rows);
             if (data.empty())
@@ -2131,8 +2133,9 @@ namespace sogen
                     {
                         break;
                     }
-                    uint32_t pixel = 0;
-                    std::memcpy(&pixel, row + static_cast<size_t>(src_x) * sizeof(uint32_t), sizeof(pixel));
+                    const uint8_t* px = row + static_cast<size_t>(src_x) * bytes_per_pixel;
+                    const uint32_t pixel =
+                        static_cast<uint32_t>(px[0]) | (static_cast<uint32_t>(px[1]) << 8) | (static_cast<uint32_t>(px[2]) << 16);
                     set_surface_pixel(*surface, x_dest + origin_x + static_cast<int>(i), y_dest + origin_y + static_cast<int>(j),
                                       pixel | 0xFF000000u);
                 }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -3240,8 +3240,14 @@ namespace sogen
 
             const int dst_w = std::abs(dst_width);
             const int dst_h = std::abs(dst_height);
+            const int src_w = std::abs(src_width);
+            const int src_h = std::abs(src_height);
             const bool flip_x = dst_width < 0;
             const bool flip_y = dst_height < 0;
+            // Negative source extents mirror the source image (GDI semantics), independently of the
+            // destination flip; sample the mirrored position within the (absolute) source rectangle.
+            const bool flip_src_x = src_width < 0;
+            const bool flip_src_y = src_height < 0;
 
             const uint32_t pattern = get_dc_brush_color(c, dst_dc);
 
@@ -3256,7 +3262,8 @@ namespace sogen
                 int sy = 0;
                 if (needs_source)
                 {
-                    sy = y_src + src_origin_y + static_cast<int>(static_cast<int64_t>(dy) * src_height / dst_h);
+                    const int src_dy = static_cast<int>(static_cast<int64_t>(dy) * src_h / dst_h);
+                    sy = y_src + src_origin_y + (flip_src_y ? (src_h - 1 - src_dy) : src_dy);
                     if (sy < 0 || sy >= static_cast<int>(src_surface->height))
                     {
                         continue;
@@ -3276,7 +3283,8 @@ namespace sogen
                     uint32_t src = 0;
                     if (needs_source)
                     {
-                        const int sx = x_src + src_origin_x + static_cast<int>(static_cast<int64_t>(dx) * src_width / dst_w);
+                        const int src_dx = static_cast<int>(static_cast<int64_t>(dx) * src_w / dst_w);
+                        const int sx = x_src + src_origin_x + (flip_src_x ? (src_w - 1 - src_dx) : src_dx);
                         if (sx < 0 || sx >= static_cast<int>(src_surface->width))
                         {
                             continue;

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -469,17 +469,49 @@ namespace sogen
                     return;
                 }
 
-                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
-                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                if (surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
                 {
                     return;
                 }
 
-                for (uint32_t y = 0; y < surface.height; ++y)
+                if (surface.guest_bpp == 32)
                 {
-                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
-                    auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
-                    c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst, row_bytes);
+                    const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
+                    if (surface.guest_stride < row_bytes)
+                    {
+                        return;
+                    }
+
+                    for (uint32_t y = 0; y < surface.height; ++y)
+                    {
+                        const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                        auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                        c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst, row_bytes);
+                    }
+                }
+                else if (surface.guest_bpp == 24)
+                {
+                    const size_t row_bytes = static_cast<size_t>(surface.width) * 3;
+                    if (surface.guest_stride < row_bytes)
+                    {
+                        return;
+                    }
+
+                    std::vector<uint8_t> row(row_bytes);
+                    for (uint32_t y = 0; y < surface.height; ++y)
+                    {
+                        const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                        c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, row.data(),
+                                          row_bytes);
+
+                        auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                        for (uint32_t x = 0; x < surface.width; ++x)
+                        {
+                            const uint8_t* px = row.data() + static_cast<size_t>(x) * 3;
+                            dst[x] = static_cast<uint32_t>(px[0]) | (static_cast<uint32_t>(px[1]) << 8) |
+                                     (static_cast<uint32_t>(px[2]) << 16) | 0xFF000000u;
+                        }
+                    }
                 }
             }
 
@@ -595,17 +627,41 @@ namespace sogen
                     return;
                 }
 
-                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
-                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                if (surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
                 {
                     return;
                 }
 
+                if (surface.guest_bpp != 24 && surface.guest_bpp != 32)
+                {
+                    return;
+                }
+
+                const size_t bytes_per_pixel = surface.guest_bpp / 8;
+                const size_t row_bytes = static_cast<size_t>(surface.width) * bytes_per_pixel;
+                if (surface.guest_stride < row_bytes)
+                {
+                    return;
+                }
+
+                std::vector<uint8_t> row(row_bytes);
                 for (uint32_t y = 0; y < surface.height; ++y)
                 {
                     const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
                     const auto* src = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
-                    c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, src, row_bytes);
+                    for (uint32_t x = 0; x < surface.width; ++x)
+                    {
+                        uint8_t* px = row.data() + static_cast<size_t>(x) * bytes_per_pixel;
+                        const uint32_t pixel = src[x];
+                        px[0] = static_cast<uint8_t>(pixel & 0xFF);
+                        px[1] = static_cast<uint8_t>((pixel >> 8) & 0xFF);
+                        px[2] = static_cast<uint8_t>((pixel >> 16) & 0xFF);
+                        if (bytes_per_pixel == 4)
+                        {
+                            px[3] = static_cast<uint8_t>((pixel >> 24) & 0xFF);
+                        }
+                    }
+                    c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, row.data(), row_bytes);
                 }
             }
 
@@ -1966,6 +2022,7 @@ namespace sogen
             auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
             surface.guest_bits = guest_bits;
             surface.guest_stride = stride;
+            surface.guest_bpp = header.biBitCount;
             surface.guest_top_down = header.biHeight < 0;
             surface.guest_owns_memory = true;
 
@@ -2186,7 +2243,7 @@ namespace sogen
             c.emu.read_memory(info + 0, &bi_size, sizeof(bi_size));
             c.emu.read_memory(info + 32, &clr_used, sizeof(clr_used)); // BITMAPINFOHEADER.biClrUsed
 
-            if ((bit_count != 4 && bit_count != 32) || compression != bi_rgb || bi_width <= 0 || bi_height == 0)
+            if ((bit_count != 4 && bit_count != 24 && bit_count != 32) || compression != bi_rgb || bi_width <= 0 || bi_height == 0)
             {
                 c.win_emu.log.warn("NtGdiStretchDIBitsInternal: unsupported DIB (bpp=%u compression=%u width=%d)\n", bit_count, compression,
                                    bi_width);
@@ -2272,6 +2329,12 @@ namespace sogen
                     {
                         std::memcpy(&pixel, row + static_cast<size_t>(img_x) * sizeof(uint32_t), sizeof(pixel));
                         pixel |= 0xFF000000u;
+                    }
+                    else if (bit_count == 24)
+                    {
+                        const uint8_t* px = row + static_cast<size_t>(img_x) * 3;
+                        pixel = static_cast<uint32_t>(px[0]) | (static_cast<uint32_t>(px[1]) << 8) | (static_cast<uint32_t>(px[2]) << 16) |
+                                0xFF000000u;
                     }
                     else // 4bpp BI_RGB
                     {

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2501,8 +2501,44 @@ namespace sogen
                 return 0;
             }
 
-            std::vector<uint8_t> zeroed(object_size, 0);
-            c.emu.write_memory(buffer, zeroed.data(), zeroed.size());
+            std::vector<uint8_t> object_data(object_size, 0);
+
+            if (entry.Type == k_gdi_bitmap_type)
+            {
+                const auto bmp_it = c.proc.gdi_bitmap_surfaces.find(handle_value);
+                if (bmp_it != c.proc.gdi_bitmap_surfaces.end())
+                {
+                    const auto& surface = bmp_it->second;
+                    const auto bpp = static_cast<uint16_t>(surface.guest_bpp != 0 ? surface.guest_bpp : 32u);
+                    const auto width_bytes = surface.guest_stride != 0
+                                                 ? surface.guest_stride
+                                                 : static_cast<uint32_t>(((static_cast<uint64_t>(surface.width) * bpp + 31u) / 32u) * 4u);
+
+                    // BITMAP (32-bit layout): bmType@0, bmWidth@4, bmHeight@8, bmWidthBytes@12,
+                    // bmPlanes@16 (WORD), bmBitsPixel@18 (WORD), bmBits@20 (PVOID32).
+                    const auto put32 = [&](const size_t off, const uint32_t v) {
+                        if (off + sizeof(v) <= object_data.size())
+                        {
+                            std::memcpy(object_data.data() + off, &v, sizeof(v));
+                        }
+                    };
+                    const auto put16 = [&](const size_t off, const uint16_t v) {
+                        if (off + sizeof(v) <= object_data.size())
+                        {
+                            std::memcpy(object_data.data() + off, &v, sizeof(v));
+                        }
+                    };
+
+                    put32(4, surface.width);
+                    put32(8, surface.height);
+                    put32(12, width_bytes);
+                    put16(16, 1);
+                    put16(18, bpp);
+                    put32(20, static_cast<uint32_t>(surface.guest_bits));
+                }
+            }
+
+            c.emu.write_memory(buffer, object_data.data(), object_data.size());
             return object_size;
         }
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <bit>
 #include <limits>
+#include <utils/buffer_accessor.hpp>
 
 // #define ENABLE_DXGK_LOGGING
 
@@ -2516,25 +2517,13 @@ namespace sogen
 
                     // BITMAP (32-bit layout): bmType@0, bmWidth@4, bmHeight@8, bmWidthBytes@12,
                     // bmPlanes@16 (WORD), bmBitsPixel@18 (WORD), bmBits@20 (PVOID32).
-                    const auto put32 = [&](const size_t off, const uint32_t v) {
-                        if (off + sizeof(v) <= object_data.size())
-                        {
-                            std::memcpy(object_data.data() + off, &v, sizeof(v));
-                        }
-                    };
-                    const auto put16 = [&](const size_t off, const uint16_t v) {
-                        if (off + sizeof(v) <= object_data.size())
-                        {
-                            std::memcpy(object_data.data() + off, &v, sizeof(v));
-                        }
-                    };
-
-                    put32(4, surface.width);
-                    put32(8, surface.height);
-                    put32(12, width_bytes);
-                    put16(16, 1);
-                    put16(18, bpp);
-                    put32(20, static_cast<uint32_t>(surface.guest_bits));
+                    const utils::safe_buffer_accessor<uint8_t> bitmap{object_data};
+                    bitmap.as<int32_t>(4).set(static_cast<int32_t>(surface.width));
+                    bitmap.as<int32_t>(8).set(static_cast<int32_t>(surface.height));
+                    bitmap.as<int32_t>(12).set(static_cast<int32_t>(width_bytes));
+                    bitmap.as<uint16_t>(16).set(1);
+                    bitmap.as<uint16_t>(18).set(bpp);
+                    bitmap.as<uint32_t>(20).set(static_cast<uint32_t>(surface.guest_bits));
                 }
             }
 
@@ -3203,6 +3192,103 @@ namespace sogen
 
             present_win_surface(c, present_handle, dst_surface);
 
+            return TRUE;
+        }
+
+        // Like BitBlt, but nearest-neighbour scales the source rectangle onto the destination rectangle.
+        // Used by the user32 SS_BITMAP static control to paint its image (e.g. the open-iw5 splash).
+        BOOL handle_NtGdiStretchBlt(const syscall_context& c, const hdc dst_dc, const int x_dst, const int y_dst, const int dst_width,
+                                    const int dst_height, const hdc src_dc, const int x_src, const int y_src, const int src_width,
+                                    const int src_height, const DWORD rop, const DWORD /*cr_back_color*/)
+        {
+            if (dst_dc == 0 || dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0)
+            {
+                return FALSE;
+            }
+
+            (void)handle_NtGdiFlush(c);
+
+            int32_t dst_origin_x = 0;
+            int32_t dst_origin_y = 0;
+            uint32_t present_handle = 0;
+            gdi_bitmap_surface* dst_surface = resolve_dc_surface(c, dst_dc, dst_origin_x, dst_origin_y, present_handle);
+            if (!dst_surface || dst_surface->width == 0 || dst_surface->height == 0 || dst_surface->pixels.empty())
+            {
+                return FALSE;
+            }
+
+            const auto rop3 = static_cast<uint8_t>((rop >> 16) & 0xFFu);
+            const bool needs_source = rop3_uses_source(rop3);
+
+            int32_t src_origin_x = 0;
+            int32_t src_origin_y = 0;
+            gdi_bitmap_surface* src_surface = nullptr;
+            if (needs_source)
+            {
+                if (src_dc == 0)
+                {
+                    return FALSE;
+                }
+
+                uint32_t unused_present_handle = 0;
+                src_surface = resolve_dc_surface(c, src_dc, src_origin_x, src_origin_y, unused_present_handle);
+                if (!src_surface || src_surface->width == 0 || src_surface->height == 0 || src_surface->pixels.empty())
+                {
+                    return FALSE;
+                }
+            }
+
+            const int dst_w = std::abs(dst_width);
+            const int dst_h = std::abs(dst_height);
+            const bool flip_x = dst_width < 0;
+            const bool flip_y = dst_height < 0;
+
+            const uint32_t pattern = get_dc_brush_color(c, dst_dc);
+
+            for (int dy = 0; dy < dst_h; ++dy)
+            {
+                const int out_y = y_dst + dst_origin_y + (flip_y ? (dst_h - 1 - dy) : dy);
+                if (out_y < 0 || out_y >= static_cast<int>(dst_surface->height))
+                {
+                    continue;
+                }
+
+                int sy = 0;
+                if (needs_source)
+                {
+                    sy = y_src + src_origin_y + static_cast<int>(static_cast<int64_t>(dy) * src_height / dst_h);
+                    if (sy < 0 || sy >= static_cast<int>(src_surface->height))
+                    {
+                        continue;
+                    }
+                }
+
+                auto* dst_row = dst_surface->pixels.data() + static_cast<size_t>(out_y) * dst_surface->width;
+
+                for (int dx = 0; dx < dst_w; ++dx)
+                {
+                    const int out_x = x_dst + dst_origin_x + (flip_x ? (dst_w - 1 - dx) : dx);
+                    if (out_x < 0 || out_x >= static_cast<int>(dst_surface->width))
+                    {
+                        continue;
+                    }
+
+                    uint32_t src = 0;
+                    if (needs_source)
+                    {
+                        const int sx = x_src + src_origin_x + static_cast<int>(static_cast<int64_t>(dx) * src_width / dst_w);
+                        if (sx < 0 || sx >= static_cast<int>(src_surface->width))
+                        {
+                            continue;
+                        }
+                        src = src_surface->pixels[static_cast<size_t>(sy) * src_surface->width + static_cast<size_t>(sx)];
+                    }
+
+                    dst_row[out_x] = apply_rop3(rop3, src, dst_row[out_x], pattern) | 0xFF000000u;
+                }
+            }
+
+            present_win_surface(c, present_handle, dst_surface);
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3141,6 +3141,37 @@ namespace sogen
             return TRUE;
         }
 
+        void collect_pending_paint_tree(const syscall_context& c, window& win, std::vector<uint64_t>& order)
+        {
+            if (win.update_pending && win.thread_id == c.proc.active_thread->id)
+            {
+                order.push_back(static_cast<uint64_t>(win.handle));
+            }
+
+            for (auto& [index, child] : c.proc.windows)
+            {
+                (void)index;
+                if (child.parent_handle == win.handle && (child.style & WS_VISIBLE) != 0)
+                {
+                    collect_pending_paint_tree(c, child, order);
+                }
+            }
+        }
+
+        BOOL dispatch_pending_window_paint(const syscall_context& c, window_update_state state)
+        {
+            while (!state.pending.empty())
+            {
+                if (auto* win = c.proc.windows.get(static_cast<hwnd>(state.pending.back())))
+                {
+                    dispatch_window_message(c, callback_id::NtUserUpdateWindow, std::move(state), *win, WM_PAINT);
+                    return {};
+                }
+                state.pending.pop_back();
+            }
+            return TRUE;
+        }
+
         BOOL handle_NtUserUpdateWindow(const syscall_context& c, const hwnd hwnd)
         {
             auto* win = c.proc.windows.get(hwnd);
@@ -3149,11 +3180,50 @@ namespace sogen
                 return FALSE;
             }
 
-            if (win->update_pending)
+            // UpdateWindow paints synchronously, bypassing the message queue. Apps such as the open-iw5 splash
+            // rely on this to display content without running a message loop, so a merely queued WM_PAINT would
+            // never be pumped. Dispatch WM_PAINT now to the window and its invalid visible child controls.
+            // Cross-thread windows cannot be painted on this thread, so fall back to posting the paint.
+            if (win->thread_id != c.proc.active_thread->id)
             {
-                queue_window_paint(c, *win);
+                if (win->update_pending)
+                {
+                    queue_window_paint(c, *win);
+                }
+                return TRUE;
             }
-            return TRUE;
+
+            std::vector<uint64_t> order;
+            collect_pending_paint_tree(c, *win, order);
+            if (order.empty())
+            {
+                return TRUE;
+            }
+
+            // back() is dispatched first, so reverse the parent-first paint order into the queue.
+            window_update_state state{};
+            state.pending.assign(order.rbegin(), order.rend());
+            return dispatch_pending_window_paint(c, std::move(state));
+        }
+
+        BOOL completion_NtUserUpdateWindow(const syscall_context& c, const hwnd /*hwnd*/)
+        {
+            auto& state = c.get_completion_state<window_update_state>();
+
+            if (!state.pending.empty())
+            {
+                const auto painted = state.pending.back();
+                state.pending.pop_back();
+
+                if (auto* win = c.proc.windows.get(static_cast<hwnd>(painted)))
+                {
+                    (void)handle_NtGdiFlush(c);
+                    present_existing_guest_window_surface(c, *win);
+                    validate_window(*win);
+                }
+            }
+
+            return dispatch_pending_window_paint(c, std::move(state));
         }
 
         BOOL handle_NtUserPostMessage(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t wParam,

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3164,6 +3164,8 @@ namespace sogen
             {
                 if (auto* win = c.proc.windows.get(static_cast<hwnd>(state.pending.back())))
                 {
+                    // Painting continues asynchronously through completion_NtUserUpdateWindow; the guest is
+                    // suspended here, so this immediate return value is unused (matches handle_NtUserShowWindow).
                     dispatch_window_message(c, callback_id::NtUserUpdateWindow, std::move(state), *win, WM_PAINT);
                     return {};
                 }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4833,6 +4833,38 @@ namespace sogen
         {
             return 1;
         }
+
+        BOOL handle_NtUserOpenClipboard()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserCloseClipboard()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserEmptyClipboard()
+        {
+            return TRUE;
+        }
+
+        uint64_t handle_NtUserGetClipboardData()
+        {
+            return 0;
+        }
+
+        uint64_t handle_NtUserConvertMemHandle()
+        {
+            // Return a non-null placeholder clipboard handle so SetClipboardData succeeds. The contents are
+            // not stored; reads via NtUserGetClipboardData report an empty clipboard.
+            return 1;
+        }
+
+        uint64_t handle_NtUserSetClipboardData()
+        {
+            return 1;
+        }
     }
 
 } // namespace sogen

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -711,7 +711,14 @@ namespace sogen
                 {
                     flags &= ~SDL_WINDOW_HIDDEN;
                 }
-                if ((desc.style & WS_CHILD) == 0)
+                // A window without a full caption (e.g. a WS_POPUP splash screen) has no title bar and no
+                // minimize/maximize/close controls; mirror that on the host window.
+                if ((desc.style & WS_CAPTION) != WS_CAPTION)
+                {
+                    flags |= SDL_WINDOW_BORDERLESS;
+                }
+                // Only windows with a sizing border (WS_THICKFRAME) can be resized by the user.
+                if ((desc.style & WS_CHILD) == 0 && (desc.style & WS_THICKFRAME) != 0)
                 {
                     flags |= SDL_WINDOW_RESIZABLE;
                 }


### PR DESCRIPTION
Two small Windows-API gaps found bringing up Unreal Tournament III (combines #1111 and #1112).

### gdi: 24bpp DIBs in `NtGdiSetDIBitsToDeviceInternal`
The handler only accepted 32bpp `BI_RGB` DIBs, dropping everything else. 24bpp `BI_RGB` is common (e.g. game splash screens — UT3's splash is a 24bpp 572px bitmap), so the splash window stayed blank. Now accepts 24bpp too: DWORD-aligned stride and 3 bytes (BGR) per pixel.

### syscalls: clipboard open/close/empty/get/set stubs
The clipboard NtUser syscalls were unimplemented, so any app touching the clipboard at startup stopped emulation (UT3 via wxWidgets hits `NtUserOpenClipboard` then the `SetClipboardData` write path). Adds minimal stubs:
- `NtUserOpenClipboard`/`NtUserCloseClipboard`/`NtUserEmptyClipboard` → success
- `NtUserGetClipboardData` → no data
- `NtUserConvertMemHandle`/`NtUserSetClipboardData` → non-null placeholder so `SetClipboardData` succeeds

Contents aren't stored (reads report an empty clipboard) — sufficient for apps that only probe or set the clipboard.

## Verification
- Release build clean; smoke test 26/26 (incl. GDI + Dir I/O).
- UT3 (WHP): splash blits (no more `unsupported DIB` warning) and it no longer stops at the clipboard syscalls.

Supersedes #1111 and #1112.