### PR TITLE
Hide the host cursor when a game captures the mouse

### DIFF
--- a/src/emulator-platform/platform/ui_backend.hpp
+++ b/src/emulator-platform/platform/ui_backend.hpp
@@ -102,6 +102,12 @@ namespace sogen
         virtual void set_cursor_position(const hwnd /*window*/, const int32_t /*screen_x*/, const int32_t /*screen_y*/)
         {
         }
+        // Show or hide the host cursor. Games that capture the mouse hide it (ShowCursor(FALSE) /
+        // SetCursor(NULL)) and recenter every frame; without honoring this the host cursor stays visible
+        // and flickers as the guest warps it back to the center.
+        virtual void set_cursor_visibility(const bool /*visible*/)
+        {
+        }
     };
 
     class null_ui_backend final : public ui_backend

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -601,6 +601,7 @@ namespace sogen
         buffer.write(this->cursor_y);
         buffer.write(this->current_cursor);
         buffer.write(this->cursor_show_count);
+        buffer.write(this->cursor_shape_visible);
         buffer.write(this->key_state);
         buffer.write(this->raw_mouse_registered);
         buffer.write(this->raw_mouse_target);
@@ -688,6 +689,7 @@ namespace sogen
         buffer.read(this->cursor_y);
         buffer.read(this->current_cursor);
         buffer.read(this->cursor_show_count);
+        buffer.read(this->cursor_shape_visible);
         buffer.read(this->key_state);
         buffer.read(this->raw_mouse_registered);
         buffer.read(this->raw_mouse_target);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -405,6 +405,11 @@ namespace sogen
         int32_t cursor_y{};
         hcursor current_cursor{};
         int32_t cursor_show_count{};
+        // Whether the current cursor has a visible shape. SetCursor(NULL) clears it to hide the pointer
+        // without touching the show count (some games hide the cursor that way). Defaults to true since a
+        // window without an explicit SetCursor still shows its class cursor. The host pointer is shown only
+        // when cursor_show_count >= 0 and this is set.
+        bool cursor_shape_visible{true};
         // Per-virtual-key pressed state (0x80 = down), updated from key/mouse-button events and reported by
         // GetKeyState; games poll this for in-game input (movement, etc.) rather than window messages.
         std::array<uint8_t, 256> key_state{};

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1904,17 +1904,28 @@ namespace sogen
             return (c.proc.key_state[static_cast<uint32_t>(virtual_key) & 0xFF] & 0x80) ? 0x8000u : 0u;
         }
 
+        // The host pointer is shown only when the display count is non-negative and the current cursor has a
+        // visible shape; mirror that to the UI so a captured (hidden + recentered) cursor stops flickering.
+        void apply_cursor_visibility(const syscall_context& c)
+        {
+            c.win_emu.ui().set_cursor_visibility(c.proc.cursor_show_count >= 0 && c.proc.cursor_shape_visible);
+        }
+
         // ShowCursor(bShow) adjusts the cursor display counter (+1 to show, -1 to hide) and returns the new
         // value. Games spin on it to drive the count to a target (e.g. IN_ActivateMouse hides the cursor), so
         // it must actually track and return the running count or those loops never terminate.
         int32_t handle_NtUserShowCursor(const syscall_context& c, const BOOL show)
         {
             c.proc.cursor_show_count += show ? 1 : -1;
+            apply_cursor_visibility(c);
             return c.proc.cursor_show_count;
         }
 
         hcursor handle_NtUserSetCursor(const syscall_context& c, const hcursor cursor)
         {
+            // SetCursor(NULL) removes the cursor shape (hides it); a non-null handle restores it.
+            c.proc.cursor_shape_visible = cursor != 0;
+            apply_cursor_visibility(c);
             return std::exchange(c.proc.current_cursor, cursor);
         }
 

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -891,6 +891,23 @@ namespace sogen
 #endif
             }
 
+            void set_cursor_visibility(const bool visible) override
+            {
+#ifdef SOGEN_HAS_SDL3
+                // SDL cursor visibility is process-global, which matches the single foreground guest game.
+                if (visible)
+                {
+                    SDL_ShowCursor();
+                }
+                else
+                {
+                    SDL_HideCursor();
+                }
+#else
+                (void)visible;
+#endif
+            }
+
           private:
 #ifdef SOGEN_HAS_SDL3
             bool ensure_initialized()


### PR DESCRIPTION
## Problem

Games that capture the mouse hide the cursor (`ShowCursor(FALSE)` or `SetCursor(NULL)`) and recenter it every frame, reading the relative delta for mouse-look. In a windowed SDL session the cursor wasn't hidden, so you'd see the system pointer **flickering around the window center** — the user's motion fighting the game's per-frame recenter.

The relative-look itself already works: `handle_NtUserSetCursorPos` warps the host cursor (`SDL_WarpMouseInWindow`) and the WM_INPUT delta synthesis cancels the warp echo. The emulator also already tracked the show count in `cursor_show_count`. The only missing piece was that nothing ever told the UI backend to actually **hide** the cursor.

## Fix

- Add `ui_backend::set_cursor_visibility(bool)`, implemented in the SDL backend with `SDL_ShowCursor()` / `SDL_HideCursor()` (process-global, which matches the single foreground guest game). Other backends inherit the no-op default.
- Drive it from `NtUserShowCursor` and `NtUserSetCursor`. The host pointer is shown only when **the display count is ≥ 0 and the current cursor has a visible shape**.
- Track the `SetCursor(NULL)` case with a new `cursor_shape_visible` flag (default `true`, so windows relying on their class cursor are unaffected — `current_cursor` defaults to 0 and isn't a reliable visibility signal on its own). Serialized alongside the other cursor state.

Once the cursor is hidden, the per-frame recenter warps are invisible, so the flicker is gone. No change to the relative-motion path, and the bigger SDL relative-mouse-mode rework was intentionally avoided.

## Scope / notes

- Visibility is process-global via SDL; fine for the single foreground game.
- This layer has no UI-backend test harness in the repo, so no unit test was added; the logic is small and compile-verified (`user.cpp`, `process_context.cpp`, `sdl_ui_backend.cpp` all build clean).