### PR TITLE
Fix lsapolicylookup port in WoW64

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1588,9 +1588,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_threads, "Threads")
     RUN_TEST(test_threads_winapi, "Threads WinAPI")
     RUN_TEST(test_env, "Environment")
-#ifdef _WIN64
     RUN_TEST(test_lookup_account_sid, "LSA")
-#endif
     RUN_TEST(test_exceptions, "Exceptions")
 #ifndef __MINGW64__
     RUN_TEST(test_native_exceptions, "Native Exceptions")

--- a/src/windows-emulator/port.cpp
+++ b/src/windows-emulator/port.cpp
@@ -253,7 +253,7 @@ namespace sogen
         std::memcpy(header.data() + 12, &call_id, sizeof(call_id));
 
         std::vector<uint8_t> payload;
-        utils::aligned_binary_writer writer(payload);
+        utils::aligned_binary_writer writer(payload, win_emu.process.is_wow64_process ? sizeof(uint32_t) : sizeof(uint64_t));
         writer.write(header.data(), header.size());
 
         lpc_request_context rpc_context{};

--- a/src/windows-emulator/ports/lsa_policy_lookup.cpp
+++ b/src/windows-emulator/ports/lsa_policy_lookup.cpp
@@ -11,15 +11,24 @@ namespace sogen
     namespace
     {
         constexpr NTSTATUS k_status_none_mapped = static_cast<NTSTATUS>(0xC0000073);
-        constexpr ULONG k_open_policy_reply_size = 0x44;
+        constexpr ULONG k_open_policy_reply_size_32 = 0x40;
+        constexpr ULONG k_open_policy_reply_size_64 = 0x44;
         constexpr ULONG k_lookup_sids_not_mapped_reply_size = 0x18;
-        constexpr ULONG k_lookup_sids_min_success_reply_size = 0x10C;
-        constexpr ULONG k_close_policy_reply_size = 0x44;
+        constexpr ULONG k_lookup_sids_min_success_reply_size_32 = 0xCC;
+        constexpr ULONG k_lookup_sids_min_success_reply_size_64 = 0x10C;
+        constexpr ULONG k_close_policy_reply_size_32 = 0x40;
+        constexpr ULONG k_close_policy_reply_size_64 = 0x44;
+
         constexpr uint32_t k_lsa_max_referenced_domains = 0x20;
         constexpr uint32_t k_sid_type_user = 1;
         constexpr std::array<uint8_t, 16> k_policy_context_uuid = {
             0xBA, 0xA3, 0xDA, 0x01, 0x6E, 0x16, 0x62, 0x49, 0x81, 0x46, 0x13, 0x9B, 0x8A, 0x70, 0x69, 0xE7,
         };
+
+        ULONG select_by_pointer_size(const utils::aligned_binary_writer& writer, const ULONG size_32, const ULONG size_64)
+        {
+            return writer.pointer_size() == utils::aligned_binary_writer::pointer_size_32 ? size_32 : size_64;
+        }
 
         bool request_contains_sid(windows_emulator& win_emu, const lpc_request_context& c, const std::span<const uint8_t> sid)
         {
@@ -113,14 +122,18 @@ namespace sogen
             writer.write_pointer_sized(1);
 
             write_lsa_translated_name(writer, user);
+            writer.align_to(utils::aligned_binary_writer::pointer_size_64);
             writer.write_ndr_u16string(user, false);
 
             writer.write<uint32_t>(1);
             writer.write(STATUS_SUCCESS);
 
-            if (writer.offset() < k_lookup_sids_min_success_reply_size)
+            const auto min_reply_size =
+                select_by_pointer_size(writer, k_lookup_sids_min_success_reply_size_32, k_lookup_sids_min_success_reply_size_64);
+
+            if (writer.offset() < min_reply_size)
             {
-                writer.pad(static_cast<size_t>(k_lookup_sids_min_success_reply_size - writer.offset()));
+                writer.pad(static_cast<size_t>(min_reply_size - writer.offset()));
             }
         }
 
@@ -154,7 +167,7 @@ namespace sogen
             {
                 (void)win_emu;
                 const auto reply_offset = writer.offset();
-                writer.pad(k_open_policy_reply_size);
+                writer.pad(select_by_pointer_size(writer, k_open_policy_reply_size_32, k_open_policy_reply_size_64));
                 writer.write_at(reply_offset + 0x04, k_policy_context_uuid.data(), k_policy_context_uuid.size());
 
                 return STATUS_SUCCESS;
@@ -188,7 +201,7 @@ namespace sogen
             static NTSTATUS handle_close_policy(windows_emulator& win_emu, utils::aligned_binary_writer& writer)
             {
                 (void)win_emu;
-                writer.pad(k_close_policy_reply_size);
+                writer.pad(select_by_pointer_size(writer, k_close_policy_reply_size_32, k_close_policy_reply_size_64));
                 return STATUS_SUCCESS;
             }
         };

--- a/src/windows-emulator/ports/lsa_policy_lookup.cpp
+++ b/src/windows-emulator/ports/lsa_policy_lookup.cpp
@@ -80,7 +80,7 @@ namespace sogen
             return domain_sid;
         }
 
-        void write_lsa_unicode_string(utils::aligned_binary_writer& writer, const std::u16string_view value)
+        void write_lsa_unicode_string_header(utils::aligned_binary_writer& writer, const std::u16string_view value)
         {
             writer.write(static_cast<uint16_t>(value.size() * sizeof(char16_t)));
             writer.write(static_cast<uint16_t>((value.size() + 1) * sizeof(char16_t)));
@@ -91,9 +91,11 @@ namespace sogen
         {
             writer.write(k_sid_type_user);
             writer.align_to(writer.pointer_size());
-            write_lsa_unicode_string(writer, value);
+            write_lsa_unicode_string_header(writer, value);
+            writer.write<int32_t>(0);
             writer.write<int32_t>(0);
             writer.align_to(writer.pointer_size());
+            writer.write_ndr_u16string(value, false);
         }
 
         void write_lookup_sids_success_reply(utils::aligned_binary_writer& writer, const std::u16string_view domain,
@@ -106,9 +108,8 @@ namespace sogen
             writer.write(k_lsa_max_referenced_domains);
 
             writer.write_pointer_sized(1);
-            write_lsa_unicode_string(writer, domain);
+            write_lsa_unicode_string_header(writer, domain);
             writer.write_ndr_pointer(true);
-
             writer.write_ndr_u16string(domain, false);
             writer.align_to(writer.pointer_size());
 
@@ -120,10 +121,7 @@ namespace sogen
             writer.write<uint32_t>(1);
             writer.write_ndr_pointer(true);
             writer.write_pointer_sized(1);
-
             write_lsa_translated_name(writer, user);
-            writer.align_to(utils::aligned_binary_writer::pointer_size_64);
-            writer.write_ndr_u16string(user, false);
 
             writer.write<uint32_t>(1);
             writer.write(STATUS_SUCCESS);
@@ -139,6 +137,10 @@ namespace sogen
 
         struct lsa_policy_lookup_port : rpc_port
         {
+            /*
+             * The layout for this RPC port seems to be all documented here:
+             * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/1b5471ef-4c33-4a91-b079-dfcbb82f05cc
+             */
             NTSTATUS handle_rpc(windows_emulator& win_emu, const uint32_t procedure_id, const lpc_request_context& c,
                                 utils::aligned_binary_writer& writer) override
             {


### PR DESCRIPTION
This PR fixes the lsapolicylookup port under WoW64.