### PR TITLE
gdi: blit 24bpp DIB sections and StretchDIBits sources

### DIFF
--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -91,6 +91,7 @@ namespace sogen
 
         emulator_pointer guest_bits{};
         uint32_t guest_stride{};
+        uint32_t guest_bpp{32};
         bool guest_top_down{};
         bool guest_owns_memory{};
 
@@ -101,6 +102,7 @@ namespace sogen
             buffer.write_vector(this->pixels);
             buffer.write(this->guest_bits);
             buffer.write(this->guest_stride);
+            buffer.write(this->guest_bpp);
             buffer.write(this->guest_top_down);
             buffer.write(this->guest_owns_memory);
         }
@@ -112,6 +114,7 @@ namespace sogen
             buffer.read_vector(this->pixels);
             buffer.read(this->guest_bits);
             buffer.read(this->guest_stride);
+            buffer.read(this->guest_bpp);
             buffer.read(this->guest_top_down);
             buffer.read(this->guest_owns_memory);
         }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -469,17 +469,49 @@ namespace sogen
                     return;
                 }
 
-                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
-                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                if (surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
                 {
                     return;
                 }
 
-                for (uint32_t y = 0; y < surface.height; ++y)
+                if (surface.guest_bpp == 32)
                 {
-                    const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
-                    auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
-                    c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst, row_bytes);
+                    const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
+                    if (surface.guest_stride < row_bytes)
+                    {
+                        return;
+                    }
+
+                    for (uint32_t y = 0; y < surface.height; ++y)
+                    {
+                        const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                        auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                        c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, dst, row_bytes);
+                    }
+                }
+                else if (surface.guest_bpp == 24)
+                {
+                    const size_t row_bytes = static_cast<size_t>(surface.width) * 3;
+                    if (surface.guest_stride < row_bytes)
+                    {
+                        return;
+                    }
+
+                    std::vector<uint8_t> row(row_bytes);
+                    for (uint32_t y = 0; y < surface.height; ++y)
+                    {
+                        const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
+                        c.emu.read_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, row.data(),
+                                          row_bytes);
+
+                        auto* dst = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
+                        for (uint32_t x = 0; x < surface.width; ++x)
+                        {
+                            const uint8_t* px = row.data() + static_cast<size_t>(x) * 3;
+                            dst[x] = static_cast<uint32_t>(px[0]) | (static_cast<uint32_t>(px[1]) << 8) |
+                                     (static_cast<uint32_t>(px[2]) << 16) | 0xFF000000u;
+                        }
+                    }
                 }
             }
 
@@ -595,17 +627,41 @@ namespace sogen
                     return;
                 }
 
-                const size_t row_bytes = static_cast<size_t>(surface.width) * sizeof(uint32_t);
-                if (surface.guest_stride < row_bytes || surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
+                if (surface.pixels.size() < static_cast<size_t>(surface.width) * surface.height)
                 {
                     return;
                 }
 
+                if (surface.guest_bpp != 24 && surface.guest_bpp != 32)
+                {
+                    return;
+                }
+
+                const size_t bytes_per_pixel = surface.guest_bpp / 8;
+                const size_t row_bytes = static_cast<size_t>(surface.width) * bytes_per_pixel;
+                if (surface.guest_stride < row_bytes)
+                {
+                    return;
+                }
+
+                std::vector<uint8_t> row(row_bytes);
                 for (uint32_t y = 0; y < surface.height; ++y)
                 {
                     const uint32_t guest_row = surface.guest_top_down ? y : (surface.height - 1 - y);
                     const auto* src = surface.pixels.data() + static_cast<size_t>(y) * surface.width;
-                    c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, src, row_bytes);
+                    for (uint32_t x = 0; x < surface.width; ++x)
+                    {
+                        uint8_t* px = row.data() + static_cast<size_t>(x) * bytes_per_pixel;
+                        const uint32_t pixel = src[x];
+                        px[0] = static_cast<uint8_t>(pixel & 0xFF);
+                        px[1] = static_cast<uint8_t>((pixel >> 8) & 0xFF);
+                        px[2] = static_cast<uint8_t>((pixel >> 16) & 0xFF);
+                        if (bytes_per_pixel == 4)
+                        {
+                            px[3] = static_cast<uint8_t>((pixel >> 24) & 0xFF);
+                        }
+                    }
+                    c.emu.write_memory(surface.guest_bits + static_cast<uint64_t>(guest_row) * surface.guest_stride, row.data(), row_bytes);
                 }
             }
 
@@ -1966,6 +2022,7 @@ namespace sogen
             auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
             surface.guest_bits = guest_bits;
             surface.guest_stride = stride;
+            surface.guest_bpp = header.biBitCount;
             surface.guest_top_down = header.biHeight < 0;
             surface.guest_owns_memory = true;
 
@@ -2183,7 +2240,7 @@ namespace sogen
             c.emu.read_memory(info + 0, &bi_size, sizeof(bi_size));
             c.emu.read_memory(info + 32, &clr_used, sizeof(clr_used)); // BITMAPINFOHEADER.biClrUsed
 
-            if ((bit_count != 4 && bit_count != 32) || compression != bi_rgb || bi_width <= 0 || bi_height == 0)
+            if ((bit_count != 4 && bit_count != 24 && bit_count != 32) || compression != bi_rgb || bi_width <= 0 || bi_height == 0)
             {
                 c.win_emu.log.warn("NtGdiStretchDIBitsInternal: unsupported DIB (bpp=%u compression=%u width=%d)\n", bit_count, compression,
                                    bi_width);
@@ -2269,6 +2326,12 @@ namespace sogen
                     {
                         std::memcpy(&pixel, row + static_cast<size_t>(img_x) * sizeof(uint32_t), sizeof(pixel));
                         pixel |= 0xFF000000u;
+                    }
+                    else if (bit_count == 24)
+                    {
+                        const uint8_t* px = row + static_cast<size_t>(img_x) * 3;
+                        pixel = static_cast<uint32_t>(px[0]) | (static_cast<uint32_t>(px[1]) << 8) | (static_cast<uint32_t>(px[2]) << 16) |
+                                0xFF000000u;
                     }
                     else // 4bpp BI_RGB
                     {


### PR DESCRIPTION
Splash screens (and other 24bpp bitmaps) rendered empty. The standard splash path is `LoadImage`/`CreateDIBSection` → app draws pixels into the section → `BitBlt` to the window. Two GDI paths silently dropped 24bpp:

### DIB-section guest↔host sync
`CreateDIBSection` allocates **guest** memory the app draws into, separate from the surface's host pixel buffer. `sync_surface_from_guest_dib` / `sync_surface_to_guest_dib` bridge the two, but assumed 32bpp: `row_bytes = width*4` and an early `return` when `guest_stride < row_bytes` — always true for 24bpp (stride ≈ width*3). So the host surface stayed zeroed and `BitBlt` copied an empty image.

Fix: record the section's bit depth on the surface (`guest_bpp`) and convert 24bpp (BGR) rows to/from the host 32bpp surface. 32bpp keeps its fast `memcpy` path.

### StretchDIBits
`NtGdiStretchDIBitsInternal` accepted only 4/32bpp; added a 24bpp case (used by software-present paths and some splashes).

## Verification
- Release build clean; smoke test 27/27.
- Logically: 24bpp DIB sections now sync instead of bailing; needs a visual splash check on a game.

Complements #1113, which covers the direct `NtGdiSetDIBitsToDeviceInternal` 24bpp blit path; together these cover the common 24bpp bitmap routes.