### PR TITLE
Decode ANSI window text as CP-1252 instead of UTF-8

### DIFF
--- a/src/emulator-platform/platform/unicode.hpp
+++ b/src/emulator-platform/platform/unicode.hpp
@@ -266,6 +266,72 @@ namespace sogen
         return convert_from_u8<std::wstring>(view);
     }
 
+    // Maps a Windows-1252 (CP-1252) byte in the 0x80-0x9F range to its Unicode code point.
+    // Bytes 0x00-0x7F and 0xA0-0xFF map identically to U+0000-U+007F and U+00A0-U+00FF.
+    // The five unassigned slots (0x81, 0x8D, 0x8F, 0x90, 0x9D) pass through as their raw byte value.
+    constexpr char16_t cp1252_high_to_u16(const uint8_t ch)
+    {
+        constexpr char16_t table[0x20] = {
+            0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, // 0x80-0x87
+            0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F, // 0x88-0x8F
+            0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, // 0x90-0x97
+            0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178, // 0x98-0x9F
+        };
+        return table[ch - 0x80];
+    }
+
+    // Decodes a Windows-1252 (ANSI default codepage) byte string to UTF-16. Unlike u8_to_u16,
+    // this is what the *A window/text APIs expect: a lone high byte such as 0xA9 ('©') is a valid
+    // CP-1252 character, not an invalid UTF-8 lead byte.
+    constexpr std::u16string cp1252_to_u16(const std::string_view view)
+    {
+        std::u16string result;
+        result.reserve(view.size());
+
+        for (const char raw : view)
+        {
+            const auto ch = static_cast<uint8_t>(raw);
+            result.push_back(ch < 0x80 || ch >= 0xA0 ? static_cast<char16_t>(ch) : cp1252_high_to_u16(ch));
+        }
+
+        return result;
+    }
+
+    // Inverse of cp1252_to_u16: encodes one UTF-16 code unit to a Windows-1252 byte. Code points with
+    // no CP-1252 representation (including surrogate halves) map to the default char '?', matching
+    // WideCharToMultiByte. The 0x80-0x9F block is reverse-looked-up against cp1252_high_to_u16 so the
+    // two directions share a single source of truth.
+    constexpr char u16_to_cp1252_char(const char16_t ch)
+    {
+        if (ch <= 0x7F || (ch >= 0xA0 && ch <= 0xFF))
+        {
+            return static_cast<char>(static_cast<uint8_t>(ch));
+        }
+
+        for (uint8_t i = 0; i < 0x20; ++i)
+        {
+            if (cp1252_high_to_u16(static_cast<uint8_t>(0x80 + i)) == ch)
+            {
+                return static_cast<char>(static_cast<uint8_t>(0x80 + i));
+            }
+        }
+
+        return '?';
+    }
+
+    constexpr std::string u16_to_cp1252(const std::u16string_view view)
+    {
+        std::string result;
+        result.reserve(view.size());
+
+        for (const char16_t ch : view)
+        {
+            result.push_back(u16_to_cp1252_char(ch));
+        }
+
+        return result;
+    }
+
     template <typename string_view_type>
         requires(std::is_same_v<string_view_type, std::u16string_view> || std::is_same_v<string_view_type, std::u32string_view> ||
                  std::is_same_v<string_view_type, std::wstring_view>)

--- a/src/emulator-platform/platform/unicode.hpp
+++ b/src/emulator-platform/platform/unicode.hpp
@@ -4,6 +4,7 @@
 #include <share.h>
 #endif
 
+#include <array>
 #include <string>
 #include <filesystem>
 #include <type_traits>
@@ -271,13 +272,13 @@ namespace sogen
     // The five unassigned slots (0x81, 0x8D, 0x8F, 0x90, 0x9D) pass through as their raw byte value.
     constexpr char16_t cp1252_high_to_u16(const uint8_t ch)
     {
-        constexpr char16_t table[0x20] = {
+        constexpr std::array<char16_t, 0x20> table = {
             0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, // 0x80-0x87
             0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F, // 0x88-0x8F
             0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, // 0x90-0x97
             0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178, // 0x98-0x9F
         };
-        return table[ch - 0x80];
+        return table[static_cast<size_t>(ch - 0x80)];
     }
 
     // Decodes a Windows-1252 (ANSI default codepage) byte string to UTF-16. Unlike u8_to_u16,

--- a/src/windows-emulator-test/unicode_test.cpp
+++ b/src/windows-emulator-test/unicode_test.cpp
@@ -257,4 +257,48 @@ namespace sogen::test
             EXPECT_TRUE(u8_byte_len == u8_conv.length() && memcmp(u8_str, u8_conv.data(), u8_byte_len) == 0);
         }
     }
+
+    TEST(UnicodeConversionsTest, test_cp1252_to_u16)
+    {
+        // Plain ASCII passes through unchanged.
+        EXPECT_EQ(cp1252_to_u16("\x47\x61\x6d\x65"), std::u16string(u"Game"));
+
+        // The copyright sign is byte 0xA9 in CP-1252 (an invalid UTF-8 lead byte) -> U+00A9.
+        EXPECT_EQ(cp1252_to_u16("\xA9\x20\x32\x30\x32\x34"), (std::u16string{0x00A9, 0x20, 0x32, 0x30, 0x32, 0x34}));
+
+        // 0xA0-0xFF map identically to Latin-1 (0xE9 -> U+00E9, 0xAE -> U+00AE).
+        EXPECT_EQ(cp1252_to_u16("\x63\x61\x66\xE9"), (std::u16string{0x63, 0x61, 0x66, 0x00E9}));
+        EXPECT_EQ(cp1252_to_u16("\xAE"), (std::u16string{0x00AE}));
+
+        // The 0x80-0x9F block is remapped: 0x80 -> U+20AC, 0x99 -> U+2122, 0x93/0x94 -> smart quotes.
+        EXPECT_EQ(cp1252_to_u16("\x80"), (std::u16string{0x20AC}));
+        EXPECT_EQ(cp1252_to_u16("\x99"), (std::u16string{0x2122}));
+        EXPECT_EQ(cp1252_to_u16("\x93\x68\x69\x94"), (std::u16string{0x201C, 0x68, 0x69, 0x201D}));
+
+        // The five unassigned slots pass through as their raw byte value (0x81 -> U+0081).
+        EXPECT_EQ(cp1252_to_u16("\x81"), (std::u16string{0x0081}));
+    }
+
+    TEST(UnicodeConversionsTest, test_u16_to_cp1252)
+    {
+        // Plain ASCII passes through unchanged.
+        EXPECT_EQ(u16_to_cp1252(u"Game"), std::string("\x47\x61\x6d\x65"));
+
+        // Inverse of cp1252_to_u16: U+00A9 -> byte 0xA9, Latin-1 0xA0-0xFF identity.
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x00A9, 0x20, 0x32, 0x30, 0x32, 0x34}), std::string("\xA9\x20\x32\x30\x32\x34"));
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x63, 0x61, 0x66, 0x00E9}), std::string("\x63\x61\x66\xE9"));
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x00AE}), std::string("\xAE"));
+
+        // The remapped 0x80-0x9F block reverses: U+20AC -> 0x80, U+2122 -> 0x99, smart quotes -> 0x93/0x94.
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x20AC}), std::string("\x80"));
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x2122}), std::string("\x99"));
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x201C, 0x68, 0x69, 0x201D}), std::string("\x93\x68\x69\x94"));
+
+        // The five unassigned slots reverse to their raw byte (U+0081 -> 0x81).
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x0081}), std::string("\x81"));
+
+        // Code points with no CP-1252 representation map to the default char (U+4E2D, U+0080).
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x4E2D}), std::string("\x3F"));
+        EXPECT_EQ(u16_to_cp1252(std::u16string{0x0080}), std::string("\x3F"));
+    }
 } // namespace sogen::test

--- a/src/windows-emulator/emulator_utils.hpp
+++ b/src/windows-emulator/emulator_utils.hpp
@@ -435,7 +435,7 @@ namespace sogen
         }
 
         const auto ansi_string = read_string<char>(*str_obj.get_memory_interface(), str.Buffer, str.Length);
-        return u8_to_u16(ansi_string);
+        return cp1252_to_u16(ansi_string);
     }
 
     inline uint64_t get_function_argument_x64_fastcall(x86_64_emulator& emu, const size_t index)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -593,10 +593,10 @@ namespace sogen
             case WM_GETTEXT:
                 return copy_def_window_text(c, win, w_param, l_param, ansi != FALSE);
 
-            case WM_GETTEXTLENGTH: {
-                const auto text = read_guest_window_text(c, win);
-                return ansi ? u16_to_cp1252(text).size() : text.size();
-            }
+            case WM_GETTEXTLENGTH:
+                // CP-1252 is 1:1 with UTF-16 code units, so the ANSI byte count equals the code-unit
+                // count; no need to encode just to measure it.
+                return read_guest_window_text(c, win).size();
 
             case WM_ERASEBKGND:
                 return TRUE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -538,7 +538,7 @@ namespace sogen
             const auto text = read_guest_window_text(c, win);
             if (ansi)
             {
-                const auto narrow = u16_to_u8(text);
+                const auto narrow = u16_to_cp1252(text);
                 const auto copy_count = std::min<uint64_t>(narrow.size(), character_count - 1);
                 if (copy_count != 0 && !c.win_emu.memory.try_write_memory(buffer, narrow.data(), static_cast<size_t>(copy_count)))
                 {
@@ -582,7 +582,7 @@ namespace sogen
                 }
                 else if (ansi)
                 {
-                    update_window_title(c, win, u8_to_u16(read_string<char>(c.win_emu.memory, l_param)));
+                    update_window_title(c, win, cp1252_to_u16(read_string<char>(c.win_emu.memory, l_param)));
                 }
                 else
                 {
@@ -595,7 +595,7 @@ namespace sogen
 
             case WM_GETTEXTLENGTH: {
                 const auto text = read_guest_window_text(c, win);
-                return ansi ? u16_to_u8(text).size() : text.size();
+                return ansi ? u16_to_cp1252(text).size() : text.size();
             }
 
             case WM_ERASEBKGND:
@@ -1104,7 +1104,7 @@ namespace sogen
                     // mis-handle non-ASCII Unicode such as a CJK title).
                     if (str->bAnsi)
                     {
-                        return u8_to_u16(read_string<char>(c.win_emu.memory, str->Buffer, length));
+                        return cp1252_to_u16(read_string<char>(c.win_emu.memory, str->Buffer, length));
                     }
 
                     return read_string<char16_t>(c.win_emu.memory, str->Buffer, length / sizeof(char16_t));
@@ -1124,7 +1124,7 @@ namespace sogen
 
             if (first_bytes[0] >= 0x20 && first_bytes[0] < 0x7F)
             {
-                return u8_to_u16(read_string<char>(c.win_emu.memory, text.value()));
+                return cp1252_to_u16(read_string<char>(c.win_emu.memory, text.value()));
             }
 
             return read_string<char16_t>(c.win_emu.memory, text.value());
@@ -2945,7 +2945,7 @@ namespace sogen
                 }
                 else if (ansi)
                 {
-                    update_window_title(c, *win, u8_to_u16(read_string<char>(c.win_emu.memory, l_param)));
+                    update_window_title(c, *win, cp1252_to_u16(read_string<char>(c.win_emu.memory, l_param)));
                 }
                 else
                 {
@@ -2960,7 +2960,7 @@ namespace sogen
                 {
                     if (win->unicode_proc)
                     {
-                        const auto wide = u8_to_u16(read_string<char>(c.win_emu.memory, l_param));
+                        const auto wide = cp1252_to_u16(read_string<char>(c.win_emu.memory, l_param));
                         const auto bytes = (wide.size() + 1) * sizeof(char16_t);
                         scratch_text =
                             c.win_emu.memory.allocate_memory(static_cast<size_t>(page_align_up(bytes)), memory_permission::read_write);
@@ -2968,7 +2968,7 @@ namespace sogen
                     }
                     else
                     {
-                        const auto narrow = u16_to_u8(read_string<char16_t>(c.win_emu.memory, l_param));
+                        const auto narrow = u16_to_cp1252(read_string<char16_t>(c.win_emu.memory, l_param));
                         const auto bytes = narrow.size() + 1;
                         scratch_text =
                             c.win_emu.memory.allocate_memory(static_cast<size_t>(page_align_up(bytes)), memory_permission::read_write);


### PR DESCRIPTION
## Problem

A game that creates a window with a copyright symbol (`©`) in its title showed only a replacement glyph (U+FFFD, the "?-in-a-box") when rendered via SDL.

The title wasn't corrupted by SDL — it was already wrong by the time it reached SDL. The game uses the ANSI (`*A`) window-text APIs (`CreateWindowExA`, `SetWindowTextA`, ANSI `WM_SETTEXT`), which deliver text in the Windows ANSI codepage. The emulator decoded those bytes with `u8_to_u16`, a **strict UTF-8 decoder**. `©` is the single byte `0xA9` in CP-1252 — a valid character there, but an invalid UTF-8 lead byte — so it decoded to U+FFFD before it ever reached the UI backend. ASCII was unaffected because CP-1252 and UTF-8 agree below `0x80`.

## Fix

- Add a portable, table-based `cp1252_to_u16` / `u16_to_cp1252` pair in `unicode.hpp` — no `MultiByteToWideChar`, so it works on every host. Bytes `0x00–0x7F` and `0xA0–0xFF` map straight through (Latin-1); the `0x80–0x9F` block uses a 32-entry table (€, ™, smart quotes, …), with the 5 unassigned slots passing through as their raw value.
- Route the ANSI window/control/menu text paths through them **in both directions**:
  - decode: `read_large_string`, default-proc and `NtUserMessageCall` `WM_SETTEXT`, the `LARGE_STRING` `bAnsi` paths, and the ANSI→wide scratch re-encode.
  - encode: `WM_GETTEXT` (`copy_def_window_text`), `WM_GETTEXTLENGTH`, and the wide→ANSI scratch re-encode — so ANSI callers get correct bytes back.
- The two directions reverse-look-up the same `0x80–0x9F` table, so they can't drift. Code points with no CP-1252 representation map to the default char `?`, matching `WideCharToMultiByte`.
- Genuinely UTF-8 paths (file/registry/section names, host-side logging) are left on `u8_to_u16`/`u16_to_u8`.

## Notes / scope

- The ANSI codepage is assumed to be CP-1252 (the common Western default). A non-Western guest locale would need its actual codepage; deferred.

## Tests

Added `test_cp1252_to_u16` and `test_u16_to_cp1252` (round-trip, the `0x80–0x9F` remaps, Latin-1 identity, unassigned-slot passthrough, and the default-char fallback). Both pass:

```
[  PASSED  ] 2 tests.
```