### PR TITLE
win32: report window client size, fixing soft windowed rendering

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2947,10 +2947,13 @@ namespace sogen
                 if (const uint64_t surface_hwnd = this->vulkan_.get_surface_hwnd(request.surface); surface_hwnd != 0)
                 {
                     if (const auto* win = win_emu.process.windows.get(static_cast<hwnd>(surface_hwnd));
-                        win && win->width > 0 && win->height > 0)
+                        win && win->client_width() > 0 && win->client_height() > 0)
                     {
-                        window_width = static_cast<uint32_t>(win->width);
-                        window_height = static_cast<uint32_t>(win->height);
+                        // Report the client size, not the outer window size: DXVK pins its swapchain to this
+                        // extent, and if it exceeds the client-sized backbuffer the present blit upscales (a 1px
+                        // border alone softens the whole frame).
+                        window_width = static_cast<uint32_t>(win->client_width());
+                        window_height = static_cast<uint32_t>(win->client_height());
                     }
                 }
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2949,9 +2949,8 @@ namespace sogen
                     if (const auto* win = win_emu.process.windows.get(static_cast<hwnd>(surface_hwnd));
                         win && win->client_width() > 0 && win->client_height() > 0)
                     {
-                        // Report the client size, not the outer window size: DXVK pins its swapchain to this
-                        // extent, and if it exceeds the client-sized backbuffer the present blit upscales (a 1px
-                        // border alone softens the whole frame).
+                        // Client size, not outer: DXVK pins its swapchain to this extent and must match its
+                        // client-sized backbuffer, else the present upscales (see window::nonclient_border).
                         window_width = static_cast<uint32_t>(win->client_width());
                         window_height = static_cast<uint32_t>(win->client_height());
                     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -339,7 +339,7 @@ namespace sogen
 
         RECT get_client_rect(const window& win)
         {
-            return RECT{.left = 0, .top = 0, .right = win.width, .bottom = win.height};
+            return RECT{.left = 0, .top = 0, .right = win.client_width(), .bottom = win.client_height()};
         }
 
         RECT get_window_rect(const window& win)
@@ -347,18 +347,26 @@ namespace sogen
             return RECT{.left = win.x, .top = win.y, .right = win.x + win.width, .bottom = win.y + win.height};
         }
 
-        ui_insets get_host_ui_client_insets(const window& /*win*/)
+        ui_insets get_host_ui_client_insets(const window& win)
         {
-            return {};
+            // The host window shows only the client area (we don't draw a non-client frame), so report the
+            // window's non-client border as insets. This keeps the host window sized to the client area the
+            // guest renders into, so the presented frame maps 1:1 instead of being stretched onto the slightly
+            // larger outer rect.
+            const auto border = win.nonclient_border();
+            return {.left = border, .top = border, .right = border, .bottom = border};
         }
 
         void sync_guest_window_rects(window& win)
         {
             const auto window_rect = get_window_rect(win);
+            // The client rect is the window minus its non-client frame; report it top-left aligned with the
+            // window origin (we don't render a frame) so client-side GetClientRect matches the syscall path.
+            const RECT client_rect{.left = win.x, .top = win.y, .right = win.x + win.client_width(), .bottom = win.y + win.client_height()};
 
             win.guest.access([&](USER_WINDOW& guest_win) {
                 guest_win.rcWindow = window_rect;
-                guest_win.rcClient = window_rect;
+                guest_win.rcClient = client_rect;
             });
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -349,10 +349,6 @@ namespace sogen
 
         ui_insets get_host_ui_client_insets(const window& win)
         {
-            // The host window shows only the client area (we don't draw a non-client frame), so report the
-            // window's non-client border as insets. This keeps the host window sized to the client area the
-            // guest renders into, so the presented frame maps 1:1 instead of being stretched onto the slightly
-            // larger outer rect.
             const auto border = win.nonclient_border();
             return {.left = border, .top = border, .right = border, .bottom = border};
         }
@@ -360,8 +356,7 @@ namespace sogen
         void sync_guest_window_rects(window& win)
         {
             const auto window_rect = get_window_rect(win);
-            // The client rect is the window minus its non-client frame; report it top-left aligned with the
-            // window origin (we don't render a frame) so client-side GetClientRect matches the syscall path.
+            // Frameless: the client sits at the window origin, so it shares the top-left and shrinks by the frame.
             const RECT client_rect{.left = win.x, .top = win.y, .right = win.x + win.client_width(), .bottom = win.y + win.client_height()};
 
             win.guest.access([&](USER_WINDOW& guest_win) {

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -721,9 +721,7 @@ namespace sogen
                     flags |= SDL_WINDOW_RESIZABLE;
                 }
 
-                // Size the host window to the client area (outer rect minus the non-client frame). We don't
-                // render a frame, so the client is what the guest paints/presents into; sizing to the client
-                // keeps the presented frame 1:1 instead of fitting it into the slightly larger outer rect.
+                // Size the host window to the client area; we render no frame, so sizing to it keeps the present 1:1.
                 const auto width = std::max<int>(1, static_cast<int>(desc.rect.right - desc.rect.left) - desc.client_insets.left -
                                                         desc.client_insets.right);
                 const auto height = std::max<int>(1, static_cast<int>(desc.rect.bottom - desc.rect.top) - desc.client_insets.top -

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -721,8 +721,13 @@ namespace sogen
                     flags |= SDL_WINDOW_RESIZABLE;
                 }
 
-                const auto width = std::max<int>(1, static_cast<int>(desc.rect.right - desc.rect.left));
-                const auto height = std::max<int>(1, static_cast<int>(desc.rect.bottom - desc.rect.top));
+                // Size the host window to the client area (outer rect minus the non-client frame). We don't
+                // render a frame, so the client is what the guest paints/presents into; sizing to the client
+                // keeps the presented frame 1:1 instead of fitting it into the slightly larger outer rect.
+                const auto width = std::max<int>(1, static_cast<int>(desc.rect.right - desc.rect.left) - desc.client_insets.left -
+                                                        desc.client_insets.right);
+                const auto height = std::max<int>(1, static_cast<int>(desc.rect.bottom - desc.rect.top) - desc.client_insets.top -
+                                                         desc.client_insets.bottom);
                 const auto title = u16_to_u8(desc.title);
                 auto* window = SDL_CreateWindow(title.c_str(), static_cast<int>(width), static_cast<int>(height), flags);
                 if (!window)
@@ -774,8 +779,10 @@ namespace sogen
                     state->desc.rect = rect;
                     if (state->desc.top_level)
                     {
+                        const auto& insets = state->desc.client_insets;
                         SDL_SetWindowPosition(state->window, rect.left, rect.top);
-                        SDL_SetWindowSize(state->window, rect.right - rect.left, rect.bottom - rect.top);
+                        SDL_SetWindowSize(state->window, std::max<int>(1, (rect.right - rect.left) - insets.left - insets.right),
+                                          std::max<int>(1, (rect.bottom - rect.top) - insets.top - insets.bottom));
                     }
                     this->redraw_related(window);
                 }
@@ -981,6 +988,10 @@ namespace sogen
                 if (state.texture)
                 {
                     SDL_SetTextureBlendMode(state.texture, SDL_BLENDMODE_NONE);
+                    // Nearest-neighbour keeps the guest frame crisp when the window is resized larger than the
+                    // guest resolution (the letterbox fit would otherwise blur it with linear filtering). At the
+                    // default 1:1 size this is identical to linear.
+                    SDL_SetTextureScaleMode(state.texture, SDL_SCALEMODE_NEAREST);
                     state.texture_width = surface.width;
                     state.texture_height = surface.height;
                     state.texture_format = surface.format;

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -9,6 +9,7 @@
 #include <utils/file_handle.hpp>
 #include <platform/synchronisation.hpp>
 #include <platform/win_pefile.hpp>
+#include <platform/window.hpp>
 
 namespace sogen
 {
@@ -139,6 +140,27 @@ namespace sogen
         bool is_dialog() const
         {
             return this->class_name == builtin_dialog_class_name;
+        }
+
+        // The guest sizes its window via AdjustWindowRect, which inflates the client rect it wants to render
+        // into by the non-client frame. user32 always adds a 1px border for framed windows (SM_CXBORDER/
+        // SM_CYBORDER are hardcoded to 1) and our system metrics for the sizing frame and caption are zero, so
+        // the only inset is that 1px border. Mirror it so the client size we report (GetClientRect, the Vulkan
+        // surface extent, the presented surface) matches what the guest actually renders -- otherwise the
+        // layer (DXVK) renders its whole frame onto a 1px-larger surface and the upscaled image softens.
+        int32_t nonclient_border() const
+        {
+            return (this->style & (WS_BORDER | WS_DLGFRAME | WS_THICKFRAME)) != 0 ? 1 : 0;
+        }
+
+        int32_t client_width() const
+        {
+            return std::max(0, this->width - 2 * this->nonclient_border());
+        }
+
+        int32_t client_height() const
+        {
+            return std::max(0, this->height - 2 * this->nonclient_border());
         }
 
         void serialize_object(utils::buffer_serializer& buffer) const override


### PR DESCRIPTION
## Problem

Windowed games rendered through DXVK → GPU bridge looked slightly soft (most visible on UI/menu text — the faint smear of an off-by-one resample).

Root cause: the emulator treated **window == client** (zero non-client frame). So `GetClientRect`, the guest `USER_WINDOW.rcClient`, and the GPU-bridge Vulkan **surface extent** all reported the *outer* window size. A guest that sizes its window with `AdjustWindowRect` (client + a 1px border) then rendered its entire frame onto a surface 2px larger than intended: DXVK pinned its swapchain to the outer extent and laid out the whole frame — fonts included — scaled up ~0.16%, softening everything.

## Evidence (RenderDoc)

Captured the same open-iw5 main menu through the bridge and natively (DXVK on the real GPU):

| | Swapchain / color targets | Format |
|---|---|---|
| Bridge (before) | **1282×722** | UNORM |
| Native (reference) | **1280×720** | UNORM |
| Bridge (after this fix) | **1280×720** ✅ | UNORM |

Native renders everything at exactly 1280×720; the bridge rendered everything at 1282×722. With the fix, the bridge matches native pixel-for-pixel. (sRGB/gamma was ruled out — every image is `B8G8R8A8_UNORM`.)

## Fix

- `window::nonclient_border()` / `client_width()` / `client_height()` — report the 1px border user32 adds for framed windows (`WS_BORDER|WS_DLGFRAME|WS_THICKFRAME`).
- `get_client_rect`, `sync_guest_window_rects` (`rcClient`), and `get_host_ui_client_insets` return the client size.
- GPU-bridge surface caps report the **client** size, so DXVK's swapchain matches its client-sized backbuffer → 1:1 present, no upscale.
- SDL backend sizes the host window to the client area, and presents the guest frame with `SCALEMODE_NEAREST` so a **resized** window stays crisp instead of blurring the letterboxed fit (nearest == linear at the default 1:1 size, so no downside there).

## Testing

- open-iw5 (MW3) menu text is now as crisp as native (RenderDoc-confirmed identical 1280×720 render).
- Baba Is You: resizing/maximizing the window stays crisp (previously the letterbox upscale blurred it).
- Release build + `analyzer -s test-sample.exe` smoke test pass.

## Note

This supersedes the parked `windowed-render-sharpness` branch, whose doc concluded the client-size fix "did not resolve the softness." The RenderDoc comparison shows it does — that branch's fix was incomplete (the guest still requested an outer-sized backbuffer). The RenderDoc capture tooling used to prove this is kept separate from this fix.