### PR TITLE
Fix DirectInput keyboard and mouse input

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -46,7 +46,9 @@ namespace sogen
         uint64_t apfnClientA[FNID_ARRAY_SIZE];
         uint64_t apfnClientW[FNID_ARRAY_SIZE];
         uint64_t apfnClientWorker[FNID_ARRAY_SIZE];
-        uint8_t pad_3c8[0xE90];
+        uint8_t pad_3c8[0x3A0];
+        int32_t systemMetrics[0x61];
+        uint8_t pad_8ec[0x96C];
         uint64_t ahbrSystem[USER_SERVERINFO_BRUSH_SLOT_COUNT];
         uint8_t pad_1358[0x34];
         int32_t defaultFontHeightScale;
@@ -57,6 +59,7 @@ namespace sogen
         uint64_t foregroundWindow;
     };
     static_assert(offsetof(USER_SERVERINFO, apfnClientA) == 0x188);
+    static_assert(offsetof(USER_SERVERINFO, systemMetrics) == 0x768);
     static_assert(offsetof(USER_SERVERINFO, ahbrSystem) == 0x1258);
     static_assert(offsetof(USER_SERVERINFO, defaultFontHeightScale) == 0x138C);
     static_assert(offsetof(USER_SERVERINFO, defaultFontWidthScale) == 0x1390);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -460,6 +460,10 @@ namespace sogen
         hwnd handle_NtUserSetCapture(const syscall_context& c, hwnd window);
         BOOL handle_NtUserReleaseCapture(const syscall_context& c);
         BOOL handle_NtUserRegisterRawInputDevices(const syscall_context& c, emulator_pointer devices, uint32_t device_count, uint32_t size);
+        ULONG handle_NtUserGetRawInputDeviceList(const syscall_context& c, emulator_pointer devices, emulator_pointer device_count,
+                                                 uint32_t size);
+        ULONG handle_NtUserGetRawInputDeviceInfo(const syscall_context& c, handle device, uint32_t command, emulator_pointer data,
+                                                 emulator_pointer size);
         uint32_t handle_NtUserGetRawInputData(const syscall_context& c, emulator_pointer raw_input, uint32_t command, emulator_pointer data,
                                               emulator_object<uint32_t> size_ptr, uint32_t header_size);
         BOOL handle_NtUserDefSetText(const syscall_context& c, hwnd window, emulator_object<LARGE_STRING> text);
@@ -1046,11 +1050,6 @@ namespace sogen
             return STATUS_NOT_SUPPORTED;
         }
 
-        ULONG handle_NtUserGetRawInputDeviceList()
-        {
-            return 0;
-        }
-
         ULONG handle_NtUserGetKeyboardType()
         {
             return 0;
@@ -1132,6 +1131,10 @@ namespace sogen
             }
         }
 
+        NTSTATUS handle_NtNotifyChangeDirectoryFile()
+        {
+            return STATUS_SUCCESS;
+        }
     }
 
     // NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
@@ -1443,6 +1446,7 @@ namespace sogen
         add_handler(NtUserToUnicodeEx);
         add_handler(NtUserSetProcessDpiAwarenessContext);
         add_handler(NtUserGetRawInputDeviceList);
+        add_handler(NtUserGetRawInputDeviceInfo);
         add_handler(NtUserGetKeyboardType);
         add_handler(NtUserEnumDisplayDevices);
         add_handler(NtUserEnumDisplaySettings);
@@ -1616,6 +1620,7 @@ namespace sogen
         add_handler(NtUserAttachThreadInput);
         add_handler(NtUserRegisterTouchHitTestingWindow);
         add_handler(NtUserActivateKeyboardLayout);
+        add_handler(NtNotifyChangeDirectoryFile);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1640,6 +1640,165 @@ namespace sogen
             return TRUE;
         }
 
+        ULONG handle_NtUserGetRawInputDeviceList(const syscall_context& c, const emulator_pointer devices,
+                                                 const emulator_pointer device_count, const uint32_t size)
+        {
+            constexpr uint32_t required_count = 2;
+            constexpr uint32_t list32_size = 8;
+            constexpr uint32_t list64_size = 16;
+            constexpr uint64_t mouse_handle = 0x10001;
+            constexpr uint64_t keyboard_handle = 0x10002;
+
+            if (device_count == 0 || (size != list32_size && size != list64_size))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return static_cast<ULONG>(-1);
+            }
+
+            uint32_t capacity = 0;
+            if (!c.emu.try_read_memory(device_count, &capacity, sizeof(capacity)))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return static_cast<ULONG>(-1);
+            }
+
+            if (devices == 0)
+            {
+                c.emu.write_memory(device_count, &required_count, sizeof(required_count));
+                return 0;
+            }
+
+            if (capacity < required_count)
+            {
+                c.emu.write_memory(device_count, &required_count, sizeof(required_count));
+                set_guest_last_error(c, 122); // ERROR_INSUFFICIENT_BUFFER
+                return static_cast<ULONG>(-1);
+            }
+
+            if (size == list32_size)
+            {
+                struct raw_input_device_list32
+                {
+                    uint32_t device;
+                    uint32_t type;
+                };
+
+                const std::array device_list = {
+                    raw_input_device_list32{.device = static_cast<uint32_t>(mouse_handle), .type = RIM_TYPEMOUSE},
+                    raw_input_device_list32{.device = static_cast<uint32_t>(keyboard_handle), .type = RIM_TYPEKEYBOARD},
+                };
+                c.emu.write_memory(devices, device_list.data(), sizeof(device_list));
+            }
+            else
+            {
+                struct raw_input_device_list64
+                {
+                    uint64_t device;
+                    uint32_t type;
+                };
+
+                const std::array device_list = {
+                    raw_input_device_list64{.device = mouse_handle, .type = RIM_TYPEMOUSE},
+                    raw_input_device_list64{.device = keyboard_handle, .type = RIM_TYPEKEYBOARD},
+                };
+                c.emu.write_memory(devices, device_list.data(), sizeof(device_list));
+            }
+
+            c.emu.write_memory(device_count, &required_count, sizeof(required_count));
+            return required_count;
+        }
+
+        ULONG handle_NtUserGetRawInputDeviceInfo(const syscall_context& c, const handle device, const uint32_t command,
+                                                 const emulator_pointer data, const emulator_pointer size)
+        {
+            constexpr uint64_t mouse_handle = 0x10001;
+            constexpr uint64_t keyboard_handle = 0x10002;
+            constexpr uint32_t ridi_device_name = 0x20000007;
+            constexpr uint32_t ridi_device_info = 0x2000000B;
+            constexpr std::u16string_view mouse_name = u"\\\\?\\HID#SOGEN_MOUSE#0001#{378de44c-56ef-11d1-bc8c-00a0c91405dd}";
+            constexpr std::u16string_view keyboard_name = u"\\\\?\\HID#SOGEN_KEYBOARD#0001#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}";
+
+            if (size == 0 || (device != mouse_handle && device != keyboard_handle))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return static_cast<ULONG>(-1);
+            }
+
+            uint32_t capacity = 0;
+            if (!c.emu.try_read_memory(size, &capacity, sizeof(capacity)))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return static_cast<ULONG>(-1);
+            }
+
+            if (command == ridi_device_name)
+            {
+                const auto name = device == mouse_handle ? mouse_name : keyboard_name;
+                const auto required_characters = static_cast<uint32_t>(name.size() + 1);
+                if (data == 0)
+                {
+                    c.emu.write_memory(size, &required_characters, sizeof(required_characters));
+                    return 0;
+                }
+                if (capacity < required_characters)
+                {
+                    c.emu.write_memory(size, &required_characters, sizeof(required_characters));
+                    set_guest_last_error(c, 122); // ERROR_INSUFFICIENT_BUFFER
+                    return static_cast<ULONG>(-1);
+                }
+
+                c.emu.write_memory(data, name.data(), name.size() * sizeof(char16_t));
+                const char16_t terminator = 0;
+                c.emu.write_memory(data + name.size() * sizeof(char16_t), &terminator, sizeof(terminator));
+                c.emu.write_memory(size, &required_characters, sizeof(required_characters));
+                return static_cast<ULONG>(name.size());
+            }
+
+            if (command == ridi_device_info)
+            {
+                struct raw_input_device_info
+                {
+                    uint32_t structure_size;
+                    uint32_t type;
+                    std::array<uint32_t, 6> details;
+                };
+                static_assert(sizeof(raw_input_device_info) == 32);
+
+                constexpr uint32_t required_bytes = sizeof(raw_input_device_info);
+                if (data == 0)
+                {
+                    c.emu.write_memory(size, &required_bytes, sizeof(required_bytes));
+                    return 0;
+                }
+                if (capacity < required_bytes)
+                {
+                    c.emu.write_memory(size, &required_bytes, sizeof(required_bytes));
+                    set_guest_last_error(c, 122); // ERROR_INSUFFICIENT_BUFFER
+                    return static_cast<ULONG>(-1);
+                }
+
+                raw_input_device_info info{};
+                info.structure_size = required_bytes;
+                if (device == mouse_handle)
+                {
+                    info.type = RIM_TYPEMOUSE;
+                    info.details = {1, 3, 100, 0, 0, 0};
+                }
+                else
+                {
+                    info.type = RIM_TYPEKEYBOARD;
+                    info.details = {4, 0, 1, 12, 3, 101};
+                }
+
+                c.emu.write_memory(data, &info, sizeof(info));
+                c.emu.write_memory(size, &required_bytes, sizeof(required_bytes));
+                return required_bytes;
+            }
+
+            set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+            return static_cast<ULONG>(-1);
+        }
+
         // GetRawInputData fetches the payload referenced by a WM_INPUT message's lParam (an HRAWINPUT token we
         // minted in handle_ui_event). We only synthesize relative mouse motion, so reconstruct a RAWINPUT whose
         // mouse delta is the {dx, dy} stored for the token. uiCommand selects the header-only (RID_HEADER) or

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -39,6 +39,10 @@ namespace sogen
                 srv.defaultFontHeightScale = -11;
                 srv.defaultFontWidthScale = 0;
                 srv.systemDpi = 96;
+                srv.systemMetrics[19] = 1; // SM_MOUSEPRESENT
+                srv.systemMetrics[43] = 3; // SM_CMOUSEBUTTONS
+                srv.systemMetrics[75] = 1; // SM_MOUSEWHEELPRESENT
+                srv.systemMetrics[91] = 1; // SM_MOUSEHORIZONTALWHEELPRESENT
             });
 
             const auto handle_table_size = static_cast<size_t>(page_align_up(sizeof(USER_HANDLEENTRY) * MAX_HANDLES));


### PR DESCRIPTION
This PR fixes the `GetSystemMetrics` function and Raw Input syscalls so DirectInput works for keyboard and mouse input. It also stubs the `NtNotifyChangeDirectoryFile` syscall to return success.