### PR TITLE
kvm: WOW64 compatibility-mode execution and memslot performance

### DIFF
--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1358,9 +1358,9 @@ namespace sogen::kvm
                 // GDT here so the flat 4 GB descriptor persists across the IRETQ. Runs at CPL0; RAX is preserved.
                 //   push rax; mov eax,0x2B; mov ds,ax; mov es,ax; pop rax; iretq
                 constexpr uint32_t iretq_stub_offset = exception_vector_count * exception_stub_stride;
-                static constexpr uint8_t iretq_trampoline_code[] = {0x50, 0xB8, 0x2B, 0x00, 0x00, 0x00, 0x8E,
-                                                                    0xD8, 0x8E, 0xC0, 0x58, 0x48, 0xCF};
-                std::memcpy(stubs + iretq_stub_offset, iretq_trampoline_code, sizeof(iretq_trampoline_code));
+                static constexpr std::array<uint8_t, 13> iretq_trampoline_code = {0x50, 0xB8, 0x2B, 0x00, 0x00, 0x00, 0x8E,
+                                                                                  0xD8, 0x8E, 0xC0, 0x58, 0x48, 0xCF};
+                std::memcpy(stubs + iretq_stub_offset, iretq_trampoline_code.data(), iretq_trampoline_code.size());
                 this->iretq_trampoline_ = this->exception_stub_page_ + iretq_stub_offset;
 
                 // 64-bit interrupt gates (DPL 3 so software int instructions are also trapped) using IST1.

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -406,6 +406,7 @@ namespace sogen::kvm
                     }
 
                     this->refresh_mmio_pages();
+                    this->flush_dirty_mappings();
                     this->flush_register_cache();
 
                     this->run_active_ = true;
@@ -1427,7 +1428,26 @@ namespace sogen::kvm
                     },
                     guest_address, physical_page);
             }
+            // Defer the (O(total mappings)) memslot reconciliation. A single high-level memory operation can
+            // allocate several page-table pages, each of which would otherwise trigger its own full rebuild,
+            // making memory mapping quadratic. Mark the layout dirty here and flush it once before the next
+            // KVM_RUN: the memslots are only consumed by the guest (the emulator accesses guest memory through
+            // host pointers, not memslots), so they need only be current when the vCPU actually runs.
             void rebuild_mappings()
+            {
+                this->mappings_dirty_ = true;
+            }
+            void flush_dirty_mappings()
+            {
+                if (!this->mappings_dirty_)
+                {
+                    return;
+                }
+
+                this->mappings_dirty_ = false;
+                this->synchronize_memslots();
+            }
+            void synchronize_memslots()
             {
                 // Project mapped_pages_ onto the desired memslot layout (physically contiguous,
                 // host-contiguous runs of pages with the same flags become one memslot), then reconcile it
@@ -2228,6 +2248,7 @@ namespace sogen::kvm
             bool readonly_mem_supported_ = false;
             int next_slot_id_ = 0;
             std::map<uint64_t, installed_memslot> current_slots_{};
+            bool mappings_dirty_ = false;
             std::vector<int> free_slot_ids_{};
             std::map<uint64_t, std::unique_ptr<mapped_page>> mapped_pages_{};
             std::unordered_map<uint64_t, uint64_t*> page_table_views_{};

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1158,7 +1158,16 @@ namespace sogen::kvm
 
                 for (size_t offset = 0; offset < size; offset += page_size)
                 {
-                    this->mapped_pages_.erase(address + offset);
+                    const auto entry = this->mapped_pages_.find(address + offset);
+                    if (entry == this->mapped_pages_.end())
+                    {
+                        continue;
+                    }
+                    if (entry->second && entry->second->physical_page)
+                    {
+                        this->gpa_pages_.erase(*entry->second->physical_page);
+                    }
+                    this->mapped_pages_.erase(entry);
                 }
 
                 // Drop any MMIO region whose backing pages were just removed. Regions are mapped and
@@ -1411,6 +1420,7 @@ namespace sogen::kvm
                 page->physical_page = page_gpa;
 
                 this->mapped_pages_[page_gpa] = std::move(page);
+                this->gpa_pages_[page_gpa] = this->mapped_pages_[page_gpa].get();
                 this->page_table_views_[page_gpa] = reinterpret_cast<uint64_t*>(raw_page);
 
                 if (map_into_guest)
@@ -1437,6 +1447,7 @@ namespace sogen::kvm
                 if (!page.physical_page)
                 {
                     page.physical_page = this->allocate_guest_physical_page();
+                    this->gpa_pages_[*page.physical_page] = &page;
                 }
 
                 return *page.physical_page;
@@ -1479,56 +1490,45 @@ namespace sogen::kvm
                 // each time.
                 struct desired_page
                 {
+                    uint64_t gpa = 0;
                     uint8_t* host = nullptr;
                     uint32_t flags = 0;
                 };
 
-                std::map<uint64_t, desired_page> pages{};
-                for (const auto& entry : this->mapped_pages_)
+                // Iterate the GPA-sorted view directly: it is already ordered and deduplicated (unique
+                // physical addresses), so no per-flush sort or std::map rebuild is needed even with
+                // hundreds of thousands of mapped pages.
+                std::vector<desired_page> pages{};
+                pages.reserve(this->gpa_pages_.size());
+                for (const auto& [gpa, page] : this->gpa_pages_)
                 {
-                    const auto& page = entry.second;
                     if (!page || page->host_page == nullptr || page->permissions == memory_permission::none)
                     {
                         continue;
                     }
-                    if (!page->physical_page)
-                    {
-                        throw std::logic_error("KVM mapped page is missing a guest physical address");
-                    }
 
-                    const auto inserted =
-                        pages
-                            .emplace(*page->physical_page, desired_page{.host = static_cast<uint8_t*>(page->host_page),
-                                                                        .flags = this->to_kvm_map_flags(page->permissions)})
-                            .second;
-                    if (!inserted)
-                    {
-                        throw std::logic_error("Duplicate KVM guest physical page");
-                    }
+                    pages.push_back(desired_page{
+                        .gpa = gpa, .host = static_cast<uint8_t*>(page->host_page), .flags = this->to_kvm_map_flags(page->permissions)});
                 }
 
                 std::map<uint64_t, installed_memslot> desired{};
-                for (auto it = pages.begin(); it != pages.end();)
+                for (size_t i = 0; i < pages.size();)
                 {
-                    const auto run_gpa = it->first;
-                    auto* const run_host_base = it->second.host;
-                    const auto run_flags = it->second.flags;
+                    const auto run_gpa = pages[i].gpa;
+                    auto* const run_host_base = pages[i].host;
+                    const auto run_flags = pages[i].flags;
 
                     size_t run_size = page_size;
-                    auto jt = std::next(it);
-                    while (jt != pages.end())
+                    size_t j = i + 1;
+                    while (j < pages.size() && pages[j].gpa == run_gpa + run_size && pages[j].host == run_host_base + run_size &&
+                           pages[j].flags == run_flags)
                     {
-                        if (jt->first != run_gpa + run_size || jt->second.host != run_host_base + run_size || jt->second.flags != run_flags)
-                        {
-                            break;
-                        }
-
                         run_size += page_size;
-                        ++jt;
+                        ++j;
                     }
 
                     desired[run_gpa] = installed_memslot{.size = run_size, .host = run_host_base, .flags = run_flags};
-                    it = jt;
+                    i = j;
                 }
 
                 for (auto it = this->current_slots_.begin(); it != this->current_slots_.end();)
@@ -2273,6 +2273,9 @@ namespace sogen::kvm
             bool mappings_dirty_ = false;
             std::vector<int> free_slot_ids_{};
             std::map<uint64_t, std::unique_ptr<mapped_page>> mapped_pages_{};
+            // GPA-sorted view of mapped_pages_ (guest physical address -> page), kept in sync so
+            // synchronize_memslots can project in memslot order without re-sorting every flush.
+            std::map<uint64_t, mapped_page*> gpa_pages_{};
             std::unordered_map<uint64_t, uint64_t*> page_table_views_{};
             uint64_t pml4_gpa_ = 0;
             uint64_t next_guest_physical_page_ = guest_physical_page_base;

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1185,16 +1185,38 @@ namespace sogen::kvm
                     throw std::runtime_error("KVM protection changes must be page aligned");
                 }
 
+                // Only presence and writability (read-only vs read-write) are projected into KVM memslots;
+                // finer protection bits (NX, read-vs-execute) are enforced elsewhere and never change a memslot.
+                // A protection change that leaves the memslot projection identical (the common case, e.g. the
+                // game's frequent NtProtectVirtualMemory) needs no reconciliation, so skip the O(total mappings)
+                // rebuild unless a page's memslot contribution actually changes.
+                constexpr uint32_t absent = ~0u;
+                bool memslot_change = false;
                 for (size_t offset = 0; offset < size; offset += page_size)
                 {
                     const auto it = this->mapped_pages_.find(address + offset);
-                    if (it != this->mapped_pages_.end())
+                    if (it == this->mapped_pages_.end() || !it->second)
                     {
-                        it->second->permissions = permissions;
+                        continue;
                     }
+
+                    auto& page = *it->second;
+                    const bool present = page.host_page != nullptr;
+                    const auto old_key =
+                        (present && page.permissions != memory_permission::none) ? this->to_kvm_map_flags(page.permissions) : absent;
+                    const auto new_key = (present && permissions != memory_permission::none) ? this->to_kvm_map_flags(permissions) : absent;
+                    if (old_key != new_key)
+                    {
+                        memslot_change = true;
+                    }
+
+                    page.permissions = permissions;
                 }
 
-                this->rebuild_mappings();
+                if (memslot_change)
+                {
+                    this->rebuild_mappings();
+                }
             }
 
             void ensure_platform_support()

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1317,6 +1317,20 @@ namespace sogen::kvm
                     stubs[vector * exception_stub_stride] = 0xF4;
                 }
 
+                // Trampoline used to return into a 32-bit compatibility-mode (WOW64) context past the per-vector
+                // stubs. KVM_SET_SREGS sets segment descriptors but cannot switch the vCPU out of 64-bit mode,
+                // so compat faults are returned through a real IRETQ which performs the hardware mode transition
+                // from the frame's CS (and reloads SS from the GDT). DS/ES are not part of the IRET frame and a
+                // 64-bit data-segment load on this host can leave their cached descriptor with G=0 (1 MB limit),
+                // which faults once compat mode enforces the limit; reload them (KGDT64_R3_DATA 0x2B) from the
+                // GDT here so the flat 4 GB descriptor persists across the IRETQ. Runs at CPL0; RAX is preserved.
+                //   push rax; mov eax,0x2B; mov ds,ax; mov es,ax; pop rax; iretq
+                constexpr uint32_t iretq_stub_offset = exception_vector_count * exception_stub_stride;
+                static constexpr uint8_t iretq_trampoline_code[] = {0x50, 0xB8, 0x2B, 0x00, 0x00, 0x00, 0x8E,
+                                                                    0xD8, 0x8E, 0xC0, 0x58, 0x48, 0xCF};
+                std::memcpy(stubs + iretq_stub_offset, iretq_trampoline_code, sizeof(iretq_trampoline_code));
+                this->iretq_trampoline_ = this->exception_stub_page_ + iretq_stub_offset;
+
                 // 64-bit interrupt gates (DPL 3 so software int instructions are also trapped) using IST1.
                 auto* idt = static_cast<uint8_t*>(this->mapped_pages_.at(this->exception_idt_page_)->host_page);
                 for (uint32_t vector = 0; vector < exception_vector_count; ++vector)
@@ -1788,6 +1802,11 @@ namespace sogen::kvm
                 } frame{};
                 this->read_memory(frame_address, &frame, sizeof(frame));
 
+                // A 32-bit compatibility-mode (WOW64) fault must be resumed through a real IRETQ: KVM_SET_SREGS
+                // applies segment descriptors but cannot switch the vCPU out of 64-bit mode. 64-bit contexts
+                // are resumed directly from the reconstructed state below.
+                const bool compat_mode = (frame.cs | 3u) != 0x33;
+
                 // Undo the exception entry so the emulator's handlers observe the faulting context, and
                 // a resumed instruction re-executes from where it faulted.
                 regs.rip = frame.rip;
@@ -1804,11 +1823,53 @@ namespace sogen::kvm
                 this->set_regs(regs);
 
                 auto sregs = this->get_sregs();
-                sregs.cs = make_segment(static_cast<uint16_t>(frame.cs), true, (frame.cs & 3) == 3);
-                sregs.ss = make_segment(static_cast<uint16_t>(frame.ss), false, (frame.ss & 3) == 3);
+                if (!compat_mode)
+                {
+                    sregs.cs = make_segment(static_cast<uint16_t>(frame.cs), true, (frame.cs & 3) == 3);
+                    sregs.ss = make_segment(static_cast<uint16_t>(frame.ss), false, (frame.ss & 3) == 3);
+                }
+                // Refresh DS/ES from their selectors too. A 64-bit `mov ds` on this host can leave a G=0
+                // (1 MB) cached descriptor; once compatibility mode (WOW64) enforces the limit, a data access
+                // above 1 MB faults. The CPU does not save DS/ES in the exception frame, so rebuild them from
+                // the current selectors as flat 4 GB segments, matching what the GDT describes.
+                if (sregs.ds.selector & ~3u)
+                {
+                    sregs.ds = make_segment(sregs.ds.selector, false, (sregs.ds.selector & 3) == 3);
+                }
+                if (sregs.es.selector & ~3u)
+                {
+                    sregs.es = make_segment(sregs.es.selector, false, (sregs.es.selector & 3) == 3);
+                }
                 this->set_sregs(sregs);
 
-                return this->handle_exception(vector, error_code);
+                if (!this->handle_exception(vector, error_code))
+                {
+                    return false;
+                }
+
+                if (compat_mode)
+                {
+                    // Re-arm the exception frame with the (possibly handler-adjusted) register state and return
+                    // through the CPL0 IRETQ trampoline, which loads CS from the GDT and switches the vCPU back
+                    // into 32-bit compatibility mode. CS/SS stay at the kernel stub segments so the trampoline
+                    // runs at CPL0; the IRETQ transitions to the CPL3 user context. DS/ES (set above) persist.
+                    const auto resumed = this->get_regs();
+                    const exception_frame iret_frame{
+                        .rip = resumed.rip,
+                        .cs = frame.cs,
+                        .rflags = resumed.rflags,
+                        .rsp = resumed.rsp,
+                        .ss = frame.ss,
+                    };
+                    this->write_memory(frame_address, &iret_frame, sizeof(iret_frame));
+
+                    auto trampoline = resumed;
+                    trampoline.rsp = frame_address;
+                    trampoline.rip = this->iretq_trampoline_;
+                    this->set_regs(trampoline);
+                }
+
+                return true;
             }
             void clear_pending_exception_state()
             {
@@ -2179,6 +2240,7 @@ namespace sogen::kvm
             int kick_signal_ = 0;
             uint64_t syscall_hook_page_ = 0;
             uint64_t exception_stub_page_ = 0;
+            uint64_t iretq_trampoline_ = 0;
             uint64_t exception_idt_page_ = 0;
             uint64_t exception_tss_page_ = 0;
             uint64_t exception_stack_page_ = 0;
@@ -2197,6 +2259,12 @@ namespace sogen::kvm
 
         kvm_segment make_segment(const uint16_t selector, const bool is_code, const bool is_user)
         {
+            // A 64-bit code segment runs in long mode (L=1, D=0); 32-bit compatibility-mode code (the WOW64
+            // selector 0x23) and all data segments use D=1, L=0. Deriving this from the selector is required
+            // when reconstructing a faulting WOW64 context: hardcoding L=1 on a 32-bit code selector re-enters
+            // the 32-bit code in 64-bit mode and misdecodes it. Windows x64 uses 0x33 for 64-bit user code.
+            const bool long_mode_code = is_code && ((selector | 3) == 0x33);
+
             kvm_segment segment{};
             segment.base = 0;
             segment.limit = 0xFFFFF;
@@ -2204,9 +2272,9 @@ namespace sogen::kvm
             segment.type = is_code ? 0xB : 0x3;
             segment.present = 1;
             segment.dpl = is_user ? 3 : 0;
-            segment.db = is_code ? 0 : 1;
+            segment.db = long_mode_code ? 0 : 1;
             segment.s = 1;
-            segment.l = is_code ? 1 : 0;
+            segment.l = long_mode_code ? 1 : 0;
             segment.g = 1;
             segment.avl = 0;
             segment.unusable = 0;

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1420,7 +1420,10 @@ namespace sogen::kvm
                 page->physical_page = page_gpa;
 
                 this->mapped_pages_[page_gpa] = std::move(page);
-                this->gpa_pages_[page_gpa] = this->mapped_pages_[page_gpa].get();
+                if (!this->gpa_pages_.emplace(page_gpa, this->mapped_pages_[page_gpa].get()).second)
+                {
+                    throw std::logic_error("Duplicate KVM guest physical page");
+                }
                 this->page_table_views_[page_gpa] = reinterpret_cast<uint64_t*>(raw_page);
 
                 if (map_into_guest)
@@ -1447,7 +1450,10 @@ namespace sogen::kvm
                 if (!page.physical_page)
                 {
                     page.physical_page = this->allocate_guest_physical_page();
-                    this->gpa_pages_[*page.physical_page] = &page;
+                    if (!this->gpa_pages_.emplace(*page.physical_page, &page).second)
+                    {
+                        throw std::logic_error("Duplicate KVM guest physical page");
+                    }
                 }
 
                 return *page.physical_page;
@@ -1847,7 +1853,7 @@ namespace sogen::kvm
                 // A 32-bit compatibility-mode (WOW64) fault must be resumed through a real IRETQ: KVM_SET_SREGS
                 // applies segment descriptors but cannot switch the vCPU out of 64-bit mode. 64-bit contexts
                 // are resumed directly from the reconstructed state below.
-                const bool compat_mode = (frame.cs | 3u) != 0x33;
+                const bool compat_mode = (static_cast<uint16_t>(frame.cs) | 3u) != 0x33;
 
                 // Undo the exception entry so the emulator's handlers observe the faulting context, and
                 // a resumed instruction re-executes from where it faulted.
@@ -1908,6 +1914,11 @@ namespace sogen::kvm
                     auto trampoline = resumed;
                     trampoline.rsp = frame_address;
                     trampoline.rip = this->iretq_trampoline_;
+                    // Clear TF for the trampoline itself: if the faulting context had single-stepping
+                    // enabled, each trampoline instruction would raise a #DB before IRETQ runs, and since
+                    // every vector shares IST1 that nested trap would overwrite the iret_frame staged
+                    // above. IRETQ still restores the guest's real TF from iret_frame.rflags.
+                    trampoline.rflags &= ~(1ULL << 8);
                     this->set_regs(trampoline);
                 }
 


### PR DESCRIPTION
Four fixes to the Linux KVM backend, developed while bringing up a demanding 32-bit (WOW64) title.

## WOW64 (32-bit compatibility mode) execution
`KVM_SET_SREGS` applies segment descriptors but cannot switch the vCPU's execution mode, so a fault taken in compat mode was resumed in 64-bit mode and spun in an interrupt loop. Faults are now returned through a real `iretq` trampoline (in the exception stub page) that switches mode from the frame's CS and reloads DS/ES, and `make_segment` derives L/D from the selector.

## Memslot performance
A game's guest working set is large (hundreds of thousands of mapped pages), and every `KVM_SET_USER_MEMORY_REGION` forces an NPT/TLB rebuild, so how the memslot layout is reconciled on each memory operation matters a lot:

- **Defer reconciliation.** `rebuild_mappings()` was O(total mappings) and ran from every memory op (and every internal page-table allocation), making mapping quadratic. It now just marks dirty; the real reconciliation runs once before `KVM_RUN`.
- **Skip no-op protections.** KVM memslots only encode presence + writability, so most `NtProtectVirtualMemory` calls are no-ops for KVM. Only mark dirty when a page's memslot contribution (absent / read-only / read-write) actually changes.
- **Keep a GPA-sorted page index.** Reconciliation projected all mapped pages into a temporary `std::map` keyed by guest physical address on every flush; that per-node allocation dominated the profile and collapsed menu frame rates. A persistent `gpa_pages_` index is maintained instead, so the flush iterates an already-ordered, deduplicated view.

The memslot layout produced is unchanged throughout; these only change how it is computed.
