### PR TITLE
Several improvements for GDI and USER syscalls

### DIFF
--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -4,6 +4,154 @@
 
 namespace sogen
 {
+#ifndef OS_WINDOWS
+#define ANSI_CHARSET       0
+#define DEFAULT_CHARSET    1
+#define GREEK_CHARSET      161
+#define TURKISH_CHARSET    162
+#define VIETNAMESE_CHARSET 163
+#define HEBREW_CHARSET     177
+#define ARABIC_CHARSET     178
+#define BALTIC_CHARSET     186
+#define RUSSIAN_CHARSET    204
+#define EASTEUROPE_CHARSET 238
+
+#define DEFAULT_PITCH      0
+#define FF_SWISS           0x20
+#define FW_NORMAL          400
+#define FW_BOLD            700
+#define NTM_ITALIC         0x00000001
+#define NTM_BOLD           0x00000020
+#define NTM_REGULAR        0x00000040
+#define TRUETYPE_FONTTYPE  0x00000004
+#define RDH_RECTANGLES     1
+
+    struct ABC
+    {
+        int abcA;
+        UINT abcB;
+        int abcC;
+    };
+
+    struct RGNDATAHEADER
+    {
+        DWORD dwSize;
+        DWORD iType;
+        DWORD nCount;
+        DWORD nRgnSize;
+        RECT rcBound;
+    };
+#endif
+
+    struct EMU_LOGFONTW
+    {
+        LONG lfHeight;
+        LONG lfWidth;
+        LONG lfEscapement;
+        LONG lfOrientation;
+        LONG lfWeight;
+        BYTE lfItalic;
+        BYTE lfUnderline;
+        BYTE lfStrikeOut;
+        BYTE lfCharSet;
+        BYTE lfOutPrecision;
+        BYTE lfClipPrecision;
+        BYTE lfQuality;
+        BYTE lfPitchAndFamily;
+        char16_t lfFaceName[32];
+    };
+    static_assert(sizeof(EMU_LOGFONTW) == 0x5C);
+
+    struct EMU_ENUMLOGFONTEXW
+    {
+        EMU_LOGFONTW elfLogFont;
+        char16_t elfFullName[64];
+        char16_t elfStyle[32];
+        char16_t elfScript[32];
+    };
+    static_assert(sizeof(EMU_ENUMLOGFONTEXW) == 0x15C);
+
+    struct EMU_NEWTEXTMETRICW
+    {
+        LONG tmHeight;
+        LONG tmAscent;
+        LONG tmDescent;
+        LONG tmInternalLeading;
+        LONG tmExternalLeading;
+        LONG tmAveCharWidth;
+        LONG tmMaxCharWidth;
+        LONG tmWeight;
+        LONG tmOverhang;
+        LONG tmDigitizedAspectX;
+        LONG tmDigitizedAspectY;
+        char16_t tmFirstChar;
+        char16_t tmLastChar;
+        char16_t tmDefaultChar;
+        char16_t tmBreakChar;
+        BYTE tmItalic;
+        BYTE tmUnderlined;
+        BYTE tmStruckOut;
+        BYTE tmPitchAndFamily;
+        BYTE tmCharSet;
+        DWORD ntmFlags;
+        UINT ntmSizeEM;
+        UINT ntmCellHeight;
+        UINT ntmAvgWidth;
+    };
+    static_assert(sizeof(EMU_NEWTEXTMETRICW) == 0x4C);
+
+    struct EMU_NEWTEXTMETRICEXW
+    {
+        EMU_NEWTEXTMETRICW ntmTm;
+        DWORD fsUsb[4];
+        DWORD fsCsb[2];
+    };
+    static_assert(sizeof(EMU_NEWTEXTMETRICEXW) == 0x64);
+
+    struct FIXED
+    {
+        uint16_t fract;
+        int16_t value;
+    };
+    static_assert(sizeof(FIXED) == 0x04);
+
+    struct POINTFX
+    {
+        FIXED x;
+        FIXED y;
+    };
+    static_assert(sizeof(POINTFX) == 0x08);
+
+    struct EMU_TTPOLYGONHEADER
+    {
+        uint32_t cb{};
+        uint32_t dwType{};
+        POINTFX pfxStart{};
+    };
+    static_assert(sizeof(EMU_TTPOLYGONHEADER) == 0x10);
+
+    struct EMU_TTPOLYCURVE_HEADER
+    {
+        uint16_t wType{};
+        uint16_t cpfx{};
+    };
+    static_assert(sizeof(EMU_TTPOLYCURVE_HEADER) == 0x04);
+
+    struct EMU_BITMAPINFOHEADER
+    {
+        DWORD biSize;
+        LONG biWidth;
+        LONG biHeight;
+        WORD biPlanes;
+        WORD biBitCount;
+        DWORD biCompression;
+        DWORD biSizeImage;
+        LONG biXPelsPerMeter;
+        LONG biYPelsPerMeter;
+        DWORD biClrUsed;
+        DWORD biClrImportant;
+    };
+    static_assert(sizeof(EMU_BITMAPINFOHEADER) == 0x28);
 
     struct GDI_HANDLE_ENTRY64
     {
@@ -394,6 +542,25 @@ namespace sogen
     {
         LUID AdapterLuid;
         UINT32 hAdapter;
+    };
+
+    struct EMU_D3DKMT_CREATEDCFROMMEMORY
+    {
+        UINT64 pMemory;
+        UINT32 Format;
+        UINT32 Width;
+        UINT32 Height;
+        UINT32 Pitch;
+        UINT64 hDeviceDc;
+        UINT64 pColorTable;
+        UINT64 hDc;
+        UINT64 hBitmap;
+    };
+
+    struct EMU_D3DKMT_DESTROYDCFROMMEMORY
+    {
+        UINT64 hDc;
+        UINT64 hBitmap;
     };
 } // namespace sogen
 

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -1228,6 +1228,24 @@ namespace sogen
     };
 
     template <typename Traits>
+    struct SYSTEM_MEMORY_USAGE
+    {
+        typename Traits::PVOID Name;
+        USHORT Valid;
+        USHORT Standby;
+        USHORT Modified;
+        USHORT PageTables;
+    };
+
+    template <typename Traits>
+    struct SYSTEM_MEMORY_USAGE_INFORMATION
+    {
+        ULONG Reserved;
+        typename Traits::PVOID EndOfData;
+        SYSTEM_MEMORY_USAGE<Traits> MemoryUsage[1];
+    };
+
+    template <typename Traits>
     struct SYSTEM_PROCESS_INFORMATION
     {
         ULONG NextEntryOffset;

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -42,24 +42,27 @@ namespace sogen
     {
         DWORD dwSRVIFlags;
         uint64_t cHandleEntries;
-        uint8_t unknown1[0x178];
+        uint8_t pad_10[0x178];
         uint64_t apfnClientA[FNID_ARRAY_SIZE];
         uint64_t apfnClientW[FNID_ARRAY_SIZE];
         uint64_t apfnClientWorker[FNID_ARRAY_SIZE];
-        uint8_t unknown2[0xE90];
+        uint8_t pad_3c8[0xE90];
         uint64_t ahbrSystem[USER_SERVERINFO_BRUSH_SLOT_COUNT];
-        uint8_t unknown3a[0x34];
+        uint8_t pad_1358[0x34];
         int32_t defaultFontHeightScale;
         int32_t defaultFontWidthScale;
-        uint8_t unknown3b[0x7C2];
+        uint8_t pad_1394[0x7C2];
         uint16_t systemDpi;
+        uint8_t pad_1b58[0x286];
+        uint64_t foregroundWindow;
     };
     static_assert(offsetof(USER_SERVERINFO, apfnClientA) == 0x188);
     static_assert(offsetof(USER_SERVERINFO, ahbrSystem) == 0x1258);
     static_assert(offsetof(USER_SERVERINFO, defaultFontHeightScale) == 0x138C);
     static_assert(offsetof(USER_SERVERINFO, defaultFontWidthScale) == 0x1390);
     static_assert(offsetof(USER_SERVERINFO, systemDpi) == 0x1B56);
-    static_assert(sizeof(USER_SERVERINFO) == 0x1B58);
+    static_assert(offsetof(USER_SERVERINFO, foregroundWindow) == 0x1DE0);
+    static_assert(sizeof(USER_SERVERINFO) == 0x1de8);
 
     struct USER_DISPINFO
     {
@@ -314,6 +317,11 @@ namespace sogen
     static_assert(offsetof(USER_MENU, rgItems) == 0x20);
     static_assert(offsetof(USER_MENU, flags) == 0x28);
     static_assert(offsetof(USER_MENU, cItems) == 0x2C);
+
+    struct USER_ACCELERATOR_TABLE
+    {
+        uint8_t padding[1]{};
+    };
 
     struct USER_MENU_ITEM
     {

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -320,7 +320,7 @@ namespace sogen
 
     struct USER_ACCELERATOR_TABLE
     {
-        uint8_t padding[1]{};
+        uint8_t padding[0xFF]{};
     };
 
     struct USER_MENU_ITEM

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -25,18 +25,6 @@ namespace sogen
         LONG y;
     } POINTL;
 
-    typedef struct _FIXED
-    {
-        uint16_t fract;
-        int16_t value;
-    } FIXED;
-
-    typedef struct tagPOINTFX
-    {
-        FIXED x;
-        FIXED y;
-    } POINTFX;
-
     typedef struct tagSIZE
     {
         LONG cx;

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -99,6 +99,14 @@ namespace sogen
         hbitmap hbmColor;
     };
 
+    struct EMU_CURSORINFO
+    {
+        DWORD cbSize;
+        DWORD flags;
+        hcursor hCursor;
+        POINT ptScreenPos;
+    };
+
     struct EMU_MINMAXINFO
     {
         POINT ptReserved;
@@ -164,224 +172,252 @@ namespace sogen
 #define EMU_HWND_MESSAGE ((hwnd) - 3)
 
 #ifndef OS_WINDOWS
-#define MAXINTATOM           0xC000
+#define MAXINTATOM             0xC000
 
-#define WS_POPUP             0x80000000L
-#define WS_CHILD             0x40000000L
-#define WS_VISIBLE           0x10000000L
-#define WS_DISABLED          0x08000000L
-#define WS_CLIPSIBLINGS      0x04000000L
-#define WS_CLIPCHILDREN      0x02000000L
-#define WS_CAPTION           0x00C00000L
-#define WS_BORDER            0x00800000L
-#define WS_DLGFRAME          0x00400000L
-#define WS_SYSMENU           0x00080000L
-#define WS_THICKFRAME        0x00040000L
-#define WS_MINIMIZEBOX       0x00020000L
-#define WS_MAXIMIZEBOX       0x00010000L
+#define WS_POPUP               0x80000000L
+#define WS_CHILD               0x40000000L
+#define WS_VISIBLE             0x10000000L
+#define WS_DISABLED            0x08000000L
+#define WS_CLIPSIBLINGS        0x04000000L
+#define WS_CLIPCHILDREN        0x02000000L
+#define WS_CAPTION             0x00C00000L
+#define WS_BORDER              0x00800000L
+#define WS_DLGFRAME            0x00400000L
+#define WS_SYSMENU             0x00080000L
+#define WS_THICKFRAME          0x00040000L
+#define WS_MINIMIZEBOX         0x00020000L
+#define WS_MAXIMIZEBOX         0x00010000L
 
-#define SWP_NOSIZE           0x0001
-#define SWP_NOMOVE           0x0002
-#define SWP_NOREDRAW         0x0008
-#define SWP_SHOWWINDOW       0x0040
-#define SWP_HIDEWINDOW       0x0080
+#define SWP_NOSIZE             0x0001
+#define SWP_NOMOVE             0x0002
+#define SWP_NOREDRAW           0x0008
+#define SWP_SHOWWINDOW         0x0040
+#define SWP_HIDEWINDOW         0x0080
 
-#define WM_CREATE            0x0001
-#define WM_DESTROY           0x0002
-#define WM_MOVE              0x0003
-#define WM_SIZE              0x0005
-#define WM_ACTIVATE          0x0006
-#define WM_SETFOCUS          0x0007
-#define WM_KILLFOCUS         0x0008
-#define WM_QUIT              0x0012
-#define WM_SHOWWINDOW        0x0018
-#define WM_SETTEXT           0x000C
-#define WM_GETTEXT           0x000D
-#define WM_GETTEXTLENGTH     0x000E
-#define WM_PAINT             0x000F
-#define WM_CLOSE             0x0010
-#define WM_ERASEBKGND        0x0014
-#define WM_GETMINMAXINFO     0x0024
-#define WM_KEYDOWN           0x0100
-#define WM_KEYUP             0x0101
-#define WM_CHAR              0x0102
-#define WM_DEADCHAR          0x0103
-#define WM_SYSKEYDOWN        0x0104
-#define WM_SYSKEYUP          0x0105
-#define WM_SYSCHAR           0x0106
-#define WM_SYSDEADCHAR       0x0107
-#define WM_MOUSEMOVE         0x0200
-#define WM_LBUTTONDOWN       0x0201
-#define WM_LBUTTONUP         0x0202
-#define WM_RBUTTONDOWN       0x0204
-#define WM_RBUTTONUP         0x0205
-#define WM_COMMAND           0x0111
-#define WM_TIMER             0x0113
-#define WM_WINDOWPOSCHANGING 0x0046
-#define WM_WINDOWPOSCHANGED  0x0047
-#define WM_NCCREATE          0x0081
-#define WM_NCDESTROY         0x0082
-#define WM_NCCALCSIZE        0x0083
-#define WM_NCACTIVATE        0x0086
-#define WM_NCMOUSEMOVE       0x00A0
-#define WM_INPUT             0x00FF
+#define WM_CREATE              0x0001
+#define WM_DESTROY             0x0002
+#define WM_MOVE                0x0003
+#define WM_SIZE                0x0005
+#define WM_ACTIVATE            0x0006
+#define WM_SETFOCUS            0x0007
+#define WM_KILLFOCUS           0x0008
+#define WM_QUIT                0x0012
+#define WM_SHOWWINDOW          0x0018
+#define WM_SETTEXT             0x000C
+#define WM_GETTEXT             0x000D
+#define WM_GETTEXTLENGTH       0x000E
+#define WM_PAINT               0x000F
+#define WM_CLOSE               0x0010
+#define WM_ERASEBKGND          0x0014
+#define WM_NCHITTEST           0x0084
+#define WM_GETMINMAXINFO       0x0024
+#define WM_KEYDOWN             0x0100
+#define WM_KEYUP               0x0101
+#define WM_CHAR                0x0102
+#define WM_DEADCHAR            0x0103
+#define WM_SYSKEYDOWN          0x0104
+#define WM_SYSKEYUP            0x0105
+#define WM_SYSCHAR             0x0106
+#define WM_SYSDEADCHAR         0x0107
+#define WM_UNICHAR             0x0109
+#define WM_MOUSEMOVE           0x0200
+#define WM_LBUTTONDOWN         0x0201
+#define WM_LBUTTONUP           0x0202
+#define WM_LBUTTONDBLCLK       0x0203
+#define WM_RBUTTONDOWN         0x0204
+#define WM_RBUTTONUP           0x0205
+#define WM_RBUTTONDBLCLK       0x0206
+#define WM_MBUTTONDOWN         0x0207
+#define WM_MBUTTONUP           0x0208
+#define WM_MBUTTONDBLCLK       0x0209
+#define WM_MOUSEWHEEL          0x020A
+#define WM_XBUTTONDOWN         0x020B
+#define WM_XBUTTONUP           0x020C
+#define WM_XBUTTONDBLCLK       0x020D
+#define WM_MOUSEHWHEEL         0x020E
+#define WM_COMMAND             0x0111
+#define WM_TIMER               0x0113
+#define WM_HOTKEY              0x0312
+#define WM_WINDOWPOSCHANGING   0x0046
+#define WM_WINDOWPOSCHANGED    0x0047
+#define WM_NCCREATE            0x0081
+#define WM_NCDESTROY           0x0082
+#define WM_NCCALCSIZE          0x0083
+#define WM_NCACTIVATE          0x0086
+#define WM_NCMOUSEMOVE         0x00A0
+#define WM_NCLBUTTONDOWN       0x00A1
+#define WM_NCLBUTTONUP         0x00A2
+#define WM_NCLBUTTONDBLCLK     0x00A3
+#define WM_NCRBUTTONDOWN       0x00A4
+#define WM_NCRBUTTONUP         0x00A5
+#define WM_NCRBUTTONDBLCLK     0x00A6
+#define WM_NCMBUTTONDOWN       0x00A7
+#define WM_NCMBUTTONUP         0x00A8
+#define WM_NCMBUTTONDBLCLK     0x00A9
+#define WM_NCXBUTTONDOWN       0x00AB
+#define WM_NCXBUTTONUP         0x00AC
+#define WM_NCXBUTTONDBLCLK     0x00AD
+#define WM_INPUT_DEVICE_CHANGE 0x00FE
+#define WM_INPUT               0x00FF
 
-#define RID_INPUT            0x10000003
-#define RID_HEADER           0x10000005
+#define HTCLIENT               1
 
-#define RIM_TYPEMOUSE        0
-#define RIM_TYPEKEYBOARD     1
-#define RIM_TYPEHID          2
+#define RID_INPUT              0x10000003
+#define RID_HEADER             0x10000005
 
-#define RIM_INPUT            0
-#define RIM_INPUTSINK        1
+#define RIM_TYPEMOUSE          0
+#define RIM_TYPEKEYBOARD       1
+#define RIM_TYPEHID            2
 
-#define RIDEV_REMOVE         0x00000001
-#define RIDEV_EXCLUDE        0x00000010
-#define RIDEV_INPUTSINK      0x00000100
+#define RIM_INPUT              0
+#define RIM_INPUTSINK          1
 
-#define MOUSE_MOVE_RELATIVE  0x0000
-#define MOUSE_MOVE_ABSOLUTE  0x0001
+#define RIDEV_REMOVE           0x00000001
+#define RIDEV_EXCLUDE          0x00000010
+#define RIDEV_INPUTSINK        0x00000100
 
-#define WA_INACTIVE          0
-#define WA_ACTIVE            1
-#define WA_CLICKACTIVE       2
+#define MOUSE_MOVE_RELATIVE    0x0000
+#define MOUSE_MOVE_ABSOLUTE    0x0001
 
-#define BN_CLICKED           0
+#define WA_INACTIVE            0
+#define WA_ACTIVE              1
+#define WA_CLICKACTIVE         2
 
-#define MK_LBUTTON           0x0001
+#define BN_CLICKED             0
 
-#define VK_ESCAPE            0x1B
-#define VK_RETURN            0x0D
-#define VK_BACK              0x08
-#define VK_TAB               0x09
-#define VK_SHIFT             0x10
-#define VK_CONTROL           0x11
-#define VK_MENU              0x12
-#define VK_PAUSE             0x13
-#define VK_CAPITAL           0x14
-#define VK_SPACE             0x20
-#define VK_PRIOR             0x21
-#define VK_NEXT              0x22
-#define VK_END               0x23
-#define VK_HOME              0x24
-#define VK_LEFT              0x25
-#define VK_UP                0x26
-#define VK_RIGHT             0x27
-#define VK_DOWN              0x28
-#define VK_INSERT            0x2D
-#define VK_DELETE            0x2E
-#define VK_LWIN              0x5B
-#define VK_RWIN              0x5C
-#define VK_APPS              0x5D
-#define VK_NUMPAD0           0x60
-#define VK_NUMPAD1           0x61
-#define VK_NUMPAD2           0x62
-#define VK_NUMPAD3           0x63
-#define VK_NUMPAD4           0x64
-#define VK_NUMPAD5           0x65
-#define VK_NUMPAD6           0x66
-#define VK_NUMPAD7           0x67
-#define VK_NUMPAD8           0x68
-#define VK_NUMPAD9           0x69
-#define VK_MULTIPLY          0x6A
-#define VK_ADD               0x6B
-#define VK_SEPARATOR         0x6C
-#define VK_SUBTRACT          0x6D
-#define VK_DECIMAL           0x6E
-#define VK_DIVIDE            0x6F
-#define VK_F1                0x70
-#define VK_F2                0x71
-#define VK_F3                0x72
-#define VK_F4                0x73
-#define VK_F5                0x74
-#define VK_F6                0x75
-#define VK_F7                0x76
-#define VK_F8                0x77
-#define VK_F9                0x78
-#define VK_F10               0x79
-#define VK_F11               0x7A
-#define VK_F12               0x7B
-#define VK_NUMLOCK           0x90
-#define VK_SCROLL            0x91
-#define VK_OEM_1             0xBA
-#define VK_OEM_PLUS          0xBB
-#define VK_OEM_COMMA         0xBC
-#define VK_OEM_MINUS         0xBD
-#define VK_OEM_PERIOD        0xBE
-#define VK_OEM_2             0xBF
-#define VK_OEM_3             0xC0
-#define VK_OEM_4             0xDB
-#define VK_OEM_5             0xDC
-#define VK_OEM_6             0xDD
-#define VK_OEM_7             0xDE
-#define VK_OEM_102           0xE2
+#define MK_LBUTTON             0x0001
 
-#define IDOK                 1
-#define IDCANCEL             2
-#define IDABORT              3
-#define IDRETRY              4
-#define IDIGNORE             5
-#define IDYES                6
-#define IDNO                 7
+#define VK_ESCAPE              0x1B
+#define VK_RETURN              0x0D
+#define VK_BACK                0x08
+#define VK_TAB                 0x09
+#define VK_SHIFT               0x10
+#define VK_CONTROL             0x11
+#define VK_MENU                0x12
+#define VK_PAUSE               0x13
+#define VK_CAPITAL             0x14
+#define VK_SPACE               0x20
+#define VK_PRIOR               0x21
+#define VK_NEXT                0x22
+#define VK_END                 0x23
+#define VK_HOME                0x24
+#define VK_LEFT                0x25
+#define VK_UP                  0x26
+#define VK_RIGHT               0x27
+#define VK_DOWN                0x28
+#define VK_INSERT              0x2D
+#define VK_DELETE              0x2E
+#define VK_LWIN                0x5B
+#define VK_RWIN                0x5C
+#define VK_APPS                0x5D
+#define VK_NUMPAD0             0x60
+#define VK_NUMPAD1             0x61
+#define VK_NUMPAD2             0x62
+#define VK_NUMPAD3             0x63
+#define VK_NUMPAD4             0x64
+#define VK_NUMPAD5             0x65
+#define VK_NUMPAD6             0x66
+#define VK_NUMPAD7             0x67
+#define VK_NUMPAD8             0x68
+#define VK_NUMPAD9             0x69
+#define VK_MULTIPLY            0x6A
+#define VK_ADD                 0x6B
+#define VK_SEPARATOR           0x6C
+#define VK_SUBTRACT            0x6D
+#define VK_DECIMAL             0x6E
+#define VK_DIVIDE              0x6F
+#define VK_F1                  0x70
+#define VK_F2                  0x71
+#define VK_F3                  0x72
+#define VK_F4                  0x73
+#define VK_F5                  0x74
+#define VK_F6                  0x75
+#define VK_F7                  0x76
+#define VK_F8                  0x77
+#define VK_F9                  0x78
+#define VK_F10                 0x79
+#define VK_F11                 0x7A
+#define VK_F12                 0x7B
+#define VK_NUMLOCK             0x90
+#define VK_SCROLL              0x91
+#define VK_OEM_1               0xBA
+#define VK_OEM_PLUS            0xBB
+#define VK_OEM_COMMA           0xBC
+#define VK_OEM_MINUS           0xBD
+#define VK_OEM_PERIOD          0xBE
+#define VK_OEM_2               0xBF
+#define VK_OEM_3               0xC0
+#define VK_OEM_4               0xDB
+#define VK_OEM_5               0xDC
+#define VK_OEM_6               0xDD
+#define VK_OEM_7               0xDE
+#define VK_OEM_102             0xE2
 
-#define PM_NOREMOVE          0x0000
-#define PM_REMOVE            0x0001
-#define PM_NOYIELD           0x0002
+#define IDOK                   1
+#define IDCANCEL               2
+#define IDABORT                3
+#define IDRETRY                4
+#define IDIGNORE               5
+#define IDYES                  6
+#define IDNO                   7
 
-#define QS_KEY               0x0001
-#define QS_MOUSEMOVE         0x0002
-#define QS_MOUSEBUTTON       0x0004
-#define QS_POSTMESSAGE       0x0008
-#define QS_TIMER             0x0010
-#define QS_PAINT             0x0020
-#define QS_SENDMESSAGE       0x0040
-#define QS_HOTKEY            0x0080
-#define QS_ALLPOSTMESSAGE    0x0100
-#define QS_RAWINPUT          0x0400
-#define QS_TOUCH             0x0800
-#define QS_POINTER           0x1000
-#define QS_MOUSE             (QS_MOUSEMOVE | QS_MOUSEBUTTON)
-#define QS_INPUT             (QS_MOUSE | QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
-#define QS_ALLEVENTS         (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY)
-#define QS_ALLINPUT          (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY | QS_SENDMESSAGE)
+#define PM_NOREMOVE            0x0000
+#define PM_REMOVE              0x0001
+#define PM_NOYIELD             0x0002
 
-#define RDW_INVALIDATE       0x0001
-#define RDW_INTERNALPAINT    0x0002
-#define RDW_ERASE            0x0004
-#define RDW_VALIDATE         0x0008
-#define RDW_NOINTERNALPAINT  0x0010
-#define RDW_NOERASE          0x0020
-#define RDW_UPDATENOW        0x0100
-#define RDW_ERASENOW         0x0200
+#define QS_KEY                 0x0001
+#define QS_MOUSEMOVE           0x0002
+#define QS_MOUSEBUTTON         0x0004
+#define QS_POSTMESSAGE         0x0008
+#define QS_TIMER               0x0010
+#define QS_PAINT               0x0020
+#define QS_SENDMESSAGE         0x0040
+#define QS_HOTKEY              0x0080
+#define QS_ALLPOSTMESSAGE      0x0100
+#define QS_RAWINPUT            0x0400
+#define QS_TOUCH               0x0800
+#define QS_POINTER             0x1000
+#define QS_MOUSE               (QS_MOUSEMOVE | QS_MOUSEBUTTON)
+#define QS_INPUT               (QS_MOUSE | QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
+#define QS_ALLEVENTS           (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY)
+#define QS_ALLINPUT            (QS_INPUT | QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY | QS_SENDMESSAGE)
 
-#define ETO_OPAQUE           0x0002
-#define ETO_CLIPPED          0x0004
+#define RDW_INVALIDATE         0x0001
+#define RDW_INTERNALPAINT      0x0002
+#define RDW_ERASE              0x0004
+#define RDW_VALIDATE           0x0008
+#define RDW_NOINTERNALPAINT    0x0010
+#define RDW_NOERASE            0x0020
+#define RDW_UPDATENOW          0x0100
+#define RDW_ERASENOW           0x0200
 
-#define GWLP_WNDPROC         (-4)
-#define GWLP_HINSTANCE       (-6)
-#define GWLP_HWNDPARENT      (-8)
-#define GWLP_USERDATA        (-21)
-#define GWLP_ID              (-12)
+#define ETO_OPAQUE             0x0002
+#define ETO_CLIPPED            0x0004
 
-#define MIIM_STATE           0x0001
-#define MIIM_ID              0x0002
-#define MIIM_SUBMENU         0x0004
-#define MIIM_CHECKMARKS      0x0008
-#define MIIM_TYPE            0x0010
-#define MIIM_DATA            0x0020
-#define MIIM_STRING          0x0040
-#define MIIM_BITMAP          0x0080
-#define MIIM_FTYPE           0x0100
+#define GWLP_WNDPROC           (-4)
+#define GWLP_HINSTANCE         (-6)
+#define GWLP_HWNDPARENT        (-8)
+#define GWLP_USERDATA          (-21)
+#define GWLP_ID                (-12)
 
-#define MF_INSERT            0x0000
-#define MF_CHANGE            0x0080
-#define MF_APPEND            0x0100
-#define MF_DELETE            0x0200
-#define MF_REMOVE            0x1000
+#define MIIM_STATE             0x0001
+#define MIIM_ID                0x0002
+#define MIIM_SUBMENU           0x0004
+#define MIIM_CHECKMARKS        0x0008
+#define MIIM_TYPE              0x0010
+#define MIIM_DATA              0x0020
+#define MIIM_STRING            0x0040
+#define MIIM_BITMAP            0x0080
+#define MIIM_FTYPE             0x0100
 
-#define MF_BYCOMMAND         0x0000
-#define MF_BYPOSITION        0x0400
+#define MF_INSERT              0x0000
+#define MF_CHANGE              0x0080
+#define MF_APPEND              0x0100
+#define MF_DELETE              0x0200
+#define MF_REMOVE              0x1000
+
+#define MF_BYCOMMAND           0x0000
+#define MF_BYPOSITION          0x0400
 #endif
 
 #define WM_UAHDESTROYWINDOW 0x0090

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -295,12 +295,55 @@ namespace sogen
             case WM_PAINT:
                 return QS_PAINT;
 
+            case WM_HOTKEY:
+                return QS_HOTKEY;
+
             case WM_KEYDOWN:
             case WM_KEYUP:
+            case WM_SYSKEYDOWN:
+            case WM_SYSKEYUP:
+            case WM_CHAR:
+            case WM_DEADCHAR:
+            case WM_SYSCHAR:
+            case WM_SYSDEADCHAR:
+            case WM_UNICHAR:
                 return QS_KEY;
 
             case WM_INPUT:
+            case WM_INPUT_DEVICE_CHANGE:
                 return QS_RAWINPUT;
+
+            case WM_MOUSEMOVE:
+            case WM_NCMOUSEMOVE:
+                return QS_MOUSEMOVE;
+
+            case WM_LBUTTONDOWN:
+            case WM_LBUTTONUP:
+            case WM_LBUTTONDBLCLK:
+            case WM_RBUTTONDOWN:
+            case WM_RBUTTONUP:
+            case WM_RBUTTONDBLCLK:
+            case WM_MBUTTONDOWN:
+            case WM_MBUTTONUP:
+            case WM_MBUTTONDBLCLK:
+            case WM_XBUTTONDOWN:
+            case WM_XBUTTONUP:
+            case WM_XBUTTONDBLCLK:
+            case WM_MOUSEWHEEL:
+            case WM_MOUSEHWHEEL:
+            case WM_NCLBUTTONDOWN:
+            case WM_NCLBUTTONUP:
+            case WM_NCLBUTTONDBLCLK:
+            case WM_NCRBUTTONDOWN:
+            case WM_NCRBUTTONUP:
+            case WM_NCRBUTTONDBLCLK:
+            case WM_NCMBUTTONDOWN:
+            case WM_NCMBUTTONUP:
+            case WM_NCMBUTTONDBLCLK:
+            case WM_NCXBUTTONDOWN:
+            case WM_NCXBUTTONUP:
+            case WM_NCXBUTTONDBLCLK:
+                return QS_MOUSEBUTTON;
 
             default:
                 return QS_POSTMESSAGE | QS_ALLPOSTMESSAGE;

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -35,6 +35,7 @@ namespace sogen
             worker_factory,
             private_namespace,
             process,
+            accelerator_table,
         };
     };
 

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -628,6 +628,7 @@ namespace sogen
         buffer.write(this->desktops);
         buffer.write(this->windows);
         buffer.write(this->timers);
+        buffer.write(this->accelerator_tables);
         buffer.write(this->registry_keys);
         buffer.write(this->private_namespaces);
         buffer.write_map(this->atoms);
@@ -716,6 +717,7 @@ namespace sogen
         buffer.read(this->desktops);
         buffer.read(this->windows);
         buffer.read(this->timers);
+        buffer.read(this->accelerator_tables);
         buffer.read(this->registry_keys);
         buffer.read(this->private_namespaces);
         buffer.read_map(this->atoms);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -463,6 +463,7 @@ namespace sogen
         user_handle_store<handle_types::window, window> windows{user_handles};
         user_handle_store<handle_types::type::menu, menu> menus{user_handles};
         handle_store<handle_types::timer, timer> timers{};
+        user_handle_store<handle_types::accelerator_table, accelerator_table> accelerator_tables{user_handles};
         handle_store<handle_types::registry, registry_key, 2> registry_keys{};
         std::map<uint32_t, handle> thread_handles_by_id{};
         std::map<uint16_t, atom_entry> atoms{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -440,7 +440,8 @@ namespace sogen
 
         // syscalls/user.cpp:
         NTSTATUS handle_NtUserTraceLoggingSendMixedModeTelemetry();
-        NTSTATUS handle_NtUserRegisterWindowMessage();
+        uint32_t handle_NtUserRegisterWindowMessage(const syscall_context& c,
+                                                    emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> message_name);
         uint64_t handle_NtUserGetThreadState(const syscall_context& c, ULONG routine);
         uint64_t handle_NtUserSetThreadState(const syscall_context& c, uint64_t value, uint64_t mask);
         uint64_t completion_NtUserGetThreadState(const syscall_context& c, ULONG routine);
@@ -453,6 +454,7 @@ namespace sogen
         hdc handle_NtUserGetDCEx(const syscall_context& c, hwnd window, uint64_t clip_region, ULONG flags);
         hdc handle_NtUserGetDC(const syscall_context& c, hwnd window);
         hdc handle_NtUserGetWindowDC(const syscall_context& c, hwnd window);
+        hwnd handle_NtUserWindowFromDC(const syscall_context& c, hdc dc);
         uint64_t handle_NtUserGetControlBrush(const syscall_context& c, hwnd window, hdc dc, uint32_t control_type);
         BOOL handle_NtUserReleaseDC();
         hwnd handle_NtUserSetCapture(const syscall_context& c, hwnd window);
@@ -470,6 +472,7 @@ namespace sogen
         hdc handle_NtUserBeginPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
         BOOL handle_NtUserEndPaint(const syscall_context& c, hwnd window, emulator_object<EMU_PAINTSTRUCT> paint_struct);
         BOOL handle_NtUserGetCursorPos(const syscall_context& c, emulator_pointer point_ptr);
+        BOOL handle_NtUserGetCursorInfo(const syscall_context& c, emulator_object<EMU_CURSORINFO> cursor_info);
         BOOL handle_NtUserGetClipCursor(const syscall_context& c, emulator_pointer rect_ptr);
         BOOL handle_NtUserTransformPoint(const syscall_context& c, emulator_pointer point, uint32_t from_dpi, uint32_t to_dpi,
                                          uint32_t flags);
@@ -529,7 +532,9 @@ namespace sogen
         BOOL handle_NtUserSetProp(const syscall_context& c, hwnd window, uint16_t atom, uint64_t data);
         BOOL handle_NtUserSetProp2(const syscall_context& c, hwnd window, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str,
                                    uint64_t data);
+        uint64_t handle_NtUserGetProp(const syscall_context& c, hwnd window, uint16_t atom);
         uint64_t handle_NtUserGetProp2(const syscall_context& c, hwnd window, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str);
+        uint64_t handle_NtUserRemoveProp(const syscall_context& c, hwnd window, uint16_t atom);
         uint64_t handle_NtUserChangeWindowMessageFilterEx();
         BOOL handle_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
         BOOL completion_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
@@ -567,9 +572,11 @@ namespace sogen
                                               uint64_t param);
         BOOL completion_NtUserEnumDisplayMonitors(const syscall_context& c, hdc hdc_in, uint64_t clip_rect_ptr, uint64_t callback,
                                                   uint64_t param);
+        BOOL handle_NtUserInheritWindowMonitor(const syscall_context& c, hwnd hwnd_tgt, hwnd hwnd_inherit);
         BOOL handle_NtUserGetHDevName(const syscall_context& c, handle hdev, emulator_pointer device_name);
         emulator_pointer handle_NtUserMapDesktopObject(const syscall_context& c, handle handle);
         BOOL handle_NtUserTransformRect(const syscall_context& c, emulator_object<RECT> rect, hwnd hwnd, uint32_t type, uint64_t unknown);
+        hwnd handle_NtUserSetParent(const syscall_context& c, hwnd hwnd_child, hwnd hwnd_new_parent);
         BOOL handle_NtUserSetWindowPos(const syscall_context& c, hwnd hWnd, hwnd hwnd_insert_after, int x, int y, int cx, int cy,
                                        UINT flags);
         NTSTATUS handle_NtUserSetForegroundWindow();
@@ -611,7 +618,9 @@ namespace sogen
         BOOL handle_NtUserValidateTimerCallback(const syscall_context& c, uint64_t timer_proc);
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, UINT flags);
         uint32_t handle_NtUserGetQueueStatus(const syscall_context& c, UINT flags);
-        NTSTATUS handle_NtUserCreateAcceleratorTable();
+        uint64_t handle_NtUserCreateAcceleratorTable(const syscall_context& c, emulator_pointer entries, int32_t entry_count);
+        BOOL handle_NtUserDestroyAcceleratorTable(const syscall_context& c, handle accelerator_table);
+        int32_t handle_NtUserCopyAcceleratorTable();
         int32_t handle_NtUserTranslateAccelerator();
         hmenu handle_NtUserCreateMenu(const syscall_context& c);
         BOOL handle_NtUserThunkedMenuItemInfo(const syscall_context& c, hmenu menu, UINT position, BOOL by_position, BOOL insert,
@@ -619,6 +628,8 @@ namespace sogen
                                               emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text);
         hmenu handle_NtUserCreatePopupMenu(const syscall_context& c);
         BOOL handle_NtUserSetMenu();
+        BOOL handle_NtUserSetMenuDefaultItem(const syscall_context& c, hmenu menu, UINT item, UINT by_position);
+        BOOL handle_NtUserEndMenu();
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
         BOOL handle_NtUserDestroyMenu(const syscall_context& c, hmenu menu);
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
@@ -650,6 +661,15 @@ namespace sogen
         uint64_t handle_NtUserGetClipboardData();
         uint64_t handle_NtUserConvertMemHandle();
         uint64_t handle_NtUserSetClipboardData();
+        uint64_t handle_NtUserGetProcessDpiAwarenessContext();
+        NTSTATUS handle_NtUserSetProcessDpiAwarenessContext();
+        uint32_t handle_NtUserMapVirtualKeyEx(const syscall_context& c, uint32_t code, uint32_t map_type, uint32_t keyboard_id,
+                                              uint64_t keyboard_layout);
+        NTSTATUS handle_NtUserToUnicodeEx();
+        uint64_t handle_NtUserSetKeyboardState();
+        uint64_t handle_NtUserAttachThreadInput();
+        BOOL handle_NtUserRegisterTouchHitTestingWindow();
+        uint64_t handle_NtUserActivateKeyboardLayout();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -700,7 +720,8 @@ namespace sogen
         BOOL handle_NtGdiSetBrushOrg(const syscall_context& c, hdc dc, int x, int y, emulator_pointer prev);
         uint64_t handle_NtGdiHfontCreate(const syscall_context& c, emulator_pointer logfont, uint32_t angle);
         uint32_t handle_NtGdiExtGetObjectW(const syscall_context& c, uint32_t handle_value, uint32_t size, emulator_pointer buffer);
-        uint32_t handle_NtGdiEnumFonts();
+        BOOL handle_NtGdiEnumFonts(const syscall_context& c, hdc dc, ULONG type, ULONG win32_compat, ULONG face_name_len,
+                                   emulator_pointer face_name, ULONG charset, emulator_pointer count, emulator_pointer buffer);
         uint32_t handle_NtGdiGetTextCharsetInfo(const syscall_context& c, hdc dc, emulator_pointer sig, uint32_t flags);
         uint32_t handle_NtGdiQueryFontAssocInfo(const syscall_context& c, hdc dc);
         uint32_t handle_NtGdiGetTextMetricsW(const syscall_context& c, hdc dc, emulator_pointer ptm, uint32_t cj);
@@ -713,11 +734,17 @@ namespace sogen
                                        ULONG flags);
         BOOL handle_NtGdiGetCharWidthW(const syscall_context& c, hdc dc, UINT first_char, UINT char_count, emulator_pointer chars,
                                        UINT flags, emulator_pointer buffer);
+        BOOL handle_NtGdiGetCharABCWidthsW(const syscall_context& c, hdc dc, UINT first_char, UINT char_count, emulator_pointer chars,
+                                           UINT flags, emulator_pointer buffer);
         NTSTATUS handle_NtGdiExtCreateRegion();
         NTSTATUS handle_NtGdiTransparentBlt();
         uint64_t handle_NtGdiCreateRectRgn(const syscall_context& c, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
         int32_t handle_NtGdiGetRandomRgn(const syscall_context& c, hdc dc, uint64_t region, LONG index);
+        uint32_t handle_NtGdiGetRegionData(const syscall_context& c, handle hrgn, ULONG buffer_size, emulator_pointer region_data);
+        int32_t handle_NtGdiGetAppClipBox(const syscall_context& c, hdc dc, emulator_object<RECT> rect);
+        int32_t handle_NtGdiExcludeClipRect(const syscall_context& c, hdc dc, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
         int32_t handle_NtGdiIntersectClipRect(const syscall_context& c, hdc dc, LONG x_left, LONG y_top, LONG x_right, LONG y_bottom);
+        BOOL handle_NtGdiRectVisible(const syscall_context& c, hdc dc, emulator_object<RECT> rect);
         uint32_t handle_NtGdiGetCharSet(const syscall_context& c, hdc dc);
         int32_t handle_NtGdiExtSelectClipRgn(const syscall_context& c, hdc dc, uint64_t region, LONG mode);
         BOOL handle_NtGdiLineTo(const syscall_context& c, hdc dc, LONG x_end, LONG y_end);
@@ -737,6 +764,7 @@ namespace sogen
         int32_t handle_NtGdiSetIcmMode();
         NTSTATUS handle_NtGdiSetLayout();
         NTSTATUS handle_NtGdiGetDCObject();
+        BOOL handle_NtGdiUnrealizeObject(const syscall_context& c, handle h);
         BOOL handle_NtGdiMoveToEx(const syscall_context& c, hdc dc, LONG x, LONG y, emulator_pointer old_point_ptr);
         uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
         uint64_t handle_NtGdiSelectPenLocal(const syscall_context& c, hdc dc, uint32_t pen, emulator_pointer old_pen_ptr);
@@ -768,6 +796,8 @@ namespace sogen
                                                     emulator_object<EMU_D3DKMT_DESTROYALLOCATION> destroy_allocation);
         NTSTATUS handle_NtGdiDdDDIDestroyContext();
         NTSTATUS handle_NtGdiDdDDIDestroyDevice();
+        NTSTATUS handle_NtGdiDdDDICreateDCFromMemory(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEDCFROMMEMORY> create_dc);
+        NTSTATUS handle_NtGdiDdDDIDestroyDCFromMemory(const syscall_context& c, emulator_object<EMU_D3DKMT_DESTROYDCFROMMEMORY> destroy_dc);
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromLuid(const syscall_context& c,
                                                       emulator_object<EMU_D3DKMT_OPENADAPTERFROMLUID> open_adapter);
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter);
@@ -1016,21 +1046,6 @@ namespace sogen
             return STATUS_NOT_SUPPORTED;
         }
 
-        NTSTATUS handle_NtUserMapVirtualKeyEx()
-        {
-            return 0;
-        }
-
-        NTSTATUS handle_NtUserToUnicodeEx()
-        {
-            return 0;
-        }
-
-        NTSTATUS handle_NtUserSetProcessDpiAwarenessContext()
-        {
-            return 0;
-        }
-
         ULONG handle_NtUserGetRawInputDeviceList()
         {
             return 0;
@@ -1116,6 +1131,7 @@ namespace sogen
             }
             }
         }
+
     }
 
     // NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
@@ -1250,10 +1266,15 @@ namespace sogen
         add_handler(NtGdiGetTextFaceW);
         add_handler(NtGdiGetTextExtent);
         add_handler(NtGdiGetCharWidthW);
+        add_handler(NtGdiGetCharABCWidthsW);
         add_handler(NtGdiGetGlyphOutline);
         add_handler(NtGdiCreateRectRgn);
         add_handler(NtGdiGetRandomRgn);
+        add_handler(NtGdiGetRegionData);
+        add_handler(NtGdiGetAppClipBox);
+        add_handler(NtGdiExcludeClipRect);
         add_handler(NtGdiIntersectClipRect);
+        add_handler(NtGdiRectVisible);
         add_handler(NtGdiGetCharSet);
         add_handler(NtGdiExtSelectClipRgn);
         add_handler(NtGdiLineTo);
@@ -1269,6 +1290,7 @@ namespace sogen
         add_handler(NtGdiMoveToEx);
         add_handler(NtGdiSelectBrushLocal);
         add_handler(NtGdiSelectPenLocal);
+        add_handler(NtGdiUnrealizeObject);
         add_handler(NtUserGetThreadState);
         add_handler(NtUserSetThreadState);
         add_handler(NtUserProcessConnect);
@@ -1333,6 +1355,7 @@ namespace sogen
         add_handler(NtUserGetDCEx);
         add_handler(NtUserGetDC);
         add_handler(NtUserGetWindowDC);
+        add_handler(NtUserWindowFromDC);
         add_handler(NtUserGetControlBrush);
         add_handler(NtUserGetOemBitmapSize);
         add_handler(NtUserSetCapture);
@@ -1373,8 +1396,8 @@ namespace sogen
         add_handler(NtUserGetRequiredCursorSizes);
         add_handler(NtUserDestroyCursor);
         add_handler(NtUserGetCursorFrameInfo);
-        add_handler(NtUserGetIconSize);
         add_handler(NtUserGetIconInfo);
+        add_handler(NtUserGetIconSize);
         add_handler(NtUserDrawIconEx);
         add_handler(NtUserMessageBeep);
         add_handler(NtSetContextThread);
@@ -1415,6 +1438,7 @@ namespace sogen
         add_handler(NtUserInvalidateRect);
         add_handler(NtUserValidateRect);
         add_handler(NtUserUpdateWindow);
+        add_handler(NtUserGetCursorInfo);
         add_handler(NtUserMapVirtualKeyEx);
         add_handler(NtUserToUnicodeEx);
         add_handler(NtUserSetProcessDpiAwarenessContext);
@@ -1425,9 +1449,12 @@ namespace sogen
         add_handler(NtUserChangeDisplaySettings);
         add_handler(NtUserBuildHwndList);
         add_handler(NtUserEnumDisplayMonitors);
+        add_handler(NtUserInheritWindowMonitor);
         add_handler(NtUserSetProp);
         add_handler(NtUserSetProp2);
+        add_handler(NtUserGetProp);
         add_handler(NtUserGetProp2);
+        add_handler(NtUserRemoveProp);
         add_handler(NtUserChangeWindowMessageFilterEx);
         add_handler(NtUserDestroyWindow);
         add_handler(NtQueryInformationByName);
@@ -1461,6 +1488,7 @@ namespace sogen
         add_handler(NtUserMapDesktopObject);
         add_handler(NtAlpcSetInformation);
         add_handler(NtUserTransformRect);
+        add_handler(NtUserSetParent);
         add_handler(NtUserSetWindowPos);
         add_handler(NtUserSetForegroundWindow);
         add_handler(NtUserGetForegroundWindow);
@@ -1510,6 +1538,8 @@ namespace sogen
         add_handler(NtGdiDdDDIDestroyAllocation);
         add_handler(NtGdiDdDDIDestroyContext);
         add_handler(NtGdiDdDDIDestroyDevice);
+        add_handler(NtGdiDdDDICreateDCFromMemory);
+        add_handler(NtGdiDdDDIDestroyDCFromMemory);
         add_handler(NtAllocateLocallyUniqueId);
         add_handler(NtUserAllowSetForegroundWindow);
         add_handler(NtGdiOpenDCW);
@@ -1533,6 +1563,8 @@ namespace sogen
         add_handler(NtUserSetActiveWindow);
         add_handler(NtGdiTransparentBlt);
         add_handler(NtUserCreateAcceleratorTable);
+        add_handler(NtUserDestroyAcceleratorTable);
+        add_handler(NtUserCopyAcceleratorTable);
         add_handler(NtUserTranslateAccelerator);
         add_handler(NtGdiSetLayout);
         add_handler(NtGdiGetDCObject);
@@ -1541,6 +1573,8 @@ namespace sogen
         add_handler(NtUserIsTouchWindow);
         add_handler(NtUserCreatePopupMenu);
         add_handler(NtUserSetMenu);
+        add_handler(NtUserSetMenuDefaultItem);
+        add_handler(NtUserEndMenu);
         add_handler(NtUserRemoveMenu);
         add_handler(NtUserDestroyMenu);
         add_handler(NtUserDrawMenuBar);
@@ -1569,6 +1603,7 @@ namespace sogen
         add_handler(NtUserGetDoubleClickTime);
         add_handler(NtGdiSetIcmMode);
         add_handler(NtUserGetKeyboardState);
+        add_handler(NtUserSetKeyboardState);
         add_handler(NtUserModifyWindowTouchCapability);
         add_handler(NtUserGetClipboardSequenceNumber);
         add_handler(NtUserOpenClipboard);
@@ -1577,6 +1612,10 @@ namespace sogen
         add_handler(NtUserGetClipboardData);
         add_handler(NtUserConvertMemHandle);
         add_handler(NtUserSetClipboardData);
+        add_handler(NtUserGetProcessDpiAwarenessContext);
+        add_handler(NtUserAttachThreadInput);
+        add_handler(NtUserRegisterTouchHitTestingWindow);
+        add_handler(NtUserActivateKeyboardLayout);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1242,8 +1242,14 @@ namespace sogen
             }
 
             uint32_t create_gdi_bitmap_surface(const syscall_context& c, const uint32_t width, const uint32_t height,
-                                               const uint32_t fill = k_default_bitmap_fill)
+                                               const uint32_t fill = k_default_bitmap_fill,
+                                               gdi_bitmap_surface** const created_surface = nullptr)
             {
+                if (created_surface != nullptr)
+                {
+                    *created_surface = nullptr;
+                }
+
                 const auto handle_value = allocate_gdi_object(c, k_gdi_bitmap_type, k_gdi_bitmap_attr_size);
                 if (handle_value == 0)
                 {
@@ -1254,6 +1260,10 @@ namespace sogen
                 surface.width = width;
                 surface.height = height;
                 surface.pixels.assign(static_cast<size_t>(width) * static_cast<size_t>(height), fill);
+                if (created_surface != nullptr)
+                {
+                    *created_surface = &surface;
+                }
                 return handle_value;
             }
 
@@ -1947,14 +1957,14 @@ namespace sogen
         uint64_t handle_NtGdiCreateBitmap(const syscall_context& c, const uint32_t width, const uint32_t height, const uint32_t planes,
                                           const uint32_t bits_pixel, const emulator_pointer bits)
         {
-            const auto handle_value = create_gdi_bitmap_surface(c, width, height);
-            if (handle_value != 0)
+            gdi_bitmap_surface* surface = nullptr;
+            const auto handle_value = create_gdi_bitmap_surface(c, width, height, k_default_bitmap_fill, &surface);
+            if (surface != nullptr)
             {
-                auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
                 if (bits != 0 && planes == 1 && bits_pixel == 32)
                 {
                     const auto byte_count = static_cast<size_t>(width) * static_cast<size_t>(height) * sizeof(uint32_t);
-                    c.emu.read_memory(bits, surface.pixels.data(), byte_count);
+                    c.emu.read_memory(bits, surface->pixels.data(), byte_count);
                 }
             }
             return handle_value;
@@ -2003,19 +2013,19 @@ namespace sogen
             std::vector<uint8_t> zeroed(static_cast<size_t>(allocation_bytes), 0);
             c.emu.write_memory(guest_bits, zeroed.data(), zeroed.size());
 
-            const auto handle_value = create_gdi_bitmap_surface(c, width, abs_height, 0);
+            gdi_bitmap_surface* surface = nullptr;
+            const auto handle_value = create_gdi_bitmap_surface(c, width, abs_height, 0, &surface);
             if (handle_value == 0)
             {
                 c.win_emu.memory.release_memory(guest_bits, 0);
                 return 0;
             }
 
-            auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
-            surface.guest_bits = guest_bits;
-            surface.guest_stride = stride;
-            surface.guest_bpp = header.biBitCount;
-            surface.guest_top_down = header.biHeight < 0;
-            surface.guest_owns_memory = true;
+            surface->guest_bits = guest_bits;
+            surface->guest_stride = stride;
+            surface->guest_bpp = header.biBitCount;
+            surface->guest_top_down = header.biHeight < 0;
+            surface->guest_owns_memory = true;
 
             bits.write(guest_bits);
             return handle_value;
@@ -2026,14 +2036,14 @@ namespace sogen
                                                     const uint32_t /*info_header_size*/, const uint32_t /*init*/, const uint32_t /*offset*/,
                                                     const uint32_t /*cj*/, const uint32_t /*i_usage*/)
         {
-            const auto handle_value = create_gdi_bitmap_surface(c, width, height);
-            if (handle_value != 0)
+            gdi_bitmap_surface* surface = nullptr;
+            const auto handle_value = create_gdi_bitmap_surface(c, width, height, k_default_bitmap_fill, &surface);
+            if (surface != nullptr)
             {
-                auto& surface = c.proc.gdi_bitmap_surfaces[handle_value];
                 if (bits != 0)
                 {
                     const auto byte_count = static_cast<size_t>(width) * static_cast<size_t>(height) * sizeof(uint32_t);
-                    c.emu.read_memory(bits, surface.pixels.data(), byte_count);
+                    c.emu.read_memory(bits, surface->pixels.data(), byte_count);
                 }
             }
             return handle_value;
@@ -4668,14 +4678,9 @@ namespace sogen
                 return STATUS_INVALID_PARAMETER;
             }
 
-            const auto bitmap_handle = create_gdi_bitmap_surface(c, params.Width, params.Height, 0);
+            gdi_bitmap_surface* surface = nullptr;
+            const auto bitmap_handle = create_gdi_bitmap_surface(c, params.Width, params.Height, 0, &surface);
             if (bitmap_handle == 0)
-            {
-                return STATUS_NO_MEMORY;
-            }
-
-            auto surface_it = c.proc.gdi_bitmap_surfaces.find(bitmap_handle);
-            if (surface_it == c.proc.gdi_bitmap_surfaces.end())
             {
                 return STATUS_NO_MEMORY;
             }
@@ -4696,13 +4701,12 @@ namespace sogen
                     return false;
                 }
 
-                auto& surface = surface_it->second;
                 std::vector<uint32_t> row(width);
                 for (size_t y = 0; y < height; ++y)
                 {
                     c.emu.read_memory(params.pMemory + (y * pitch), row.data(), row_bytes);
 
-                    auto* dst = surface.pixels.data() + (y * width);
+                    auto* dst = surface->pixels.data() + (y * width);
                     switch (params.Format)
                     {
                     case k_d3dddifmt_a8r8g8b8:

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -15,6 +15,8 @@ namespace sogen
 
     namespace syscalls
     {
+        uint32_t handle_NtGdiDeleteObjectApp(const syscall_context& c, uint32_t handle_value);
+
         namespace
         {
             constexpr uint8_t k_gdi_dc_type = 0x01;
@@ -65,6 +67,25 @@ namespace sogen
             constexpr int k_text_cell_width = static_cast<int>(k_default_font_width);
             constexpr int k_text_cell_height = static_cast<int>(k_default_font_height);
             constexpr int k_text_glyph_y_offset = (k_text_cell_height - debug_font::glyph_height) / 2;
+
+            struct font_enum_record
+            {
+                uint32_t size;
+                uint32_t text_metric_offset;
+                uint32_t type;
+                EMU_ENUMLOGFONTEXW log_font;
+                std::array<uint32_t, 2> log_font_design_vector{0x08007664, 0};
+                std::array<uint32_t, 2> text_metric_header{};
+                EMU_NEWTEXTMETRICEXW text_metric;
+                std::array<uint32_t, 2> text_metric_design_vector{0x08006C61, 0};
+            };
+
+            static_assert(offsetof(font_enum_record, log_font) == 0x0C);
+            static_assert(offsetof(font_enum_record, log_font_design_vector) == 0x168);
+            static_assert(offsetof(font_enum_record, text_metric_header) == 0x170);
+            static_assert(offsetof(font_enum_record, text_metric) == 0x178);
+            static_assert(offsetof(font_enum_record, text_metric_design_vector) == 0x1DC);
+            static_assert(sizeof(font_enum_record) == 0x1E4);
 
             constexpr uint32_t k_default_dpi = 96;
             constexpr uint32_t k_default_width = 1920;
@@ -169,37 +190,6 @@ namespace sogen
                 POINTL viewport_org{};
                 std::array<gdi_batch_pat_rect, 1> rects{};
             };
-
-            struct emu_ttpolygonheader
-            {
-                uint32_t cb{};
-                uint32_t dwType{};
-                POINTFX pfxStart{};
-            };
-            static_assert(sizeof(emu_ttpolygonheader) == 16);
-
-            struct emu_ttpolycurve_header
-            {
-                uint16_t wType{};
-                uint16_t cpfx{};
-            };
-            static_assert(sizeof(emu_ttpolycurve_header) == 4);
-
-            struct bitmap_info_header
-            {
-                DWORD biSize;
-                LONG biWidth;
-                LONG biHeight;
-                WORD biPlanes;
-                WORD biBitCount;
-                DWORD biCompression;
-                DWORD biSizeImage;
-                LONG biXPelsPerMeter;
-                LONG biYPelsPerMeter;
-                DWORD biClrUsed;
-                DWORD biClrImportant;
-            };
-            static_assert(sizeof(bitmap_info_header) == 40);
 
             constexpr uint32_t k_dxgk_adapter_count = 1;
             constexpr uint32_t k_dxgk_adapter_handle = 0x4000;
@@ -1764,24 +1754,24 @@ namespace sogen
             auto& thread = c.win_emu.current_thread();
             if (thread.teb64)
             {
-                GDI_TEB_BATCH64 batch{};
+                BOOL result = TRUE;
                 thread.teb64->access([&](TEB64& teb) {
-                    batch = teb.GdiTebBatch;
+                    result = flush_gdi_text_batch(c, teb.GdiTebBatch) ? TRUE : FALSE;
                     teb.GdiTebBatch = {};
                     teb.GdiBatchCount = 0;
                 });
-                return flush_gdi_text_batch(c, batch) ? TRUE : FALSE;
+                return result;
             }
 
             if (thread.teb32)
             {
-                GDI_TEB_BATCH32 batch{};
+                BOOL result = TRUE;
                 thread.teb32->access([&](TEB32& teb) {
-                    batch = teb.GdiTebBatch;
+                    result = flush_gdi_text_batch(c, teb.GdiTebBatch) ? TRUE : FALSE;
                     teb.GdiTebBatch = {};
                     teb.GdiBatchCount = 0;
                 });
-                return flush_gdi_text_batch(c, batch) ? TRUE : FALSE;
+                return result;
             }
 
             return TRUE;
@@ -1975,15 +1965,15 @@ namespace sogen
                                               const uint32_t header_size, const uint32_t /*flags*/, const uint64_t /*color_space*/,
                                               const emulator_object<emulator_pointer> bits)
         {
-            if (info == 0 || !bits || header_size < sizeof(bitmap_info_header))
+            if (info == 0 || !bits || header_size < sizeof(EMU_BITMAPINFOHEADER))
             {
                 return 0;
             }
 
-            bitmap_info_header header{};
+            EMU_BITMAPINFOHEADER header{};
             c.emu.read_memory(info, &header, sizeof(header));
 
-            if (header.biSize < sizeof(bitmap_info_header) || header.biWidth <= 0 || header.biHeight == 0 || header.biBitCount == 0)
+            if (header.biSize < sizeof(EMU_BITMAPINFOHEADER) || header.biWidth <= 0 || header.biHeight == 0 || header.biBitCount == 0)
             {
                 return 0;
             }
@@ -2531,9 +2521,123 @@ namespace sogen
             return object_size;
         }
 
-        uint32_t handle_NtGdiEnumFonts()
+        BOOL handle_NtGdiEnumFonts(const syscall_context& c, const hdc dc, const ULONG /*type*/, const ULONG /*win32_compat*/,
+                                   const ULONG face_name_len, const emulator_pointer face_name, const ULONG charset,
+                                   const emulator_pointer count, const emulator_pointer buffer)
         {
-            return 0;
+            if (dc == 0 || count == 0 || (face_name_len != 0 && face_name == 0))
+            {
+                return FALSE;
+            }
+
+            std::array<char16_t, 32> face_filter{};
+            if (face_name_len != 0)
+            {
+                const auto copied_length = std::min<size_t>(face_name_len, face_filter.size() - 1);
+                c.emu.read_memory(face_name, face_filter.data(), copied_length * sizeof(char16_t));
+            }
+
+            std::vector<font_enum_record> fonts;
+            if (face_filter.front() == u'\0' ||
+                utils::string::equals_ignore_case(std::u16string_view{face_filter.data()}, std::u16string_view{u"Segoe UI"}))
+            {
+                struct font_style
+                {
+                    std::u16string_view full_name;
+                    std::u16string_view style;
+                    LONG weight;
+                    bool italic;
+                    bool supports_arabic_and_hebrew;
+                };
+
+                constexpr std::array styles{
+                    font_style{.full_name = u"Segoe UI",
+                               .style = u"Regular",
+                               .weight = FW_NORMAL,
+                               .italic = false,
+                               .supports_arabic_and_hebrew = true},
+                    font_style{.full_name = u"Segoe UI Bold",
+                               .style = u"Bold",
+                               .weight = FW_BOLD,
+                               .italic = false,
+                               .supports_arabic_and_hebrew = true},
+                    font_style{.full_name = u"Segoe UI Bold Italic",
+                               .style = u"Bold Italic",
+                               .weight = FW_BOLD,
+                               .italic = true,
+                               .supports_arabic_and_hebrew = false},
+                    font_style{.full_name = u"Segoe UI Italic",
+                               .style = u"Italic",
+                               .weight = FW_NORMAL,
+                               .italic = true,
+                               .supports_arabic_and_hebrew = false},
+                };
+                constexpr std::array<std::pair<BYTE, std::u16string_view>, 9> scripts{
+                    std::pair{static_cast<BYTE>(ANSI_CHARSET), u"Western"sv},
+                    std::pair{static_cast<BYTE>(HEBREW_CHARSET), u"Hebrew"sv},
+                    std::pair{static_cast<BYTE>(ARABIC_CHARSET), u"Arabic"sv},
+                    std::pair{static_cast<BYTE>(GREEK_CHARSET), u"Greek"sv},
+                    std::pair{static_cast<BYTE>(TURKISH_CHARSET), u"Turkish"sv},
+                    std::pair{static_cast<BYTE>(BALTIC_CHARSET), u"Baltic"sv},
+                    std::pair{static_cast<BYTE>(EASTEUROPE_CHARSET), u"Central European"sv},
+                    std::pair{static_cast<BYTE>(RUSSIAN_CHARSET), u"Cyrillic"sv},
+                    std::pair{static_cast<BYTE>(VIETNAMESE_CHARSET), u"Vietnamese"sv},
+                };
+
+                for (const auto& style : styles)
+                {
+                    for (const auto& [font_charset, script] : scripts)
+                    {
+                        if ((!style.supports_arabic_and_hebrew && (font_charset == ARABIC_CHARSET || font_charset == HEBREW_CHARSET)) ||
+                            (charset != DEFAULT_CHARSET && charset != font_charset))
+                        {
+                            continue;
+                        }
+
+                        auto& font = fonts.emplace_back();
+                        font.size = sizeof(font);
+                        font.text_metric_offset = offsetof(font_enum_record, text_metric) - offsetof(font_enum_record, type);
+                        font.type = TRUETYPE_FONTTYPE;
+                        font.log_font.elfLogFont.lfHeight = k_default_font_height;
+                        font.log_font.elfLogFont.lfWeight = style.weight;
+                        font.log_font.elfLogFont.lfItalic = style.italic ? UINT8_MAX : 0;
+                        font.log_font.elfLogFont.lfCharSet = font_charset;
+                        font.log_font.elfLogFont.lfPitchAndFamily = DEFAULT_PITCH | FF_SWISS;
+                        utils::string::copy(font.log_font.elfLogFont.lfFaceName, u"Segoe UI");
+                        utils::string::copy(font.log_font.elfFullName, style.full_name);
+                        utils::string::copy(font.log_font.elfStyle, style.style);
+                        utils::string::copy(font.log_font.elfScript, script);
+                        font.text_metric.ntmTm.tmHeight = k_default_font_height;
+                        font.text_metric.ntmTm.tmAscent = k_default_font_ascent;
+                        font.text_metric.ntmTm.tmDescent = k_default_font_descent;
+                        font.text_metric.ntmTm.tmAveCharWidth = k_default_font_width;
+                        font.text_metric.ntmTm.tmMaxCharWidth = k_default_font_width;
+                        font.text_metric.ntmTm.tmWeight = style.weight;
+                        font.text_metric.ntmTm.tmItalic = style.italic ? UINT8_MAX : 0;
+                        font.text_metric.ntmTm.tmCharSet = font_charset;
+                        font.text_metric.ntmTm.tmPitchAndFamily = DEFAULT_PITCH | FF_SWISS;
+                        font.text_metric.ntmTm.ntmFlags =
+                            (style.weight == FW_BOLD ? NTM_BOLD : NTM_REGULAR) | (style.italic ? NTM_ITALIC : 0);
+                    }
+                }
+            }
+
+            const auto required_size = static_cast<uint32_t>(fonts.size() * sizeof(font_enum_record));
+            if (buffer == 0)
+            {
+                c.emu.write_memory(count, &required_size, sizeof(required_size));
+                return TRUE;
+            }
+
+            uint32_t buffer_size = 0;
+            c.emu.read_memory(count, &buffer_size, sizeof(buffer_size));
+            const auto written_size = std::min(buffer_size, required_size) / sizeof(font_enum_record) * sizeof(font_enum_record);
+            if (written_size != 0)
+            {
+                c.emu.write_memory(buffer, fonts.data(), written_size);
+            }
+            c.emu.write_memory(count, &written_size, sizeof(written_size));
+            return TRUE;
         }
 
         uint32_t handle_NtGdiGetTextCharsetInfo(const syscall_context& c, const hdc /*dc*/, const emulator_pointer sig,
@@ -2607,7 +2711,7 @@ namespace sogen
                 return 0;
             }
 
-            static constexpr std::wstring_view k_default_font_name = L"Segoe UI";
+            static constexpr std::u16string_view k_default_font_name = u"Segoe UI";
             const auto required = static_cast<int32_t>(k_default_font_name.size() + 1);
 
             if (face_name == 0)
@@ -2623,11 +2727,11 @@ namespace sogen
             const auto writable_chars = std::min<int32_t>(count - 1, static_cast<int32_t>(k_default_font_name.size()));
             if (writable_chars > 0)
             {
-                c.emu.write_memory(face_name, k_default_font_name.data(), static_cast<size_t>(writable_chars) * sizeof(wchar_t));
+                c.emu.write_memory(face_name, k_default_font_name.data(), static_cast<size_t>(writable_chars) * sizeof(char16_t));
             }
 
-            const wchar_t terminator = L'\0';
-            c.emu.write_memory(face_name + static_cast<uint64_t>(writable_chars) * sizeof(wchar_t), &terminator, sizeof(terminator));
+            const char16_t terminator = u'\0';
+            c.emu.write_memory(face_name + static_cast<uint64_t>(writable_chars) * sizeof(char16_t), &terminator, sizeof(terminator));
             return required;
         }
 
@@ -2660,7 +2764,25 @@ namespace sogen
             return TRUE;
         }
 
-        uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, const hdc dc, const UINT /*character*/, const UINT format,
+        BOOL handle_NtGdiGetCharABCWidthsW(const syscall_context& c, const hdc dc, const UINT /*first_char*/, const UINT char_count,
+                                           const emulator_pointer /*chars*/, const UINT /*flags*/, const emulator_pointer buffer)
+        {
+            if (dc == 0 || buffer == 0)
+            {
+                return FALSE;
+            }
+
+            const ABC metrics{
+                .abcA = 0,
+                .abcB = k_default_font_width,
+                .abcC = 0,
+            };
+            const std::vector<ABC> widths(char_count, metrics);
+            c.emu.write_memory(buffer, widths.data(), widths.size() * sizeof(ABC));
+            return TRUE;
+        }
+
+        uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, const hdc dc, const UINT character, const UINT format,
                                              const emulator_pointer glyph_metrics, const DWORD buffer_size, const emulator_pointer buffer,
                                              const emulator_pointer mat2)
         {
@@ -2723,12 +2845,12 @@ namespace sogen
                     make_pointfx(0, 0),
                 };
 
-                const emu_ttpolycurve_header curve{
+                const EMU_TTPOLYCURVE_HEADER curve{
                     .wType = 1,
                     .cpfx = static_cast<uint16_t>(points.size()),
                 };
-                const emu_ttpolygonheader header{
-                    .cb = static_cast<uint32_t>(sizeof(emu_ttpolygonheader) + sizeof(emu_ttpolycurve_header) + sizeof(points)),
+                const EMU_TTPOLYGONHEADER header{
+                    .cb = static_cast<uint32_t>(sizeof(EMU_TTPOLYGONHEADER) + sizeof(EMU_TTPOLYCURVE_HEADER) + sizeof(points)),
                     .dwType = 24,
                     .pfxStart = make_pointfx(0, 0),
                 };
@@ -2777,17 +2899,26 @@ namespace sogen
             else
             {
                 std::vector<uint8_t> bitmap(required_size);
-                constexpr int center_x = glyph_width / 2;
-                constexpr int center_y = glyph_height / 2;
-                constexpr int dot_radius = 1;
+                gdi_bitmap_surface glyph_surface{
+                    .width = glyph_width,
+                    .height = glyph_height,
+                    .pixels = std::vector<uint32_t>(glyph_width * glyph_height),
+                };
+                const auto glyph_character = static_cast<char16_t>(
+                    character >= debug_font::first_codepoint && character <= debug_font::last_codepoint ? character : u'.');
+                draw_text(glyph_surface, 0, 0, std::u16string_view{&glyph_character, 1}, 0xFFFFFFFFu);
+
                 if (glyph_format == ggo_bitmap)
                 {
                     constexpr auto row_size = ((glyph_width + 31) / 32) * 4;
-                    for (int y = center_y - dot_radius; y <= center_y + dot_radius; ++y)
+                    for (uint32_t y = 0; y < glyph_height; ++y)
                     {
-                        for (int x = center_x - dot_radius; x <= center_x + dot_radius; ++x)
+                        for (uint32_t x = 0; x < glyph_width; ++x)
                         {
-                            bitmap[y * row_size + x / 8] |= static_cast<uint8_t>(0x80u >> (x % 8));
+                            if (glyph_surface.pixels[y * glyph_width + x] != 0)
+                            {
+                                bitmap[y * row_size + x / 8] |= static_cast<uint8_t>(0x80u >> (x % 8));
+                            }
                         }
                     }
                 }
@@ -2802,11 +2933,14 @@ namespace sogen
                     {
                         intensity = 16;
                     }
-                    for (int y = center_y - dot_radius; y <= center_y + dot_radius; ++y)
+                    for (uint32_t y = 0; y < glyph_height; ++y)
                     {
-                        for (int x = center_x - dot_radius; x <= center_x + dot_radius; ++x)
+                        for (uint32_t x = 0; x < glyph_width; ++x)
                         {
-                            bitmap[y * glyph_width + x] = intensity;
+                            if (glyph_surface.pixels[y * glyph_width + x] != 0)
+                            {
+                                bitmap[y * glyph_width + x] = intensity;
+                            }
                         }
                     }
                 }
@@ -2958,10 +3092,141 @@ namespace sogen
             return (dc != 0 && region != 0) ? 1 : 0;
         }
 
+        uint32_t handle_NtGdiGetRegionData(const syscall_context& c, const handle hrgn, const ULONG buffer_size,
+                                           const emulator_pointer region_data)
+        {
+            uint64_t region_attr = 0;
+            if (!get_gdi_object_address(c, static_cast<uint32_t>(hrgn.bits), k_gdi_region_type, region_attr))
+            {
+                return 0;
+            }
+
+            (void)region_attr;
+
+            constexpr DWORD required_size = sizeof(RGNDATAHEADER);
+            if (region_data == 0)
+            {
+                return required_size;
+            }
+
+            if (buffer_size < required_size)
+            {
+                return 0;
+            }
+
+            RGNDATAHEADER header{};
+            header.dwSize = sizeof(header);
+            header.iType = RDH_RECTANGLES;
+            header.nCount = 0;
+            header.nRgnSize = 0;
+            header.rcBound = RECT{};
+            c.emu.write_memory(region_data, &header, sizeof(header));
+            return required_size;
+        }
+
+        int32_t handle_NtGdiGetAppClipBox(const syscall_context& c, const hdc dc, const emulator_object<RECT> rect)
+        {
+            if (dc == 0 || !rect)
+            {
+                return 0;
+            }
+
+            const auto dc_it = c.proc.gdi_dc_states.find(static_cast<uint32_t>(dc));
+            if (dc_it == c.proc.gdi_dc_states.end())
+            {
+                return 0;
+            }
+
+            RECT clip_rect{};
+            const auto& dc_state = dc_it->second;
+
+            if (dc_state.selected_bitmap != 0)
+            {
+                const auto bmp_it = c.proc.gdi_bitmap_surfaces.find(dc_state.selected_bitmap);
+                if (bmp_it == c.proc.gdi_bitmap_surfaces.end())
+                {
+                    return 0;
+                }
+
+                clip_rect.right = static_cast<LONG>(bmp_it->second.width);
+                clip_rect.bottom = static_cast<LONG>(bmp_it->second.height);
+                rect.write(clip_rect);
+                return 2;
+            }
+
+            const auto* win = dc_state.target_window != 0 ? c.proc.windows.get(dc_state.target_window) : nullptr;
+            if (!win)
+            {
+                return 0;
+            }
+
+            clip_rect.right = win->width;
+            clip_rect.bottom = win->height;
+            rect.write(clip_rect);
+            return 2;
+        }
+
+        int32_t handle_NtGdiExcludeClipRect(const syscall_context&, const hdc dc, const LONG /*x_left*/, const LONG /*y_top*/,
+                                            const LONG /*x_right*/, const LONG /*y_bottom*/)
+        {
+            return dc != 0 ? 2 : 0;
+        }
+
         int32_t handle_NtGdiIntersectClipRect(const syscall_context&, const hdc dc, const LONG /*x_left*/, const LONG /*y_top*/,
                                               const LONG /*x_right*/, const LONG /*y_bottom*/)
         {
             return dc != 0 ? 2 : 0;
+        }
+
+        BOOL handle_NtGdiRectVisible(const syscall_context& c, const hdc dc, const emulator_object<RECT> rect)
+        {
+            if (dc == 0 || !rect)
+            {
+                return FALSE;
+            }
+
+            RECT target = rect.read();
+            if (target.left >= target.right || target.top >= target.bottom)
+            {
+                return FALSE;
+            }
+
+            const auto dc_it = c.proc.gdi_dc_states.find(static_cast<uint32_t>(dc));
+            if (dc_it == c.proc.gdi_dc_states.end())
+            {
+                return FALSE;
+            }
+
+            RECT clip{};
+            const auto& dc_state = dc_it->second;
+            if (dc_state.selected_bitmap != 0)
+            {
+                const auto bmp_it = c.proc.gdi_bitmap_surfaces.find(dc_state.selected_bitmap);
+                if (bmp_it == c.proc.gdi_bitmap_surfaces.end())
+                {
+                    return FALSE;
+                }
+
+                clip.right = static_cast<LONG>(bmp_it->second.width);
+                clip.bottom = static_cast<LONG>(bmp_it->second.height);
+            }
+            else
+            {
+                const auto* win = dc_state.target_window != 0 ? c.proc.windows.get(dc_state.target_window) : nullptr;
+                if (!win)
+                {
+                    return FALSE;
+                }
+
+                clip.right = win->width;
+                clip.bottom = win->height;
+            }
+
+            const LONG visible_left = (std::max)(target.left, clip.left);
+            const LONG visible_top = (std::max)(target.top, clip.top);
+            const LONG visible_right = (std::min)(target.right, clip.right);
+            const LONG visible_bottom = (std::min)(target.bottom, clip.bottom);
+            return (visible_left < visible_right && visible_top < visible_bottom) ? TRUE : FALSE;
         }
 
         uint32_t handle_NtGdiGetCharSet(const syscall_context&, const hdc dc)
@@ -3526,6 +3791,13 @@ namespace sogen
         NTSTATUS handle_NtGdiGetDCObject()
         {
             return STATUS_SUCCESS;
+        }
+
+        BOOL handle_NtGdiUnrealizeObject(const syscall_context& c, const handle h)
+        {
+            GDI_HANDLE_ENTRY64 entry{};
+            uint64_t entry_addr = 0;
+            return read_gdi_entry_for_handle(c, static_cast<uint32_t>(h.bits), entry, entry_addr) ? TRUE : FALSE;
         }
 
         NTSTATUS write_default_dxgk_adapter_array(const syscall_context& c, const UINT32 num_adapters, const UINT64 adapters_ptr)
@@ -4374,6 +4646,164 @@ namespace sogen
 
         NTSTATUS handle_NtGdiDdDDIDestroyDevice()
         {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDICreateDCFromMemory(const syscall_context& c,
+                                                     const emulator_object<EMU_D3DKMT_CREATEDCFROMMEMORY> create_dc)
+        {
+            if (!create_dc)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            const auto params = create_dc.read();
+            if (params.Width == 0 || params.Height == 0 || params.Pitch == 0 || params.pMemory == 0)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (params.hDeviceDc != 0 && !c.proc.gdi_dc_states.contains(static_cast<uint32_t>(params.hDeviceDc)))
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            const auto bitmap_handle = create_gdi_bitmap_surface(c, params.Width, params.Height, 0);
+            if (bitmap_handle == 0)
+            {
+                return STATUS_NO_MEMORY;
+            }
+
+            auto surface_it = c.proc.gdi_bitmap_surfaces.find(bitmap_handle);
+            if (surface_it == c.proc.gdi_bitmap_surfaces.end())
+            {
+                return STATUS_NO_MEMORY;
+            }
+
+            const auto initialize_surface = [&] {
+                constexpr uint32_t k_d3dddifmt_a8r8g8b8 = 21;
+                constexpr uint32_t k_d3dddifmt_x8r8g8b8 = 22;
+                constexpr uint32_t k_d3dddifmt_a8b8g8r8 = 32;
+                constexpr uint32_t k_d3dddifmt_x8b8g8r8 = 33;
+                constexpr size_t pixel_size = sizeof(uint32_t);
+
+                const auto width = static_cast<size_t>(params.Width);
+                const auto height = static_cast<size_t>(params.Height);
+                const auto pitch = static_cast<size_t>(params.Pitch);
+                const auto row_bytes = width * pixel_size;
+                if (pitch < row_bytes)
+                {
+                    return false;
+                }
+
+                auto& surface = surface_it->second;
+                std::vector<uint32_t> row(width);
+                for (size_t y = 0; y < height; ++y)
+                {
+                    c.emu.read_memory(params.pMemory + (y * pitch), row.data(), row_bytes);
+
+                    auto* dst = surface.pixels.data() + (y * width);
+                    switch (params.Format)
+                    {
+                    case k_d3dddifmt_a8r8g8b8:
+                        std::memcpy(dst, row.data(), row_bytes);
+                        break;
+
+                    case k_d3dddifmt_x8r8g8b8:
+                        for (size_t x = 0; x < width; ++x)
+                        {
+                            dst[x] = row[x] | 0xFF000000u;
+                        }
+                        break;
+
+                    case k_d3dddifmt_a8b8g8r8:
+                    case k_d3dddifmt_x8b8g8r8:
+                        for (size_t x = 0; x < width; ++x)
+                        {
+                            const auto src = row[x];
+                            const auto alpha = params.Format == k_d3dddifmt_x8b8g8r8 ? 0xFF000000u : (src & 0xFF000000u);
+                            dst[x] = alpha | ((src & 0x000000FFu) << 16) | (src & 0x0000FF00u) | ((src & 0x00FF0000u) >> 16);
+                        }
+                        break;
+
+                    default:
+                        return false;
+                    }
+                }
+
+                return true;
+            };
+
+            if (!initialize_surface())
+            {
+                handle_NtGdiDeleteObjectApp(c, bitmap_handle);
+                return STATUS_NOT_SUPPORTED;
+            }
+
+            uint64_t dc_attr = 0;
+            const auto dc_handle = allocate_gdi_dc(c, dc_attr);
+            if (dc_handle == 0)
+            {
+                handle_NtGdiDeleteObjectApp(c, bitmap_handle);
+                return STATUS_NO_MEMORY;
+            }
+
+            auto dc_it = c.proc.gdi_dc_states.find(dc_handle);
+            if (dc_it == c.proc.gdi_dc_states.end())
+            {
+                handle_NtGdiDeleteObjectApp(c, dc_handle);
+                handle_NtGdiDeleteObjectApp(c, bitmap_handle);
+                return STATUS_NO_MEMORY;
+            }
+
+            dc_it->second.is_memory_dc = true;
+            dc_it->second.selected_bitmap = bitmap_handle;
+
+            create_dc.access([&](EMU_D3DKMT_CREATEDCFROMMEMORY& writable) {
+                writable.hDc = dc_handle;
+                writable.hBitmap = bitmap_handle;
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIDestroyDCFromMemory(const syscall_context& c,
+                                                      const emulator_object<EMU_D3DKMT_DESTROYDCFROMMEMORY> destroy_dc)
+        {
+            if (!destroy_dc)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            const auto params = destroy_dc.read();
+            const auto dc_handle = static_cast<uint32_t>(params.hDc);
+            const auto bitmap_handle = static_cast<uint32_t>(params.hBitmap);
+            if (dc_handle == 0 || bitmap_handle == 0)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            const auto dc_it = c.proc.gdi_dc_states.find(dc_handle);
+            if (dc_it == c.proc.gdi_dc_states.end() || !dc_it->second.is_memory_dc)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (!c.proc.gdi_bitmap_surfaces.contains(bitmap_handle))
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (handle_NtGdiDeleteObjectApp(c, dc_handle) == 0)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            if (handle_NtGdiDeleteObjectApp(c, bitmap_handle) == 0)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
             return STATUS_SUCCESS;
         }
 

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -186,6 +186,30 @@ namespace sogen
                         i.CheckSum = optional_header.CheckSum;
                     });
 
+            case ProcessQuotaLimits: {
+                constexpr uint32_t quota_limits32_size = 0x20;
+                constexpr uint32_t quota_limits64_size = 0x30;
+
+                if (process_information_length != quota_limits32_size && process_information_length != quota_limits64_size)
+                {
+                    if (return_length)
+                    {
+                        return_length.write(quota_limits64_size);
+                    }
+                    return STATUS_INFO_LENGTH_MISMATCH;
+                }
+
+                const std::vector<std::byte> zeroed(process_information_length, std::byte{0});
+                c.emu.write_memory(process_information, zeroed.data(), zeroed.size());
+
+                if (return_length)
+                {
+                    return_length.write(process_information_length);
+                }
+
+                return STATUS_SUCCESS;
+            }
+
             case ProcessVmCounters: {
                 constexpr uint32_t vm_counters_size = 88;
                 constexpr uint32_t vm_counters_ex_size = 96;
@@ -266,7 +290,9 @@ namespace sogen
                 || info_class == ProcessPriorityBoost                        //
                 || info_class == ProcessPriorityClassEx                      //
                 || info_class == ProcessQuotaLimits                          //
-                || info_class == ProcessPriorityClass || info_class == ProcessAffinityMask)
+                || info_class == ProcessPriorityClass                        //
+                || info_class == ProcessAffinityMask                         //
+                || info_class == ProcessTelemetryCoverage)
             {
                 return STATUS_SUCCESS;
             }
@@ -430,7 +456,7 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            c.win_emu.log.error("Unsupported info process class: %X\n", info_class);
+            c.win_emu.log.error("Unsupported info process class: 0x%X\n", info_class);
             c.emu.stop();
 
             return STATUS_NOT_SUPPORTED;

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -26,6 +26,7 @@ namespace sogen
 
                 if (info_class == SystemMemoryUsageInformation && system_information_length == sizeof(basic_memory_status_information))
                 {
+                    // Simulated physical memory size (~13 GB).
                     constexpr uint64_t total_physical_bytes = 0x00c9c7ffULL * 0x1000;
 
                     const basic_memory_status_information info{

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -9,6 +9,79 @@ namespace sogen
     {
         namespace
         {
+            NTSTATUS handle_system_memory_usage_information(const syscall_context& c, const uint32_t info_class,
+                                                            const uint64_t system_information, const uint32_t system_information_length,
+                                                            const emulator_object<uint32_t> return_length)
+            {
+                struct basic_memory_status_information
+                {
+                    uint64_t total_physical_bytes;
+                    uint64_t available_physical_bytes;
+                    uint64_t reserved0;
+                    uint64_t committed_bytes;
+                    uint64_t reserved1;
+                    uint64_t commit_limit_bytes;
+                    uint64_t reserved2;
+                };
+
+                if (info_class == SystemMemoryUsageInformation && system_information_length == sizeof(basic_memory_status_information))
+                {
+                    constexpr uint64_t total_physical_bytes = 0x00c9c7ffULL * 0x1000;
+
+                    const basic_memory_status_information info{
+                        .total_physical_bytes = total_physical_bytes,
+                        .available_physical_bytes = total_physical_bytes / 2,
+                        .reserved0 = 0,
+                        .committed_bytes = total_physical_bytes / 4,
+                        .reserved1 = 0,
+                        .commit_limit_bytes = total_physical_bytes + total_physical_bytes / 2,
+                        .reserved2 = 0,
+                    };
+
+                    c.emu.write_memory(system_information, &info, sizeof(info));
+                    if (return_length)
+                    {
+                        return_length.write(sizeof(info));
+                    }
+
+                    return STATUS_SUCCESS;
+                }
+
+                using Traits = EmulatorTraits<Emu64>;
+                using info_t = SYSTEM_MEMORY_USAGE_INFORMATION<Traits>;
+                using usage_t = SYSTEM_MEMORY_USAGE<Traits>;
+
+                constexpr auto header_size = static_cast<uint32_t>(offsetof(info_t, MemoryUsage));
+                constexpr auto usage_name = std::to_array(u"System Memory");
+                constexpr auto required_length = header_size + static_cast<uint32_t>(sizeof(usage_t) + sizeof(usage_name));
+
+                if (return_length)
+                {
+                    return_length.write(required_length);
+                }
+
+                if (system_information_length < required_length)
+                {
+                    return STATUS_INFO_LENGTH_MISMATCH;
+                }
+
+                const info_t header{.Reserved = 0, .EndOfData = system_information + header_size + sizeof(usage_t), .MemoryUsage = {}};
+                c.emu.write_memory(system_information, &header, header_size);
+
+                const USHORT base_valid = info_class == SystemFullMemoryInformation ? 0x2000 : 0x1000;
+                const usage_t usage{
+                    .Name = system_information + header_size + sizeof(usage_t),
+                    .Valid = base_valid,
+                    .Standby = static_cast<USHORT>(base_valid / 2),
+                    .Modified = static_cast<USHORT>(base_valid / 8),
+                    .PageTables = static_cast<USHORT>(base_valid / 16),
+                };
+
+                c.emu.write_memory(system_information + header_size, &usage, sizeof(usage));
+                c.emu.write_memory(system_information + header_size + sizeof(usage), usage_name.data(), sizeof(usage_name));
+                return STATUS_SUCCESS;
+            }
+
             NTSTATUS handle_logical_processor_and_group_information(const syscall_context& c, const uint64_t input_buffer,
                                                                     const uint32_t input_buffer_length, const uint64_t system_information,
                                                                     const uint32_t system_information_length,
@@ -277,7 +350,6 @@ namespace sogen
 
             case 250: // Build 27744
             case SystemFlushInformation:
-            case SystemMemoryUsageInformation:
             case SystemCodeIntegrityPolicyInformation:
             case SystemHypervisorSharedPageInformation:
             case SystemFeatureConfigurationInformation:
@@ -378,6 +450,11 @@ namespace sogen
 
                         dtzi.DynamicDaylightTimeDisabled = FALSE;
                     });
+
+            case SystemMemoryUsageInformation:
+            case SystemFullMemoryInformation:
+            case SystemSummaryMemoryInformation:
+                return handle_system_memory_usage_information(c, info_class, system_information, system_information_length, return_length);
 
             case SystemRangeStartInformation:
                 return handle_query<SYSTEM_RANGE_START_INFORMATION64>(c.emu, system_information, system_information_length, return_length,
@@ -548,6 +625,13 @@ namespace sogen
             case SystemRecommendedSharedDataAlignment:
                 return handle_query<ULONG>(c.emu, system_information, system_information_length, return_length,
                                            [&](ULONG& alignment) { alignment = 64; });
+
+            case SystemNumaAvailableMemory:
+                return handle_query<SYSTEM_NUMA_INFORMATION64>(c.emu, system_information, system_information_length, return_length,
+                                                               [&](SYSTEM_NUMA_INFORMATION64& info) {
+                                                                   memset(&info, 0, sizeof(info));
+                                                                   info.AvailableMemory[0] = 0x80000000ull;
+                                                               });
 
             case SystemSupportedProcessorArchitectures: {
                 constexpr auto num_arch = 2;

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -271,7 +271,7 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            if (token_information_class == TokenIsAppContainer)
+            if (token_information_class == TokenIsAppContainer || token_information_class == TokenIsAppSilo)
             {
                 constexpr auto required_size = sizeof(ULONG);
                 return_length.write(required_size);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3710,10 +3710,16 @@ namespace sogen
                 return old_parent;
             }
 
-            if (child->handle == effective_parent->handle)
+            auto* ancestor = effective_parent;
+            for (size_t guard = 0; ancestor != nullptr && guard < c.proc.windows.size(); ++guard)
             {
-                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
-                return 0;
+                if (ancestor->handle == child->handle)
+                {
+                    set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                    return 0;
+                }
+
+                ancestor = c.proc.windows.get(ancestor->parent_handle);
             }
 
             const auto child_ptr = child->guest.value();
@@ -4850,12 +4856,9 @@ namespace sogen
             return TRUE;
         }
 
-        BOOL handle_NtUserSetMenuDefaultItem(const syscall_context& c, const hmenu menu, const UINT item, const UINT by_position)
+        BOOL handle_NtUserSetMenuDefaultItem(const syscall_context& /*c*/, const hmenu /*menu*/, const UINT /*item*/,
+                                             const UINT /*by_position*/)
         {
-            (void)c;
-            (void)menu;
-            (void)item;
-            (void)by_position;
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1303,15 +1303,44 @@ namespace sogen
         BOOL handle_NtGdiFlush(const syscall_context& c);
         gdi_bitmap_surface* get_dc_present_surface(const syscall_context& c, hdc dc, uint32_t& present_handle);
         void draw_system_button_glyph(const syscall_context& c, hdc dc, int x, int y, uint32_t index);
+        BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
 
         NTSTATUS handle_NtUserTraceLoggingSendMixedModeTelemetry()
         {
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtUserRegisterWindowMessage()
+        uint32_t handle_NtUserRegisterWindowMessage(const syscall_context& c,
+                                                    const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> message_name)
         {
-            return STATUS_NOT_SUPPORTED;
+            if (!message_name)
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return 0;
+            }
+
+            const auto raw = message_name.try_read();
+            if (!raw || raw->Buffer == 0 || raw->Length == 0 || raw->Length > raw->MaximumLength || (raw->Length & 1) != 0)
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return 0;
+            }
+
+            std::u16string name(raw->Length / sizeof(char16_t), u'\0');
+            if (!c.win_emu.memory.try_read_memory(raw->Buffer, name.data(), raw->Length))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return 0;
+            }
+
+            const auto message = static_cast<uint32_t>(c.proc.add_or_find_atom(std::move(name)));
+
+            if (c.win_emu.callbacks.on_generic_activity)
+            {
+                c.win_emu.callbacks.on_generic_activity("RegisterWindowMessage atom=#" + std::to_string(message));
+            }
+
+            return message;
         }
 
         uint64_t handle_NtUserGetThreadState(const syscall_context& c, const ULONG routine)
@@ -1500,6 +1529,23 @@ namespace sogen
         hdc handle_NtUserGetWindowDC(const syscall_context& c, const hwnd window)
         {
             return handle_NtUserGetDCEx(c, window, 0, 0);
+        }
+
+        hwnd handle_NtUserWindowFromDC(const syscall_context& c, const hdc dc)
+        {
+            const auto it = c.proc.gdi_dc_states.find(static_cast<uint32_t>(dc));
+            if (it == c.proc.gdi_dc_states.end())
+            {
+                return 0;
+            }
+
+            const auto window = it->second.target_window;
+            if (window == 0 || !c.proc.windows.get(window))
+            {
+                return 0;
+            }
+
+            return window;
         }
 
         uint64_t handle_NtUserGetControlBrush(const syscall_context& c, hwnd /*window*/, hdc /*dc*/, uint32_t control_type)
@@ -1841,6 +1887,22 @@ namespace sogen
             // POINT is { LONG x; LONG y; }. Report the last tracked cursor position in screen coordinates.
             const std::array<int32_t, 2> pt = {c.proc.cursor_x, c.proc.cursor_y};
             c.emu.write_memory(point_ptr, pt.data(), sizeof(pt));
+            return TRUE;
+        }
+
+        BOOL handle_NtUserGetCursorInfo(const syscall_context& c, const emulator_object<EMU_CURSORINFO> cursor_info)
+        {
+            if (!cursor_info)
+            {
+                return FALSE;
+            }
+
+            cursor_info.write({
+                .cbSize = sizeof(EMU_CURSORINFO),
+                .flags = c.proc.cursor_show_count >= 0 && c.proc.cursor_shape_visible ? 1u : 0u,
+                .hCursor = c.proc.current_cursor,
+                .ptScreenPos = {.x = c.proc.cursor_x, .y = c.proc.cursor_y},
+            });
             return TRUE;
         }
 
@@ -2780,6 +2842,20 @@ namespace sogen
             return TRUE;
         }
 
+        uint64_t handle_NtUserGetProp(const syscall_context& c, const hwnd window, const uint16_t atom)
+        {
+            const auto* win = c.proc.windows.get(window);
+            const auto prop = c.proc.get_atom_name(atom);
+
+            if (!win || !prop)
+            {
+                return 0;
+            }
+
+            const auto entry = win->props.find(*prop);
+            return entry != win->props.end() ? entry->second : 0;
+        }
+
         uint64_t handle_NtUserGetProp2(const syscall_context& c, const hwnd window,
                                        const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str)
         {
@@ -2797,6 +2873,26 @@ namespace sogen
 
             const auto entry = win->props.find(prop);
             return entry != win->props.end() ? entry->second : 0;
+        }
+
+        uint64_t handle_NtUserRemoveProp(const syscall_context& c, const hwnd window, const uint16_t atom)
+        {
+            auto* win = c.proc.windows.get(window);
+            const auto prop = c.proc.get_atom_name(atom);
+            if (!win || !prop)
+            {
+                return 0;
+            }
+
+            const auto entry = win->props.find(*prop);
+            if (entry == win->props.end())
+            {
+                return 0;
+            }
+
+            const auto data = entry->second;
+            win->props.erase(entry);
+            return data;
         }
 
         uint64_t handle_NtUserChangeWindowMessageFilterEx()
@@ -3507,6 +3603,11 @@ namespace sogen
             return c.get_callback_result<BOOL>();
         }
 
+        BOOL handle_NtUserInheritWindowMonitor(const syscall_context& c, const hwnd hwnd_tgt, const hwnd hwnd_inherit)
+        {
+            return c.proc.windows.get(hwnd_tgt) != nullptr && (hwnd_inherit == 0 || c.proc.windows.get(hwnd_inherit) != nullptr);
+        }
+
         BOOL handle_NtUserGetHDevName(const syscall_context& c, handle hdev, emulator_pointer device_name)
         {
             if (hdev != c.proc.default_monitor_handle)
@@ -3567,6 +3668,130 @@ namespace sogen
 
             rect.write(get_window_rect(*win));
             return TRUE;
+        }
+
+        hwnd handle_NtUserSetParent(const syscall_context& c, const hwnd hwnd_child, const hwnd hwnd_new_parent)
+        {
+            auto* child = c.proc.windows.get(hwnd_child);
+            if (!child)
+            {
+                set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                return 0;
+            }
+
+            auto* new_parent = c.proc.windows.get(hwnd_new_parent);
+            if (hwnd_new_parent != 0 && !new_parent)
+            {
+                set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                return 0;
+            }
+
+            const hwnd desktop = c.proc.default_desktop_window_handle.bits;
+            auto* effective_parent = new_parent;
+            if (!effective_parent)
+            {
+                effective_parent = c.proc.windows.get(desktop);
+            }
+
+            hwnd old_parent = child->parent_handle;
+            if (old_parent == desktop)
+            {
+                old_parent = 0;
+            }
+
+            if (!effective_parent)
+            {
+                child->parent_handle = 0;
+                child->guest.access([&](USER_WINDOW& guest_win) {
+                    guest_win.spwndParent = 0;
+                    guest_win.spwndPrev = 0;
+                    guest_win.spwndNext = 0;
+                });
+                return old_parent;
+            }
+
+            if (child->handle == effective_parent->handle)
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return 0;
+            }
+
+            const auto child_ptr = child->guest.value();
+            const auto unlink_from_parent = [&] {
+                const auto guest_child = child->guest.read();
+                if (guest_child.spwndParent != 0)
+                {
+                    emulator_object<USER_WINDOW>{c.emu, guest_child.spwndParent}.access([&](USER_WINDOW& parent_guest) {
+                        if (parent_guest.spwndChild == child_ptr)
+                        {
+                            parent_guest.spwndChild = guest_child.spwndNext;
+                        }
+                    });
+                }
+                if (guest_child.spwndPrev != 0)
+                {
+                    emulator_object<USER_WINDOW>{c.emu, guest_child.spwndPrev}.access([&](USER_WINDOW& previous_guest) {
+                        if (previous_guest.spwndNext == child_ptr)
+                        {
+                            previous_guest.spwndNext = guest_child.spwndNext;
+                        }
+                    });
+                }
+                if (guest_child.spwndNext != 0)
+                {
+                    emulator_object<USER_WINDOW>{c.emu, guest_child.spwndNext}.access([&](USER_WINDOW& next_guest) {
+                        if (next_guest.spwndPrev == child_ptr)
+                        {
+                            next_guest.spwndPrev = guest_child.spwndPrev;
+                        }
+                    });
+                }
+            };
+
+            const auto append_to_parent = [&] {
+                uint64_t current = 0;
+                effective_parent->guest.access([&](USER_WINDOW& parent_guest) {
+                    current = parent_guest.spwndChild;
+                    if (current == 0)
+                    {
+                        parent_guest.spwndChild = child_ptr;
+                    }
+                });
+
+                for (size_t guard = 0; current != 0 && guard < c.proc.windows.size(); ++guard)
+                {
+                    uint64_t following = 0;
+                    bool appended = false;
+                    emulator_object<USER_WINDOW>{c.emu, current}.access([&](USER_WINDOW& current_guest) {
+                        following = current_guest.spwndNext;
+                        if (following == 0)
+                        {
+                            current_guest.spwndNext = child_ptr;
+                            appended = true;
+                        }
+                    });
+                    if (appended)
+                    {
+                        child->guest.access([&](USER_WINDOW& guest_child) { guest_child.spwndPrev = current; });
+                        return;
+                    }
+
+                    current = following;
+                }
+            };
+
+            unlink_from_parent();
+
+            child->parent_handle = effective_parent->handle;
+            child->guest.access([&](USER_WINDOW& guest_win) {
+                guest_win.spwndParent = effective_parent->guest.value();
+                guest_win.spwndPrev = 0;
+                guest_win.spwndNext = 0;
+            });
+
+            append_to_parent();
+
+            return old_parent;
         }
 
         BOOL handle_NtUserSetWindowPos(const syscall_context& c, const hwnd hWnd, const hwnd /*hwnd_insert_after*/, const int x,
@@ -3775,6 +4000,7 @@ namespace sogen
                     case GWLP_WNDPROC:
                         oldValue = guest_win.lpfnWndProc;
                         guest_win.lpfnWndProc = dwNewLong;
+                        win->wnd_proc = dwNewLong;
                         break;
 
                     default:
@@ -4021,9 +4247,9 @@ namespace sogen
             return was_enabled ? FALSE : TRUE;
         }
 
-        BOOL handle_NtUserDeleteMenu(const syscall_context& /*c*/, const uint64_t /*menu*/, const UINT /*position*/, const UINT /*flags*/)
+        BOOL handle_NtUserDeleteMenu(const syscall_context& c, const uint64_t menu, const UINT position, const UINT flags)
         {
-            return TRUE;
+            return handle_NtUserRemoveMenu(c, static_cast<hmenu>(menu), position, flags);
         }
 
         uint64_t handle_NtUserGetSystemMenu(const syscall_context& c, const hwnd hwnd, const BOOL revert)
@@ -4481,9 +4707,33 @@ namespace sogen
             return result;
         }
 
-        NTSTATUS handle_NtUserCreateAcceleratorTable()
+        uint64_t handle_NtUserCreateAcceleratorTable(const syscall_context& c, const emulator_pointer entries, const int32_t entry_count)
         {
-            return STATUS_SUCCESS;
+            constexpr int32_t max_entry_count = 0x10000;
+            if (entries == 0 || entry_count <= 0 || entry_count > max_entry_count)
+            {
+                return 0;
+            }
+
+            auto [table_handle, table] = c.proc.accelerator_tables.create(c.win_emu.memory);
+            table.entries.resize(static_cast<size_t>(entry_count));
+            if (!c.win_emu.memory.try_read_memory(entries, table.entries.data(), table.entries.size() * sizeof(accelerator_table_entry)))
+            {
+                c.proc.accelerator_tables.erase(table_handle);
+                return 0;
+            }
+
+            return table_handle.bits;
+        }
+
+        BOOL handle_NtUserDestroyAcceleratorTable(const syscall_context& c, const handle accelerator_table)
+        {
+            return c.proc.accelerator_tables.erase(accelerator_table) ? TRUE : FALSE;
+        }
+
+        int32_t handle_NtUserCopyAcceleratorTable()
+        {
+            return 0;
         }
 
         int32_t handle_NtUserTranslateAccelerator()
@@ -4600,15 +4850,24 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserSetMenuDefaultItem(const syscall_context& c, const hmenu menu, const UINT item, const UINT by_position)
+        {
+            (void)c;
+            (void)menu;
+            (void)item;
+            (void)by_position;
+            return TRUE;
+        }
+
+        BOOL handle_NtUserEndMenu()
+        {
+            return TRUE;
+        }
+
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, const hmenu menu, const UINT position, const UINT flags)
         {
             auto* m = c.proc.menus.get(menu);
-            if (!m)
-            {
-                return FALSE;
-            }
-
-            if (m->items.empty())
+            if (!m || m->items.empty())
             {
                 return FALSE;
             }
@@ -4621,17 +4880,18 @@ namespace sogen
                 }
 
                 m->items.erase(m->items.begin() + static_cast<ptrdiff_t>(position));
-                m->sync_guest_items(c.win_emu.memory);
-                return TRUE;
             }
-
-            const auto it = std::ranges::find_if(m->items, [&](const auto& item) { return item.id == position; });
-            if (it == m->items.end())
+            else
             {
-                return FALSE;
+                const auto item = std::ranges::find_if(m->items, [&](const auto& entry) { return entry.id == position; });
+                if (item == m->items.end())
+                {
+                    return FALSE;
+                }
+
+                m->items.erase(item);
             }
 
-            m->items.erase(it);
             m->sync_guest_items(c.win_emu.memory);
             return TRUE;
         }
@@ -4999,6 +5259,267 @@ namespace sogen
         uint64_t handle_NtUserSetClipboardData()
         {
             return 1;
+        }
+
+        uint64_t handle_NtUserGetProcessDpiAwarenessContext()
+        {
+            return 0;
+        }
+
+        NTSTATUS handle_NtUserSetProcessDpiAwarenessContext()
+        {
+            return 0;
+        }
+
+        uint32_t handle_NtUserMapVirtualKeyEx(const syscall_context& /*c*/, const uint32_t code, const uint32_t map_type,
+                                              const uint32_t /*keyboard_id*/, const uint64_t /*keyboard_layout*/)
+        {
+            constexpr std::array<uint8_t, 26> letter_scans{
+                0x1E, 0x30, 0x2E, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17, 0x24, 0x25, 0x26, 0x32,
+                0x31, 0x18, 0x19, 0x10, 0x13, 0x1F, 0x14, 0x16, 0x2F, 0x11, 0x2D, 0x15, 0x2C,
+            };
+            constexpr std::array<uint8_t, 10> digit_scans{0x0B, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A};
+            constexpr std::array<uint8_t, 10> numpad_scans{0x52, 0x4F, 0x50, 0x51, 0x4B, 0x4C, 0x4D, 0x47, 0x48, 0x49};
+
+            const auto virtual_key_to_scan_code = [&](const uint32_t virtual_key) -> uint32_t {
+                if (virtual_key >= 'A' && virtual_key <= 'Z')
+                {
+                    return letter_scans[virtual_key - 'A'];
+                }
+                if (virtual_key >= '0' && virtual_key <= '9')
+                {
+                    return digit_scans[virtual_key - '0'];
+                }
+                if (virtual_key >= VK_NUMPAD0 && virtual_key <= VK_NUMPAD9)
+                {
+                    return numpad_scans[virtual_key - VK_NUMPAD0];
+                }
+                if (virtual_key >= VK_F1 && virtual_key <= VK_F10)
+                {
+                    return 0x3B + virtual_key - VK_F1;
+                }
+
+                switch (virtual_key)
+                {
+                case VK_F11:
+                    return 0x57;
+                case VK_F12:
+                    return 0x58;
+                case VK_ESCAPE:
+                    return 0x01;
+                case VK_BACK:
+                    return 0x0E;
+                case VK_TAB:
+                    return 0x0F;
+                case VK_RETURN:
+                    return 0x1C;
+                case VK_SHIFT:
+                case 0xA0:
+                    return 0x2A;
+                case 0xA1:
+                    return 0x36;
+                case VK_CONTROL:
+                case 0xA2:
+                    return 0x1D;
+                case 0xA3:
+                    return 0xE01D;
+                case VK_MENU:
+                case 0xA4:
+                    return 0x38;
+                case 0xA5:
+                    return 0xE038;
+                case VK_PAUSE:
+                    return 0xE11D;
+                case VK_CAPITAL:
+                    return 0x3A;
+                case VK_SPACE:
+                    return 0x39;
+                case VK_PRIOR:
+                    return 0xE049;
+                case VK_NEXT:
+                    return 0xE051;
+                case VK_END:
+                    return 0xE04F;
+                case VK_HOME:
+                    return 0xE047;
+                case VK_LEFT:
+                    return 0xE04B;
+                case VK_UP:
+                    return 0xE048;
+                case VK_RIGHT:
+                    return 0xE04D;
+                case VK_DOWN:
+                    return 0xE050;
+                case VK_INSERT:
+                    return 0xE052;
+                case VK_DELETE:
+                    return 0xE053;
+                case VK_LWIN:
+                    return 0xE05B;
+                case VK_RWIN:
+                    return 0xE05C;
+                case VK_APPS:
+                    return 0xE05D;
+                case VK_MULTIPLY:
+                    return 0x37;
+                case VK_ADD:
+                    return 0x4E;
+                case VK_SUBTRACT:
+                    return 0x4A;
+                case VK_DECIMAL:
+                    return 0x53;
+                case VK_DIVIDE:
+                    return 0xE035;
+                case VK_NUMLOCK:
+                    return 0x45;
+                case VK_SCROLL:
+                    return 0x46;
+                case VK_OEM_1:
+                    return 0x27;
+                case VK_OEM_PLUS:
+                    return 0x0D;
+                case VK_OEM_COMMA:
+                    return 0x33;
+                case VK_OEM_MINUS:
+                    return 0x0C;
+                case VK_OEM_PERIOD:
+                    return 0x34;
+                case VK_OEM_2:
+                    return 0x35;
+                case VK_OEM_3:
+                    return 0x29;
+                case VK_OEM_4:
+                    return 0x1A;
+                case VK_OEM_5:
+                    return 0x2B;
+                case VK_OEM_6:
+                    return 0x1B;
+                case VK_OEM_7:
+                    return 0x28;
+                case VK_OEM_102:
+                    return 0x56;
+                default:
+                    return 0;
+                }
+            };
+
+            if (map_type == 0 || map_type == 4)
+            {
+                const auto scan_code = virtual_key_to_scan_code(code);
+                return map_type == 0 ? scan_code & 0xFF : scan_code;
+            }
+
+            if (map_type == 2)
+            {
+                if ((code >= '0' && code <= '9') || (code >= 'A' && code <= 'Z') || code == VK_SPACE)
+                {
+                    return code;
+                }
+
+                switch (code)
+                {
+                case VK_OEM_1:
+                    return ';';
+                case VK_OEM_PLUS:
+                    return '=';
+                case VK_OEM_COMMA:
+                    return ',';
+                case VK_OEM_MINUS:
+                    return '-';
+                case VK_OEM_PERIOD:
+                    return '.';
+                case VK_OEM_2:
+                    return '/';
+                case VK_OEM_3:
+                    return '`';
+                case VK_OEM_4:
+                    return '[';
+                case VK_OEM_5:
+                    return '\\';
+                case VK_OEM_6:
+                    return ']';
+                case VK_OEM_7:
+                    return '\'';
+                default:
+                    return 0;
+                }
+            }
+
+            if (map_type == 1 || map_type == 3)
+            {
+                const auto scan_code = map_type == 1 ? code & 0xFF : code & 0xFFFF;
+                if (map_type == 1)
+                {
+                    if (scan_code == 0x2A || scan_code == 0x36)
+                    {
+                        return VK_SHIFT;
+                    }
+                    if (scan_code == 0x1D)
+                    {
+                        return VK_CONTROL;
+                    }
+                    if (scan_code == 0x38)
+                    {
+                        return VK_MENU;
+                    }
+                }
+                else
+                {
+                    switch (scan_code)
+                    {
+                    case 0x2A:
+                        return 0xA0;
+                    case 0x36:
+                        return 0xA1;
+                    case 0x1D:
+                        return 0xA2;
+                    case 0xE01D:
+                        return 0xA3;
+                    case 0x38:
+                        return 0xA4;
+                    case 0xE038:
+                        return 0xA5;
+                    default:
+                        break;
+                    }
+                }
+
+                for (uint32_t virtual_key = 1; virtual_key < 0x100; ++virtual_key)
+                {
+                    const auto candidate = virtual_key_to_scan_code(virtual_key);
+                    if ((map_type == 1 ? candidate & 0xFF : candidate) == scan_code)
+                    {
+                        return virtual_key;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        NTSTATUS handle_NtUserToUnicodeEx()
+        {
+            return 0;
+        }
+
+        uint64_t handle_NtUserSetKeyboardState()
+        {
+            return 0;
+        }
+
+        uint64_t handle_NtUserAttachThreadInput()
+        {
+            return 0;
+        }
+
+        BOOL handle_NtUserRegisterTouchHitTestingWindow()
+        {
+            return TRUE;
+        }
+
+        uint64_t handle_NtUserActivateKeyboardLayout()
+        {
+            return 0x1337;
         }
     }
 

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -68,16 +68,6 @@ namespace sogen
             return {*memory_, server_info_addr_};
         }
 
-        // user32's client-side GetForegroundWindow reads the foreground HWND straight out of the shared
-        // SERVERINFO (gpsi) via win32u!_ABI_Get_ForegroundWindow, which indexes gpsi + 0x1DE0 -- past the
-        // fields we model but within the page-aligned allocation. Keep it in sync with the active window so
-        // games that gate their input loop on GetForegroundWindow() actually read the mouse.
-        static constexpr uint64_t SERVERINFO_FOREGROUND_WINDOW_OFFSET = 0x1DE0;
-        void set_foreground_window(const uint32_t window) const
-        {
-            memory_->write_memory(server_info_addr_ + SERVERINFO_FOREGROUND_WINDOW_OFFSET, &window, sizeof(window));
-        }
-
         emulator_object<USER_HANDLEENTRY> get_handle_table() const
         {
             return {*memory_, handle_table_addr_};
@@ -284,6 +274,8 @@ namespace sogen
                 return TYPE_MENU;
             case handle_types::type::monitor:
                 return TYPE_MONITOR;
+            case handle_types::type::accelerator_table:
+                return TYPE_ACCELTABLE;
             default:
                 throw std::runtime_error("Unhandled handle type!");
             }

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -148,7 +148,6 @@ namespace sogen
                 return false;
             }
 
-            // Seed after the pfn copy: the worker-array fill above zeroes part of the MBStrings region.
             seed_messagebox_button_strings(memory, process.user_handles.get_server_info().value());
 
             refresh_dispatch_client_message(process);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1220,7 +1220,8 @@ namespace sogen
 
         // Mirror the foreground window into the shared SERVERINFO so the guest's client-side
         // GetForegroundWindow (which reads gpsi directly, never syscalling) returns the active window.
-        this->process.user_handles.set_foreground_window(static_cast<uint32_t>(this->process.foreground_window));
+        this->process.user_handles.get_server_info().access(
+            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = this->process.foreground_window; });
 
         // Maintain the polled key state (reported by GetKeyState) from key and mouse-button transitions, so
         // games that read input by polling rather than via window messages (in-game movement) see it.

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -50,6 +50,14 @@ namespace sogen
         }
     };
 
+    struct accelerator_table_entry
+    {
+        uint8_t flags{};
+        uint16_t key{};
+        uint16_t command{};
+    };
+    static_assert(sizeof(accelerator_table_entry) == 6);
+
     template <typename GuestType>
     struct user_object : ref_counted_object
     {
@@ -69,6 +77,28 @@ namespace sogen
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read(this->guest);
+        }
+    };
+
+    struct accelerator_table : user_object<USER_ACCELERATOR_TABLE>
+    {
+        std::vector<accelerator_table_entry> entries{};
+
+        accelerator_table(memory_interface& memory)
+            : user_object(memory)
+        {
+        }
+
+        void serialize_object(utils::buffer_serializer& buffer) const override
+        {
+            user_object::serialize_object(buffer);
+            buffer.write_vector(this->entries);
+        }
+
+        void deserialize_object(utils::buffer_deserializer& buffer) override
+        {
+            user_object::deserialize_object(buffer);
+            buffer.read_vector(this->entries);
         }
     };
 
@@ -104,7 +134,6 @@ namespace sogen
         {
             return u"ComboBox";
         }
-
         return class_name;
     }
 


### PR DESCRIPTION
This PR makes several GDI and USER syscalls improvements to Sogen. All of those changes should be self-contained, so I hope this PR isn’t too hard to review. If necessary, I can split it.

**GDI:**

* Implements `NtGdiEnumFonts` with a synthetic Segoe UI family containing four styles and 32 records for the default character-set enumeration.
* Improves `NtGdiGetGlyphOutline` so bitmap and grayscale requests render the requested character using the emulator’s debug font instead of returning a dot.
* Implements `NtGdiGetCharABCWidthsW` using the emulator’s fixed font width.
* Adds minimal implementations for `NtGdiGetRegionData`, `NtGdiGetAppClipBox`, `NtGdiRectVisible`, and `NtGdiUnrealizeObject`, plus a stub for `NtGdiExcludeClipRect`.
* Implements `NtGdiDdDDICreateDCFromMemory` and `NtGdiDdDDIDestroyDCFromMemory`.

**USER:**

* Fixes `get_message_queue_status_bits` classification for hotkey, keyboard, raw-input, and mouse messages.
* Implements `NtUserGetProp`, `NtUserRemoveProp`, `NtUserRegisterWindowMessage`, `NtUserWindowFromDC`, `NtUserGetCursorInfo`, and `NtUserSetParent`.
* Implements `NtUserCreateAcceleratorTable` and `NtUserDestroyAcceleratorTable`.
* Fixes `NtUserDeleteMenu` to remove the requested item.
* Adds stubs for `NtUserCopyAcceleratorTable`, `NtUserSetMenuDefaultItem`, `NtUserEndMenu`, `NtUserGetProcessDpiAwarenessContext`, `NtUserSetProcessDpiAwarenessContext`, `NtUserToUnicodeEx`, `NtUserSetKeyboardState`, `NtUserAttachThreadInput`, `NtUserRegisterTouchHitTestingWindow`, and `NtUserActivateKeyboardLayout`.

**Others:**

* Implements `SystemMemoryUsageInformation`, `SystemFullMemoryInformation`, `SystemSummaryMemoryInformation`, and `SystemNumaAvailableMemory` in `NtQuerySystemInformationEx`.
- Implements `ProcessQuotaLimits` in `NtQueryInformationProcess`.
* Handles `ProcessTelemetryCoverage` as a successful no-op and reports false for `TokenIsAppSilo`.