### PR TITLE
feat(python): added linux bindings

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1071,6 +1071,13 @@ jobs:
           LINUX_PYTHON_TEST_ROOT: /
           LINUX_PYTHON_TEST_BACKEND: unicorn
 
+      - name: Enable KVM
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run Python Linux KVM Test Script
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
         run: python src/python-bindings/test_linux.py

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1073,13 +1073,11 @@ jobs:
 
       - name: Run Python Linux KVM Test Script
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
-        shell: bash
-        run: |
-          if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
-            LINUX_PYTHON_TEST_BINARY=/bin/true LINUX_PYTHON_TEST_ROOT=/ LINUX_PYTHON_TEST_BACKEND=kvm python src/python-bindings/test_linux.py
-          else
-            echo "Skipping KVM smoke: /dev/kvm is unavailable on this runner"
-          fi
+        run: python src/python-bindings/test_linux.py
+        env:
+          LINUX_PYTHON_TEST_BINARY: /bin/true
+          LINUX_PYTHON_TEST_ROOT: /
+          LINUX_PYTHON_TEST_BACKEND: kvm
 
   build-python-sdist:
     name: Build Python Sdist

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1063,6 +1063,24 @@ jobs:
           EMULATOR_VERBOSE: ${{ inputs.verbose }}
           ANALYSIS_SAMPLE: ${{github.workspace}}/build/release/artifacts/test-sample.exe
 
+      - name: Run Python Linux Unicorn Test Script
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+        run: python src/python-bindings/test_linux.py
+        env:
+          LINUX_PYTHON_TEST_BINARY: /bin/true
+          LINUX_PYTHON_TEST_ROOT: /
+          LINUX_PYTHON_TEST_BACKEND: unicorn
+
+      - name: Run Python Linux KVM Test Script
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+        shell: bash
+        run: |
+          if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            LINUX_PYTHON_TEST_BINARY=/bin/true LINUX_PYTHON_TEST_ROOT=/ LINUX_PYTHON_TEST_BACKEND=kvm python src/python-bindings/test_linux.py
+          else
+            echo "Skipping KVM smoke: /dev/kvm is unavailable on this runner"
+          fi
+
   build-python-sdist:
     name: Build Python Sdist
     runs-on: ubuntu-24.04

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -2,7 +2,7 @@
   <a href="https://github.com/momo5502/sogen"><img src="https://momo5502.com/sogen/banner.png" height="220" alt="Sogen" /></a>
 </p>
 
-Sogen exposes Python bindings for its Windows userspace emulator. The Python API is meant for scripting runs, building small analysis helpers, and quickly iterating on callbacks and hooks without rebuilding C++.
+Sogen exposes Python bindings for Windows and Linux userspace emulation. The Python API is meant for scripting runs, building small analysis helpers, and quickly iterating on callbacks; Windows bindings also expose hooks for deeper analysis.
 
 Install from PyPI:
 
@@ -49,6 +49,23 @@ app.start()
 print("exit status:", app.process.exit_status)
 ```
 
+Linux quick start:
+
+```python
+import sogen
+
+app = sogen.linux.create_application(
+    "/bin/true",
+    emulation_root="/",
+    backend=sogen.Backend.unicorn,
+)
+
+app.start()
+print("exit status:", app.process.exit_status)
+```
+
+`sogen.linux` does not use the root-level `sogen.create_application(...)` compatibility alias.
+
 ## Minimal example with file + port mappings
 
 ```python
@@ -69,7 +86,7 @@ print("exit status:", app.process.exit_status)
 
 ## Choosing backend
 
-`sogen.windows.create_empty()` and `sogen.windows.create_application()` accept an explicit backend.
+`sogen.windows.create_empty()`, `sogen.windows.create_application()`, and `sogen.linux.create_application()` accept `backend=sogen.Backend.unicorn`.
 
 ```python
 import sogen
@@ -91,17 +108,21 @@ Default is `sogen.Backend.unicorn`.
 
 ## High-level structure
 
-Main entry points:
+Windows entry points:
 
 - `sogen.windows.create_empty(...)`
 - `sogen.windows.create_application(...)`
 
-Compatibility aliases currently remain at top level:
+Linux entry point:
+
+- `sogen.linux.create_application(...)`
+
+Windows compatibility aliases currently remain at top level:
 
 - `sogen.create_empty(...)`
 - `sogen.create_application(...)`
 
-Common objects exposed by the bindings:
+Objects exposed by the Windows bindings:
 
 - `sogen.windows.Emulator` / `sogen.windows.WindowsEmulator`
 - `ProcessContext`
@@ -110,7 +131,14 @@ Common objects exposed by the bindings:
 - `Hooks`
 - `Callbacks`
 
-Common things you will do:
+Linux-specific objects exposed by the bindings:
+
+- `sogen.linux.Emulator` / `sogen.linux.LinuxEmulator`
+- `sogen.linux.ProcessContext`
+- `sogen.linux.MemoryManager`
+- `sogen.linux.Callbacks`
+
+Common Windows workflows:
 
 - run application with `app.start()`
 - watch output with `app.callbacks.on_stdout`
@@ -231,9 +259,10 @@ emu.restore_snapshot()
 
 ## Examples
 
-Small runnable example:
+Small runnable examples:
 
-- `examples/python/basic_usage.py`
+- `examples/python/basic_usage.py` for Windows
+- `examples/python/linux_true.py` for Linux
 
 Example setup notes:
 
@@ -241,7 +270,7 @@ Example setup notes:
 
 ## Current limitations / expectations
 
-- bindings require an emulation root
-- samples in this repo assume Windows-style guest paths like `c:/...`
-- some workflows are easiest to validate against repo sample binaries such as `test-sample.exe` and `hook-sample.exe`
+- Windows bindings require an emulation root
+- Windows samples in this repo assume Windows-style guest paths like `c:/...`
+- Windows workflows are easiest to validate against repo sample binaries such as `test-sample.exe` and `hook-sample.exe`
 - backend availability depends on platform and how Sogen was built

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,7 @@
-# Python example
+# Python examples
 
-`examples/python/basic_usage.py` shows how to run the bundled `test-sample.exe`.
+`examples/python/basic_usage.py` shows how to run the bundled Windows `test-sample.exe`.
+`examples/python/linux_true.py` shows how to run `/bin/true` with the Linux bindings.
 
 Install the package:
 
@@ -12,10 +13,17 @@ Download an emulation root:
 
 https://sogen.dev/root.zip
 
-Then run the example:
+Then run the Windows example:
 
 ```bash
 python examples/python/basic_usage.py
 ```
 
+Or run the Linux example:
+
+```bash
+python examples/python/linux_true.py
+```
+
 Set `EMULATOR_ROOT` to the extracted root. If unset, the script uses `./root`.
+Set `LINUX_EMULATION_ROOT` to a Linux sysroot if `/` is not suitable; the default example uses `/` and `/bin/true` on Linux hosts.

--- a/examples/python/linux_true.py
+++ b/examples/python/linux_true.py
@@ -1,0 +1,28 @@
+"""Run /bin/true with Sogen Linux Python bindings."""
+
+from __future__ import annotations
+
+import os
+
+import sogen
+
+
+LINUX_EMULATION_ROOT = os.getenv("LINUX_EMULATION_ROOT", "/")
+LINUX_TRUE = os.getenv("LINUX_TRUE", "/bin/true")
+
+
+def main() -> int:
+    app = sogen.linux.create_application(
+        LINUX_TRUE,
+        emulation_root=LINUX_EMULATION_ROOT,
+        backend=sogen.Backend.unicorn,
+    )
+
+    app.start()
+    print("exit status:", app.process.exit_status)
+    print("executed instructions:", app.executed_instructions)
+    return app.process.exit_status if app.process.exit_status is not None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backends/kvm-emulator/kvm_x86_64_common.hpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_common.hpp
@@ -31,6 +31,7 @@ namespace sogen::kvm::detail
     {
         void* host_page = nullptr;
         memory_permission permissions = memory_permission::none;
+        std::optional<uint64_t> physical_page{};
         std::shared_ptr<uint8_t> owned_page{};
     };
 
@@ -196,7 +197,8 @@ namespace sogen::kvm::detail
 
     template <typename PageTableViews, typename AllocateInternalPageFn>
     inline void ensure_virtual_mapping(PageTableViews& page_table_views, const uint64_t pml4_gpa,
-                                       AllocateInternalPageFn&& allocate_internal_page, const uint64_t guest_address)
+                                       AllocateInternalPageFn&& allocate_internal_page, const uint64_t guest_address,
+                                       const uint64_t physical_page_base)
     {
         const auto page_base = align_down_to_page(guest_address);
         const auto pml4_index = static_cast<size_t>((page_base >> 39) & 0x1FF);
@@ -209,7 +211,7 @@ namespace sogen::kvm::detail
         const auto pt_gpa = ensure_child_table(page_table_views, allocate_internal_page, pd_gpa, pd_index);
 
         auto* const pt_entries = get_page_table_entries(page_table_views, pt_gpa);
-        pt_entries[pt_index] = page_base | page_table_entry_present | page_table_entry_writable | page_table_entry_user;
+        pt_entries[pt_index] = physical_page_base | page_table_entry_present | page_table_entry_writable | page_table_entry_user;
     }
 
     template <typename PageMap>

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cerrno>
 #include <cstring>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <optional>
@@ -1673,6 +1674,24 @@ namespace sogen::kvm
 
                 return std::nullopt;
             }
+            std::optional<uint64_t> translate_guest_physical_address(uint64_t physical_address)
+            {
+                for (auto& [guest_page, page] : this->mapped_pages_)
+                {
+                    if (!page || !page->physical_page)
+                    {
+                        continue;
+                    }
+
+                    const auto page_gpa = *page->physical_page;
+                    if (physical_address >= page_gpa && physical_address < page_gpa + page_size)
+                    {
+                        return guest_page + (physical_address - page_gpa);
+                    }
+                }
+
+                return std::nullopt;
+            }
             bool handle_mmio_exit()
             {
                 const auto& mmio = this->run_->mmio;
@@ -1692,10 +1711,13 @@ namespace sogen::kvm
                     return true;
                 }
 
+                const auto translated_guest_address = this->translate_guest_physical_address(mmio.phys_addr);
+                const auto violation_address = translated_guest_address.value_or(mmio.phys_addr);
+                const auto violation_type = translated_guest_address ? memory_violation_type::protection : memory_violation_type::unmapped;
                 const auto operation = mmio.is_write ? memory_operation::write : memory_operation::read;
                 for (auto& [_, hook] : this->memory_violation_hooks_)
                 {
-                    const auto result = hook(mmio.phys_addr, mmio.len, operation, memory_violation_type::unmapped);
+                    const auto result = hook(violation_address, mmio.len, operation, violation_type);
                     if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                     {
                         return true;

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <iterator>
 #include <map>
@@ -1217,6 +1218,12 @@ namespace sogen::kvm
                 }
 
                 this->readonly_mem_supported_ = ::ioctl(this->kvm_fd_.get(), KVM_CHECK_EXTENSION, KVM_CAP_READONLY_MEM) > 0;
+                static std::atomic_bool readonly_mem_warning_emitted{false};
+                if (!this->readonly_mem_supported_ && !readonly_mem_warning_emitted.exchange(true, std::memory_order_relaxed))
+                {
+                    std::fputs("[WARN] KVM_CAP_READONLY_MEM is unavailable; MMIO writes and read-only memory protections may not trap.\n",
+                               stderr);
+                }
 
                 // The thread-switch register snapshot relies on KVM_GET_XSAVE/KVM_SET_XSAVE.
                 if (::ioctl(this->kvm_fd_.get(), KVM_CHECK_EXTENSION, KVM_CAP_XSAVE) <= 0)

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -62,6 +62,7 @@ namespace sogen::kvm
         constexpr int invalid_opcode_interrupt = 6;
 
         constexpr uintptr_t cache_line_size = 64;
+        constexpr uint64_t guest_physical_page_base = 0x0000000100000000ull;
 
         // clflushopt is unordered, so consecutive evictions pipeline instead of serializing like clflush does
         // on every line; for the bulk flushes the GPU bridge issues before each submit that is a meaningful
@@ -1032,7 +1033,7 @@ namespace sogen::kvm
                     page->permissions = memory_permission::read;
                     const auto chunk = (std::min)(static_cast<size_t>(page_size), size - offset);
                     region.read_cb(offset, page->host_page, chunk);
-                    this->ensure_virtual_mapping(guest_address);
+                    this->ensure_virtual_mapping(guest_address, this->ensure_guest_physical_page(*page));
                 }
 
                 this->rebuild_mappings();
@@ -1073,7 +1074,7 @@ namespace sogen::kvm
                         page->owned_page = backing;
                         page->host_page = backing_base + offset;
                         page->permissions = permissions;
-                        this->ensure_virtual_mapping(guest_address);
+                        this->ensure_virtual_mapping(guest_address, this->ensure_guest_physical_page(*page));
                     }
 
                     this->rebuild_mappings();
@@ -1097,7 +1098,7 @@ namespace sogen::kvm
                     }
 
                     page->permissions = permissions;
-                    this->ensure_virtual_mapping(guest_address);
+                    this->ensure_virtual_mapping(guest_address, this->ensure_guest_physical_page(*page));
                 }
 
                 this->rebuild_mappings();
@@ -1129,7 +1130,7 @@ namespace sogen::kvm
                     page->owned_page = nullptr;
                     page->host_page = host_base + offset;
                     page->permissions = permissions;
-                    this->ensure_virtual_mapping(guest_address);
+                    this->ensure_virtual_mapping(guest_address, this->ensure_guest_physical_page(*page));
                 }
 
                 this->rebuild_mappings();
@@ -1213,6 +1214,8 @@ namespace sogen::kvm
                 {
                     this->max_memslots_ = 32;
                 }
+
+                this->readonly_mem_supported_ = ::ioctl(this->kvm_fd_.get(), KVM_CHECK_EXTENSION, KVM_CAP_READONLY_MEM) > 0;
 
                 // The thread-switch register snapshot relies on KVM_GET_XSAVE/KVM_SET_XSAVE.
                 if (::ioctl(this->kvm_fd_.get(), KVM_CHECK_EXTENSION, KVM_CAP_XSAVE) <= 0)
@@ -1360,53 +1363,98 @@ namespace sogen::kvm
                 page->owned_page = std::move(backing);
                 page->host_page = raw_page;
                 page->permissions = executable ? memory_permission::all : memory_permission::read_write;
+                page->physical_page = page_gpa;
 
                 this->mapped_pages_[page_gpa] = std::move(page);
                 this->page_table_views_[page_gpa] = reinterpret_cast<uint64_t*>(raw_page);
 
                 if (map_into_guest)
                 {
-                    this->ensure_virtual_mapping(page_gpa);
+                    this->ensure_virtual_mapping(page_gpa, page_gpa);
                 }
 
                 this->rebuild_mappings();
                 return page_gpa;
             }
-            void ensure_virtual_mapping(uint64_t guest_address)
+            uint64_t allocate_guest_physical_page()
+            {
+                const auto page_gpa = this->next_guest_physical_page_;
+                if (page_gpa >= internal_page_table_base || internal_page_table_base - page_gpa < page_size)
+                {
+                    throw std::runtime_error("Exhausted KVM guest physical page range");
+                }
+
+                this->next_guest_physical_page_ += page_size;
+                return page_gpa;
+            }
+            uint64_t ensure_guest_physical_page(mapped_page& page)
+            {
+                if (!page.physical_page)
+                {
+                    page.physical_page = this->allocate_guest_physical_page();
+                }
+
+                return *page.physical_page;
+            }
+            void ensure_virtual_mapping(uint64_t guest_address, uint64_t physical_page)
             {
                 detail::ensure_virtual_mapping(
                     this->page_table_views_, this->pml4_gpa_,
                     [this](const bool executable, const bool map_into_guest) {
                         return this->allocate_internal_page(executable, map_into_guest);
                     },
-                    guest_address);
+                    guest_address, physical_page);
             }
             void rebuild_mappings()
             {
-                // Project mapped_pages_ onto the desired memslot layout (contiguous, same-permission,
-                // host-contiguous runs of pages become one memslot), then reconcile it against the slots
-                // that are already installed, only deleting/creating the ones that actually change. Every
-                // KVM_SET_USER_MEMORY_REGION forces an NPT/TLB rebuild, so leaving unchanged slots in
-                // place is what keeps a memory operation from costing O(total mappings) each time.
-                std::map<uint64_t, installed_memslot> desired{};
-                for (auto it = this->mapped_pages_.begin(); it != this->mapped_pages_.end();)
+                // Project mapped_pages_ onto the desired memslot layout (physically contiguous,
+                // host-contiguous runs of pages with the same flags become one memslot), then reconcile it
+                // against the slots that are already installed, only deleting/creating the ones that
+                // actually change. Every KVM_SET_USER_MEMORY_REGION forces an NPT/TLB rebuild, so leaving
+                // unchanged slots in place is what keeps a memory operation from costing O(total mappings)
+                // each time.
+                struct desired_page
                 {
-                    if (!it->second || it->second->host_page == nullptr || it->second->permissions == memory_permission::none)
+                    uint8_t* host = nullptr;
+                    uint32_t flags = 0;
+                };
+
+                std::map<uint64_t, desired_page> pages{};
+                for (const auto& entry : this->mapped_pages_)
+                {
+                    const auto& page = entry.second;
+                    if (!page || page->host_page == nullptr || page->permissions == memory_permission::none)
                     {
-                        ++it;
                         continue;
                     }
+                    if (!page->physical_page)
+                    {
+                        throw std::logic_error("KVM mapped page is missing a guest physical address");
+                    }
 
-                    const auto run_address = it->first;
-                    auto* const run_host_base = static_cast<uint8_t*>(it->second->host_page);
-                    const auto run_flags = to_kvm_map_flags(it->second->permissions);
+                    const auto inserted =
+                        pages
+                            .emplace(*page->physical_page, desired_page{.host = static_cast<uint8_t*>(page->host_page),
+                                                                        .flags = this->to_kvm_map_flags(page->permissions)})
+                            .second;
+                    if (!inserted)
+                    {
+                        throw std::logic_error("Duplicate KVM guest physical page");
+                    }
+                }
+
+                std::map<uint64_t, installed_memslot> desired{};
+                for (auto it = pages.begin(); it != pages.end();)
+                {
+                    const auto run_gpa = it->first;
+                    auto* const run_host_base = it->second.host;
+                    const auto run_flags = it->second.flags;
 
                     size_t run_size = page_size;
                     auto jt = std::next(it);
-                    while (jt != this->mapped_pages_.end())
+                    while (jt != pages.end())
                     {
-                        if (!jt->second || jt->second->host_page == nullptr || jt->second->permissions != it->second->permissions ||
-                            jt->first != run_address + run_size || jt->second->host_page != run_host_base + run_size)
+                        if (jt->first != run_gpa + run_size || jt->second.host != run_host_base + run_size || jt->second.flags != run_flags)
                         {
                             break;
                         }
@@ -1415,7 +1463,7 @@ namespace sogen::kvm
                         ++jt;
                     }
 
-                    desired[run_address] = installed_memslot{.size = run_size, .host = run_host_base, .flags = run_flags};
+                    desired[run_gpa] = installed_memslot{.size = run_size, .host = run_host_base, .flags = run_flags};
                     it = jt;
                 }
 
@@ -1435,12 +1483,11 @@ namespace sogen::kvm
                     }
                 }
 
-                for (const auto& [run_address, run] : desired)
+                for (const auto& [run_gpa, run] : desired)
                 {
                     const auto slot = this->allocate_slot_id();
-                    this->set_memslot(slot, run_address, run.size, run.host, run.flags);
-                    this->current_slots_[run_address] =
-                        installed_memslot{.id = slot, .size = run.size, .host = run.host, .flags = run.flags};
+                    this->set_memslot(slot, run_gpa, run.size, run.host, run.flags);
+                    this->current_slots_[run_gpa] = installed_memslot{.id = slot, .size = run.size, .host = run.host, .flags = run.flags};
                 }
             }
             int allocate_slot_id()
@@ -1467,7 +1514,14 @@ namespace sogen::kvm
                 region.guest_phys_addr = guest_address;
                 region.memory_size = size;
                 region.userspace_addr = reinterpret_cast<uint64_t>(host_base);
-                check_ioctl_result(::ioctl(this->vm_fd_.get(), KVM_SET_USER_MEMORY_REGION, &region), "KVM_SET_USER_MEMORY_REGION");
+                if (::ioctl(this->vm_fd_.get(), KVM_SET_USER_MEMORY_REGION, &region) < 0)
+                {
+                    std::ostringstream stream;
+                    stream << "KVM_SET_USER_MEMORY_REGION failed for slot " << slot << " gpa 0x" << std::hex << guest_address << " size 0x"
+                           << size << " host 0x" << reinterpret_cast<uintptr_t>(host_base) << " flags 0x" << flags << ": "
+                           << std::strerror(errno);
+                    throw std::runtime_error(stream.str());
+                }
             }
             void delete_memslot(int slot)
             {
@@ -1477,7 +1531,7 @@ namespace sogen::kvm
                 check_ioctl_result(::ioctl(this->vm_fd_.get(), KVM_SET_USER_MEMORY_REGION, &region), "KVM_SET_USER_MEMORY_REGION");
                 this->free_slot_ids_.push_back(slot);
             }
-            static uint32_t to_kvm_map_flags(memory_permission permissions)
+            uint32_t to_kvm_map_flags(memory_permission permissions) const
             {
                 if (permissions == memory_permission::none)
                 {
@@ -1485,7 +1539,7 @@ namespace sogen::kvm
                 }
 
                 uint32_t flags = 0;
-                if ((permissions & memory_permission::write) == memory_permission::none)
+                if (this->readonly_mem_supported_ && (permissions & memory_permission::write) == memory_permission::none)
                 {
                     flags |= KVM_MEM_READONLY;
                 }
@@ -1597,12 +1651,35 @@ namespace sogen::kvm
 
                 return consumed;
             }
+            std::optional<std::pair<mmio_region*, uint64_t>> find_mmio_region_for_physical_address(uint64_t physical_address)
+            {
+                for (auto& [base, region] : this->mmio_regions_)
+                {
+                    for (size_t offset = 0; offset < region.size; offset += page_size)
+                    {
+                        const auto it = this->mapped_pages_.find(base + offset);
+                        if (it == this->mapped_pages_.end() || !it->second || !it->second->physical_page)
+                        {
+                            continue;
+                        }
+
+                        const auto page_gpa = *it->second->physical_page;
+                        if (physical_address >= page_gpa && physical_address < page_gpa + page_size)
+                        {
+                            return std::make_pair(&region, offset + (physical_address - page_gpa));
+                        }
+                    }
+                }
+
+                return std::nullopt;
+            }
             bool handle_mmio_exit()
             {
                 const auto& mmio = this->run_->mmio;
-                if (auto* region = detail::find_mmio_region(this->mmio_regions_, mmio.phys_addr))
+                if (const auto mapping = this->find_mmio_region_for_physical_address(mmio.phys_addr))
                 {
-                    const auto offset = mmio.phys_addr - region->address;
+                    auto* const region = mapping->first;
+                    const auto offset = mapping->second;
                     if (mmio.is_write)
                     {
                         region->write_cb(offset, mmio.data, mmio.len);
@@ -2058,12 +2135,14 @@ namespace sogen::kvm
             };
 
             int max_memslots_ = 0;
+            bool readonly_mem_supported_ = false;
             int next_slot_id_ = 0;
             std::map<uint64_t, installed_memslot> current_slots_{};
             std::vector<int> free_slot_ids_{};
             std::map<uint64_t, std::unique_ptr<mapped_page>> mapped_pages_{};
             std::unordered_map<uint64_t, uint64_t*> page_table_views_{};
             uint64_t pml4_gpa_ = 0;
+            uint64_t next_guest_physical_page_ = guest_physical_page_base;
             uint64_t next_internal_gpa_ = internal_page_table_base;
             std::atomic_bool stop_requested_ = false;
             std::atomic_bool run_active_ = false;

--- a/src/emulator/function_calling_convention.hpp
+++ b/src/emulator/function_calling_convention.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace sogen
+{
+    enum class function_calling_convention
+    {
+        x86_cdecl,
+        x86_stdcall,
+        x64_fastcall,
+        x64_syscall,
+    };
+}

--- a/src/linux-emulator/linux_fd_table.hpp
+++ b/src/linux-emulator/linux_fd_table.hpp
@@ -24,6 +24,7 @@ namespace sogen
         socket,
         eventfd,
         directory,
+        epoll,
     };
 
     struct linux_memory_fd

--- a/src/linux-emulator/linux_fd_table.hpp
+++ b/src/linux-emulator/linux_fd_table.hpp
@@ -3,6 +3,7 @@
 #include "std_include.hpp"
 
 #include <cstdio>
+#include <memory>
 #include <utility>
 
 #if defined(_WIN32)
@@ -17,6 +18,7 @@ namespace sogen
     enum class fd_type
     {
         file,
+        memory_file,
         pipe_read,
         pipe_write,
         socket,
@@ -24,11 +26,18 @@ namespace sogen
         directory,
     };
 
+    struct linux_memory_fd
+    {
+        std::string content{};
+        size_t offset{};
+    };
+
     struct linux_fd
     {
         fd_type type{fd_type::file};
         std::string host_path{};
         FILE* handle{};
+        std::shared_ptr<linux_memory_fd> memory_file{};
         int flags{};
         bool close_on_exec{};
 
@@ -42,6 +51,7 @@ namespace sogen
             : type(other.type),
               host_path(std::move(other.host_path)),
               handle(std::exchange(other.handle, nullptr)),
+              memory_file(std::move(other.memory_file)),
               flags(other.flags),
               close_on_exec(other.close_on_exec)
         {
@@ -54,6 +64,7 @@ namespace sogen
                 type = other.type;
                 host_path = std::move(other.host_path);
                 handle = std::exchange(other.handle, nullptr);
+                memory_file = std::move(other.memory_file);
                 flags = other.flags;
                 close_on_exec = other.close_on_exec;
             }
@@ -271,6 +282,7 @@ namespace sogen
             new_entry.close_on_exec = false; // dup clears close-on-exec
 
             new_entry.handle = duplicate_handle(existing.handle, get_stream_mode(existing));
+            new_entry.memory_file = existing.memory_file;
             if (existing.handle && !new_entry.handle)
             {
                 return std::nullopt;

--- a/src/linux-emulator/linux_process_context.cpp
+++ b/src/linux-emulator/linux_process_context.cpp
@@ -137,36 +137,30 @@ namespace sogen
         // Total entries: argc(1) + argv_ptrs(argc) + null(1) + envp_ptrs(envp.size()) + null(1) + auxv entries
         // Each auxv entry is 2 uint64_t values
 
-        struct auxv_entry
-        {
-            uint64_t type;
-            uint64_t value;
-        };
-
-        std::vector<auxv_entry> auxv{};
-        auxv.push_back({.type = AT_PHDR, .value = exe.phdr_vaddr});
-        auxv.push_back({.type = AT_PHENT, .value = exe.phdr_entry_size});
-        auxv.push_back({.type = AT_PHNUM, .value = exe.phdr_count});
-        auxv.push_back({.type = AT_PAGESZ, .value = 4096});
-        auxv.push_back({.type = AT_BASE, .value = interpreter_base}); // Interpreter load address (0 if static)
-        auxv.push_back({.type = AT_ENTRY, .value = exe.entry_point});
-        auxv.push_back({.type = AT_UID, .value = this->uid});
-        auxv.push_back({.type = AT_EUID, .value = this->euid});
-        auxv.push_back({.type = AT_GID, .value = this->gid});
-        auxv.push_back({.type = AT_EGID, .value = this->egid});
-        auxv.push_back({.type = AT_SECURE, .value = 0});
-        auxv.push_back({.type = AT_RANDOM, .value = random_addr});
-        auxv.push_back({.type = AT_PLATFORM, .value = platform_addr});
-        auxv.push_back({.type = AT_CLKTCK, .value = 100});
+        this->auxv.clear();
+        this->auxv.push_back({.type = AT_PHDR, .value = exe.phdr_vaddr});
+        this->auxv.push_back({.type = AT_PHENT, .value = exe.phdr_entry_size});
+        this->auxv.push_back({.type = AT_PHNUM, .value = exe.phdr_count});
+        this->auxv.push_back({.type = AT_PAGESZ, .value = 4096});
+        this->auxv.push_back({.type = AT_BASE, .value = interpreter_base}); // Interpreter load address (0 if static)
+        this->auxv.push_back({.type = AT_ENTRY, .value = exe.entry_point});
+        this->auxv.push_back({.type = AT_UID, .value = this->uid});
+        this->auxv.push_back({.type = AT_EUID, .value = this->euid});
+        this->auxv.push_back({.type = AT_GID, .value = this->gid});
+        this->auxv.push_back({.type = AT_EGID, .value = this->egid});
+        this->auxv.push_back({.type = AT_SECURE, .value = 0});
+        this->auxv.push_back({.type = AT_RANDOM, .value = random_addr});
+        this->auxv.push_back({.type = AT_PLATFORM, .value = platform_addr});
+        this->auxv.push_back({.type = AT_CLKTCK, .value = 100});
         if (vdso_base != 0)
         {
-            auxv.push_back({.type = AT_SYSINFO_EHDR, .value = vdso_base});
+            this->auxv.push_back({.type = AT_SYSINFO_EHDR, .value = vdso_base});
         }
-        auxv.push_back({.type = AT_NULL, .value = 0});
+        this->auxv.push_back({.type = AT_NULL, .value = 0});
 
         // Total stack frame size (in uint64_t units):
         // 1 (argc) + argc (argv ptrs) + 1 (null) + envp.size() (envp ptrs) + 1 (null) + auxv.size()*2
-        const auto total_u64s = 1 + argc + 1 + envp_values.size() + 1 + auxv.size() * 2;
+        const auto total_u64s = 1 + argc + 1 + envp_values.size() + 1 + this->auxv.size() * 2;
         const auto frame_size = total_u64s * sizeof(uint64_t);
 
         // Position sp so the frame fits
@@ -211,7 +205,7 @@ namespace sogen
         }
 
         // auxiliary vector
-        for (const auto& entry : auxv)
+        for (const auto& entry : this->auxv)
         {
             memory.write_memory(write_ptr, &entry.type, sizeof(entry.type));
             write_ptr += sizeof(uint64_t);

--- a/src/linux-emulator/linux_process_context.cpp
+++ b/src/linux-emulator/linux_process_context.cpp
@@ -103,14 +103,14 @@ namespace sogen
             envp_addrs.push_back(write_string_to_memory(memory, string_cursor, env));
         }
 
-        // Write 16 random bytes for AT_RANDOM
         const auto random_addr = string_cursor;
         {
             std::array<uint8_t, 16> random_bytes{};
-            // Fill with deterministic pseudo-random data
-            for (size_t i = 0; i < random_bytes.size(); ++i)
+            uint32_t byte_index = 0;
+            for (auto& byte : random_bytes)
             {
-                random_bytes[i] = static_cast<uint8_t>((i * 73 + 0xAB) & 0xFF);
+                byte = static_cast<uint8_t>((byte_index * 73U + 0xABU) & 0xFFU);
+                ++byte_index;
             }
             memory.write_memory(string_cursor, random_bytes.data(), random_bytes.size());
             string_cursor += random_bytes.size();

--- a/src/linux-emulator/linux_process_context.hpp
+++ b/src/linux-emulator/linux_process_context.hpp
@@ -11,6 +11,12 @@
 namespace sogen
 {
 
+    struct linux_auxv_entry
+    {
+        uint64_t type{};
+        uint64_t value{};
+    };
+
     struct linux_process_context
     {
         linux_fd_table fds{};
@@ -36,6 +42,7 @@ namespace sogen
         // Stored for procfs emulation
         std::vector<std::string> argv{};
         std::vector<std::string> envp{};
+        std::vector<linux_auxv_entry> auxv{};
 
         uint32_t create_thread(uint64_t stack_base, uint64_t stack_size, uint64_t entry_point, uint64_t fs_base = 0)
         {

--- a/src/linux-emulator/linux_process_context.hpp
+++ b/src/linux-emulator/linux_process_context.hpp
@@ -17,9 +17,31 @@ namespace sogen
         uint64_t value{};
     };
 
+    struct linux_cached_dir_entry
+    {
+        uint64_t ino{};
+        uint8_t d_type{};
+        std::string name{};
+    };
+
+    struct linux_epoll_entry
+    {
+        int fd{};
+        uint32_t events{};
+        uint64_t data{};
+    };
+
+    struct linux_epoll_instance
+    {
+        std::vector<linux_epoll_entry> entries{};
+    };
+
     struct linux_process_context
     {
         linux_fd_table fds{};
+        std::map<int, std::vector<linux_cached_dir_entry>> directory_entries{};
+        std::map<int, size_t> directory_offsets{};
+        std::map<int, std::shared_ptr<linux_epoll_instance>> epoll_instances{};
 
         uint64_t brk_base{};
         uint64_t brk_current{};

--- a/src/linux-emulator/procfs.cpp
+++ b/src/linux-emulator/procfs.cpp
@@ -131,30 +131,6 @@ namespace sogen
         return std::nullopt;
     }
 
-    FILE* procfs::open_procfs_file(const linux_emulator& emu, const std::string_view path)
-    {
-        auto content = procfs::generate_content(emu, path);
-        if (!content)
-        {
-            return nullptr;
-        }
-
-        FILE* fp = tmpfile();
-        if (!fp)
-        {
-            return nullptr;
-        }
-
-        if (!content->empty())
-        {
-            fwrite(content->data(), 1, content->size(), fp);
-        }
-
-        // Seek back to beginning so reads start from the top
-        fseek(fp, 0, SEEK_SET);
-        return fp;
-    }
-
     bool procfs::stat_procfs(const linux_emulator& emu, const std::string_view path, linux_stat& st)
     {
         memset(&st, 0, sizeof(st));
@@ -370,12 +346,24 @@ namespace sogen
 
     std::string procfs::generate_auxv(const linux_emulator& emu)
     {
-        // /proc/self/auxv: raw binary auxiliary vector
-        // For now, return an empty auxv (just AT_NULL terminator)
-        // A real implementation would read the auxv from the initial stack.
-        (void)emu;
-        uint64_t null_entry[2] = {0, 0};
-        return {reinterpret_cast<const char*>(null_entry), sizeof(null_entry)};
+        std::string result;
+        result.reserve(emu.process.auxv.size() * sizeof(uint64_t) * 2);
+
+        const auto append_u64 = [&result](const uint64_t value) { result.append(reinterpret_cast<const char*>(&value), sizeof(value)); };
+
+        for (const auto& entry : emu.process.auxv)
+        {
+            append_u64(entry.type);
+            append_u64(entry.value);
+        }
+
+        if (emu.process.auxv.empty() || emu.process.auxv.back().type != elf::AT_NULL)
+        {
+            append_u64(elf::AT_NULL);
+            append_u64(0);
+        }
+
+        return result;
     }
 
     std::string procfs::generate_proc_stat(const linux_emulator& emu)

--- a/src/linux-emulator/procfs.hpp
+++ b/src/linux-emulator/procfs.hpp
@@ -3,7 +3,6 @@
 #include "std_include.hpp"
 #include "linux_stat.hpp"
 
-#include <cstdio>
 #include <optional>
 
 // Forward declarations
@@ -13,9 +12,8 @@ namespace sogen
     class linux_emulator;
 
     // Synthesizes /proc filesystem content from emulator state.
-    // All generated content is returned as strings or byte vectors.
-    // The caller (syscall handlers) is responsible for creating fds
-    // backed by tmpfile() with the generated content.
+    // All generated content is returned as strings or byte vectors for
+    // memory-backed descriptors owned by the syscall layer.
     class procfs
     {
       public:
@@ -36,11 +34,6 @@ namespace sogen
         // Resolve a procfs symlink target (e.g., /proc/self/exe -> /path/to/binary).
         // Returns the target string, or std::nullopt if not a symlink.
         static std::optional<std::string> resolve_symlink(const linux_emulator& emu, std::string_view path);
-
-        // Create a FILE* handle backed by tmpfile() containing the generated content.
-        // The caller takes ownership of the returned handle.
-        // Returns nullptr if the path is not recognized.
-        static FILE* open_procfs_file(const linux_emulator& emu, std::string_view path);
 
         // Fill a synthetic stat buffer for a procfs path.
         // Returns true if the path was recognized, false otherwise.

--- a/src/linux-emulator/syscalls/file.cpp
+++ b/src/linux-emulator/syscalls/file.cpp
@@ -103,6 +103,72 @@ namespace sogen
 #endif
         }
 
+        linux_fd make_memory_file_fd(std::string path, std::string content, const int flags)
+        {
+            linux_fd fd{};
+            fd.type = fd_type::memory_file;
+            fd.host_path = std::move(path);
+            fd.memory_file = std::make_shared<linux_memory_fd>();
+            fd.memory_file->content = std::move(content);
+            fd.flags = flags;
+            fd.close_on_exec = (flags & LINUX_O_CLOEXEC) != 0;
+            return fd;
+        }
+
+        size_t read_memory_file_at(const linux_fd& fd, uint8_t* buffer, const size_t count, const size_t offset)
+        {
+            const auto& content = fd.memory_file->content;
+            if (count == 0)
+            {
+                return 0;
+            }
+
+            if (offset >= content.size())
+            {
+                return 0;
+            }
+
+            const auto bytes_read = std::min(count, content.size() - offset);
+            memcpy(buffer, content.data() + offset, bytes_read);
+            return bytes_read;
+        }
+
+        size_t read_memory_file(linux_fd& fd, uint8_t* buffer, const size_t count)
+        {
+            const auto bytes_read = read_memory_file_at(fd, buffer, count, fd.memory_file->offset);
+            fd.memory_file->offset += bytes_read;
+            return bytes_read;
+        }
+
+        std::optional<size_t> seek_memory_file(linux_fd& fd, const int64_t offset, const int whence)
+        {
+            const auto content_size = static_cast<int64_t>(fd.memory_file->content.size());
+            auto base = int64_t{0};
+            if (whence == 1)
+            {
+                base = static_cast<int64_t>(fd.memory_file->offset);
+            }
+            else if (whence == 2)
+            {
+                base = content_size;
+            }
+
+            if ((offset > 0 && base > std::numeric_limits<int64_t>::max() - offset) ||
+                (offset < 0 && base < std::numeric_limits<int64_t>::min() - offset))
+            {
+                return std::nullopt;
+            }
+
+            const auto target = base + offset;
+            if (target < 0)
+            {
+                return std::nullopt;
+            }
+
+            fd.memory_file->offset = static_cast<size_t>(target);
+            return fd.memory_file->offset;
+        }
+
         uint8_t file_type_to_d_type(const std::filesystem::file_type type)
         {
             // Linux DT_* values
@@ -515,6 +581,29 @@ namespace sogen
 
             return true;
         }
+
+        bool fill_memory_file_stat(const linux_syscall_context& c, const linux_fd& fd, linux_stat& ls)
+        {
+            if (!fd.memory_file)
+            {
+                return false;
+            }
+
+            const auto content_size = fd.memory_file->content.size();
+            if (!procfs::stat_procfs(c.emu_ref, fd.host_path, ls))
+            {
+                ls.st_mode = 0100444;
+                ls.st_nlink = 1;
+                ls.st_uid = c.proc.uid;
+                ls.st_gid = c.proc.gid;
+                ls.st_ino = static_cast<uint64_t>(std::hash<std::string>{}(fd.host_path));
+            }
+
+            ls.st_size = static_cast<int64_t>(content_size);
+            ls.st_blksize = 1024;
+            ls.st_blocks = static_cast<int64_t>((content_size + 511) / 512);
+            return true;
+        }
     }
 
     void sys_read(const linux_syscall_context& c)
@@ -530,10 +619,29 @@ namespace sogen
             return;
         }
 
-        if (fd == 0)
+        if (fd_entry->host_path == "/dev/stdin")
         {
             // stdin: return 0 (EOF) for now
             write_linux_syscall_result(c, 0);
+            return;
+        }
+
+        if (fd_entry->type == fd_type::memory_file)
+        {
+            if (!fd_entry->memory_file)
+            {
+                write_linux_syscall_result(c, -LINUX_EBADF);
+                return;
+            }
+
+            std::vector<uint8_t> buffer(count);
+            const auto bytes_read = read_memory_file(*fd_entry, buffer.data(), count);
+            if (bytes_read > 0)
+            {
+                c.emu.write_memory(buf_addr, buffer.data(), bytes_read);
+            }
+
+            write_linux_syscall_result(c, static_cast<int64_t>(bytes_read));
             return;
         }
 
@@ -670,18 +778,14 @@ namespace sogen
         // Intercept procfs paths
         if (procfs::is_procfs_path(guest_path))
         {
-            auto* handle = procfs::open_procfs_file(c.emu_ref, guest_path);
-            if (!handle)
+            auto content = procfs::generate_content(c.emu_ref, guest_path);
+            if (!content)
             {
                 write_linux_syscall_result(c, -LINUX_ENOENT);
                 return;
             }
 
-            linux_fd new_fd{};
-            new_fd.type = fd_type::file;
-            new_fd.host_path = guest_path;
-            new_fd.handle = handle;
-            new_fd.flags = flags;
+            auto new_fd = make_memory_file_fd(guest_path, std::move(*content), flags);
 
             const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
             write_linux_syscall_result(c, fd_num);
@@ -764,7 +868,15 @@ namespace sogen
 
         linux_stat ls{};
 
-        if (!fd_entry->host_path.empty())
+        if (fd_entry->type == fd_type::memory_file)
+        {
+            if (!fill_memory_file_stat(c, *fd_entry, ls))
+            {
+                write_linux_syscall_result(c, -LINUX_EBADF);
+                return;
+            }
+        }
+        else if (!fd_entry->host_path.empty())
         {
             fill_linux_stat(ls, fd_entry->host_path);
         }
@@ -784,9 +896,28 @@ namespace sogen
         const auto fd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
         const auto offset = static_cast<int64_t>(get_linux_syscall_argument(c.emu, 1));
         const auto whence = static_cast<int>(get_linux_syscall_argument(c.emu, 2));
-
         auto* fd_entry = c.proc.fds.get(fd);
-        if (!fd_entry || !fd_entry->handle)
+
+        if (!fd_entry)
+        {
+            write_linux_syscall_result(c, -LINUX_EBADF);
+            return;
+        }
+
+        if (fd_entry->type == fd_type::memory_file)
+        {
+            if (!fd_entry->memory_file)
+            {
+                write_linux_syscall_result(c, -LINUX_EBADF);
+                return;
+            }
+
+            const auto pos = seek_memory_file(*fd_entry, offset, whence);
+            write_linux_syscall_result(c, pos.has_value() ? static_cast<int64_t>(*pos) : -LINUX_EINVAL);
+            return;
+        }
+
+        if (!fd_entry->handle)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
@@ -850,18 +981,14 @@ namespace sogen
         // Intercept procfs paths
         if (procfs::is_procfs_path(guest_path))
         {
-            auto* handle = procfs::open_procfs_file(c.emu_ref, guest_path);
-            if (!handle)
+            auto content = procfs::generate_content(c.emu_ref, guest_path);
+            if (!content)
             {
                 write_linux_syscall_result(c, -LINUX_ENOENT);
                 return;
             }
 
-            linux_fd new_fd{};
-            new_fd.type = fd_type::file;
-            new_fd.host_path = guest_path;
-            new_fd.handle = handle;
-            new_fd.flags = flags;
+            auto new_fd = make_memory_file_fd(guest_path, std::move(*content), flags);
 
             const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
             write_linux_syscall_result(c, fd_num);
@@ -1003,7 +1130,37 @@ namespace sogen
         const auto offset = static_cast<int64_t>(get_linux_syscall_argument(c.emu, 3));
 
         auto* fd_entry = c.proc.fds.get(fd);
-        if (!fd_entry || !fd_entry->handle)
+        if (!fd_entry)
+        {
+            write_linux_syscall_result(c, -LINUX_EBADF);
+            return;
+        }
+
+        if (fd_entry->type == fd_type::memory_file)
+        {
+            if (!fd_entry->memory_file)
+            {
+                write_linux_syscall_result(c, -LINUX_EBADF);
+                return;
+            }
+            if (offset < 0)
+            {
+                write_linux_syscall_result(c, -LINUX_EINVAL);
+                return;
+            }
+
+            std::vector<uint8_t> buffer(count);
+            const auto bytes_read = read_memory_file_at(*fd_entry, buffer.data(), count, static_cast<size_t>(offset));
+            if (bytes_read > 0)
+            {
+                c.emu.write_memory(buf_addr, buffer.data(), bytes_read);
+            }
+
+            write_linux_syscall_result(c, static_cast<int64_t>(bytes_read));
+            return;
+        }
+
+        if (!fd_entry->handle)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
@@ -1427,7 +1584,15 @@ namespace sogen
             }
 
             linux_stat ls{};
-            if (!fd_entry->host_path.empty())
+            if (fd_entry->type == fd_type::memory_file)
+            {
+                if (!fill_memory_file_stat(c, *fd_entry, ls))
+                {
+                    write_linux_syscall_result(c, -LINUX_EBADF);
+                    return;
+                }
+            }
+            else if (!fd_entry->host_path.empty())
             {
                 fill_linux_stat(ls, fd_entry->host_path);
             }
@@ -1904,10 +2069,33 @@ namespace sogen
                 continue;
             }
 
-            if (fd == 0)
+            if (fd_entry->host_path == "/dev/stdin")
             {
                 // stdin: EOF
                 break;
+            }
+
+            if (fd_entry->type == fd_type::memory_file)
+            {
+                if (!fd_entry->memory_file)
+                {
+                    write_linux_syscall_result(c, -LINUX_EBADF);
+                    return;
+                }
+
+                std::vector<uint8_t> buffer(static_cast<size_t>(iov_len));
+                const auto bytes_read = read_memory_file(*fd_entry, buffer.data(), static_cast<size_t>(iov_len));
+                if (bytes_read > 0)
+                {
+                    c.emu.write_memory(iov_base, buffer.data(), bytes_read);
+                    total_read += static_cast<int64_t>(bytes_read);
+                }
+
+                if (bytes_read < iov_len)
+                {
+                    break;
+                }
+                continue;
             }
 
             if (!fd_entry->handle)

--- a/src/linux-emulator/syscalls/file.cpp
+++ b/src/linux-emulator/syscalls/file.cpp
@@ -38,16 +38,6 @@ namespace sogen
         constexpr int LINUX_O_DIRECTORY = 0200000;
         constexpr int LINUX_O_CLOEXEC = 02000000;
 
-        struct cached_dir_entry
-        {
-            uint64_t ino{};
-            uint8_t d_type{};
-            std::string name{};
-        };
-
-        std::map<int, std::vector<cached_dir_entry>> g_directory_entries{};
-        std::map<int, size_t> g_directory_offsets{};
-
         int64_t host_read_fd(const int fd, void* buffer, const size_t count)
         {
 #if defined(_WIN32)
@@ -129,7 +119,7 @@ namespace sogen
             }
 
             const auto bytes_read = std::min(count, content.size() - offset);
-            memcpy(buffer, content.data() + offset, bytes_read);
+            std::ranges::copy_n(content.begin() + static_cast<std::ptrdiff_t>(offset), static_cast<std::ptrdiff_t>(bytes_read), buffer);
             return bytes_read;
         }
 
@@ -248,9 +238,9 @@ namespace sogen
             return 0;
         }
 
-        std::vector<cached_dir_entry> build_cached_dir_entries(const std::filesystem::path& dir_path)
+        std::vector<linux_cached_dir_entry> build_cached_dir_entries(const std::filesystem::path& dir_path)
         {
-            std::vector<cached_dir_entry> entries{};
+            std::vector<linux_cached_dir_entry> entries{};
 
             // Include "." and ".." first to match Linux behavior.
             entries.push_back(
@@ -275,7 +265,7 @@ namespace sogen
                     ec.clear();
                 }
 
-                cached_dir_entry entry{};
+                linux_cached_dir_entry entry{};
                 entry.ino = get_inode_for_path(p);
                 entry.d_type = file_type_to_d_type(type);
                 entry.name = p.filename().string();
@@ -285,16 +275,85 @@ namespace sogen
             return entries;
         }
 
-        void init_directory_fd_state(const int fd, const std::filesystem::path& dir_path)
+        void init_directory_fd_state(linux_process_context& proc, const int fd, const std::filesystem::path& dir_path)
         {
-            g_directory_entries[fd] = build_cached_dir_entries(dir_path);
-            g_directory_offsets[fd] = 0;
+            proc.directory_entries[fd] = build_cached_dir_entries(dir_path);
+            proc.directory_offsets[fd] = 0;
         }
 
-        void cleanup_directory_fd_state(const int fd)
+        void cleanup_closed_fd(linux_process_context& proc, const int fd)
         {
-            g_directory_entries.erase(fd);
-            g_directory_offsets.erase(fd);
+            proc.directory_entries.erase(fd);
+            proc.directory_offsets.erase(fd);
+            proc.epoll_instances.erase(fd);
+
+            std::vector<linux_epoll_instance*> cleaned_instances{};
+            for (auto& [epfd, instance] : proc.epoll_instances)
+            {
+                (void)epfd;
+                if (!instance || std::ranges::find(cleaned_instances, instance.get()) != cleaned_instances.end())
+                {
+                    continue;
+                }
+
+                cleaned_instances.push_back(instance.get());
+                auto& entries = instance->entries;
+                entries.erase(std::ranges::remove_if(entries, [fd](const linux_epoll_entry& entry) { return entry.fd == fd; }).begin(),
+                              entries.end());
+            }
+        }
+
+        std::shared_ptr<linux_epoll_instance> get_epoll_instance(linux_process_context& proc, const int fd)
+        {
+            const auto it = proc.epoll_instances.find(fd);
+            return it != proc.epoll_instances.end() ? it->second : std::shared_ptr<linux_epoll_instance>{};
+        }
+
+        int dup_fd_preserve_epoll_state(linux_process_context& proc, const int oldfd, const int minimum_fd = 0)
+        {
+            const auto* old_entry = proc.fds.get(oldfd);
+            const bool duplicates_epoll = old_entry != nullptr && old_entry->type == fd_type::epoll;
+            const auto epoll_instance = duplicates_epoll ? get_epoll_instance(proc, oldfd) : std::shared_ptr<linux_epoll_instance>{};
+            if (duplicates_epoll && !epoll_instance)
+            {
+                return -1;
+            }
+            const auto result = proc.fds.dup_fd(oldfd, minimum_fd);
+            if (result >= 0 && duplicates_epoll)
+            {
+                proc.epoll_instances[result] = epoll_instance;
+            }
+
+            return result;
+        }
+
+        int dup2_fd_cleanup_overwrite(linux_process_context& proc, const int oldfd, const int newfd)
+        {
+            const auto* old_entry = proc.fds.get(oldfd);
+            const bool duplicates_epoll = oldfd != newfd && old_entry != nullptr && old_entry->type == fd_type::epoll;
+            const auto epoll_instance = duplicates_epoll ? get_epoll_instance(proc, oldfd) : std::shared_ptr<linux_epoll_instance>{};
+            if (duplicates_epoll && !epoll_instance)
+            {
+                return -1;
+            }
+            const bool replaces_existing_fd = oldfd != newfd && proc.fds.get(newfd) != nullptr;
+            const auto result = proc.fds.dup2_fd(oldfd, newfd);
+            if (result < 0)
+            {
+                return result;
+            }
+
+            if (replaces_existing_fd)
+            {
+                cleanup_closed_fd(proc, newfd);
+            }
+
+            if (duplicates_epoll)
+            {
+                proc.epoll_instances[newfd] = epoll_instance;
+            }
+
+            return result;
         }
 
         size_t align_up_8(const size_t value)
@@ -335,9 +394,11 @@ namespace sogen
         }
 
         std::optional<std::filesystem::path> resolve_guest_path_at(const linux_syscall_context& c, const int dirfd,
-                                                                   const std::string& guest_path)
+                                                                   const std::string& guest_path, int64_t& linux_error)
         {
-            if (!guest_path.empty() && guest_path[0] == '/')
+            linux_error = LINUX_EBADF;
+
+            if (guest_path.starts_with('/'))
             {
                 return c.emu_ref.file_sys.translate(guest_path);
             }
@@ -348,18 +409,23 @@ namespace sogen
             }
 
             auto* fd_entry = c.proc.fds.get(dirfd);
-            if (!fd_entry || fd_entry->host_path.empty())
+            if (!fd_entry)
             {
                 return std::nullopt;
             }
 
-            std::filesystem::path base = fd_entry->host_path;
             if (fd_entry->type != fd_type::directory)
             {
-                base = base.parent_path();
+                linux_error = LINUX_ENOTDIR;
+                return std::nullopt;
             }
 
-            return c.emu_ref.file_sys.translate_relative_to(base, guest_path);
+            if (fd_entry->host_path.empty())
+            {
+                return std::nullopt;
+            }
+
+            return c.emu_ref.file_sys.translate_relative_to(fd_entry->host_path, guest_path);
         }
 
 #pragma pack(push, 1)
@@ -815,7 +881,7 @@ namespace sogen
             new_fd.close_on_exec = (flags & LINUX_O_CLOEXEC) != 0;
 
             const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
-            init_directory_fd_state(fd_num, host_path);
+            init_directory_fd_state(c.proc, fd_num, host_path);
             write_linux_syscall_result(c, fd_num);
             return;
         }
@@ -842,14 +908,13 @@ namespace sogen
     {
         const auto fd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
 
-        // Tear down any per-fd directory iteration state.
-        cleanup_directory_fd_state(fd);
-
         if (!c.proc.fds.close(fd))
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
         }
+
+        cleanup_closed_fd(c.proc, fd);
 
         write_linux_syscall_result(c, 0);
     }
@@ -995,10 +1060,11 @@ namespace sogen
             return;
         }
 
-        auto resolved = resolve_guest_path_at(c, dirfd, guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
         if (!resolved.has_value())
         {
-            write_linux_syscall_result(c, -LINUX_EBADF);
+            write_linux_syscall_result(c, -resolve_error);
             return;
         }
 
@@ -1025,7 +1091,7 @@ namespace sogen
             new_fd.close_on_exec = (flags & LINUX_O_CLOEXEC) != 0;
 
             const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
-            init_directory_fd_state(fd_num, host_path);
+            init_directory_fd_state(c.proc, fd_num, host_path);
             write_linux_syscall_result(c, fd_num);
             return;
         }
@@ -1047,8 +1113,6 @@ namespace sogen
         const auto fd_num = c.proc.fds.allocate(std::move(new_fd));
         write_linux_syscall_result(c, fd_num);
     }
-
-    // --- Phase 4b: Additional file syscalls ---
 
     void sys_stat(const linux_syscall_context& c)
     {
@@ -1249,7 +1313,7 @@ namespace sogen
     void sys_dup(const linux_syscall_context& c)
     {
         const auto oldfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
-        const auto result = c.proc.fds.dup_fd(oldfd);
+        const auto result = dup_fd_preserve_epoll_state(c.proc, oldfd);
         write_linux_syscall_result(c, result >= 0 ? result : -LINUX_EBADF);
     }
 
@@ -1257,7 +1321,7 @@ namespace sogen
     {
         const auto oldfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
         const auto newfd = static_cast<int>(get_linux_syscall_argument(c.emu, 1));
-        const auto result = c.proc.fds.dup2_fd(oldfd, newfd);
+        const auto result = dup2_fd_cleanup_overwrite(c.proc, oldfd, newfd);
         write_linux_syscall_result(c, result >= 0 ? result : -LINUX_EBADF);
     }
 
@@ -1273,7 +1337,7 @@ namespace sogen
             return;
         }
 
-        const auto result = c.proc.fds.dup2_fd(oldfd, newfd);
+        const auto result = dup2_fd_cleanup_overwrite(c.proc, oldfd, newfd);
         if (result < 0)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
@@ -1324,7 +1388,7 @@ namespace sogen
                 break;
             }
 
-            const auto new_fd = c.proc.fds.dup_fd(fd, minimum_fd);
+            const auto new_fd = dup_fd_preserve_epoll_state(c.proc, fd, minimum_fd);
             write_linux_syscall_result(c, new_fd >= 0 ? new_fd : -LINUX_EMFILE);
             break;
         }
@@ -1336,7 +1400,7 @@ namespace sogen
                 break;
             }
 
-            const auto new_fd = c.proc.fds.dup_fd(fd, minimum_fd);
+            const auto new_fd = dup_fd_preserve_epoll_state(c.proc, fd, minimum_fd);
             if (new_fd >= 0)
             {
                 c.proc.fds.set_close_on_exec(new_fd, true);
@@ -1445,10 +1509,11 @@ namespace sogen
             return;
         }
 
-        auto resolved = resolve_guest_path_at(c, dirfd, guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
         if (!resolved.has_value())
         {
-            write_linux_syscall_result(c, -LINUX_EBADF);
+            write_linux_syscall_result(c, -resolve_error);
             return;
         }
 
@@ -1485,27 +1550,26 @@ namespace sogen
             return;
         }
 
-        // Lazily initialize cache if missing.
-        if (!g_directory_entries.contains(fd))
+        if (!c.proc.directory_entries.contains(fd))
         {
-            init_directory_fd_state(fd, fd_entry->host_path);
+            init_directory_fd_state(c.proc, fd, fd_entry->host_path);
         }
 
-        auto entries_it = g_directory_entries.find(fd);
-        if (entries_it == g_directory_entries.end())
+        auto entries_it = c.proc.directory_entries.find(fd);
+        if (entries_it == c.proc.directory_entries.end())
         {
             write_linux_syscall_result(c, 0);
             return;
         }
 
         auto& entries = entries_it->second;
-        auto& offset = g_directory_offsets[fd];
+        auto& offset = c.proc.directory_offsets[fd];
 
         size_t written = 0;
 
         while (offset < entries.size())
         {
-            const auto& entry = entries[offset];
+            const auto& entry = entries.at(offset);
             const auto name_bytes = entry.name.size() + 1; // include trailing NUL
             const auto reclen = align_up_8(sizeof(linux_dirent64_header) + name_bytes);
 
@@ -1527,7 +1591,7 @@ namespace sogen
 
             std::vector<uint8_t> record(reclen, 0);
             memcpy(record.data(), &hdr, sizeof(hdr));
-            memcpy(record.data() + sizeof(hdr), entry.name.c_str(), entry.name.size() + 1);
+            std::ranges::copy(entry.name, reinterpret_cast<char*>(record.data() + sizeof(hdr)));
 
             c.emu.write_memory(dirp_addr + written, record.data(), record.size());
 
@@ -1576,34 +1640,47 @@ namespace sogen
         constexpr int LINUX_AT_SYMLINK_NOFOLLOW = 0x100;
         if (guest_path.empty() && (flags & LINUX_AT_EMPTY_PATH))
         {
-            auto* fd_entry = c.proc.fds.get(dirfd);
-            if (!fd_entry)
-            {
-                write_linux_syscall_result(c, -LINUX_EBADF);
-                return;
-            }
-
             linux_stat ls{};
-            if (fd_entry->type == fd_type::memory_file)
+            if (dirfd == LINUX_AT_FDCWD)
             {
-                if (!fill_memory_file_stat(c, *fd_entry, ls))
+                fill_linux_stat(ls, c.emu_ref.file_sys.translate("/"));
+            }
+            else
+            {
+                auto* fd_entry = c.proc.fds.get(dirfd);
+                if (!fd_entry)
                 {
                     write_linux_syscall_result(c, -LINUX_EBADF);
                     return;
                 }
-            }
-            else if (!fd_entry->host_path.empty())
-            {
-                fill_linux_stat(ls, fd_entry->host_path);
-            }
-            else
-            {
-                ls.st_mode = 0020666;
-                ls.st_rdev = 0x0501;
+
+                if (fd_entry->type == fd_type::memory_file)
+                {
+                    if (!fill_memory_file_stat(c, *fd_entry, ls))
+                    {
+                        write_linux_syscall_result(c, -LINUX_EBADF);
+                        return;
+                    }
+                }
+                else if (!fd_entry->host_path.empty())
+                {
+                    fill_linux_stat(ls, fd_entry->host_path);
+                }
+                else
+                {
+                    ls.st_mode = 0020666;
+                    ls.st_rdev = 0x0501;
+                }
             }
 
             c.emu.write_memory(buf_addr, &ls, sizeof(ls));
             write_linux_syscall_result(c, 0);
+            return;
+        }
+
+        if (guest_path.empty())
+        {
+            write_linux_syscall_result(c, -LINUX_ENOENT);
             return;
         }
 
@@ -1623,10 +1700,11 @@ namespace sogen
             return;
         }
 
-        auto resolved = resolve_guest_path_at(c, dirfd, guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
         if (!resolved.has_value())
         {
-            write_linux_syscall_result(c, -LINUX_EBADF);
+            write_linux_syscall_result(c, -resolve_error);
             return;
         }
 
@@ -1650,8 +1728,6 @@ namespace sogen
         c.emu.write_memory(buf_addr, &ls, sizeof(ls));
         write_linux_syscall_result(c, 0);
     }
-
-    // --- Phase 4c: Additional file syscalls ---
 
     void sys_rename(const linux_syscall_context& c)
     {
@@ -1677,18 +1753,33 @@ namespace sogen
 
     void sys_renameat2(const linux_syscall_context& c)
     {
-        // renameat2(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags)
-        // const auto olddirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
+        const auto olddirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
         const auto oldpath_addr = get_linux_syscall_argument(c.emu, 1);
-        // const auto newdirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 2));
+        const auto newdirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 2));
         const auto newpath_addr = get_linux_syscall_argument(c.emu, 3);
-        // const auto flags = static_cast<unsigned int>(get_linux_syscall_argument(c.emu, 4));
+        (void)get_linux_syscall_argument(c.emu, 4);
 
         const auto old_guest = read_string<char>(c.emu, oldpath_addr);
         const auto new_guest = read_string<char>(c.emu, newpath_addr);
 
-        const auto old_host = c.emu_ref.file_sys.translate(old_guest);
-        const auto new_host = c.emu_ref.file_sys.translate(new_guest);
+        int64_t old_resolve_error{};
+        auto old_resolved = resolve_guest_path_at(c, olddirfd, old_guest, old_resolve_error);
+        if (!old_resolved.has_value())
+        {
+            write_linux_syscall_result(c, -old_resolve_error);
+            return;
+        }
+
+        int64_t new_resolve_error{};
+        auto new_resolved = resolve_guest_path_at(c, newdirfd, new_guest, new_resolve_error);
+        if (!new_resolved.has_value())
+        {
+            write_linux_syscall_result(c, -new_resolve_error);
+            return;
+        }
+
+        const auto& old_host = *old_resolved;
+        const auto& new_host = *new_resolved;
 
         std::error_code ec{};
         std::filesystem::rename(old_host, new_host, ec);
@@ -1727,10 +1818,11 @@ namespace sogen
 
         const auto guest_path = read_string<char>(c.emu, path_addr);
 
-        auto resolved = resolve_guest_path_at(c, dirfd, guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
         if (!resolved.has_value())
         {
-            write_linux_syscall_result(c, -LINUX_EBADF);
+            write_linux_syscall_result(c, -resolve_error);
             return;
         }
 
@@ -1741,19 +1833,28 @@ namespace sogen
         std::error_code ec{};
         if (flags & LINUX_AT_REMOVEDIR)
         {
-            if (!std::filesystem::remove(host_path, ec))
+            if (!std::filesystem::exists(host_path))
             {
                 write_linux_syscall_result(c, -LINUX_ENOENT);
+                return;
+            }
+
+            if (!std::filesystem::is_directory(host_path))
+            {
+                write_linux_syscall_result(c, -LINUX_ENOTDIR);
+                return;
+            }
+
+            if (!std::filesystem::remove(host_path, ec))
+            {
+                write_linux_syscall_result(c, -LINUX_ENOTEMPTY);
                 return;
             }
         }
-        else
+        else if (!std::filesystem::remove(host_path, ec))
         {
-            if (!std::filesystem::remove(host_path, ec))
-            {
-                write_linux_syscall_result(c, -LINUX_ENOENT);
-                return;
-            }
+            write_linux_syscall_result(c, -LINUX_ENOENT);
+            return;
         }
 
         write_linux_syscall_result(c, 0);
@@ -1785,13 +1886,19 @@ namespace sogen
 
     void sys_mkdirat(const linux_syscall_context& c)
     {
-        // mkdirat(int dirfd, const char *pathname, mode_t mode)
-        // const auto dirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
+        const auto dirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
         const auto path_addr = get_linux_syscall_argument(c.emu, 1);
-        // mode is arg 2
 
         const auto guest_path = read_string<char>(c.emu, path_addr);
-        const auto host_path = c.emu_ref.file_sys.translate(guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
+        if (!resolved.has_value())
+        {
+            write_linux_syscall_result(c, -resolve_error);
+            return;
+        }
+
+        const auto& host_path = *resolved;
 
         std::error_code ec{};
         if (!std::filesystem::create_directory(host_path, ec))
@@ -1847,14 +1954,21 @@ namespace sogen
 
     void sys_symlinkat(const linux_syscall_context& c)
     {
-        // symlinkat(const char *target, int newdirfd, const char *linkpath)
         const auto target_addr = get_linux_syscall_argument(c.emu, 0);
-        // const auto newdirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 1));
+        const auto newdirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 1));
         const auto linkpath_addr = get_linux_syscall_argument(c.emu, 2);
 
         const auto target = read_string<char>(c.emu, target_addr);
         const auto linkpath_guest = read_string<char>(c.emu, linkpath_addr);
-        const auto linkpath_host = c.emu_ref.file_sys.translate(linkpath_guest);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, newdirfd, linkpath_guest, resolve_error);
+        if (!resolved.has_value())
+        {
+            write_linux_syscall_result(c, -resolve_error);
+            return;
+        }
+
+        const auto& linkpath_host = *resolved;
 
         std::error_code ec{};
         std::filesystem::create_symlink(target, linkpath_host, ec);
@@ -1919,14 +2033,21 @@ namespace sogen
 
     void sys_fchmodat(const linux_syscall_context& c)
     {
-        // fchmodat(int dirfd, const char *pathname, mode_t mode, int flags)
-        // const auto dirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
+        const auto dirfd = static_cast<int>(get_linux_syscall_argument(c.emu, 0));
         const auto path_addr = get_linux_syscall_argument(c.emu, 1);
         const auto mode = static_cast<uint32_t>(get_linux_syscall_argument(c.emu, 2));
-        // flags is arg 3
+        (void)get_linux_syscall_argument(c.emu, 3);
 
         const auto guest_path = read_string<char>(c.emu, path_addr);
-        const auto host_path = c.emu_ref.file_sys.translate(guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
+        if (!resolved.has_value())
+        {
+            write_linux_syscall_result(c, -resolve_error);
+            return;
+        }
+
+        const auto& host_path = *resolved;
 
         std::error_code ec{};
         std::filesystem::permissions(host_path, static_cast<std::filesystem::perms>(mode), std::filesystem::perm_options::replace, ec);
@@ -2138,10 +2259,11 @@ namespace sogen
             return;
         }
 
-        auto resolved = resolve_guest_path_at(c, dirfd, guest_path);
+        int64_t resolve_error{};
+        auto resolved = resolve_guest_path_at(c, dirfd, guest_path, resolve_error);
         if (!resolved.has_value())
         {
-            write_linux_syscall_result(c, -LINUX_EBADF);
+            write_linux_syscall_result(c, -resolve_error);
             return;
         }
 

--- a/src/linux-emulator/syscalls/io.cpp
+++ b/src/linux-emulator/syscalls/io.cpp
@@ -2,11 +2,14 @@
 #include "../linux_emulator.hpp"
 #include "../linux_syscall_dispatcher.hpp"
 
+#include <array>
 #include <algorithm>
 #include <fcntl.h>
 #if defined(_WIN32)
 #include <io.h>
+#include <windows.h>
 #else
+#include <sys/select.h>
 #include <unistd.h>
 #endif
 
@@ -17,16 +20,25 @@ namespace sogen
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
-    // --- Phase 4b: I/O syscalls (pipe, eventfd) ---
-
     namespace
     {
-        int host_create_pipe(int (&pipefd)[2])
+        constexpr int EPOLL_CTL_ADD = 1;
+        constexpr int EPOLL_CTL_DEL = 2;
+        constexpr int EPOLL_CTL_MOD = 3;
+
+        constexpr uint32_t EPOLLIN = 0x001;
+        constexpr uint32_t EPOLLOUT = 0x004;
+
+        constexpr int16_t POLLIN = 0x0001;
+        constexpr int16_t POLLOUT = 0x0004;
+        constexpr int16_t POLLNVAL = 0x0020;
+
+        int host_create_pipe(std::array<int, 2>& pipefd)
         {
 #if defined(_WIN32)
-            return _pipe(pipefd, 4096, _O_BINARY);
+            return _pipe(pipefd.data(), 4096, _O_BINARY);
 #else
-            return ::pipe(pipefd);
+            return ::pipe(pipefd.data());
 #endif
         }
 
@@ -39,7 +51,7 @@ namespace sogen
 #endif
         }
 
-        void apply_pipe2_host_flags(const int (&pipefd)[2], const bool nonblock, const bool cloexec)
+        void apply_pipe2_host_flags(const std::array<int, 2>& pipefd, const bool nonblock, const bool cloexec)
         {
 #if defined(_WIN32)
             (void)pipefd;
@@ -95,19 +107,118 @@ namespace sogen
             return end < 0 || pos < end;
         }
 
-        bool fd_has_readable_data(const linux_fd& fd)
+        bool host_pipe_has_readable_data(FILE* handle)
         {
-            if (fd.type == fd_type::memory_file)
+            if (!handle)
             {
-                return fd.memory_file && fd.memory_file->offset < fd.memory_file->content.size();
+                return false;
             }
 
-            if (fd.type == fd_type::file)
+#if defined(_WIN32)
+            auto* const os_handle = reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(handle)));
+            if (os_handle == INVALID_HANDLE_VALUE)
             {
-                return host_file_has_remaining_data(fd.handle);
+                return false;
             }
 
-            return false;
+            DWORD available = 0;
+            if (PeekNamedPipe(os_handle, nullptr, 0, nullptr, &available, nullptr) != 0)
+            {
+                return available > 0;
+            }
+
+            return GetLastError() == ERROR_BROKEN_PIPE;
+#else
+            const auto fd = fileno(handle);
+            if (fd < 0 || fd >= FD_SETSIZE)
+            {
+                return false;
+            }
+
+            fd_set read_fds{};
+            FD_ZERO(&read_fds);
+            FD_SET(fd, &read_fds);
+            timeval timeout{};
+            const auto result = ::select(fd + 1, &read_fds, nullptr, nullptr, &timeout);
+            return result > 0 && FD_ISSET(fd, &read_fds);
+#endif
+        }
+
+        bool epoll_instance_has_ready_entries(linux_process_context& proc, const linux_epoll_instance& instance,
+                                              std::vector<int>& epoll_stack);
+
+        bool fd_has_readable_data(linux_process_context& proc, const int fd, const linux_fd& fd_entry, std::vector<int>& epoll_stack)
+        {
+            if (fd_entry.type == fd_type::memory_file)
+            {
+                return fd_entry.memory_file && fd_entry.memory_file->offset < fd_entry.memory_file->content.size();
+            }
+
+            if (fd_entry.type == fd_type::file)
+            {
+                return host_file_has_remaining_data(fd_entry.handle);
+            }
+
+            if (fd_entry.type == fd_type::pipe_read)
+            {
+                return host_pipe_has_readable_data(fd_entry.handle);
+            }
+
+            if (fd_entry.type != fd_type::epoll)
+            {
+                return false;
+            }
+
+            if (std::ranges::find(epoll_stack, fd) != epoll_stack.end())
+            {
+                return false;
+            }
+
+            auto it = proc.epoll_instances.find(fd);
+            if (it == proc.epoll_instances.end() || !it->second)
+            {
+                return false;
+            }
+
+            epoll_stack.push_back(fd);
+            const auto has_ready_entries = epoll_instance_has_ready_entries(proc, *it->second, epoll_stack);
+            epoll_stack.pop_back();
+            return has_ready_entries;
+        }
+
+        bool fd_accepts_write_ready(const linux_fd& fd)
+        {
+            return fd.type == fd_type::file || fd.type == fd_type::pipe_write || fd.type == fd_type::socket;
+        }
+
+        uint32_t ready_events_for_entry(linux_process_context& proc, const linux_epoll_entry& entry, std::vector<int>& epoll_stack)
+        {
+            auto* fd_entry = proc.fds.get(entry.fd);
+            if (!fd_entry)
+            {
+                return 0;
+            }
+
+            uint32_t ready_events = 0;
+            if ((entry.events & EPOLLIN) && fd_has_readable_data(proc, entry.fd, *fd_entry, epoll_stack))
+            {
+                ready_events |= EPOLLIN;
+            }
+
+            if ((entry.events & EPOLLOUT) && fd_accepts_write_ready(*fd_entry))
+            {
+                ready_events |= EPOLLOUT;
+            }
+
+            return ready_events;
+        }
+
+        bool epoll_instance_has_ready_entries(linux_process_context& proc, const linux_epoll_instance& instance,
+                                              std::vector<int>& epoll_stack)
+        {
+            return std::ranges::any_of(instance.entries, [&proc, &epoll_stack](const linux_epoll_entry& entry) {
+                return ready_events_for_entry(proc, entry, epoll_stack) != 0;
+            });
         }
     }
 
@@ -115,15 +226,15 @@ namespace sogen
     {
         const auto pipefd_addr = get_linux_syscall_argument(c.emu, 0);
 
-        int host_pipe[2] = {-1, -1};
+        std::array<int, 2> host_pipe{-1, -1};
         if (host_create_pipe(host_pipe) != 0)
         {
             write_linux_syscall_result(c, -LINUX_EMFILE);
             return;
         }
 
-        auto* read_stream = fdopen(host_pipe[0], "rb");
-        auto* write_stream = fdopen(host_pipe[1], "wb");
+        auto* read_stream = fdopen(host_pipe.at(0), "rb");
+        auto* write_stream = fdopen(host_pipe.at(1), "wb");
 
         if (!read_stream || !write_stream)
         {
@@ -131,18 +242,18 @@ namespace sogen
             {
                 fclose(read_stream);
             }
-            else if (host_pipe[0] >= 0)
+            else if (host_pipe.at(0) >= 0)
             {
-                host_close(host_pipe[0]);
+                host_close(host_pipe.at(0));
             }
 
             if (write_stream)
             {
                 fclose(write_stream);
             }
-            else if (host_pipe[1] >= 0)
+            else if (host_pipe.at(1) >= 0)
             {
-                host_close(host_pipe[1]);
+                host_close(host_pipe.at(1));
             }
 
             write_linux_syscall_result(c, -LINUX_EMFILE);
@@ -163,8 +274,8 @@ namespace sogen
         const auto read_fd = c.proc.fds.allocate(std::move(read_end));
         const auto write_fd = c.proc.fds.allocate(std::move(write_end));
 
-        int32_t fds[2] = {read_fd, write_fd};
-        c.emu.write_memory(pipefd_addr, fds, sizeof(fds));
+        const std::array<int32_t, 2> fds{read_fd, write_fd};
+        c.emu.write_memory(pipefd_addr, fds.data(), sizeof(int32_t) * fds.size());
 
         write_linux_syscall_result(c, 0);
     }
@@ -177,7 +288,7 @@ namespace sogen
         constexpr int LINUX_O_CLOEXEC = 02000000;
         constexpr int LINUX_O_NONBLOCK = 04000;
 
-        int host_pipe[2] = {-1, -1};
+        std::array<int, 2> host_pipe{-1, -1};
         if (host_create_pipe(host_pipe) != 0)
         {
             write_linux_syscall_result(c, -LINUX_EMFILE);
@@ -189,8 +300,8 @@ namespace sogen
 
         apply_pipe2_host_flags(host_pipe, nonblock, cloexec);
 
-        auto* read_stream = fdopen(host_pipe[0], "rb");
-        auto* write_stream = fdopen(host_pipe[1], "wb");
+        auto* read_stream = fdopen(host_pipe.at(0), "rb");
+        auto* write_stream = fdopen(host_pipe.at(1), "wb");
 
         if (!read_stream || !write_stream)
         {
@@ -198,18 +309,18 @@ namespace sogen
             {
                 fclose(read_stream);
             }
-            else if (host_pipe[0] >= 0)
+            else if (host_pipe.at(0) >= 0)
             {
-                host_close(host_pipe[0]);
+                host_close(host_pipe.at(0));
             }
 
             if (write_stream)
             {
                 fclose(write_stream);
             }
-            else if (host_pipe[1] >= 0)
+            else if (host_pipe.at(1) >= 0)
             {
-                host_close(host_pipe[1]);
+                host_close(host_pipe.at(1));
             }
 
             write_linux_syscall_result(c, -LINUX_EMFILE);
@@ -234,8 +345,8 @@ namespace sogen
         const auto read_fd = c.proc.fds.allocate(std::move(read_end));
         const auto write_fd = c.proc.fds.allocate(std::move(write_end));
 
-        int32_t fds[2] = {read_fd, write_fd};
-        c.emu.write_memory(pipefd_addr, fds, sizeof(fds));
+        const std::array<int32_t, 2> fds{read_fd, write_fd};
+        c.emu.write_memory(pipefd_addr, fds.data(), sizeof(int32_t) * fds.size());
 
         write_linux_syscall_result(c, 0);
     }
@@ -269,23 +380,8 @@ namespace sogen
         write_linux_syscall_result(c, fd_num);
     }
 
-    // --- Phase 4c: I/O multiplexing syscalls ---
-
     namespace
     {
-        // Epoll constants
-        constexpr int EPOLL_CTL_ADD = 1;
-        constexpr int EPOLL_CTL_DEL = 2;
-        constexpr int EPOLL_CTL_MOD = 3;
-
-        // Epoll event flags
-        constexpr uint32_t EPOLLIN = 0x001;
-        constexpr uint32_t EPOLLOUT = 0x004;
-
-        // Poll event flags
-        constexpr int16_t POLLIN = 0x0001;
-        constexpr int16_t POLLOUT = 0x0004;
-        constexpr int16_t POLLNVAL = 0x0020;
 
 #pragma pack(push, 1)
         struct linux_epoll_event
@@ -297,15 +393,6 @@ namespace sogen
 
         static_assert(sizeof(linux_epoll_event) == 12);
 
-        struct epoll_entry
-        {
-            int fd;
-            uint32_t events;
-            uint64_t data;
-        };
-
-        // Epoll instance tracking
-        std::map<int, std::vector<epoll_entry>> g_epoll_instances;
     }
 
     void sys_epoll_create1(const linux_syscall_context& c)
@@ -314,11 +401,11 @@ namespace sogen
         constexpr int LINUX_O_CLOEXEC = 02000000;
 
         linux_fd efd{};
-        efd.type = fd_type::file; // epoll fd
+        efd.type = fd_type::epoll;
         efd.close_on_exec = (flags & LINUX_O_CLOEXEC) != 0;
 
         const auto fd_num = c.proc.fds.allocate(std::move(efd));
-        g_epoll_instances[fd_num] = {};
+        c.proc.epoll_instances[fd_num] = std::make_shared<linux_epoll_instance>();
 
         write_linux_syscall_result(c, fd_num);
     }
@@ -330,8 +417,9 @@ namespace sogen
         const auto fd = static_cast<int>(get_linux_syscall_argument(c.emu, 2));
         const auto event_addr = get_linux_syscall_argument(c.emu, 3);
 
-        auto it = g_epoll_instances.find(epfd);
-        if (it == g_epoll_instances.end())
+        auto* epoll_fd = c.proc.fds.get(epfd);
+        auto it = c.proc.epoll_instances.find(epfd);
+        if (!epoll_fd || epoll_fd->type != fd_type::epoll || it == c.proc.epoll_instances.end() || !it->second)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
@@ -346,22 +434,22 @@ namespace sogen
         switch (op)
         {
         case EPOLL_CTL_ADD: {
-            epoll_entry entry{};
+            linux_epoll_entry entry{};
             entry.fd = fd;
             entry.events = ev.events;
             entry.data = ev.data;
-            it->second.push_back(entry);
+            it->second->entries.push_back(entry);
             write_linux_syscall_result(c, 0);
             break;
         }
         case EPOLL_CTL_DEL: {
-            auto& entries = it->second;
-            entries.erase(std::ranges::remove_if(entries, [fd](const epoll_entry& e) { return e.fd == fd; }).begin(), entries.end());
+            auto& entries = it->second->entries;
+            entries.erase(std::ranges::remove_if(entries, [fd](const linux_epoll_entry& e) { return e.fd == fd; }).begin(), entries.end());
             write_linux_syscall_result(c, 0);
             break;
         }
         case EPOLL_CTL_MOD: {
-            for (auto& entry : it->second)
+            for (auto& entry : it->second->entries)
             {
                 if (entry.fd == fd)
                 {
@@ -388,41 +476,24 @@ namespace sogen
 
         (void)timeout;
 
-        auto it = g_epoll_instances.find(epfd);
-        if (it == g_epoll_instances.end())
+        auto* epoll_fd = c.proc.fds.get(epfd);
+        auto it = c.proc.epoll_instances.find(epfd);
+        if (!epoll_fd || epoll_fd->type != fd_type::epoll || it == c.proc.epoll_instances.end() || !it->second)
         {
             write_linux_syscall_result(c, -LINUX_EBADF);
             return;
         }
 
-        // Simulate: check each registered fd for readiness
-        // For emulation purposes, we report writable fds as ready (common for non-blocking sockets)
         int count = 0;
-        for (const auto& entry : it->second)
+        std::vector<int> epoll_stack{epfd};
+        for (const auto& entry : it->second->entries)
         {
             if (count >= maxevents)
             {
                 break;
             }
 
-            auto* fd_entry = c.proc.fds.get(entry.fd);
-            if (!fd_entry)
-            {
-                continue;
-            }
-
-            uint32_t ready_events = 0;
-
-            if ((entry.events & EPOLLIN) && fd_has_readable_data(*fd_entry))
-            {
-                ready_events |= EPOLLIN;
-            }
-
-            // Most fds are writable
-            if (entry.events & EPOLLOUT)
-            {
-                ready_events |= EPOLLOUT;
-            }
+            const auto ready_events = ready_events_for_entry(c.proc, entry, epoll_stack);
 
             if (ready_events != 0)
             {
@@ -491,18 +562,15 @@ namespace sogen
                 continue;
             }
 
-            if ((pfd.events & POLLIN) && fd_has_readable_data(*fd_entry))
+            std::vector<int> epoll_stack{};
+            if ((pfd.events & POLLIN) && fd_has_readable_data(c.proc, pfd.fd, *fd_entry, epoll_stack))
             {
                 pfd.revents |= POLLIN;
             }
 
-            if (pfd.events & POLLOUT)
+            if ((pfd.events & POLLOUT) && fd_accepts_write_ready(*fd_entry))
             {
-                // Most fds are writable
-                if (fd_entry->type == fd_type::file || fd_entry->type == fd_type::pipe_write || fd_entry->type == fd_type::socket)
-                {
-                    pfd.revents |= POLLOUT;
-                }
+                pfd.revents |= POLLOUT;
             }
 
             if (pfd.revents != 0)
@@ -554,13 +622,13 @@ namespace sogen
             {
                 return false;
             }
-            return (bits[fd / 8] & (1 << (fd % 8))) != 0;
+            return (bits.at(static_cast<size_t>(fd / 8)) & (1 << (fd % 8))) != 0;
         };
 
         auto fd_set_bit = [](int fd, std::vector<uint8_t>& bits) {
             if (fd >= 0 && static_cast<size_t>(fd / 8) < bits.size())
             {
-                bits[fd / 8] |= static_cast<uint8_t>(1 << (fd % 8));
+                bits.at(static_cast<size_t>(fd / 8)) |= static_cast<uint8_t>(1 << (fd % 8));
             }
         };
 
@@ -595,14 +663,13 @@ namespace sogen
                 continue;
             }
 
-            if (want_write)
+            if (want_write && fd_accepts_write_ready(*fd_entry))
             {
-                // Most fds are writable
                 fd_set_bit(fd, out_write);
                 ++ready_count;
             }
-
-            if (want_read && fd_has_readable_data(*fd_entry))
+            std::vector<int> epoll_stack{};
+            if (want_read && fd_has_readable_data(c.proc, fd, *fd_entry, epoll_stack))
             {
                 fd_set_bit(fd, out_read);
                 ++ready_count;

--- a/src/linux-emulator/syscalls/io.cpp
+++ b/src/linux-emulator/syscalls/io.cpp
@@ -71,6 +71,44 @@ namespace sogen
             }
 #endif
         }
+
+        bool host_file_has_remaining_data(FILE* handle)
+        {
+            if (!handle)
+            {
+                return false;
+            }
+
+            const auto pos = ftell(handle);
+            if (pos < 0)
+            {
+                return true;
+            }
+
+            if (fseek(handle, 0, SEEK_END) != 0)
+            {
+                return true;
+            }
+
+            const auto end = ftell(handle);
+            (void)fseek(handle, pos, SEEK_SET);
+            return end < 0 || pos < end;
+        }
+
+        bool fd_has_readable_data(const linux_fd& fd)
+        {
+            if (fd.type == fd_type::memory_file)
+            {
+                return fd.memory_file && fd.memory_file->offset < fd.memory_file->content.size();
+            }
+
+            if (fd.type == fd_type::file)
+            {
+                return host_file_has_remaining_data(fd.handle);
+            }
+
+            return false;
+        }
     }
 
     void sys_pipe(const linux_syscall_context& c)
@@ -375,21 +413,9 @@ namespace sogen
 
             uint32_t ready_events = 0;
 
-            // Files/pipes with data: check if readable
-            if ((entry.events & EPOLLIN) && fd_entry->handle)
+            if ((entry.events & EPOLLIN) && fd_has_readable_data(*fd_entry))
             {
-                // Check if there's data available
-                if (fd_entry->type == fd_type::file && fd_entry->handle)
-                {
-                    const auto pos = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, 0, SEEK_END);
-                    const auto end = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, pos, SEEK_SET);
-                    if (pos < end)
-                    {
-                        ready_events |= EPOLLIN;
-                    }
-                }
+                ready_events |= EPOLLIN;
             }
 
             // Most fds are writable
@@ -465,22 +491,9 @@ namespace sogen
                 continue;
             }
 
-            // Check readiness
-            if (pfd.events & POLLIN)
+            if ((pfd.events & POLLIN) && fd_has_readable_data(*fd_entry))
             {
-                if (fd_entry->type == fd_type::file && fd_entry->handle)
-                {
-                    const auto pos = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, 0, SEEK_END);
-                    const auto end = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, pos, SEEK_SET);
-                    if (pos < end)
-                    {
-                        pfd.revents |= POLLIN;
-                    }
-                }
-                // stdin: report not ready (would block)
-                // pipes: could check but simplified for now
+                pfd.revents |= POLLIN;
             }
 
             if (pfd.events & POLLOUT)
@@ -589,20 +602,10 @@ namespace sogen
                 ++ready_count;
             }
 
-            if (want_read && fd_entry->handle)
+            if (want_read && fd_has_readable_data(*fd_entry))
             {
-                if (fd_entry->type == fd_type::file)
-                {
-                    const auto pos = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, 0, SEEK_END);
-                    const auto end = ftell(fd_entry->handle);
-                    fseek(fd_entry->handle, pos, SEEK_SET);
-                    if (pos < end)
-                    {
-                        fd_set_bit(fd, out_read);
-                        ++ready_count;
-                    }
-                }
+                fd_set_bit(fd, out_read);
+                ++ready_count;
             }
 
             // No exceptions

--- a/src/python-bindings/CMakeLists.txt
+++ b/src/python-bindings/CMakeLists.txt
@@ -17,7 +17,7 @@ if(SOGEN_DISABLE_NANOBIND_LEAK_WARNINGS)
   target_compile_definitions(sogen PRIVATE SOGEN_DISABLE_NANOBIND_LEAK_WARNINGS=1)
 endif()
 
-target_link_libraries(sogen PRIVATE windows-emulator disassembler backend-selection)
+target_link_libraries(sogen PRIVATE windows-emulator linux-emulator disassembler backend-selection)
 
 target_compile_features(sogen PRIVATE cxx_std_20)
 if(MSVC)

--- a/src/python-bindings/sogen_api_hooks.cpp
+++ b/src/python-bindings/sogen_api_hooks.cpp
@@ -1,4 +1,5 @@
 #include "sogen_internal.hpp"
+#include <windows_emulator.hpp>
 
 #include <cstdio>
 

--- a/src/python-bindings/sogen_bindings.hpp
+++ b/src/python-bindings/sogen_bindings.hpp
@@ -1,5 +1,15 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/map.h>
@@ -11,12 +21,31 @@
 #include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 
-#include <disassembler.hpp>
 #include <backend_selection.hpp>
-#include <windows_emulator.hpp>
+#include <function_calling_convention.hpp>
+#include <hook_interface.hpp>
+#include <memory_interface.hpp>
+#include <memory_permission.hpp>
+#include <platform/status.hpp>
 #include <x86_register.hpp>
 
 namespace nb = nanobind;
+
+namespace sogen
+{
+    class emulator_thread;
+    class linux_emulator;
+    class linux_memory_manager;
+    class memory_manager;
+    class windows_emulator;
+    enum class memory_region_kind : uint8_t;
+    enum class stop_reason : uint8_t;
+    struct linux_process_context;
+    struct linux_thread;
+    struct mapped_module;
+    struct nt_memory_permission;
+    struct process_context;
+}
 
 namespace sogen::py
 {
@@ -25,6 +54,10 @@ namespace sogen::py
     using sogen::emulator_thread;
     using sogen::function_calling_convention;
     using sogen::instruction_hook_continuation;
+    using sogen::linux_emulator;
+    using sogen::linux_memory_manager;
+    using sogen::linux_process_context;
+    using sogen::linux_thread;
     using sogen::mapped_module;
     using sogen::memory_interface;
     using sogen::memory_manager;
@@ -34,7 +67,6 @@ namespace sogen::py
     using sogen::nt_memory_permission;
     using sogen::process_context;
     using sogen::stop_reason;
-    using sogen::u16_to_u8;
     using sogen::windows_emulator;
     using sogen::x86_register;
 
@@ -53,6 +85,9 @@ namespace sogen::py
     struct callback_registry;
     struct sogen_process_context;
     struct sogen_windows_emulator;
+    struct linux_callback_registry;
+    struct sogen_linux_process_context;
+    struct sogen_linux_emulator;
 
     // ----- helpers -----
     std::string stop_reason_to_string(stop_reason reason);
@@ -70,8 +105,11 @@ namespace sogen::py
     std::unique_ptr<windows_emulator> create_empty_emulator(const nb::kwargs& kwargs);
     std::unique_ptr<windows_emulator> create_application_emulator(const nb::object& application, const nb::object& args,
                                                                   const nb::kwargs& kwargs);
+    std::unique_ptr<linux_emulator> create_linux_application_emulator(const nb::object& application, const nb::object& args,
+                                                                      const nb::kwargs& kwargs);
 
     void register_types_bindings(nb::module_& m);
     void register_windows_runtime_bindings(nb::module_& m);
+    void register_linux_runtime_bindings(nb::module_& m);
     void register_runtime_bindings(nb::module_& m);
 }

--- a/src/python-bindings/sogen_bindings_linux_runtime.cpp
+++ b/src/python-bindings/sogen_bindings_linux_runtime.cpp
@@ -1,0 +1,98 @@
+#include <nanobind/nanobind.h>
+
+#include "sogen_internal.hpp"
+
+#include <linux_emulator.hpp>
+
+namespace sogen::py
+{
+    namespace
+    {
+        template <auto Member>
+        void bind_linux_callback_property(nb::class_<linux_callback_registry>& c, const char* name, const char* slot_name)
+        {
+            c.def_prop_rw(
+                name, [](linux_callback_registry& self) { return self.*Member; },
+                [slot_name](linux_callback_registry& self, nb::object callback) { self.set(slot_name, std::move(callback)); },
+                nb::arg("callback").none());
+        }
+    }
+
+    void register_linux_runtime_bindings(nb::module_& m)
+    {
+        auto callbacks_class = nb::class_<linux_callback_registry>(m, "Callbacks");
+        bind_linux_callback_property<&linux_callback_registry::stdout_cb>(callbacks_class, "on_stdout", "stdout");
+        bind_linux_callback_property<&linux_callback_registry::stderr_cb>(callbacks_class, "on_stderr", "stderr");
+        callbacks_class.def("set", &linux_callback_registry::set).def("clear", &linux_callback_registry::clear);
+
+        nb::class_<linux_thread>(m, "Thread")
+            .def_prop_ro("tid", [](const linux_thread& self) { return self.tid; })
+            .def_prop_ro("stack_base", [](const linux_thread& self) { return self.stack_base; })
+            .def_prop_ro("stack_size", [](const linux_thread& self) { return self.stack_size; })
+            .def_prop_ro("fs_base", [](const linux_thread& self) { return self.fs_base; })
+            .def_prop_ro("terminated", [](const linux_thread& self) { return self.terminated; })
+            .def_prop_ro("exit_code", [](const linux_thread& self) { return self.exit_code; })
+            .def_prop_ro("executed_instructions", [](const linux_thread& self) { return self.executed_instructions; });
+
+        nb::class_<sogen_linux_process_context>(m, "ProcessContext")
+            .def_prop_ro("exit_status",
+                         [](const sogen_linux_process_context& self) -> nb::object {
+                             if (!self.exit_status().has_value())
+                             {
+                                 return nb::none();
+                             }
+
+                             return nb::int_(*self.exit_status());
+                         })
+            .def_prop_ro("pid", &sogen_linux_process_context::pid)
+            .def_prop_ro("ppid", &sogen_linux_process_context::ppid)
+            .def_prop_ro("uid", &sogen_linux_process_context::uid)
+            .def_prop_ro("gid", &sogen_linux_process_context::gid)
+            .def_prop_ro("euid", &sogen_linux_process_context::euid)
+            .def_prop_ro("egid", &sogen_linux_process_context::egid)
+            .def_prop_ro("thread_count", &sogen_linux_process_context::thread_count)
+            .def_prop_ro("active_thread", &sogen_linux_process_context::active_thread, nb::rv_policy::reference_internal);
+
+        nb::class_<linux_memory_manager>(m, "MemoryManager")
+            .def("read_memory",
+                 [](const linux_memory_manager& self, uint64_t address, size_t size) { return read_memory_bytes(self, address, size); })
+            .def("write_memory",
+                 [](linux_memory_manager& self, uint64_t address, const nb::bytes& buffer) { write_memory_bytes(self, address, buffer); })
+            .def("allocate_memory",
+                 static_cast<uint64_t (linux_memory_manager::*)(size_t, memory_permission, uint64_t)>(
+                     &linux_memory_manager::allocate_memory),
+                 nb::arg("size"), nb::arg("permissions"), nb::arg("start") = 0)
+            .def("allocate_memory_at",
+                 static_cast<bool (linux_memory_manager::*)(uint64_t, size_t, memory_permission)>(&linux_memory_manager::allocate_memory),
+                 nb::arg("address"), nb::arg("size"), nb::arg("permissions"))
+            .def("protect_memory", &linux_memory_manager::protect_memory)
+            .def("release_memory", &linux_memory_manager::release_memory)
+            .def("find_free_allocation_base", &linux_memory_manager::find_free_allocation_base, nb::arg("size"), nb::arg("start") = 0)
+            .def_prop_rw("mmap_base", &linux_memory_manager::get_mmap_base, &linux_memory_manager::set_mmap_base);
+
+        nb::class_<sogen_linux_emulator>(m, "Emulator")
+            .def("start", &sogen_linux_emulator::start, nb::arg("count") = 0, nb::call_guard<nb::gil_scoped_release>())
+            .def("stop", &sogen_linux_emulator::stop)
+            .def("read_memory", &sogen_linux_emulator::read_memory)
+            .def("write_memory", &sogen_linux_emulator::write_memory)
+            .def("read_register", &sogen_linux_emulator::read_register)
+            .def("write_register", &sogen_linux_emulator::write_register)
+            .def_prop_ro("executed_instructions", &sogen_linux_emulator::executed_instructions)
+            .def_prop_ro("backend_name", &sogen_linux_emulator::backend_name)
+            .def_prop_ro("emulation_root", &sogen_linux_emulator::emulation_root)
+            .def_prop_ro("process", &sogen_linux_emulator::process, nb::rv_policy::reference_internal)
+            .def_prop_ro("memory", &sogen_linux_emulator::memory, nb::rv_policy::reference_internal)
+            .def_prop_ro(
+                "callbacks", [](sogen_linux_emulator& self) -> linux_callback_registry& { return *self.callbacks; },
+                nb::rv_policy::reference_internal);
+
+        nb::setattr(m, "LinuxEmulator", m.attr("Emulator"));
+
+        m.def("create_application", [](const nb::object& application, const nb::kwargs& kwargs) {
+            return sogen_linux_emulator(create_linux_application_emulator(application, nb::none(), kwargs));
+        });
+        m.def("create_application", [](const nb::object& application, const nb::object& application_args, const nb::kwargs& kwargs) {
+            return sogen_linux_emulator(create_linux_application_emulator(application, application_args, kwargs));
+        });
+    }
+}

--- a/src/python-bindings/sogen_bindings_runtime.cpp
+++ b/src/python-bindings/sogen_bindings_runtime.cpp
@@ -1,6 +1,7 @@
 #include <nanobind/nanobind.h>
 
 #include "sogen_internal.hpp"
+#include <windows_emulator.hpp>
 
 namespace sogen::py
 {

--- a/src/python-bindings/sogen_bindings_types.cpp
+++ b/src/python-bindings/sogen_bindings_types.cpp
@@ -1,6 +1,7 @@
 #include <nanobind/nanobind.h>
 
 #include "sogen_internal.hpp"
+#include <windows_emulator.hpp>
 
 namespace sogen::py
 {

--- a/src/python-bindings/sogen_callbacks.cpp
+++ b/src/python-bindings/sogen_callbacks.cpp
@@ -1,4 +1,5 @@
 #include "sogen_internal.hpp"
+#include <windows_emulator.hpp>
 
 #include <array>
 

--- a/src/python-bindings/sogen_helpers.cpp
+++ b/src/python-bindings/sogen_helpers.cpp
@@ -1,4 +1,5 @@
 #include "sogen_internal.hpp"
+#include <windows_emulator.hpp>
 
 namespace sogen::py
 {

--- a/src/python-bindings/sogen_internal.hpp
+++ b/src/python-bindings/sogen_internal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sogen_bindings.hpp"
+#include <utils/function.hpp>
 
 namespace sogen::py
 {
@@ -61,6 +62,8 @@ namespace sogen::py
     {
         function_calling_convention cc{function_calling_convention::x64_fastcall};
         nb::object params = nb::none();
+
+        api_hook_signature() = default;
     };
 
     struct api_hook_hit
@@ -195,30 +198,12 @@ namespace sogen::py
 
         sogen_process_context(process_context& context, std::shared_ptr<callback_registry> callback_registry, nb::object owner);
 
-        bool is_wow64_process() const
-        {
-            return this->ctx->is_wow64_process;
-        }
-        std::optional<NTSTATUS> exit_status() const
-        {
-            return this->ctx->exit_status;
-        }
-        size_t live_thread_count() const
-        {
-            return this->ctx->get_live_thread_count();
-        }
-        uint32_t spawned_thread_count() const
-        {
-            return this->ctx->spawned_thread_count;
-        }
-        emulator_thread* active_thread() const
-        {
-            return this->ctx->active_thread;
-        }
-        callback_registry& callback_view() const
-        {
-            return *this->callbacks;
-        }
+        bool is_wow64_process() const;
+        std::optional<NTSTATUS> exit_status() const;
+        size_t live_thread_count() const;
+        uint32_t spawned_thread_count() const;
+        emulator_thread* active_thread() const;
+        callback_registry& callback_view() const;
     };
 
     struct sogen_windows_emulator
@@ -229,92 +214,102 @@ namespace sogen::py
 
         explicit sogen_windows_emulator(std::unique_ptr<windows_emulator> emulator);
 
-        windows_emulator& native() const
-        {
-            return *this->emu;
-        }
+        ~sogen_windows_emulator();
 
-        void start(size_t count = 0) const
-        {
-            this->emu->start(count);
-        }
-        void stop() const
-        {
-            this->emu->stop();
-        }
-        void save_snapshot() const
-        {
-            this->emu->save_snapshot();
-        }
-        void restore_snapshot() const
-        {
-            this->emu->restore_snapshot();
-        }
-        nb::bytes serialize_state() const
-        {
-            return serialize_state_bytes(*this->emu);
-        }
-        void deserialize_state(const nb::bytes& buffer) const
-        {
-            deserialize_state_bytes(*this->emu, buffer);
-        }
-        void setup_process_if_necessary() const
-        {
-            this->emu->setup_process_if_necessary();
-        }
-        void yield_thread(bool alertable = false) const
-        {
-            this->emu->yield_thread(alertable);
-        }
-        bool perform_thread_switch() const
-        {
-            return this->emu->perform_thread_switch();
-        }
-        bool activate_thread(uint32_t id) const
-        {
-            return this->emu->activate_thread(id);
-        }
+        sogen_windows_emulator(const sogen_windows_emulator&) = delete;
+        sogen_windows_emulator& operator=(const sogen_windows_emulator&) = delete;
+        sogen_windows_emulator(sogen_windows_emulator&&) noexcept;
+        sogen_windows_emulator& operator=(sogen_windows_emulator&&) noexcept;
+
+        windows_emulator& native() const;
+
+        void start(size_t count = 0) const;
+        void stop() const;
+        void save_snapshot() const;
+        void restore_snapshot() const;
+        nb::bytes serialize_state() const;
+        void deserialize_state(const nb::bytes& buffer) const;
+        void setup_process_if_necessary() const;
+        void yield_thread(bool alertable = false) const;
+        bool perform_thread_switch() const;
+        bool activate_thread(uint32_t id) const;
 
         sogen_process_context process();
 
-        memory_manager& memory() const
-        {
-            return this->emu->memory;
-        }
-        emulator_thread* current_thread() const
-        {
-            return this->emu->process.active_thread;
-        }
+        memory_manager& memory() const;
+        emulator_thread* current_thread() const;
         std::optional<uint32_t> current_thread_id() const;
 
-        nb::bytes read_memory(uint64_t address, size_t size) const
-        {
-            return read_memory_bytes(this->emu->memory, address, size);
-        }
-        void write_memory(uint64_t address, const nb::bytes& buffer) const
-        {
-            write_memory_bytes(this->emu->memory, address, buffer);
-        }
-        uint64_t read_register(x86_register reg) const
-        {
-            return this->emu->emu().reg<uint64_t>(reg);
-        }
-        void write_register(x86_register reg, uint64_t value) const
-        {
-            this->emu->emu().reg<uint64_t>(reg, value);
-        }
+        nb::bytes read_memory(uint64_t address, size_t size) const;
+        void write_memory(uint64_t address, const nb::bytes& buffer) const;
+        uint64_t read_register(x86_register reg) const;
+        void write_register(x86_register reg, uint64_t value) const;
 
-        uint16_t get_host_port(uint16_t emulator_port) const
-        {
-            return this->emu->get_host_port(emulator_port);
-        }
-        uint16_t get_emulator_port(uint16_t host_port) const
-        {
-            return this->emu->get_emulator_port(host_port);
-        }
-        void map_port(uint16_t emulator_port, uint16_t host_port) const
-        {
-            this->emu->map_port(emulator_port, host_port);
-        }
+        uint16_t get_host_port(uint16_t emulator_port) const;
+        uint16_t get_emulator_port(uint16_t host_port) const;
+        void map_port(uint16_t emulator_port, uint16_t host_port) const;
+    };
+
+    struct linux_callback_registry
+    {
+        linux_emulator* emu{};
+        nb::object stdout_cb = nb::none();
+        nb::object stderr_cb = nb::none();
+
+        explicit linux_callback_registry(linux_emulator& emulator);
+
+        void set(std::string_view name, nb::object callable);
+        void clear(std::string_view name);
+
+        static nb::object linux_callback_registry::* slot_for(std::string_view name);
+    };
+
+    struct sogen_linux_process_context
+    {
+        linux_process_context* ctx{};
+        nb::object owner = nb::none();
+
+        sogen_linux_process_context(linux_process_context& context, nb::object owner);
+
+        std::optional<int> exit_status() const;
+        uint32_t pid() const;
+        uint32_t ppid() const;
+        uint32_t uid() const;
+        uint32_t gid() const;
+        uint32_t euid() const;
+        uint32_t egid() const;
+        size_t thread_count() const;
+        linux_thread* active_thread() const;
+    };
+
+    struct sogen_linux_emulator
+    {
+        std::unique_ptr<linux_emulator> emu{};
+        std::shared_ptr<linux_callback_registry> callbacks{};
+
+        explicit sogen_linux_emulator(std::unique_ptr<linux_emulator> emulator);
+
+        ~sogen_linux_emulator();
+
+        sogen_linux_emulator(const sogen_linux_emulator&) = delete;
+        sogen_linux_emulator& operator=(const sogen_linux_emulator&) = delete;
+        sogen_linux_emulator(sogen_linux_emulator&&) noexcept;
+        sogen_linux_emulator& operator=(sogen_linux_emulator&&) noexcept;
+
+        linux_emulator& native() const;
+
+        void start(size_t count = 0) const;
+        void stop() const;
+
+        sogen_linux_process_context process();
+
+        linux_memory_manager& memory() const;
+        nb::bytes read_memory(uint64_t address, size_t size) const;
+        void write_memory(uint64_t address, const nb::bytes& buffer) const;
+        uint64_t read_register(x86_register reg) const;
+        void write_register(x86_register reg, uint64_t value) const;
+        uint64_t executed_instructions() const;
+        std::string backend_name() const;
+        std::filesystem::path emulation_root() const;
     };
 }

--- a/src/python-bindings/sogen_linux_callbacks.cpp
+++ b/src/python-bindings/sogen_linux_callbacks.cpp
@@ -1,0 +1,74 @@
+#include "sogen_internal.hpp"
+
+#include <linux_emulator.hpp>
+
+#include <array>
+
+namespace sogen::py
+{
+    namespace
+    {
+        void invoke_linux_callback(const nb::object& cb, std::string_view data)
+        {
+            if (cb.is_none())
+            {
+                return;
+            }
+
+            nb::gil_scoped_acquire gil{};
+            cb(std::string(data));
+        }
+
+        struct linux_callback_slot
+        {
+            std::string_view name;
+            nb::object linux_callback_registry::* member;
+        };
+
+        constexpr std::array linux_callback_slots{
+            linux_callback_slot{.name = "stdout", .member = &linux_callback_registry::stdout_cb},
+            linux_callback_slot{.name = "stderr", .member = &linux_callback_registry::stderr_cb},
+        };
+    }
+
+    nb::object linux_callback_registry::* linux_callback_registry::slot_for(const std::string_view name)
+    {
+        const auto key = name.starts_with("on_") ? name.substr(3) : name;
+        for (const auto& slot : linux_callback_slots)
+        {
+            if (slot.name == key)
+            {
+                return slot.member;
+            }
+        }
+        return nullptr;
+    }
+
+    linux_callback_registry::linux_callback_registry(linux_emulator& emulator)
+        : emu(&emulator)
+    {
+        this->emu->on_stdout = [this](std::string_view data) { invoke_linux_callback(this->stdout_cb, data); };
+        this->emu->on_stderr = [this](std::string_view data) { invoke_linux_callback(this->stderr_cb, data); };
+    }
+
+    void linux_callback_registry::set(const std::string_view name, nb::object callable)
+    {
+        if (callable.is_valid() && !callable.is_none() && !PyCallable_Check(callable.ptr()))
+        {
+            throw std::runtime_error("callback must be callable or None");
+        }
+
+        const auto member = slot_for(name);
+        if (!member)
+        {
+            throw std::runtime_error("Unknown callback name: " + std::string(name));
+        }
+
+        this->*member = std::move(callable);
+    }
+
+    void linux_callback_registry::clear(const std::string_view name)
+    {
+        set(name, nb::none());
+    }
+}

--- a/src/python-bindings/sogen_linux_wrappers.cpp
+++ b/src/python-bindings/sogen_linux_wrappers.cpp
@@ -1,0 +1,204 @@
+#include "sogen_internal.hpp"
+
+#include <linux_emulator.hpp>
+
+namespace sogen::py
+{
+    namespace
+    {
+        nb::object get_kwarg_object(const nb::kwargs& kwargs, const char* name)
+        {
+            return kwargs.get(name, nb::none());
+        }
+
+        template <typename T>
+        T get_kwarg(const nb::kwargs& kwargs, const char* name, const T& default_value)
+        {
+            const auto value = get_kwarg_object(kwargs, name);
+            return value.is_none() ? default_value : nb::cast<T>(value);
+        }
+
+        std::vector<std::string> parse_linux_arguments(const nb::object& object)
+        {
+            std::vector<std::string> result{};
+            if (object.is_none())
+            {
+                return result;
+            }
+
+            const auto seq = nb::cast<nb::sequence>(object);
+            result.reserve(static_cast<size_t>(nb::len(seq)));
+            for (const auto& item : seq)
+            {
+                result.emplace_back(nb::cast<std::string>(item));
+            }
+
+            return result;
+        }
+
+        std::vector<std::string> parse_linux_environment(const nb::object& object)
+        {
+            std::vector<std::string> result{};
+            if (object.is_none())
+            {
+                return {"PATH=/usr/bin:/bin", "HOME=/root", "TERM=xterm"};
+            }
+
+            const auto dict = nb::cast<nb::dict>(object);
+            result.reserve(static_cast<size_t>(nb::len(dict)));
+            for (const auto& item : dict)
+            {
+                result.emplace_back(nb::cast<std::string>(item.first) + "=" + nb::cast<std::string>(item.second));
+            }
+
+            return result;
+        }
+
+        backend_type get_backend_type(const nb::kwargs& kwargs)
+        {
+            return get_kwarg<backend_type>(kwargs, "backend", backend_type::unicorn);
+        }
+    }
+
+    std::unique_ptr<linux_emulator> create_linux_application_emulator(const nb::object& application, const nb::object& args,
+                                                                      const nb::kwargs& kwargs)
+    {
+        const auto application_path = nb::cast<std::filesystem::path>(application);
+        auto argv = std::vector<std::string>{application_path.string()};
+        auto application_args = parse_linux_arguments(args);
+        for (auto& arg : application_args)
+        {
+            argv.emplace_back(std::move(arg));
+        }
+
+        auto envp = parse_linux_environment(get_kwarg_object(kwargs, "environment"));
+        auto linux_emu = std::make_unique<linux_emulator>(create_x86_64_emulator(get_backend_type(kwargs)),
+                                                          get_kwarg<std::filesystem::path>(kwargs, "emulation_root", {}), application_path,
+                                                          std::move(argv), envp);
+        linux_emu->log.disable_output(get_kwarg<bool>(kwargs, "disable_logging", true));
+        return linux_emu;
+    }
+
+    sogen_linux_process_context::sogen_linux_process_context(linux_process_context& context, nb::object owner)
+        : ctx(&context),
+          owner(std::move(owner))
+    {
+    }
+
+    std::optional<int> sogen_linux_process_context::exit_status() const
+    {
+        return this->ctx->exit_status;
+    }
+
+    uint32_t sogen_linux_process_context::pid() const
+    {
+        return this->ctx->pid;
+    }
+
+    uint32_t sogen_linux_process_context::ppid() const
+    {
+        return this->ctx->ppid;
+    }
+
+    uint32_t sogen_linux_process_context::uid() const
+    {
+        return this->ctx->uid;
+    }
+
+    uint32_t sogen_linux_process_context::gid() const
+    {
+        return this->ctx->gid;
+    }
+
+    uint32_t sogen_linux_process_context::euid() const
+    {
+        return this->ctx->euid;
+    }
+
+    uint32_t sogen_linux_process_context::egid() const
+    {
+        return this->ctx->egid;
+    }
+
+    size_t sogen_linux_process_context::thread_count() const
+    {
+        return this->ctx->threads.size();
+    }
+
+    linux_thread* sogen_linux_process_context::active_thread() const
+    {
+        return this->ctx->active_thread;
+    }
+
+    sogen_linux_emulator::sogen_linux_emulator(std::unique_ptr<linux_emulator> emulator)
+        : emu(std::move(emulator)),
+          callbacks(std::make_shared<linux_callback_registry>(*this->emu))
+    {
+    }
+
+    sogen_linux_emulator::~sogen_linux_emulator() = default;
+
+    sogen_linux_emulator::sogen_linux_emulator(sogen_linux_emulator&&) noexcept = default;
+
+    sogen_linux_emulator& sogen_linux_emulator::operator=(sogen_linux_emulator&&) noexcept = default;
+
+    linux_emulator& sogen_linux_emulator::native() const
+    {
+        return *this->emu;
+    }
+
+    void sogen_linux_emulator::start(const size_t count) const
+    {
+        this->emu->start(count);
+    }
+
+    void sogen_linux_emulator::stop() const
+    {
+        this->emu->stop();
+    }
+
+    sogen_linux_process_context sogen_linux_emulator::process()
+    {
+        return {this->emu->process, nb::cast(this, nb::rv_policy::reference_internal)};
+    }
+
+    linux_memory_manager& sogen_linux_emulator::memory() const
+    {
+        return this->emu->memory;
+    }
+
+    nb::bytes sogen_linux_emulator::read_memory(const uint64_t address, const size_t size) const
+    {
+        return read_memory_bytes(this->emu->memory, address, size);
+    }
+
+    void sogen_linux_emulator::write_memory(const uint64_t address, const nb::bytes& buffer) const
+    {
+        write_memory_bytes(this->emu->memory, address, buffer);
+    }
+
+    uint64_t sogen_linux_emulator::read_register(const x86_register reg) const
+    {
+        return this->emu->emu().reg<uint64_t>(reg);
+    }
+
+    void sogen_linux_emulator::write_register(const x86_register reg, const uint64_t value) const
+    {
+        this->emu->emu().reg<uint64_t>(reg, value);
+    }
+
+    uint64_t sogen_linux_emulator::executed_instructions() const
+    {
+        return this->emu->get_executed_instructions();
+    }
+
+    std::string sogen_linux_emulator::backend_name() const
+    {
+        return this->emu->emu().get_name();
+    }
+
+    std::filesystem::path sogen_linux_emulator::emulation_root() const
+    {
+        return this->emu->emulation_root;
+    }
+}

--- a/src/python-bindings/sogen_module.cpp
+++ b/src/python-bindings/sogen_module.cpp
@@ -15,6 +15,8 @@ namespace sogen::py
 
             auto windows = m.def_submodule("windows", "Windows emulator bindings");
             register_windows_runtime_bindings(windows);
+            auto linux_module = m.def_submodule("linux", "Linux emulator bindings");
+            register_linux_runtime_bindings(linux_module);
             register_runtime_bindings(m);
         }
     }

--- a/src/python-bindings/sogen_wrappers.cpp
+++ b/src/python-bindings/sogen_wrappers.cpp
@@ -1,5 +1,7 @@
 #include "sogen_internal.hpp"
 
+#include <windows_emulator.hpp>
+
 namespace sogen::py
 {
     // ----- hook_registry -----
@@ -106,6 +108,36 @@ namespace sogen::py
     {
     }
 
+    bool sogen_process_context::is_wow64_process() const
+    {
+        return this->ctx->is_wow64_process;
+    }
+
+    std::optional<NTSTATUS> sogen_process_context::exit_status() const
+    {
+        return this->ctx->exit_status;
+    }
+
+    size_t sogen_process_context::live_thread_count() const
+    {
+        return this->ctx->get_live_thread_count();
+    }
+
+    uint32_t sogen_process_context::spawned_thread_count() const
+    {
+        return this->ctx->spawned_thread_count;
+    }
+
+    emulator_thread* sogen_process_context::active_thread() const
+    {
+        return this->ctx->active_thread;
+    }
+
+    callback_registry& sogen_process_context::callback_view() const
+    {
+        return *this->callbacks;
+    }
+
     // ----- sogen_windows_emulator -----
 
     sogen_windows_emulator::sogen_windows_emulator(std::unique_ptr<windows_emulator> emulator)
@@ -113,6 +145,112 @@ namespace sogen::py
           callbacks(std::make_shared<callback_registry>(*this->emu)),
           hooks(std::make_shared<hook_registry>(*this->emu))
     {
+    }
+
+    sogen_windows_emulator::~sogen_windows_emulator() = default;
+
+    sogen_windows_emulator::sogen_windows_emulator(sogen_windows_emulator&&) noexcept = default;
+
+    sogen_windows_emulator& sogen_windows_emulator::operator=(sogen_windows_emulator&&) noexcept = default;
+
+    windows_emulator& sogen_windows_emulator::native() const
+    {
+        return *this->emu;
+    }
+
+    void sogen_windows_emulator::start(const size_t count) const
+    {
+        this->emu->start(count);
+    }
+
+    void sogen_windows_emulator::stop() const
+    {
+        this->emu->stop();
+    }
+
+    void sogen_windows_emulator::save_snapshot() const
+    {
+        this->emu->save_snapshot();
+    }
+
+    void sogen_windows_emulator::restore_snapshot() const
+    {
+        this->emu->restore_snapshot();
+    }
+
+    nb::bytes sogen_windows_emulator::serialize_state() const
+    {
+        return serialize_state_bytes(*this->emu);
+    }
+
+    void sogen_windows_emulator::deserialize_state(const nb::bytes& buffer) const
+    {
+        deserialize_state_bytes(*this->emu, buffer);
+    }
+
+    void sogen_windows_emulator::setup_process_if_necessary() const
+    {
+        this->emu->setup_process_if_necessary();
+    }
+
+    void sogen_windows_emulator::yield_thread(const bool alertable) const
+    {
+        this->emu->yield_thread(alertable);
+    }
+
+    bool sogen_windows_emulator::perform_thread_switch() const
+    {
+        return this->emu->perform_thread_switch();
+    }
+
+    bool sogen_windows_emulator::activate_thread(const uint32_t id) const
+    {
+        return this->emu->activate_thread(id);
+    }
+
+    memory_manager& sogen_windows_emulator::memory() const
+    {
+        return this->emu->memory;
+    }
+
+    emulator_thread* sogen_windows_emulator::current_thread() const
+    {
+        return this->emu->process.active_thread;
+    }
+
+    nb::bytes sogen_windows_emulator::read_memory(const uint64_t address, const size_t size) const
+    {
+        return read_memory_bytes(this->emu->memory, address, size);
+    }
+
+    void sogen_windows_emulator::write_memory(const uint64_t address, const nb::bytes& buffer) const
+    {
+        write_memory_bytes(this->emu->memory, address, buffer);
+    }
+
+    uint64_t sogen_windows_emulator::read_register(const x86_register reg) const
+    {
+        return this->emu->emu().reg<uint64_t>(reg);
+    }
+
+    void sogen_windows_emulator::write_register(const x86_register reg, const uint64_t value) const
+    {
+        this->emu->emu().reg<uint64_t>(reg, value);
+    }
+
+    uint16_t sogen_windows_emulator::get_host_port(const uint16_t emulator_port) const
+    {
+        return this->emu->get_host_port(emulator_port);
+    }
+
+    uint16_t sogen_windows_emulator::get_emulator_port(const uint16_t host_port) const
+    {
+        return this->emu->get_emulator_port(host_port);
+    }
+
+    void sogen_windows_emulator::map_port(const uint16_t emulator_port, const uint16_t host_port) const
+    {
+        this->emu->map_port(emulator_port, host_port);
     }
 
     sogen_process_context sogen_windows_emulator::process()

--- a/src/python-bindings/test_linux.py
+++ b/src/python-bindings/test_linux.py
@@ -1,0 +1,71 @@
+import gc
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.getcwd())
+repo_artifacts = Path(__file__).resolve().parents[2] / "build" / "release" / "artifacts"
+if repo_artifacts.exists():
+    sys.path.insert(0, str(repo_artifacts))
+
+import sogen
+
+assert sogen.create_application is sogen.windows.create_application
+
+linux = sogen.linux
+assert linux.create_application is not sogen.create_application
+
+binary = os.getenv("LINUX_PYTHON_TEST_BINARY", "/bin/true")
+root = os.getenv("LINUX_PYTHON_TEST_ROOT", "/")
+requested_backend = os.getenv("LINUX_PYTHON_TEST_BACKEND", "unicorn")
+
+backends = {
+    "unicorn": (sogen.Backend.unicorn, "Unicorn Engine"),
+    "kvm": (sogen.Backend.kvm, "Linux KVM"),
+}
+assert requested_backend in backends, f"unsupported backend: {requested_backend!r}"
+backend, expected_backend_name = backends[requested_backend]
+
+stdout_chunks = []
+stderr_chunks = []
+
+
+def capture_output(chunks):
+    def capture(data):
+        if isinstance(data, str):
+            chunks.append(data.encode())
+        else:
+            chunks.append(bytes(data))
+
+    return capture
+
+
+app = linux.create_application(
+    binary,
+    emulation_root=root,
+    backend=backend,
+    disable_logging=True,
+)
+app.callbacks.on_stdout = capture_output(stdout_chunks)
+app.callbacks.on_stderr = capture_output(stderr_chunks)
+app.start()
+
+stdout_data = b"".join(stdout_chunks)
+stderr_data = b"".join(stderr_chunks)
+
+print(f"exit_status={app.process.exit_status}", flush=True)
+print(f"backend={app.backend_name}", flush=True)
+print(f"requested_backend={requested_backend}", flush=True)
+print(f"executed_instructions={app.executed_instructions}", flush=True)
+
+assert app.process.exit_status == 0, f"non-zero exit: {app.process.exit_status}"
+assert stdout_data == b"", f"unexpected stdout: {stdout_data!r}"
+assert stderr_data == b"", f"unexpected stderr: {stderr_data!r}"
+assert app.backend_name == expected_backend_name, (
+    f"backend name {app.backend_name!r} != {expected_backend_name!r}"
+)
+if requested_backend == "unicorn":
+    assert app.executed_instructions > 0, "unicorn did not execute any instructions"
+
+app = None
+gc.collect()

--- a/src/windows-emulator/emulator_utils.hpp
+++ b/src/windows-emulator/emulator_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <arch_emulator.hpp>
+#include <function_calling_convention.hpp>
 
 #include "memory_manager.hpp"
 #include "memory_utils.hpp"
@@ -205,14 +206,6 @@ namespace sogen
 
             this->write(obj, index);
         }
-    };
-
-    enum class function_calling_convention
-    {
-        x86_cdecl,
-        x86_stdcall,
-        x64_fastcall,
-        x64_syscall,
     };
 
     // TODO: warning emulator_utils is hardcoded for 64bit unicode_string usage


### PR DESCRIPTION
## Summary
- added `sogen.linux` Python bindings with Linux emulator/process/memory/callback wrappers while preserving existing root Windows aliases
- added Linux `/bin/true` Python smoke coverage for Unicorn and conditional KVM CI paths
- fixed runtime gaps required by the smoke/tests: KVM high-address page projection, procfs memory-backed fds, `newfstatat(AT_EMPTY_PATH)` stats, and poll/select/epoll readiness for memory-backed procfs descriptors

## Verification
- `uvx --with ninja cmake --build --preset release --parallel 2`
- `uv run --no-project python src/python-bindings/test_linux.py` with `LINUX_PYTHON_TEST_BACKEND=unicorn`
- `uv run --no-project python src/python-bindings/test_linux.py` with `LINUX_PYTHON_TEST_BACKEND=kvm`
- `build/release/artifacts/linux-emulator-test`
- `uvx --with ninja cmake --build --preset tidy --parallel 2` was attempted and failed before feature sources on existing cleanup-only clang-tidy diagnostics in `src/common/network/address.cpp` and `src/common/network/socket.cpp`; those cleanup changes are preserved in the separate tidy worktree/branch

## Notes
- source branch: `vmcall:feat/linux-python-bindings`
- local commit: `f0c1859d`