### PR TITLE
Implement NtUserSetSystemTimer and NtUserGetIconInfo

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -102,6 +102,15 @@ namespace sogen
         hicon hIconSm;
     };
 
+    struct EMU_ICONINFO
+    {
+        BOOL fIcon;
+        DWORD xHotspot;
+        DWORD yHotspot;
+        hbitmap hbmMask;
+        hbitmap hbmColor;
+    };
+
     struct EMU_MINMAXINFO
     {
         POINT ptReserved;

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -388,6 +388,7 @@ namespace sogen
 #endif
 
 #define WM_UAHDESTROYWINDOW 0x0090
+#define WM_SYSTIMER         0x0118
 
     struct EMU_DISPLAY_DEVICEW
     {

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -289,6 +289,7 @@ namespace sogen
             switch (queued_message.message)
             {
             case WM_TIMER:
+            case WM_SYSTIMER:
                 return QS_TIMER;
 
             case WM_PAINT:
@@ -641,7 +642,7 @@ namespace sogen
 
     user_timer& emulator_thread::create_user_timer(process_context& process, const hwnd hwnd, uint64_t timer_id, const uint64_t timer_proc,
                                                    const std::chrono::milliseconds interval,
-                                                   const std::chrono::steady_clock::time_point now)
+                                                   const std::chrono::steady_clock::time_point now, const bool is_system)
     {
         if (hwnd == 0)
         {
@@ -672,6 +673,7 @@ namespace sogen
         timer.hwnd = hwnd;
         timer.timer_id = timer_id;
         timer.timer_proc = timer_proc;
+        timer.is_system = is_system;
         timer.interval = interval;
         timer.due_time = now + interval;
 
@@ -719,7 +721,7 @@ namespace sogen
 
             msg timer_message{};
             timer_message.window = user_timer.hwnd;
-            timer_message.message = WM_TIMER;
+            timer_message.message = user_timer.is_system ? WM_SYSTIMER : WM_TIMER;
             timer_message.wParam = user_timer.timer_id;
             timer_message.lParam = user_timer.timer_proc;
 
@@ -852,6 +854,7 @@ namespace sogen
             return true;
 
         case WM_TIMER:
+        case WM_SYSTIMER:
             return tail_msg.wParam == msg.wParam && tail_msg.lParam == msg.lParam;
 
         default:

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -28,6 +28,7 @@ namespace sogen
         sogen::hwnd hwnd{};
         uint64_t timer_id{};
         uint64_t timer_proc{};
+        bool is_system{};
         std::optional<std::chrono::steady_clock::time_point> due_time{};
         std::chrono::steady_clock::duration interval{};
 
@@ -37,6 +38,7 @@ namespace sogen
             buffer.write(this->hwnd);
             buffer.write(this->timer_id);
             buffer.write(this->timer_proc);
+            buffer.write(this->is_system);
             buffer.write_optional(this->due_time);
             buffer.write(this->interval);
         }
@@ -47,6 +49,7 @@ namespace sogen
             buffer.read(this->hwnd);
             buffer.read(this->timer_id);
             buffer.read(this->timer_proc);
+            buffer.read(this->is_system);
             buffer.read_optional(this->due_time);
             buffer.read(this->interval);
         }
@@ -359,7 +362,8 @@ namespace sogen
 
         user_timer* find_user_timer(hwnd hwnd, uint64_t timer_id);
         user_timer& create_user_timer(process_context& process, hwnd hwnd, uint64_t timer_id, uint64_t timer_proc,
-                                      std::chrono::milliseconds interval, std::chrono::steady_clock::time_point now);
+                                      std::chrono::milliseconds interval, std::chrono::steady_clock::time_point now,
+                                      bool is_system = false);
         bool delete_user_timer(hwnd hwnd, uint64_t timer_id);
         bool synthesize_due_user_timer(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0);
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -489,6 +489,10 @@ namespace sogen
         hicon handle_NtUserGetCursorFrameInfo(const syscall_context& c, hicon icon, UINT frame, emulator_object<uint32_t> rate_jiffies,
                                               emulator_object<uint32_t> frame_count);
         BOOL handle_NtUserGetIconSize(const syscall_context& c, hicon icon, UINT frame, emulator_object<int> cx, emulator_object<int> cy);
+        BOOL handle_NtUserGetIconInfo(const syscall_context& c, hicon icon, emulator_object<EMU_ICONINFO> icon_info,
+                                      emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> inst_name,
+                                      emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> res_name, emulator_object<uint32_t> bpp,
+                                      BOOL internal);
         BOOL handle_NtUserDrawIconEx(const syscall_context& c, hdc dc, int x, int y, hicon icon, int cx, int cy, UINT istep,
                                      uint64_t flicker_brush, UINT di_flags);
         BOOL handle_NtUserMessageBeep();
@@ -1370,6 +1374,7 @@ namespace sogen
         add_handler(NtUserDestroyCursor);
         add_handler(NtUserGetCursorFrameInfo);
         add_handler(NtUserGetIconSize);
+        add_handler(NtUserGetIconInfo);
         add_handler(NtUserDrawIconEx);
         add_handler(NtUserMessageBeep);
         add_handler(NtSetContextThread);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -602,6 +602,7 @@ namespace sogen
         BOOL handle_NtUserDrainThreadCoreMessagingCompletions2();
         uint64_t handle_NtUserScheduleDispatchNotification(const syscall_context& c, hwnd hwnd);
         uint64_t handle_NtUserSetTimer(const syscall_context& c, hwnd hwnd, uint64_t timer_id, uint32_t elapsed_ms, uint64_t timer_proc);
+        uint64_t handle_NtUserSetSystemTimer(const syscall_context& c, hwnd hwnd, uint64_t timer_id, uint32_t elapsed_ms);
         BOOL handle_NtUserKillTimer(const syscall_context& c, hwnd hwnd, uint64_t timer_id);
         BOOL handle_NtUserValidateTimerCallback(const syscall_context& c, uint64_t timer_proc);
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, UINT flags);
@@ -1513,6 +1514,7 @@ namespace sogen
         add_handler(NtUserInitThreadCoreMessagingIocp2);
         add_handler(NtUserDrainThreadCoreMessagingCompletions2);
         add_handler(NtUserSetTimer);
+        add_handler(NtUserSetSystemTimer);
         add_handler(NtUserKillTimer);
         add_handler(NtUserValidateTimerCallback);
         add_handler(NtAllocateReserveObject);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1992,12 +1992,13 @@ namespace sogen
 
             // The emulator's icons/cursors are bare pseudo-handles with no backing pixel data, so report a
             // standard 32x32 icon with a centered hotspot and no mask/color bitmaps.
-            EMU_ICONINFO info{};
-            info.fIcon = TRUE;
-            info.xHotspot = 16;
-            info.yHotspot = 16;
-            info.hbmMask = 0;
-            info.hbmColor = 0;
+            const EMU_ICONINFO info{
+                .fIcon = TRUE,
+                .xHotspot = 16,
+                .yHotspot = 16,
+                .hbmMask = 0,
+                .hbmColor = 0,
+            };
             icon_info.write(info);
 
             const auto clear_name = [&](const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>>& name) {

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1979,6 +1979,42 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserGetIconInfo(const syscall_context& c, const hicon icon, const emulator_object<EMU_ICONINFO> icon_info,
+                                      const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> inst_name,
+                                      const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> res_name,
+                                      const emulator_object<uint32_t> bpp, const BOOL /*internal*/)
+        {
+            if (icon == 0 || !icon_info)
+            {
+                set_guest_last_error(c, 1414); // ERROR_INVALID_CURSOR_HANDLE
+                return FALSE;
+            }
+
+            // The emulator's icons/cursors are bare pseudo-handles with no backing pixel data, so report a
+            // standard 32x32 icon with a centered hotspot and no mask/color bitmaps.
+            EMU_ICONINFO info{};
+            info.fIcon = TRUE;
+            info.xHotspot = 16;
+            info.yHotspot = 16;
+            info.hbmMask = 0;
+            info.hbmColor = 0;
+            icon_info.write(info);
+
+            const auto clear_name = [&](const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>>& name) {
+                if (name)
+                {
+                    auto value = name.read();
+                    value.Length = 0;
+                    name.write(value);
+                }
+            };
+            clear_name(inst_name);
+            clear_name(res_name);
+
+            bpp.write_if_valid(32);
+            return TRUE;
+        }
+
         BOOL handle_NtUserMessageBeep()
         {
             return TRUE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4310,8 +4310,8 @@ namespace sogen
             return 2;
         }
 
-        uint64_t handle_NtUserSetTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id, const uint32_t elapsed_ms,
-                                       const uint64_t timer_proc)
+        uint64_t set_user_timer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id, const uint32_t elapsed_ms,
+                                const uint64_t timer_proc, const bool is_system)
         {
             auto interval = std::chrono::milliseconds{elapsed_ms};
             if (interval < k_user_timer_minimum)
@@ -4346,10 +4346,23 @@ namespace sogen
                 timer->interval = interval;
                 timer->due_time = now + interval;
                 timer->timer_proc = timer_proc;
+                timer->is_system = is_system;
                 return timer_id;
             }
 
-            return target_thread->create_user_timer(c.proc, hwnd, timer_id, timer_proc, interval, now).timer_id;
+            return target_thread->create_user_timer(c.proc, hwnd, timer_id, timer_proc, interval, now, is_system).timer_id;
+        }
+
+        uint64_t handle_NtUserSetTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id, const uint32_t elapsed_ms,
+                                       const uint64_t timer_proc)
+        {
+            return set_user_timer(c, hwnd, timer_id, elapsed_ms, timer_proc, false);
+        }
+
+        uint64_t handle_NtUserSetSystemTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id,
+                                             const uint32_t elapsed_ms)
+        {
+            return set_user_timer(c, hwnd, timer_id, elapsed_ms, 0, true);
         }
 
         BOOL handle_NtUserKillTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4396,8 +4396,7 @@ namespace sogen
             return set_user_timer(c, hwnd, timer_id, elapsed_ms, timer_proc, false);
         }
 
-        uint64_t handle_NtUserSetSystemTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id,
-                                             const uint32_t elapsed_ms)
+        uint64_t handle_NtUserSetSystemTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id, const uint32_t elapsed_ms)
         {
             return set_user_timer(c, hwnd, timer_id, elapsed_ms, 0, true);
         }


### PR DESCRIPTION
## Summary

Implements two previously-unimplemented win32u syscalls. Each one was aborting emulation when first hit.

### `NtUserSetSystemTimer`

Sets an internal *system* timer that posts `WM_SYSTIMER` messages and, unlike `NtUserSetTimer`, takes no timer callback proc.

- **`syscalls/user.cpp`**: Extract a shared `set_user_timer` helper; `handle_NtUserSetTimer` (proc, non-system) and the new `handle_NtUserSetSystemTimer` (no proc, system) both delegate to it.
- **`emulator_thread.hpp`**: Add an `is_system` flag to `user_timer` (serialized) and an `is_system` parameter to `create_user_timer`.
- **`emulator_thread.cpp`**: Due-timer synthesis posts `WM_SYSTIMER` vs `WM_TIMER` based on the flag; `WM_SYSTIMER` is treated like `WM_TIMER` for `QS_TIMER` queue status and message coalescing.
- **`window.hpp`**: Define `WM_SYSTIMER` (`0x0118`). It is undocumented and absent from the Windows SDK, so it lives outside the `OS_WINDOWS` guard alongside `WM_UAHDESTROYWINDOW`.

### `NtUserGetIconInfo`

Fills the caller's `ICONINFO` with a standard 32x32 icon and a centered hotspot, clears the optional instance/resource name strings, and reports 32bpp. The emulator's icons/cursors are bare pseudo-handles with no backing pixel data, so no mask/color bitmaps are returned.

- **`syscalls/user.cpp`**: New `handle_NtUserGetIconInfo`.
- **`window.hpp`**: Matching `EMU_ICONINFO` struct.

## Testing

- `cmake --build --preset=release` builds cleanly.
- `analyzer.exe -s test-sample.exe` passes all smoke tests (incl. `User Timer`).
- `analyzer --skip-syscalls --backend whp "Baba Is You.exe"` no longer aborts on `NtUserGetIconInfo`; it now runs through DXVK initialization (subsequently stalls on the separate, pre-existing `clbcatq` COM-catalog wall).