### PR TITLE
win32: seed rcClient with the client rect at window creation

### DIFF
--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2484,7 +2484,10 @@ namespace sogen
                 guest_win.dwExStyle = ex_style;
                 guest_win.dwStyle = style;
                 guest_win.rcWindow = {.left = x, .top = y, .right = x + width, .bottom = y + height};
-                guest_win.rcClient = guest_win.rcWindow;
+                // The client rect is the window minus its non-client frame (see window::nonclient_border). The
+                // guest reads rcClient client-side to size its render target/backbuffer, so seeding it with the
+                // outer rect here makes a framed window render 2px too large and rescale (softening the frame).
+                guest_win.rcClient = {.left = x, .top = y, .right = x + win.client_width(), .bottom = y + win.client_height()};
                 if (parent_win && has_child_parent)
                 {
                     guest_win.spwndParent = parent_win->guest.value();


### PR DESCRIPTION
## Problem

Follow-up to the client-size fix (#1129). open-iw5 (MW3/iw4x via DXVK) was still slightly blurry — most visible on menu text — even after that fix made the swapchain render at the native 1280×720.

Root cause: `NtUserCreateWindowEx` initialized the guest `USER_WINDOW.rcClient` to the **outer** window rect (`rcClient = rcWindow`). A framed guest reads `rcClient` *client-side* (no syscall) to size its render target / D3D9 backbuffer, so it picked the 2px-larger outer size (1282×722) instead of the client (1280×720). `#1129` fixed `GetClientRect`/`sync_guest_window_rects`/the surface extent, but this creation-time seed was a separate path it didn't cover.

The result was a double rescale per frame:
- UI rendered crisp to a 1280×720 render target,
- blitted through a 1282×722 (backbuffer-sized) viewport,
- then down-blitted to the 1280×720 swapchain.

A 1280→1282→1280 round-trip softens the entire frame.

## Evidence (RenderDoc)

Captured the guest's Vulkan frame through the GPU bridge. Every UI draw rendered at `1280x720`, but the final present draw was:

```
vkCmdDraw  vp=0,0 1282x722  ->  1280x720 swapchain
```

— the outer window size leaking into the final composite. After this fix the guest sizes its backbuffer to 1280×720 and the present is 1:1; the menu is pixel-crisp, matching native.

## Fix

Seed `rcClient` with the client rect (`win.client_width()/client_height()`) at creation, matching `sync_guest_window_rects` and `get_client_rect`.

## Testing

- open-iw5 multiplayer menu is now crisp (was blurry), confirmed against a native DXVK run.
- `analyzer -s test-sample.exe` smoke test passes.