### PR TITLE
Multi-vCPU support: run guest threads in parallel on WHP

### DIFF
--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -29,13 +29,23 @@ Status: in progress on branch `multi-vcpu`
       legacy `current_thread()` observer API is made correct via `scoped_dispatch`: a
       `windows_emulator::dispatch_vcpu_` member set at each handler entry under the kernel
       lock (race-free because the BEL serializes handlers — not a global or thread-local).
-      With these fixes N>1 now runs the entire smoke suite correctly through ~15 tests
-      (Registry, System Info, Time Zone, Exceptions, …) and fails only at the **Threads**
-      test — the one test that exercises genuinely concurrent guest threads. That failure
-      is parallelism-specific (Threads passes at N=1) and is the remaining Phase 3 work:
-      wait/signal ordering under true concurrency and any remaining shared state touched
-      off-lock. Remaining Phase 2 polish still open: ready_cv instead of sleep-poll; device
-      pump on scheduler ticks; N=1 boot benchmark; clang-cl -Wthread-safety annotations.
+      Also fixed a WHP premature-termination bug: `flush_virtual_address_mappings` cancels
+      other running VPs (`WHvCancelRunVirtualProcessor`) without setting `stop_requested_`,
+      and `run()`'s Canceled handler returned (instead of restarting) when rip had advanced
+      — so a vCPU cancelled for a peer's page-table change returned to the worker, which saw
+      `!switch_thread` and ended the whole run ("Emulation terminated without status"). A
+      cancel without `stop_requested_` is now always a TLB-flush re-entry, never a stop.
+      With these fixes N>1 runs the entire smoke suite correctly through ~15 tests and the
+      verbose run reaches a clean `NtTerminateProcess` (status 0). The **Threads** test
+      still fails under `-s` (silent, fastest/most-parallel) — a genuine timing race
+      (Heisenbug: host logging serializes enough to hide it). A guest thread raises an
+      unhandled exception (WER is contacted) under contention. Prime suspect: the
+      partition-global EPT single-step dance in the WHP section-first-execution hooks (two
+      vCPUs flipping/​restoring exec on the same shared page — the accepted-race from §4;
+      may not be benign under real contention). Remaining Phase 3: pin down and fix that
+      race; cross-vCPU kicks; stop-the-world for snapshots; guest CPU count = vcpu_count.
+      Remaining Phase 2 polish: ready_cv instead of sleep-poll; device pump on ticks; N=1
+      boot benchmark; clang-cl -Wthread-safety annotations.
 - [ ] Phase 3 — cross-vCPU correctness
 - [ ] Phase 4 — stress testing + contention profiling
 - [ ] Phase 5 — KVM parity, linux-emulator

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -20,7 +20,23 @@ Status: in progress on branch `multi-vcpu`
       deferred TLB flush (flag + cancel, applied at run-loop top) replacing the
       cross-vCPU CR3 rewrite. N=1 keeps its proven inline loop (workers only spawn at
       N>1); N=1 + all tests unaffected.
-- [~] Phase 3 — cross-vCPU correctness. Fixed the register-routing bug that made every
+- [x] Phase 3 (core) — **parallel execution is stable**. The Threads-test race was a
+      spurious access violation: under multiple vCPUs a page that is backed with permissions
+      that allow the access still faulted because this vCPU held a *stale translation* (a
+      peer had just mapped/committed/reprotected it — e.g. ntdll `.mrdata`/`.00cfg`/`.rsrc`
+      flipping RO↔RW during loader init). The escalated fault delivered a bogus 0xC0000005.
+      Fix: `try_repair_spurious_fault` in all three WHP fault paths re-establishes the
+      mapping + flushes this vCPU's TLB + retries whenever the page is backed and its
+      intended permissions allow the operation (guard/no-access pages map with permission
+      `none`, so genuine violations are still delivered); a per-vCPU (page,rip) retry
+      counter (cap 256) rides out concurrent re-clears at high vCPU counts without looping.
+      Result: `--vcpus 2` 70/70, `--vcpus 4` 27/28, `--vcpus 8` ~125/126 smoke runs pass;
+      N=1 and the 23 unit tests unaffected. Remaining Phase 3 (non-blocking): cross-vCPU
+      kicks for alert/APC/suspend/terminate targeting a *running* thread (currently take
+      effect at the next ~20ms timer preemption); NtGet/SetContextThread force-save;
+      stop-the-world snapshot quiesce (snapshots still N=1); guest CPU count tied to
+      vcpu_count. Details of the earlier register/dispatch fixes below.
+- [~] Phase 3 (earlier fixes) — Fixed the register-routing bug that made every
       syscall on a non-zero vCPU touch vCPU 0's registers: `syscall_context::emu` (and the
       argument/register helpers, `callback_frame`, exception dispatch, rdtsc/rdtscp/
       interrupt/violation hooks) now use the acting vCPU's `x86_64_cpu` instead of

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -1,6 +1,26 @@
 # Multi-vCPU Support — Design
 
-Status: proposal (not implemented)
+Status: in progress on branch `multi-vcpu`
+
+- [x] Phase 0a — capability query, `vcpu_count` setting, `--vcpus`, hard-error validation (4aa27ba1)
+- [x] Phase 0b — `x86_64_cpu` extraction (5611f1d4); hook callbacks carry the triggering CPU
+      (a68338eb); `vcpu_context` replaces `process_context::active_thread`, `CURRENT_THREAD`
+      resolution takes the calling thread explicitly, snapshot format unchanged (9d6be10b)
+- [x] Phase 1 — WHP drives N VPs: per-VP `whp_vcpu` objects, parameterized VP index,
+      `partition_mutex_` (shared_mutex, copy-then-invoke callback discipline),
+      `ProcessorCount = N`, factory takes `vcpu_count` (eef2e558). Clang-tidy clean.
+- [ ] Phase 2 — BEL + vcpu_worker scheduler. Done: `kernel_lock` (owner-tracking,
+      non-recursive, assert-based interior checks) acquired at every entry point (hook
+      callbacks, UI event delivery, scheduler loop — released across guest execution
+      and idle sleeps), logger print mutex, startup conflict validation
+      (instruction precision / relative time / instruction budgets / gdb at N>1).
+      Remaining: per-vCPU worker loops + ready_cv, timer kicks for all running vCPUs,
+      device pump on scheduler ticks, N=1 boot benchmark vs main, clang-cl
+      -Wthread-safety annotations.
+- [ ] Phase 3 — cross-vCPU correctness
+- [ ] Phase 4 — stress testing + contention profiling
+- [ ] Phase 5 — KVM parity, linux-emulator
+
 Scope: WHP backend first, KVM second; windows-emulator first, linux-emulator second.
 Goal: run guest threads truly in parallel — one host thread drives one vCPU — instead of
 cooperatively multiplexing all guest threads onto a single vCPU.

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -59,16 +59,27 @@ Status: in progress on branch `multi-vcpu`
       is present; the residual case is a **committed page whose eager WHP mapping is absent
       on the faulting vCPU** — likely the image/COW mapping path (not the eager
       `map_memory`) not being established/flushed across vCPUs. Next: instrument the WHP
-      violation fall-through to log GvaValid + mapped_pages_ state + is_virtual_mapping_present
-      for that address, and check whether ntdll `.data` COW pages are mapped lazily.
-      **Residual**: ~5/12 of silent `--vcpus 2` runs still fail at the **Threads** test with
-      NO emulator-side error (the guest observes the fault), and it vanishes under any
-      added logging (Heisenbug). This last race needs dedicated tooling — a deterministic
-      repro or the Linux/KVM build under ThreadSanitizer (TSan is unavailable on WHP) —
-      rather than trial-and-error. Remaining Phase 3: that race; cross-vCPU kicks;
-      stop-the-world for snapshots; guest CPU count = vcpu_count. Remaining Phase 2 polish:
-      ready_cv instead of sleep-poll; device pump on ticks; N=1 boot benchmark;
-      clang-cl -Wthread-safety annotations.
+      violation fall-through to log GvaValid + mapped_pages_ state + is_virtual_mapping_present.
+      Root-caused it: guest page faults escalate to WHP's *unrecoverable-exception* exit
+      (the guest IDT can't dispatch #PF), and that path read CR2 and delivered a memory
+      violation **without** any spurious-fault check — so a fault on an actually-backed
+      page (peer map/commit, or a transient protection/COW remap on another vCPU clearing
+      this vCPU's PTE) became a bogus AV. Fix: `try_repair_spurious_fault` (re-establishes
+      the mapping + flushes this vCPU's TLB + retries, with a per-vCPU (page,rip) guard so
+      genuine violations — null derefs, wrong-permission pages — are still delivered after
+      one cycle) now runs in all three fault paths (`handle_exception` #PF,
+      `handle_memory_access` GpaUnmapped, `handle_unrecoverable_exception`). This lifted
+      the `--vcpus 2` smoke pass rate to ~16/24 (was ~1/2). A speculative flush in
+      `apply_memory_protection` was tried and reverted (no clear help; Hyper-V handles
+      EPT-level coherency; added churn).
+      **Residual**: ~1/3 of silent `--vcpus 2` runs still fail at the **Threads** test — the
+      repair fires but the page is sometimes concurrently re-cleared (guard trips → AV
+      delivered), pointing at a tighter map/unmap/protect race on a shared page, or a
+      guest-level loader-lock / .mrdata race. Still Heisenbug-y (vanishes under hot-path
+      logging); the env-gated post-mortem tracer (`SOGEN_TRACE_EXCEPTIONS=1`) is the tool.
+      Remaining Phase 3: that race; cross-vCPU kicks; stop-the-world for snapshots; guest
+      CPU count = vcpu_count. Remaining Phase 2 polish: ready_cv instead of sleep-poll;
+      device pump on ticks; N=1 boot benchmark; clang-cl -Wthread-safety annotations.
 - [ ] Phase 3 — cross-vCPU correctness
 - [ ] Phase 4 — stress testing + contention profiling
 - [ ] Phase 5 — KVM parity, linux-emulator

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -102,8 +102,12 @@ Status: in progress on branch `multi-vcpu`
       Remaining Phase 3: that race; cross-vCPU kicks; stop-the-world for snapshots; guest
       CPU count = vcpu_count. Remaining Phase 2 polish: ready_cv instead of sleep-poll;
       device pump on ticks; N=1 boot benchmark; clang-cl -Wthread-safety annotations.
-- [ ] Phase 3 — cross-vCPU correctness
-- [ ] Phase 4 — stress testing + contention profiling
+- [~] Phase 3 — cross-vCPU correctness (WHP: 64-bit + WoW64 32-bit run at N=1..8;
+      real game open-iw5/MW3 runs to self-exit at N=2. Fixes landed: per-vCPU GDTs,
+      SDL UI marshaling to the pump thread, acting-vCPU attribution for
+      syscalls/rdtsc/rdtscp/cpuid/read-hooks. Converged, not closed — more workloads
+      will surface more races.)
+- [x] Phase 4 — stress testing + contention profiling (see §9 Phase 4 for results)
 - [ ] Phase 5 — KVM parity, linux-emulator
 
 Scope: WHP backend first, KVM second; windows-emulator first, linux-emulator second.
@@ -646,12 +650,33 @@ Kicks for alert/APC/suspend/terminate targeting running threads; force-save for
 snapshot restriction); guest-visible CPU identity (KUSD count,
 `NtGetCurrentProcessorNumberEx`).
 
-**Phase 4 — validation + performance.**
-Guest stress test (in the test-sample or a dedicated sample: N threads hammering
-interlocked ops, events, mutants, waits, VirtualAlloc churn) run at `--vcpus 2..8`;
-BEL contention profiling (extend the `SOGEN_WHP_PROFILE` infrastructure); then targeted
-lock refinement *only where measured*: likely candidates are KUSD reads, hot device
-ioctls (GPU bridge), and `memory_manager` read paths (a `shared_mutex` split).
+**Phase 4 — validation + performance.** *(done)*
+Guest stress test: `src/samples/stress-sample` — 8 threads hammering interlocked ops, a
+`CRITICAL_SECTION`-guarded counter, a semaphore producer/consumer, auto-reset event
+ping-pong, and `VirtualAlloc` churn with write/read verification, each asserting a
+deterministic invariant. Passes at `--vcpus 1..8` for both x64 and WoW64 (x86) on WHP;
+no new races surfaced.
+
+BEL contention profiling: `kernel_lock` is instrumented under `SOGEN_LOCK_PROFILE`
+(acquisitions / contended / wait time / held time, summarized at end of run; zero cost
+when unset). Measured contention (contended acquisitions ÷ total):
+
+| workload                    | N=2   | N=4   | N=8   |
+|-----------------------------|-------|-------|-------|
+| pure-synchronization stress | 43.5% | 51.6% | 53.7% |
+| real game (open-iw5/MW3)    | 1.4%  | 2.6%  | —     |
+
+Held time stays ~constant (~4.7 s stress, ~5–6 s game) across vCPU counts — the BEL
+serializes a fixed amount of work. The stress numbers are a worst case (the workload is
+almost entirely syscalls); the game is guest-compute-dominated, so the BEL is contended
+only 1–3% of the time and is **not** a bottleneck for the target workloads.
+
+Targeted lock refinement: **none warranted** by the measurements. Per the rule above
+("only where measured"), refining a 1–3% game-workload contention would be speculative
+and risk new lock-ordering bugs, so it is deliberately not done. If a future syscall-heavy
+workload proves otherwise, the profiler points the way and the candidates remain KUSD
+reads, hot device ioctls (GPU bridge), and `memory_manager` read paths (a `shared_mutex`
+split).
 
 **Phase 5 — secondary targets.**
 KVM parity (§8); linux-emulator adopts the same scheduler/BEL shape (it mirrors the

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -49,7 +49,19 @@ Status: in progress on branch `multi-vcpu`
       reading the time page tore `kusd_`; now guarded by an internal mutex. That, plus the
       cancel-return fix, took the `--vcpus 2` smoke suite from near-always-failing to
       ~6/8 passing (full suite completes, clean `NtTerminateProcess`).
-      **Residual**: ~25% of silent `--vcpus 2` runs still fail at the **Threads** test with
+      Post-mortem exception tracer added (env `SOGEN_TRACE_EXCEPTIONS=1`, dumped after the
+      run so it doesn't perturb the race): it pinpointed the crash as a spurious access
+      violation (0xC0000005) on a page the memory manager reports **committed** — the guest
+      page-table entry is absent on the faulting vCPU. Deterministic fault address
+      (ntdll+0x1ea598, an image `.data`/COW page) but intermittent by timing. Added a
+      stale-TLB retry: a not-present #PF whose guest PTE is actually present flushes the
+      vCPU's TLB and resumes instead of delivering a bogus AV. That only helps when the PTE
+      is present; the residual case is a **committed page whose eager WHP mapping is absent
+      on the faulting vCPU** — likely the image/COW mapping path (not the eager
+      `map_memory`) not being established/flushed across vCPUs. Next: instrument the WHP
+      violation fall-through to log GvaValid + mapped_pages_ state + is_virtual_mapping_present
+      for that address, and check whether ntdll `.data` COW pages are mapped lazily.
+      **Residual**: ~5/12 of silent `--vcpus 2` runs still fail at the **Threads** test with
       NO emulator-side error (the guest observes the fault), and it vanishes under any
       added logging (Heisenbug). This last race needs dedicated tooling — a deterministic
       repro or the Linux/KVM build under ThreadSanitizer (TSan is unavailable on WHP) —

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -42,10 +42,21 @@ Status: in progress on branch `multi-vcpu`
       unhandled exception (WER is contacted) under contention. Prime suspect: the
       partition-global EPT single-step dance in the WHP section-first-execution hooks (two
       vCPUs flipping/​restoring exec on the same shared page — the accepted-race from §4;
-      may not be benign under real contention). Remaining Phase 3: pin down and fix that
-      race; cross-vCPU kicks; stop-the-world for snapshots; guest CPU count = vcpu_count.
-      Remaining Phase 2 polish: ready_cv instead of sleep-poll; device pump on ticks; N=1
-      boot benchmark; clang-cl -Wthread-safety annotations.
+      may not be benign under real contention) — but `--whp-exec-hook int3` fails
+      identically, so the exec-hook mechanism was **ruled out**. Fixed a real off-lock
+      race since: KUSD MMIO reads (`kusd_mmio::read`/`update`) run on the worker thread
+      during guest execution (kernel lock released) and were unguarded, so two vCPUs
+      reading the time page tore `kusd_`; now guarded by an internal mutex. That, plus the
+      cancel-return fix, took the `--vcpus 2` smoke suite from near-always-failing to
+      ~6/8 passing (full suite completes, clean `NtTerminateProcess`).
+      **Residual**: ~25% of silent `--vcpus 2` runs still fail at the **Threads** test with
+      NO emulator-side error (the guest observes the fault), and it vanishes under any
+      added logging (Heisenbug). This last race needs dedicated tooling — a deterministic
+      repro or the Linux/KVM build under ThreadSanitizer (TSan is unavailable on WHP) —
+      rather than trial-and-error. Remaining Phase 3: that race; cross-vCPU kicks;
+      stop-the-world for snapshots; guest CPU count = vcpu_count. Remaining Phase 2 polish:
+      ready_cv instead of sleep-poll; device pump on ticks; N=1 boot benchmark;
+      clang-cl -Wthread-safety annotations.
 - [ ] Phase 3 — cross-vCPU correctness
 - [ ] Phase 4 — stress testing + contention profiling
 - [ ] Phase 5 — KVM parity, linux-emulator

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -1,0 +1,583 @@
+# Multi-vCPU Support — Design
+
+Status: proposal (not implemented)
+Scope: WHP backend first, KVM second; windows-emulator first, linux-emulator second.
+Goal: run guest threads truly in parallel — one host thread drives one vCPU — instead of
+cooperatively multiplexing all guest threads onto a single vCPU.
+
+---
+
+## 1. Where we are today
+
+The whole stack is built around **one vCPU, one host execution thread**:
+
+- Each backend instance *is* one vCPU. WHP hardcodes `constexpr UINT32 vp_index = 0`
+  (`whp_x86_64_emulator.cpp:29`) into every `WHvCreateVirtualProcessor` /
+  `WHvRunVirtualProcessor` / `WHvGet/SetVirtualProcessorRegisters` /
+  `WHvCancelRunVirtualProcessor` call, and sets partition `ProcessorCount = 1`
+  (`:1866`). KVM mirrors this (`kvm_x86_64_emulator.cpp:62`, one `vcpu_fd_`).
+- Guest threads are multiplexed cooperatively: a context switch serializes the entire
+  register file into `emulator_thread::last_registers` (`emulator_thread.hpp:335`) via
+  `save_registers()`/`restore_registers()` and swaps another thread's blob into the single
+  vCPU (`switch_to_thread`, `windows_emulator.cpp:385`).
+- Scheduling lives in `windows_emulator::start()` (`windows_emulator.cpp:1023`):
+  round-robin (`switch_to_next_thread`, `:442`), preempted either per-instruction /
+  per-basic-block (unicorn/icicle) or by a 20 ms interrupt thread that calls
+  `emu().stop()` → `WHvCancelRunVirtualProcessor` (WHP/KVM, `:1052-1068`).
+- **Almost nothing is synchronized**, because it never had to be. The entire concurrency
+  surface today: `switch_thread_` / `should_stop` atomics, the
+  `memory_manager::layout_version_` counter, the interrupt thread, and one web-UI mutex.
+
+State a second concurrently-executing vCPU would race on, ranked by blast radius:
+
+| # | Shared state | Location |
+|---|--------------|----------|
+| 1 | The single vCPU register file (save/restore blob swap) | `emulator_thread.hpp:335,379-388` |
+| 2 | Scheduler state: `threads`, `active_thread`, `thread_handles_by_id` | `process_context.hpp:468,483-484` |
+| 3 | All `handle_store` object tables (events, mutants, files, sections, windows, …) + non-atomic ref counts | `handles.hpp:184,147`, `process_context.hpp:449-467` |
+| 4 | `memory_manager::reserved_regions_` (plain `std::map`, mutated by NtAllocate/Protect/FreeVirtualMemory) | `memory_manager.hpp:155` |
+| 5 | WHP partition tables: `mapped_pages_`, `guest_pages_by_gpa_`, `free_guest_gpa_indices_`, `page_table_views_`, `mmio_regions_`, all hook maps | `whp_x86_64_emulator.cpp:1809-1839` |
+| 6 | Wait/APC bookkeeping written cross-thread (NtQueueApcThread, NtAlertThreadByThreadId target *other* threads) | `syscalls/thread.cpp:555,974` |
+| 7 | KUSD (`kusd_mmio::update()` recomputed on every read) | `kusd_mmio.cpp:157-179` |
+| 8 | Devices (`io_device::work()` polled from the CPU thread, `block_mutation` reentrancy hack) | `windows_emulator.cpp:301-310`, `io_device.hpp:190` |
+| 9 | Hook containers in every backend (unlocked maps/vectors, hooks deleted from inside callbacks) | e.g. `whp_x86_64_emulator.cpp:1826-1833`, `windows_emulator.cpp:748-752` |
+
+Two facts make this project tractable:
+
+1. **Guest thread state is already decoupled from the vCPU.** The register-blob model
+   (`last_registers`) is exactly what an N-vCPU scheduler needs — a thread's context can
+   be restored onto *any* vCPU.
+2. **WHP/KVM already keep the expensive state at partition scope.** EPT/GPA mappings,
+   page tables, MMIO regions and hooks are per-partition, which is precisely what
+   multiple vCPUs must share. The per-vCPU part (registers, run/cancel, single-step
+   state) is small and cleanly separable.
+
+---
+
+## 2. The two core design decisions
+
+### Decision 1 — N vCPUs + a real scheduler (not one host thread per guest thread)
+
+Two possible execution models:
+
+- **(a) 1 guest thread = 1 vCPU = 1 host thread.** No scheduler at all; blocked guest
+  threads park on host condition variables. Rejected: guest processes create dozens to
+  hundreds of threads (worker factories, thread pools); WHP `ProcessorCount` is fixed at
+  partition setup and vCPUs are heavyweight; guests also behave badly when the apparent
+  CPU count is huge.
+- **(b) N vCPUs (N = configured processor count, e.g. 4), M guest threads multiplexed
+  onto them by a scheduler — like a real kernel.** Each vCPU is driven by one dedicated
+  host worker thread: pick a ready guest thread, restore its register blob onto *this*
+  vCPU, run until yield/preempt/wait, save the blob back, repeat.
+
+**(b) is the design.** It preserves the existing, proven `save/restore` context-switch
+machinery, keeps the guest-visible CPU count consistent with what we already fake
+(`fake_environment_config::number_of_processors = 4`, `windows_emulator.hpp:85`), and
+degrades gracefully to today's behavior at N=1.
+
+### Decision 2 — a Big Emulator Lock (BEL) for the "kernel", parallel guest usermode
+
+The windows-emulator layer is effectively a kernel: `process_context`, handle stores,
+memory manager, devices, and ~hundreds of syscall handlers, all written assuming
+serialized execution. Options:
+
+- **Fine-grained locks per structure.** Rejected as the starting point: syscall handlers
+  assume atomicity *across* structures (e.g. `NtWaitForMultipleObjects` reads several
+  object tables and thread wait state together; `is_thread_ready` /
+  `consume_object_signal` rely on "nothing else runs while I decide"). Retrofitting
+  per-structure locks means auditing every handler for cross-structure invariants and
+  invites deadlocks. This is a months-long audit with a long bug tail.
+- **A dedicated kernel thread (actor model)** — vCPU exits post messages to one kernel
+  thread and block. Rejected: same serialization as a lock but adds two thread handoffs
+  of latency to every syscall.
+- **One global kernel mutex (the BEL).** Guest code executes with the lock *released* —
+  that is where the parallelism win is, since programs spend the vast majority of time in
+  usermode. Every VM exit that enters emulator C++ code (syscall, exec-hook, MMIO,
+  exception, memory violation) acquires the BEL, handles the exit, releases it, resumes
+  the guest.
+
+**The BEL is the design.** It is the same evolution QEMU took (single-threaded TCG → the
+"Big QEMU Lock" + MTTCG) and it keeps virtually all existing windows-emulator code
+correct without modification, because everything that touches shared state already runs
+in exit context. Contention is bounded by syscall/exit frequency, which profiling has
+shown to be far lower than guest execution time for the workloads we care about (games).
+Lock granularity can be reduced *later*, guided by profiling, without another
+architecture change (§9).
+
+Guest-side synchronization needs no help from us: guest usermode interlocked operations
+act on real shared memory through the shared GPA space and work natively across vCPUs;
+their contention slow paths are syscalls, which the BEL serializes.
+
+---
+
+## 3. Core interface changes (`src/emulator`)
+
+Split "the machine" from "a CPU". Today `emulator` multiply-inherits
+`cpu_interface + memory_interface + hook_interface` (`emulator.hpp:12`). New shape:
+
+```
+emulator (machine: memory_interface + hook_interface + vCPU registry)
+ ├── supports_multiple_vcpus() const -> bool
+ ├── vcpu_count() const -> size_t              // configured at creation
+ └── get_cpu(size_t index) -> x86_64_cpu&
+
+x86_64_cpu (per-vCPU: cpu_interface + typed register helpers + machine access)
+ ├── start(count) / stop()
+ ├── read/write_raw_register, reg<T>(), save_registers()/restore_registers()
+ ├── memory access, delegated to the shared machine
+ └── index() const
+```
+
+Key points:
+
+- **Explicit CPU context — no thread-local state.** Each vCPU worker thread owns its
+  `x86_64_cpu` for the lifetime of the run and passes it explicitly down every call
+  chain. Nothing resolves "the current CPU" implicitly; there is no ambient state to get
+  wrong when code runs on an unexpected thread.
+- **Hook callbacks gain the triggering CPU as a parameter.** Every callback type in
+  `hook_interface.hpp:44-55` gets `cpu_interface&` (typed `x86_64_cpu&` at the arch
+  layer) as its first argument; the backend invokes callbacks with the vCPU whose exit
+  is being handled, always on that vCPU's worker thread.
+- **`x86_64_cpu` is "a CPU's view of the machine".** Registers and run control are
+  native per-VP; the memory surface delegates to the shared machine. Today's syscall
+  layer uses one `x86_64_emulator&` for both registers and memory
+  (`syscall_context::emu`), so swapping that member — and the exit-handling paths — to
+  `x86_64_cpu&` keeps the hundreds of `c.emu.reg(...)` / `c.emu.read_memory(...)` sites
+  compiling unchanged while making the target CPU explicit. The typed register helpers
+  in `typed_emulator.hpp` are factored into a mixin `x86_64_cpu` reuses.
+- **Capability query:** the emulator interface exposes
+  `bool supports_multiple_vcpus() const`. WHP returns `true`; unicorn and icicle return
+  `false`; KVM returns `false` for now (the hypervisor supports it, but multi-vCPU KVM
+  is deferred to Phase 5 and reports unsupported until implemented).
+- **Creation:** `create_x86_64_emulator(backend_type, emulator_creation_settings{ .vcpu_count })`
+  (`backend_selection.hpp:10-19`). `vcpu_count` defaults to `1`. Requesting more than one
+  vCPU on a backend where `supports_multiple_vcpus()` is `false` is a hard error at
+  creation time — no silent clamping.
+- **Thread-safety contract, stated at the interface:**
+  - Per-vCPU operations (`start`, `stop`, register access, save/restore) are safe to call
+    concurrently on *different* vCPUs; register access to a vCPU is only valid from its
+    owning worker thread or while it is known-stopped.
+  - Memory mutation (`map/unmap/protect`) and hook add/remove require external
+    serialization by the caller (the BEL provides it). Backends additionally guard their
+    internal partition tables (§4) because some mutations happen on exit-handling paths
+    inside `start()`.
+  - `stop()` on any vCPU remains callable from any thread (this is what
+    `is_stop_thread_safe()` already promises for WHP/KVM) — it becomes the **IPI/kick
+    primitive** (§5.2).
+
+`memory_manager` stays a single shared instance (it already is, held by value on
+`windows_emulator`); its metadata is BEL-protected because it is only mutated from
+syscall/exit context.
+
+---
+
+## 4. WHP backend changes
+
+Reference: everything below is in `src/backends/whp-emulator/whp_x86_64_emulator.cpp`.
+
+**Per-vCPU (new `whp_vcpu` struct, one per index):**
+- `virtual_processor_handle` (`:96-118`) — created per index; partition
+  `ProcessorCount = N` in `configure_partition()` (`:1866`).
+- Run state: `stop_requested_`, `run_active_` (`:1820-1821`).
+- Single-step machinery: `pending_execution_step_` (`:1822`), `pending_mmio_step_`
+  (`:1837`), `deferred_patched_breakpoint_` / `deferred_execution_page_` (`:1834-1835`).
+- Exit context buffer, per-vCPU register setup (LSTAR → shared HLT syscall page, GDT/IDT
+  bases can point at the same shared structures; the syscall intercept page `:1948-1957`
+  is read-only and shared).
+- All `WHvRunVirtualProcessor` / `WHvCancelRunVirtualProcessor` /
+  `WHvGet/SetVirtualProcessorRegisters` calls parameterized on the vCPU index instead of
+  the file-scope `vp_index`.
+
+**Partition-shared, needs an internal `partition_mutex_`:**
+`mapped_pages_`, `guest_pages_by_gpa_`, `free_guest_gpa_indices_`, `page_table_views_`,
+`pml4_gpa_`, `next_internal_gpa_` (`:1809-1819`), `mmio_regions_` +
+`mmio_read_grace_deadlines_` (`:1836-1838`), all hook maps + `next_hook_id_` +
+`syscall_hook_` (`:1824-1839`), `patched_execution_breakpoints_` (`:1833`).
+
+Why the backend needs its own lock even with the BEL: exec-hook and MMIO exit handling
+(`handle_memory_access` → `remap_hook_page` / `remap_pages`, `:2174-2291`) mutates these
+tables *inside* `start()`, i.e. while the caller does **not** hold the BEL. Locking
+discipline to avoid inversion:
+
+- Lock order is **BEL → partition_mutex**, never the reverse.
+- The backend must never hold `partition_mutex_` while invoking a user callback
+  (callbacks acquire the BEL). The existing copy-callbacks-into-a-local-vector-then-invoke
+  pattern (`:3154`, `:3276`) already supports this — take the lock only around container
+  access.
+- `WHvMapGpaRange`/`WHvUnmapGpaRange` are partition-level; Hyper-V performs its own EPT
+  invalidation across running VPs. We still serialize *our* calls under
+  `partition_mutex_` so the bookkeeping and the hypervisor state cannot diverge.
+  (Verify empirically in Phase 1 that remapping while other VPs run behaves; if not,
+  unmap/protect must briefly kick all vCPUs — a stop-the-world helper we need anyway,
+  §5.2.)
+
+**The exec-hook single-step window (known, accepted race):**
+Section-first-execution hooks strip EPT exec from a page; on the fault, the handler fires
+callbacks, temporarily restores exec, single-steps via TF, and re-protects
+(`effective_page_permissions :2162`, `arm_execution_single_step :2479`,
+`complete_execution_step :2527`). EPT permissions are partition-global — while vCPU A
+steps over a hooked page, vCPU B could execute that page without faulting. Consequences:
+
+- For **section-first-execution** hooks this is benign: the callback semantic is
+  "fire once on first execution", enforced under the BEL by the `first_execute` flag
+  check in `track_section_first_execution` (`windows_emulator.cpp:741`). A near-miss
+  duplicate fault is filtered; a missed extra execution is irrelevant.
+- For **precise breakpoints** (gdb stub, debugger, int3-patched breakpoints — the 0xCC
+  byte is removed from shared memory during the step, `:2408-2477`) the race is *not*
+  acceptable. Resolution: when precise execution hooks / breakpoints are active, either
+  run with `vcpu_count = 1` (the analyzer/debugger default) or use the stop-the-world
+  helper around the step window. Do not attempt per-vCPU EPT views — WHP (and KVM
+  memslots) have no per-VP GPA mappings.
+
+**Not supported under multi-vCPU (unchanged constraints):** instruction counting
+(`supports_instruction_counting()` is already `false`, `:1734`), `start(count)` with
+exact budgets, instruction-precision mode. Combining these with `vcpu_count > 1` is a
+hard error at startup (decision: no silent clamping, consistent with the
+unsupported-backend rule).
+
+---
+
+## 5. windows-emulator changes
+
+### 5.1 The scheduler
+
+`windows_emulator::start()` (`windows_emulator.cpp:1023`) becomes a coordinator:
+
+```
+start():
+    spawn N vcpu_worker threads (N = min(settings.vcpu_count, emu().vcpu_count()))
+    main thread: pump UI events + user timers, until exit/stop     // SDL wants the main thread
+    join workers
+
+vcpu_worker(cpu):
+    loop:
+        lock BEL
+        thread = pick_ready_thread()            // round-robin over process.threads, skipping
+                                                // threads currently running on another vCPU
+        if none: wait on ready_cv (with timeout for timed waits / host-condition polls)
+        thread->restore(cpu)                    // blob -> this vCPU
+        mark thread running-on(cpu); unlock BEL
+        cpu.start()                             // guest runs in parallel, BEL released
+        lock BEL
+        thread->save(cpu)                       // exits for syscalls etc. acquired BEL internally
+        handle wait state / APCs / termination; mark not-running
+        unlock BEL
+```
+
+- **`vcpu_context` replaces the global "current thread" notion.** A per-vCPU struct
+  owned by `windows_emulator` (in a plain vector, no globals or thread-locals):
+
+  ```cpp
+  struct vcpu_context
+  {
+      x86_64_cpu& cpu;
+      emulator_thread* active_thread{};   // replaces process_context::active_thread
+      std::atomic_bool switch_thread{};   // per-vCPU yield request (timer thread writes it)
+      bool apc_alertable{};
+  };
+  ```
+
+  `process_context::active_thread` (`process_context.hpp:484`) and the global
+  `switch_thread_` go away. `windows_emulator::current_thread()` is removed; every path
+  that needs it — syscall handlers (via `syscall_context`), exception dispatch, user
+  callback dispatch, hook lambdas — receives the `vcpu_context&` explicitly. Hook
+  callbacks carry the triggering `x86_64_cpu&` (§3), and `windows_emulator` maps
+  `cpu.index()` to its `vcpu_context` in O(1). This is the main churn cost of avoiding
+  ambient state: a wide but compiler-guided, purely mechanical refactor (delete
+  `current_thread()`, follow the errors).
+- `should_stop` stays a single member atomic on `windows_emulator`.
+- `ready_cv` is signaled whenever a thread becomes ready: object signaled
+  (`NtSetEvent`, `NtReleaseMutant`, …), APC queued, alert delivered, thread created or
+  resumed. All of these already run under the BEL, so the wakeup is race-free.
+- **Time-slicing:** one timer thread (evolution of today's interrupt thread,
+  `windows_emulator.cpp:1052-1068`) kicks (`cpu.stop()`) every running vCPU whose slice
+  expired — but only when `ready_threads > running_vcpus`, so an under-committed guest
+  never pays preemption exits.
+- **Device pump:** `perform_context_switch_work()` (`:301-310`, devices `work()`,
+  thread reaping) moves to a scheduler tick executed under the BEL by whichever worker
+  hits it next (deadline-based), preserving the `block_mutation` invariant because the
+  BEL serializes it.
+- **`start(count)`** (instruction budgets, used by the analyzer's `-c` and gdb
+  single-step) is incompatible with `vcpu_count > 1` — hard error at startup.
+- **N=1 runs through the same scheduler** (decision): a single `vcpu_worker` with an
+  uncontended BEL replaces the legacy loop entirely, so there is exactly one scheduling
+  code path. Phase 2 must benchmark N=1 boot wall-time against main before merging.
+
+### 5.2 Cross-vCPU operations need a kick (IPI equivalent)
+
+Today, targeting *another* thread always mutates a parked thread. Now the target may be
+executing on another vCPU. All of these run under the BEL and use `cpu.stop()` on the
+target's vCPU as the kick:
+
+- `NtAlertThreadByThreadId` / `NtQueueApcThread` (`syscalls/thread.cpp:555,974`): set the
+  flag/queue the APC (BEL makes it safe), then kick the target's vCPU so an alertable
+  wait or APC delivery is prompt.
+- `NtSuspendThread` / `NtTerminateThread`: kick, and the worker parks the thread when it
+  observes `suspended`/`exit_status` on the next exit.
+- `NtGetContextThread` / `NtSetContextThread` on a *running* thread: kick the target vCPU,
+  wait (under BEL, via a condition) until the worker has saved the blob, then operate on
+  `last_registers` — the mechanism that already exists for parked threads.
+- **Stop-the-world helper** (needed for snapshots, precise-breakpoint stepping, possibly
+  unmap): set a global pause flag, kick all vCPUs, wait until every worker has parked
+  its thread, run the critical action, release.
+
+### 5.3 What the BEL does NOT have to fix
+
+- Guest-vs-guest memory races: same as real hardware; guest's problem.
+- Syscall handlers reading guest memory that another vCPU concurrently writes: same
+  TOCTOU exposure a real kernel has; handlers already copy-in/copy-out via
+  `emulator_object`.
+- KUSD: reads are MMIO exits → BEL-serialized `update()` (`kusd_mmio.cpp:157`). No change
+  needed initially.
+
+### 5.4 Smaller items
+
+- `executed_instructions_` (`windows_emulator.hpp:114`) → atomic (or per-vCPU counters
+  summed on read).
+- `handle_store` ref counts (`handles.hpp:147`) stay non-atomic — all mutation is under
+  the BEL. Document that invariant on the class.
+- `logger` needs an internal mutex (interleaved lines otherwise).
+- Guest-visible CPU identity (decision: **tied to `vcpu_count`**): the vCPU count drives
+  `PEB.NumberOfProcessors` (`process_context.cpp:360`),
+  `KUSER_SHARED_DATA.ActiveProcessorCount` (`kusd_mmio.cpp:72`) and derived affinity
+  masks; `fake_env.number_of_processors` becomes an explicit override for anti-analysis
+  experiments. `NtGetCurrentProcessorNumberEx` (`thread.cpp:916`) returns the index of
+  the vCPU that took the syscall (`c.cpu.index()`). Affinity/priority remain no-ops.
+- **Serialization/snapshots** (decision: **restricted to N=1 in v1**):
+  `save_snapshot()`/`serialize()` at `vcpu_count > 1` is an error until the
+  stop-the-world quiesce lands in Phase 3. Per-thread register blobs already serialize;
+  the interrupt-thread atomics currently serialized (`windows_emulator.cpp:1315`) become
+  per-vCPU state that resets on restore.
+- **gdb-stub / debugger** (`x86_64_gdb_stub_handler.hpp`, `debug_session.cpp`):
+  incompatible with `vcpu_count > 1` — hard error when combined. Multi-vCPU debugging
+  (thread ids per vCPU, stop-the-world stepping) is a later, separate feature.
+- **UI events:** `deliver_raw_input` / `handle_ui_event` (`windows_emulator.cpp:1103`)
+  are called from the main thread — they take the BEL.
+
+---
+
+## 6. Hook system thread safety
+
+Findings: hook containers are unlocked in every backend; hooks are legitimately deleted
+from inside their own callback (`track_section_first_execution`,
+`windows_emulator.cpp:748-752`); only icicle has deferred add/remove
+(`icicle_x86_64_emulator.cpp:468,645`).
+
+Rules under the new model:
+
+1. **Registration/removal is BEL-serialized by contract** (§3). All current
+   install/remove sites (all in `setup_hooks()` `windows_emulator.cpp:823` and the
+   section-first-exec paths) already run in exit context or before workers start.
+2. **Dispatch containers get the backend `partition_mutex_`** for the exit-handling
+   paths that consult them concurrently from multiple workers
+   (`handle_execution_hook :3144`, `handle_instruction_exit :3015`,
+   `handle_memory_access :3190`, `handle_syscall_halt :1959`). Copy-then-invoke (already
+   the pattern at `:3154/:3276`) keeps callbacks outside the lock.
+3. **Delete-from-callback keeps working**: the callback runs holding the BEL; removal
+   mutates the container under `partition_mutex_`; other workers only read the container
+   under the same lock and iterate over their local copy. A deleted hook may still fire
+   once from another vCPU's already-taken copy — callbacks that care (section-first-exec)
+   are idempotent-by-check under the BEL.
+4. `scoped_hook` (`scoped_hook.hpp`) needs no change — destruction happens on
+   BEL-holding paths.
+5. The **syscall hook** stays special-cased: `syscall_hook_` (`:1839`) is written once at
+   setup before workers exist; concurrent dispatch is read-only → no lock on the hot
+   path.
+
+---
+
+## 7. Concurrency discipline — race freedom and deadlock avoidance
+
+A general design rule for this project applies throughout: **no mutable global state,
+and `thread_local` counts as global.** Every piece of shared state is a member of an
+object with a clear owner, and the executing CPU/thread identity is always passed
+explicitly (§3, §5.1). This is not just style — it makes the ownership taxonomy below
+*checkable*, because there is no ambient state that can be touched from the wrong
+thread invisibly.
+
+### 7.1 Data-race freedom: every object gets exactly one ownership class
+
+Race freedom is not achieved by sprinkling locks; it is achieved by classifying **all**
+mutable state into one of six classes and enforcing each class's access rule:
+
+| Class | Rule | Examples |
+|-------|------|----------|
+| **vCPU-local** | Touched only by its owning worker thread. The *only* cross-thread operation is `stop()` (the kick). | `x86_64_cpu` registers/run state, WHP per-VP step state, `vcpu_context` (except its atomic) |
+| **Kernel state (BEL domain)** | Touched only while holding the BEL. | `process_context` + all handle stores, `memory_manager` metadata, `module_manager`, devices, scheduler queues, `emulator_thread` fields visible across threads |
+| **Partition state (backend)** | Touched only while holding the backend's `partition_mutex_`. | WHP GPA/page tables, hook dispatch containers, MMIO regions |
+| **Frozen after setup** | Written only before vCPU workers spawn; read-only afterwards, safe to read concurrently without locks. | syscall handler table (`syscall_dispatcher::handlers_`), module exports, settings, the syscall hook pointer |
+| **Designated atomics** | Individually documented, each with its ordering semantics. | `should_stop`, `layout_version_`, per-vCPU `switch_thread`, instruction counters |
+| **Guest memory** | Raced by design, like physical RAM. Kernel code must copy-in/copy-out (`emulator_object` already does) and never assume stability across two reads. | all guest pages |
+
+Enforcement, so the discipline survives contact with reality:
+
+- **Owner-tracking lock wrappers.** The BEL and `partition_mutex_` are wrapped in a
+  small class that records the owning `std::thread::id` (a member of the wrapper — not
+  thread-local). Every core mutator asserts ownership at entry:
+  `handle_store::store/erase`, all `memory_manager` mutators,
+  `process_context::create_thread/terminate_thread`, device container mutation. Debug
+  builds abort on violation; the check is cheap enough to keep enabled in release
+  during the bring-up phases.
+- **Acquire at the boundary, assert in the interior.** The BEL is taken exactly once
+  per entry point (VM-exit handler, UI event delivery, scheduler loop iteration).
+  Interior code never acquires it — it asserts it is held. No `recursive_mutex`:
+  attempted nested acquisition is a bug the owner assert catches immediately, instead
+  of a design smell a recursive lock would paper over.
+- **Static checking:** clang `-Wthread-safety` annotations (`GUARDED_BY(bel_)` /
+  `REQUIRES(bel_)`) on the core structs. A local clang-cl install (clang 21,
+  `x86_64-pc-windows-msvc`) is available for development; because clang-cl is
+  MSVC-compatible it builds the WHP backend too, so the analysis covers the actual
+  multi-vCPU code paths on Windows. No dedicated preset needed — override the compiler
+  at configure time (`-DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl` plus
+  `-Wthread-safety`) for development/verification builds, and keep them warning-clean
+  during Phases 2-3. The annotation macros compile to nothing on MSVC.
+- **Dynamic checking:** ThreadSanitizer on the Linux/KVM build once Phase 5 lands
+  (TSan is not available on Windows, including under clang-cl); on Windows, the Phase 4
+  guest stress test plus the owner asserts are the practical net.
+- **Review rule:** no new static/global/thread_local mutable state, ever; every new
+  member field belongs to exactly one class above, stated in a comment when not
+  obvious from context.
+
+### 7.2 Deadlock avoidance: a fixed, tiny lock hierarchy
+
+The design deliberately has **three lock levels, total**, strictly ordered. A thread
+holding a lock may only acquire locks of a strictly higher level:
+
+```
+L0  BEL (windows_emulator kernel mutex)     — outermost
+L1  partition_mutex_ (one per backend)      — may be taken under the BEL, never above it
+L2  leaf mutexes (logger)                   — never call out while held
+```
+
+Rules that make the hierarchy sufficient:
+
+1. **The BEL is never held while executing guest code** (`cpu.start()`) or while
+   blocking on host I/O. All waiting under the BEL goes through condition variables
+   bound to it (`ready_cv`, the stop-the-world barrier, the force-save wait in
+   `NtGetContextThread`) — a CV wait atomically releases the BEL, so the thread being
+   waited *for* can always acquire it and make progress. That closes the classic
+   "A holds the lock waiting for B, B needs the lock" cycle by construction.
+2. **`partition_mutex_` is a bookkeeping lock only**: held around container/EPT table
+   access, never across user callbacks (callbacks acquire the BEL → would invert L0/L1),
+   never across `WHvRunVirtualProcessor`, never across anything that blocks. The
+   existing copy-callbacks-then-invoke pattern (`whp_x86_64_emulator.cpp:3154,3276`)
+   already has the right shape.
+3. **Kicks are non-blocking.** `WHvCancelRunVirtualProcessor` / `pthread_kill` never
+   block, so signaling another vCPU is safe under any lock. Anything that must *wait*
+   for the kicked vCPU to react does so via a CV on the BEL (rule 1), never by spinning
+   with a lock held.
+4. **Leaf locks never call out.** The logger mutex wraps formatting+write only.
+5. **Adding a mutex requires assigning it a level** in the hierarchy (documented next
+   to the BEL). The expected steady state is that no one ever needs to: contention
+   fixes in Phase 4 should prefer sharding data or shrinking BEL scope over introducing
+   new locks with new ordering obligations.
+
+Cross-lock ordering violations (acquiring the BEL while holding `partition_mutex_`)
+cannot be detected by the wrappers' own owner fields alone, but they are structurally
+impossible if rule 2 holds — the backend only takes `partition_mutex_` in leaf
+bookkeeping functions that never call upward. That property is enforceable by review of
+a small, closed set of acquisition sites inside one file per backend.
+
+## 8. KVM backend (secondary)
+
+Until this phase lands, the KVM backend reports `supports_multiple_vcpus() == false`
+and rejects `vcpu_count > 1` like the JIT backends, even though the hypervisor itself
+could support it.
+
+Mirror of §4, structurally identical:
+
+- N `KVM_CREATE_VCPU` fds + per-vCPU `kvm_run` mmaps (`kvm_x86_64_emulator.cpp:1362-1380`).
+- Per-vCPU: `vcpu_thread_`, kick signal (`pthread_kill`, `:577-594` — already the right
+  per-thread cancel model), and crucially the **register caches**
+  (`regs_cache_`/`sregs_cache_`, `:2231-2266`) which are per-vCPU state.
+- VM-global: memslots, GPA tables, hook maps → same `partition_mutex_` treatment.
+- The design deliberately keeps everything KVM-specific out of windows-emulator: the
+  scheduler/BEL only relies on the interface contract from §3.
+
+Unicorn and icicle remain `supports_multiple_vcpus() == false`; at N=1 the unified
+scheduler runs a single worker with the same yield points and an uncontended BEL —
+functionally equivalent to today's loop.
+
+---
+
+## 9. Implementation phases
+
+Each phase builds, passes `analyzer.exe -s test-sample.exe`, and is independently
+mergeable.
+
+**Phase 0 — mechanical refactor, zero behavior change.**
+Extract `x86_64_cpu` from the emulator interface (backends expose their single CPU as
+index 0); add the triggering `x86_64_cpu&` parameter to all hook callback signatures;
+introduce `vcpu_context` and thread it through `syscall_context`, exception dispatch and
+user-callback dispatch, deleting `windows_emulator::current_thread()` and
+`process_context::active_thread` (compiler-guided); add `supports_multiple_vcpus()` to
+all backends; plumb `vcpu_count` (default 1) through `backend_selection` and
+`emulator_settings` with the hard error for unsupported backends. Still exactly one
+vCPU and one host thread. Risk: low (no behavior change, the compiler drives the
+refactor). Churn: high but mechanical.
+
+**Phase 1 — WHP backend goes N-vCPU internally.**
+`whp_vcpu` struct, per-index VP creation, `ProcessorCount = N`, parameterized register/
+run/cancel calls, `partition_mutex_` around partition tables and hook dispatch
+containers. The windows-emulator still only uses CPU 0 → no visible change. Add a
+backend-level unit test that creates N VPs, runs trivial code on two host threads in
+disjoint memory, exercises concurrent map/unmap. Empirically verify
+`WHvMapGpaRange`/`WHvUnmapGpaRange` while other VPs run.
+
+**Phase 2 — the BEL + scheduler workers (the big one).**
+Introduce the kernel mutex; acquire it in every emulator-entry callback installed by
+`setup_hooks()` and in the UI/external entry points; replace the single run loop with
+`vcpu_worker`s + `ready_cv` + timer-kick thread; per-vCPU `switch_thread_`; device pump
+on scheduler ticks; `logger` mutex; atomic instruction counters. Exposed as a setting
+(`--vcpus N`, default 1). N=1 goes through the same scheduler (one worker, uncontended
+BEL) — benchmark N=1 boot wall-time against main before merging. Startup validation:
+hard error when `vcpu_count > 1` is combined with an unsupported backend, gdb-stub,
+instruction precision, instruction budgets, relative-time mode, or snapshots (until
+Phase 3).
+
+**Phase 3 — cross-vCPU correctness.**
+Kicks for alert/APC/suspend/terminate targeting running threads; force-save for
+`NtGet/SetContextThread`; stop-the-world helper; snapshot quiesce (lifts the N=1
+snapshot restriction); guest-visible CPU identity (KUSD count,
+`NtGetCurrentProcessorNumberEx`).
+
+**Phase 4 — validation + performance.**
+Guest stress test (in the test-sample or a dedicated sample: N threads hammering
+interlocked ops, events, mutants, waits, VirtualAlloc churn) run at `--vcpus 2..8`;
+BEL contention profiling (extend the `SOGEN_WHP_PROFILE` infrastructure); then targeted
+lock refinement *only where measured*: likely candidates are KUSD reads, hot device
+ioctls (GPU bridge), and `memory_manager` read paths (a `shared_mutex` split).
+
+**Phase 5 — secondary targets.**
+KVM parity (§8); linux-emulator adopts the same scheduler/BEL shape (it mirrors the
+windows-emulator structure; consider extracting the vCPU worker/scheduler core into a
+shared component at that point, not before).
+
+---
+
+## 10. Risks and open questions
+
+- **WHP remap-while-running semantics** (§4). If `WHvUnmapGpaRange` during concurrent VP
+  execution misbehaves, every unmap/protect needs stop-the-world — correct but slower;
+  the `remap_pages` coalescing (`:2196`) limits the frequency. Resolve in Phase 1.
+- **BEL contention.** If a workload turns out syscall-heavy, the parallel win shrinks.
+  Mitigation path is §9 Phase 4; the architecture doesn't change.
+- **Single-vCPU regressions.** The BEL is uncontended at N=1 (a fetch-and-store on
+  acquire), but Phase 2 must benchmark boot wall-time at N=1 against main before
+  merging, since N=1 runs through the new scheduler.
+- **Latent single-thread assumptions.** Grep-audits won't find everything (e.g. static
+  locals in syscall handlers, scratch buffers reused across calls — the gpu-bridge
+  scratch buffers from #1172 are per-`windows_emulator`, fine, but the same pattern
+  elsewhere may not be). Phase 4 stress testing is the real net.
+- **Wait semantics under concurrency.** `is_thread_ready` / `consume_object_signal`
+  (`emulator_thread.cpp:72,176,935`) stay BEL-protected, so "consume exactly one signal"
+  stays atomic. But *wakeup ordering* changes: today round-robin position determines who
+  wins a signaled auto-reset event; with parallel workers it's whichever worker picks the
+  thread first. Windows makes no ordering promise, so this is legal — but it may surface
+  latent guest bugs that were masked by deterministic scheduling. Keep `--vcpus 1` as the
+  deterministic-repro fallback.
+- **Determinism / snapshots.** Multi-vCPU runs are inherently non-reproducible;
+  snapshot/restore stays supported (quiesced) but replay-style debugging needs N=1.
+- **WOW64.** Heaven's-gate transitions (`wow64_heaven_gate.hpp`) are per-thread register
+  state inside the blob — no extra work expected, but the 32-bit paths must be in the
+  Phase 4 stress matrix (open-iw5, t6mp are the practical testbeds).

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -9,14 +9,22 @@ Status: in progress on branch `multi-vcpu`
 - [x] Phase 1 — WHP drives N VPs: per-VP `whp_vcpu` objects, parameterized VP index,
       `partition_mutex_` (shared_mutex, copy-then-invoke callback discipline),
       `ProcessorCount = N`, factory takes `vcpu_count` (eef2e558). Clang-tidy clean.
-- [ ] Phase 2 — BEL + vcpu_worker scheduler. Done: `kernel_lock` (owner-tracking,
+- [~] Phase 2 — BEL + vcpu_worker scheduler. Done: `kernel_lock` (owner-tracking,
       non-recursive, assert-based interior checks) acquired at every entry point (hook
       callbacks, UI event delivery, scheduler loop — released across guest execution
-      and idle sleeps), logger print mutex, startup conflict validation
-      (instruction precision / relative time / instruction budgets / gdb at N>1).
-      Remaining: per-vCPU worker loops + ready_cv, timer kicks for all running vCPUs,
-      device pump on scheduler ticks, N=1 boot benchmark vs main, clang-cl
-      -Wthread-safety annotations.
+      and idle sleeps); logger print mutex; startup conflict validation (instruction
+      precision / relative time / instruction budgets / gdb at N>1); one host worker
+      thread per vCPU (`vcpu_worker`) with per-vCPU thread ownership (a guest thread
+      loaded on one vCPU is skipped by the others; detached when the vCPU goes idle);
+      timer thread kicks all running vCPUs; `stop()` cancels all vCPUs; WHP per-vCPU
+      deferred TLB flush (flag + cancel, applied at run-loop top) replacing the
+      cross-vCPU CR3 rewrite. N=1 keeps its proven inline loop (workers only spawn at
+      N>1); N=1 + all tests unaffected.
+      **N>1 launches real parallel execution but is not yet correct** — surfaces
+      concurrency bugs (`No active thread!`, guest-memory read failures) that are the
+      Phase 3 cross-vCPU-correctness work. Remaining Phase 2 polish: replace the idle
+      sleep-poll with a ready_cv; device pump on scheduler ticks; N=1 boot benchmark vs
+      main; clang-cl -Wthread-safety annotations.
 - [ ] Phase 3 — cross-vCPU correctness
 - [ ] Phase 4 — stress testing + contention profiling
 - [ ] Phase 5 — KVM parity, linux-emulator

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -20,11 +20,22 @@ Status: in progress on branch `multi-vcpu`
       deferred TLB flush (flag + cancel, applied at run-loop top) replacing the
       cross-vCPU CR3 rewrite. N=1 keeps its proven inline loop (workers only spawn at
       N>1); N=1 + all tests unaffected.
-      **N>1 launches real parallel execution but is not yet correct** — surfaces
-      concurrency bugs (`No active thread!`, guest-memory read failures) that are the
-      Phase 3 cross-vCPU-correctness work. Remaining Phase 2 polish: replace the idle
-      sleep-poll with a ready_cv; device pump on scheduler ticks; N=1 boot benchmark vs
-      main; clang-cl -Wthread-safety annotations.
+- [~] Phase 3 — cross-vCPU correctness. Fixed the register-routing bug that made every
+      syscall on a non-zero vCPU touch vCPU 0's registers: `syscall_context::emu` (and the
+      argument/register helpers, `callback_frame`, exception dispatch, rdtsc/rdtscp/
+      interrupt/violation hooks) now use the acting vCPU's `x86_64_cpu` instead of
+      `windows_emulator::emu()` (the vCPU-0 facade). Guest memory is shared, so
+      `x86_64_cpu` gained an implicit conversion to the shared `memory_interface&`. The
+      legacy `current_thread()` observer API is made correct via `scoped_dispatch`: a
+      `windows_emulator::dispatch_vcpu_` member set at each handler entry under the kernel
+      lock (race-free because the BEL serializes handlers — not a global or thread-local).
+      With these fixes N>1 now runs the entire smoke suite correctly through ~15 tests
+      (Registry, System Info, Time Zone, Exceptions, …) and fails only at the **Threads**
+      test — the one test that exercises genuinely concurrent guest threads. That failure
+      is parallelism-specific (Threads passes at N=1) and is the remaining Phase 3 work:
+      wait/signal ordering under true concurrency and any remaining shared state touched
+      off-lock. Remaining Phase 2 polish still open: ready_cv instead of sleep-poll; device
+      pump on scheduler ticks; N=1 boot benchmark; clang-cl -Wthread-safety annotations.
 - [ ] Phase 3 — cross-vCPU correctness
 - [ ] Phase 4 — stress testing + contention profiling
 - [ ] Phase 5 — KVM parity, linux-emulator

--- a/docs/multi-vcpu-design.md
+++ b/docs/multi-vcpu-design.md
@@ -29,13 +29,19 @@ Status: in progress on branch `multi-vcpu`
       mapping + flushes this vCPU's TLB + retries whenever the page is backed and its
       intended permissions allow the operation (guard/no-access pages map with permission
       `none`, so genuine violations are still delivered); a per-vCPU (page,rip) retry
-      counter (cap 256) rides out concurrent re-clears at high vCPU counts without looping.
-      Result: `--vcpus 2` 70/70, `--vcpus 4` 27/28, `--vcpus 8` ~125/126 smoke runs pass;
-      N=1 and the 23 unit tests unaffected. Remaining Phase 3 (non-blocking): cross-vCPU
-      kicks for alert/APC/suspend/terminate targeting a *running* thread (currently take
-      effect at the next ~20ms timer preemption); NtGet/SetContextThread force-save;
-      stop-the-world snapshot quiesce (snapshots still N=1); guest CPU count tied to
-      vcpu_count. Details of the earlier register/dispatch fixes below.
+      counter rides out concurrent re-clears; the cap applies only to the unrecoverable-exit
+      path whose access type is guessed, while the well-typed paths (#PF, memory access,
+      which carry the real read/write) retry uncapped since a backed+permitted fault there is
+      always transient. Result: `--vcpus 1` 100% (unchanged), `--vcpus 2`/`4` 100%, `--vcpus 8`
+      ~99% (a rare miss remains under heavy oversubscription); N=1 and the 23 unit tests
+      unaffected. Guest CPU identity done: the guest now sees `max(fake_env.number_of_processors,
+      vcpu_count)` processors (KUSD ActiveProcessorCount, PEB, SystemBasicInformation all
+      consistent) and NtGetCurrentProcessorNumber[Ex] returns the acting vCPU index.
+      Remaining Phase 3 (non-blocking, latency/feature): cross-vCPU kicks for
+      alert/APC/suspend/terminate targeting a *running* thread (currently take effect at the
+      next ~20ms timer preemption — functionally correct); NtGet/SetContextThread force-save
+      for a running thread; stop-the-world snapshot quiesce (snapshots still N=1); and the
+      rare `--vcpus 8+` miss. Details of the earlier register/dispatch fixes below.
 - [~] Phase 3 (earlier fixes) — Fixed the register-routing bug that made every
       syscall on a non-zero vCPU touch vCPU 0's registers: `syscall_context::emu` (and the
       argument/register helpers, `callback_frame`, exception dispatch, rdtsc/rdtscp/

--- a/src/backend-selection/backend_selection.cpp
+++ b/src/backend-selection/backend_selection.cpp
@@ -21,7 +21,7 @@ namespace sogen
 {
     namespace
     {
-        std::unique_ptr<x86_64_emulator> create_backend(backend_type backend, const size_t vcpu_count)
+        std::unique_ptr<x86_64_emulator> create_backend(backend_type backend, [[maybe_unused]] const size_t vcpu_count)
         {
             switch (backend)
             {

--- a/src/backend-selection/backend_selection.cpp
+++ b/src/backend-selection/backend_selection.cpp
@@ -21,7 +21,7 @@ namespace sogen
 {
     namespace
     {
-        std::unique_ptr<x86_64_emulator> create_backend(backend_type backend)
+        std::unique_ptr<x86_64_emulator> create_backend(backend_type backend, const size_t vcpu_count)
         {
             switch (backend)
             {
@@ -38,7 +38,7 @@ namespace sogen
 
 #if defined(_WIN64) && !defined(__MINGW64__)
             case backend_type::whp:
-                return whp::create_x86_64_emulator();
+                return whp::create_x86_64_emulator(vcpu_count);
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__) && (defined(__x86_64__) || defined(__amd64__))
@@ -54,12 +54,18 @@ namespace sogen
         }
     }
 
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(backend_type backend)
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(backend_type backend, const size_t vcpu_count)
     {
-        return create_backend(backend);
+        auto emulator = create_backend(backend, vcpu_count);
+        if (vcpu_count > 1 && !emulator->supports_multiple_vcpus())
+        {
+            throw std::invalid_argument("The " + emulator->get_name() + " backend does not support multiple vCPUs");
+        }
+
+        return emulator;
     }
 
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator_from_environment()
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator_from_environment(const size_t vcpu_count)
     {
         auto backend = backend_type::unicorn;
 
@@ -90,6 +96,6 @@ namespace sogen
             }
         }
 
-        return create_x86_64_emulator(backend);
+        return create_x86_64_emulator(backend, vcpu_count);
     }
 } // namespace sogen

--- a/src/backend-selection/backend_selection.hpp
+++ b/src/backend-selection/backend_selection.hpp
@@ -15,6 +15,6 @@ namespace sogen
         kvm,
     };
 
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(backend_type backend = backend_type::unicorn);
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator_from_environment();
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(backend_type backend = backend_type::unicorn, size_t vcpu_count = 1);
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator_from_environment(size_t vcpu_count = 1);
 } // namespace sogen

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -116,7 +116,7 @@ namespace sogen::icicle
         {
             uint64_t address{};
             uint64_t size{};
-            memory_access_hook_callback callback{};
+            std::function<void(uint64_t address, const void* data, size_t size)> callback{};
             bool is_read{};
         };
 
@@ -316,6 +316,14 @@ namespace sogen::icicle
             ice(res, "Failed to apply permissions");
         }
 
+        // The raw icicle hook wrappers are captureless function pointers, so the
+        // triggering CPU is bound into the stored function up front.
+        template <typename Ret, typename... Args>
+        std::function<Ret(Args...)> bind_cpu(std::function<Ret(cpu_interface&, Args...)> callback)
+        {
+            return [this, c = std::move(callback)](Args... args) { return c(*this, std::forward<Args>(args)...); };
+        }
+
         emulator_hook* hook_instruction(int instruction_type, instruction_hook_callback callback) override
         {
             if (static_cast<x86_hookable_instructions>(instruction_type) != x86_hookable_instructions::syscall)
@@ -324,7 +332,7 @@ namespace sogen::icicle
                 return nullptr;
             }
 
-            auto obj = make_function_object(std::move(callback), this->is_in_hook_);
+            auto obj = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = obj.get();
 
             const auto invoker = +[](void* cb) {
@@ -340,7 +348,7 @@ namespace sogen::icicle
 
         emulator_hook* hook_basic_block(basic_block_hook_callback callback) override
         {
-            auto object = make_function_object(std::move(callback), this->is_in_hook_);
+            auto object = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = object.get();
             auto* wrapper = +[](void* user, const uint64_t addr, const uint64_t instructions) {
                 basic_block block{};
@@ -359,7 +367,7 @@ namespace sogen::icicle
 
         emulator_hook* hook_interrupt(interrupt_hook_callback callback) override
         {
-            auto obj = make_function_object(std::move(callback), this->is_in_hook_);
+            auto obj = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = obj.get();
             auto* wrapper = +[](void* user, const int32_t code) {
                 const auto& func = *static_cast<decltype(ptr)>(user);
@@ -374,7 +382,7 @@ namespace sogen::icicle
 
         emulator_hook* hook_memory_violation(memory_violation_hook_callback callback) override
         {
-            auto obj = make_function_object(std::move(callback), this->is_in_hook_);
+            auto obj = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = obj.get();
             auto* wrapper = +[](void* user, const uint64_t address, const uint8_t operation, const int32_t unmapped) -> int32_t {
                 const auto violation_type = unmapped //
@@ -396,7 +404,7 @@ namespace sogen::icicle
 
         emulator_hook* hook_memory_execution(const uint64_t address, memory_execution_hook_callback callback) override
         {
-            auto object = make_function_object(std::move(callback), this->is_in_hook_);
+            auto object = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = object.get();
             auto* wrapper = +[](void* user, const uint64_t addr) {
                 const auto& func = *static_cast<decltype(ptr)>(user);
@@ -417,7 +425,7 @@ namespace sogen::icicle
                 return this->hook_memory_execution(address, std::move(callback));
             }
 
-            auto object = make_function_object(std::move(callback), this->is_in_hook_);
+            auto object = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = object.get();
             auto* wrapper = +[](void* user, const uint64_t addr) {
                 const auto& func = *static_cast<decltype(ptr)>(user);
@@ -432,7 +440,7 @@ namespace sogen::icicle
 
         emulator_hook* hook_memory_execution(memory_execution_hook_callback callback) override
         {
-            auto object = make_function_object(std::move(callback), this->is_in_hook_);
+            auto object = make_function_object(this->bind_cpu(std::move(callback)), this->is_in_hook_);
             auto* ptr = object.get();
             auto* wrapper = +[](void* user, const uint64_t addr) {
                 const auto& func = *static_cast<decltype(ptr)>(user);
@@ -450,7 +458,7 @@ namespace sogen::icicle
             return this->try_install_memory_access_hook(memory_access_hook{
                 .address = address,
                 .size = size,
-                .callback = std::move(callback),
+                .callback = this->bind_cpu(std::move(callback)),
                 .is_read = true,
             });
         }
@@ -460,7 +468,7 @@ namespace sogen::icicle
             return this->try_install_memory_access_hook(memory_access_hook{
                 .address = address,
                 .size = size,
-                .callback = std::move(callback),
+                .callback = this->bind_cpu(std::move(callback)),
                 .is_read = false,
             });
         }

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -112,11 +112,15 @@ namespace sogen::icicle
             return std::make_unique<function_object<T>>(std::move(func), &hook_state);
         }
 
+        // memory_access_hook_callback with the leading cpu_interface& stripped: bind_cpu binds icicle's
+        // single vCPU into the callback (icicle is single-vCPU), so the stored callback takes no cpu.
+        using bound_memory_access_hook_callback = std::function<void(uint64_t address, const void* data, size_t size)>;
+
         struct memory_access_hook
         {
             uint64_t address{};
             uint64_t size{};
-            std::function<void(uint64_t address, const void* data, size_t size)> callback{};
+            bound_memory_access_hook_callback callback{};
             bool is_read{};
         };
 

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -538,6 +538,11 @@ namespace sogen::icicle
             return true;
         }
 
+        bool supports_multiple_vcpus() const override
+        {
+            return false;
+        }
+
         std::string get_name() const override
         {
             return "icicle-emu";

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -939,6 +939,13 @@ namespace sogen::kvm
                 return true;
             }
 
+            bool supports_multiple_vcpus() const override
+            {
+                // KVM could support multiple vCPUs per VM, but the backend is
+                // single-vCPU for now (docs/multi-vcpu-design.md, Phase 5).
+                return false;
+            }
+
             std::string get_name() const override
             {
                 return "Linux KVM";

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1101,7 +1101,7 @@ namespace sogen::kvm
 
                 for (const auto& callback : callbacks)
                 {
-                    callback(address);
+                    callback(*this, address);
                 }
             }
 
@@ -1813,7 +1813,7 @@ namespace sogen::kvm
                 bool rip_changed = false;
                 for (auto& [_, hook] : this->interrupt_hooks_)
                 {
-                    hook(static_cast<int>(breakpoint_interrupt));
+                    hook(*this, static_cast<int>(breakpoint_interrupt));
                     handled = true;
                     rip_changed = rip_changed || this->read_instruction_pointer() != rip;
                 }
@@ -1841,7 +1841,7 @@ namespace sogen::kvm
                     }
 
                     handled = true;
-                    if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
+                    if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
                     {
                         skip = true;
                     }
@@ -1870,7 +1870,7 @@ namespace sogen::kvm
                         continue;
                     }
 
-                    if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
+                    if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
                     {
                         consumed = true;
                     }
@@ -1948,7 +1948,7 @@ namespace sogen::kvm
                 const auto operation = mmio.is_write ? memory_operation::write : memory_operation::read;
                 for (auto& [_, hook] : this->memory_violation_hooks_)
                 {
-                    const auto result = hook(violation_address, mmio.len, operation, violation_type);
+                    const auto result = hook(*this, violation_address, mmio.len, operation, violation_type);
                     if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                     {
                         return true;
@@ -1971,7 +1971,7 @@ namespace sogen::kvm
                     const auto type = (error_code & 0x1) ? memory_violation_type::protection : memory_violation_type::unmapped;
                     for (auto& [_, hook] : this->memory_violation_hooks_)
                     {
-                        const auto result = hook(fault_address, 1, operation, type);
+                        const auto result = hook(*this, fault_address, 1, operation, type);
                         if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                         {
                             return true;
@@ -1982,7 +1982,7 @@ namespace sogen::kvm
                 bool handled = false;
                 for (auto& [_, hook] : this->interrupt_hooks_)
                 {
-                    hook(static_cast<int>(exception));
+                    hook(*this, static_cast<int>(exception));
                     handled = true;
                 }
 
@@ -2131,7 +2131,7 @@ namespace sogen::kvm
                 bool handled = false;
                 for (auto& [_, hook] : this->interrupt_hooks_)
                 {
-                    hook(vector);
+                    hook(*this, vector);
                     handled = true;
                 }
 
@@ -2160,7 +2160,7 @@ namespace sogen::kvm
                 this->set_regs(regs);
                 this->set_sregs(sregs);
 
-                const auto continuation = this->syscall_hook_->callback(0);
+                const auto continuation = this->syscall_hook_->callback(*this, 0);
 
                 regs = this->get_regs();
                 if (continuation != instruction_hook_continuation::finalized_instruction_pointer)

--- a/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
+++ b/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
@@ -432,8 +432,8 @@ namespace sogen::unicorn
 
                 if (inst_type == x86_hookable_instructions::invalid)
                 {
-                    function_wrapper<int, uc_engine*> wrapper([c = std::move(callback)](uc_engine*) {
-                        return (c(0) == instruction_hook_continuation::skip_instruction) ? 1 : 0;
+                    function_wrapper<int, uc_engine*> wrapper([c = std::move(callback), this](uc_engine*) {
+                        return (c(*this, 0) == instruction_hook_continuation::skip_instruction) ? 1 : 0;
                     });
 
                     uce(uc_hook_add(*this, hook.make_reference(), UC_HOOK_INSN_INVALID, wrapper.get_function(), wrapper.get_user_data(), 0,
@@ -443,7 +443,7 @@ namespace sogen::unicorn
                 else if (inst_type == x86_hookable_instructions::syscall)
                 {
                     function_wrapper<void, uc_engine*> wrapper([c = std::move(callback), this](uc_engine*) {
-                        const auto continuation = c(0);
+                        const auto continuation = c(*this, 0);
                         if (continuation == instruction_hook_continuation::finalized_instruction_pointer)
                         {
                             this->reg(x86_register::rip, this->read_instruction_pointer() - syscall_instruction_size);
@@ -458,8 +458,8 @@ namespace sogen::unicorn
                 }
                 else
                 {
-                    function_wrapper<int, uc_engine*> wrapper([c = std::move(callback)](uc_engine*) {
-                        return (c(0) == instruction_hook_continuation::skip_instruction) ? 1 : 0;
+                    function_wrapper<int, uc_engine*> wrapper([c = std::move(callback), this](uc_engine*) {
+                        return (c(*this, 0) == instruction_hook_continuation::skip_instruction) ? 1 : 0;
                     });
 
                     const auto uc_instruction = map_hookable_instruction(inst_type);
@@ -479,12 +479,12 @@ namespace sogen::unicorn
             emulator_hook* hook_basic_block(basic_block_hook_callback callback) override
             {
                 function_wrapper<void, uc_engine*, uint64_t, size_t> wrapper(
-                    [c = std::move(callback)](uc_engine*, const uint64_t address, const size_t size) {
+                    [c = std::move(callback), this](uc_engine*, const uint64_t address, const size_t size) {
                         basic_block block{};
                         block.address = address;
                         block.size = size;
 
-                        c(block);
+                        c(*this, block);
                     });
 
                 unicorn_hook hook{*this};
@@ -503,7 +503,7 @@ namespace sogen::unicorn
             emulator_hook* hook_interrupt(interrupt_hook_callback callback) override
             {
                 function_wrapper<void, uc_engine*, int> wrapper(
-                    [c = std::move(callback)](uc_engine*, const int interrupt_type) { c(interrupt_type); });
+                    [c = std::move(callback), this](uc_engine*, const int interrupt_type) { c(*this, interrupt_type); });
 
                 unicorn_hook hook{*this};
                 auto container = std::make_unique<hook_container>();
@@ -529,7 +529,7 @@ namespace sogen::unicorn
                         const auto operation = map_memory_operation(type);
                         const auto violation = map_memory_violation_type(type);
 
-                        const auto result = c(address, static_cast<uint64_t>(size), operation, violation);
+                        const auto result = c(*this, address, static_cast<uint64_t>(size), operation, violation);
                         const auto restart = result == memory_violation_continuation::restart;
                         const auto resume = result == memory_violation_continuation::resume || restart;
 
@@ -576,7 +576,7 @@ namespace sogen::unicorn
             {
                 auto exec_wrapper = [c = std::move(callback), this](uc_engine*, const uint64_t address, const uint32_t /*size*/) {
                     const auto old_ip = this->read_instruction_pointer();
-                    c(address);
+                    c(*this, address);
 
                     const auto new_ip = this->read_instruction_pointer();
                     if (new_ip != old_ip)
@@ -610,12 +610,12 @@ namespace sogen::unicorn
 
             emulator_hook* hook_memory_read(const uint64_t address, const uint64_t size, memory_access_hook_callback callback) override
             {
-                auto read_wrapper = [c = std::move(callback)](uc_engine*, const uc_mem_type type, const uint64_t address, const int length,
-                                                              const uint64_t value) {
+                auto read_wrapper = [c = std::move(callback), this](uc_engine*, const uc_mem_type type, const uint64_t address,
+                                                                    const int length, const uint64_t value) {
                     const auto operation = map_memory_operation(type);
                     if (operation == memory_operation::read && length > 0)
                     {
-                        c(address, &value, std::min(static_cast<size_t>(length), sizeof(value)));
+                        c(*this, address, &value, std::min(static_cast<size_t>(length), sizeof(value)));
                     }
                 };
 
@@ -633,12 +633,12 @@ namespace sogen::unicorn
 
             emulator_hook* hook_memory_write(const uint64_t address, const uint64_t size, memory_access_hook_callback callback) override
             {
-                auto write_wrapper = [c = std::move(callback)](uc_engine*, const uc_mem_type type, const uint64_t addr, const int length,
-                                                               const uint64_t value) {
+                auto write_wrapper = [c = std::move(callback), this](uc_engine*, const uc_mem_type type, const uint64_t addr,
+                                                                     const int length, const uint64_t value) {
                     const auto operation = map_memory_operation(type);
                     if (operation == memory_operation::write && length > 0)
                     {
-                        c(addr, &value, std::min(static_cast<size_t>(length), sizeof(value)));
+                        c(*this, addr, &value, std::min(static_cast<size_t>(length), sizeof(value)));
                     }
                 };
 

--- a/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
+++ b/src/backends/unicorn-emulator/unicorn_x86_64_emulator.cpp
@@ -736,6 +736,11 @@ namespace sogen::unicorn
                 return false;
             }
 
+            bool supports_multiple_vcpus() const override
+            {
+                return false;
+            }
+
             std::string get_name() const override
             {
                 return "Unicorn Engine";

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1997,7 +1997,7 @@ namespace sogen::whp
                 };
                 this->set_registers(pre_hook_names, pre_hook_values);
 
-                const auto continuation = this->syscall_hook_->callback(0);
+                const auto continuation = this->syscall_hook_->callback(*this, 0);
 
                 constexpr std::array<WHV_REGISTER_NAME, 1> post_hook_rip_name = {WHvX64RegisterRip};
                 auto post_hook_rip_value = this->get_registers(post_hook_rip_name);
@@ -3033,7 +3033,7 @@ namespace sogen::whp
                     }
 
                     handled = true;
-                    if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
+                    if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
                     {
                         skip = true;
                     }
@@ -3058,7 +3058,7 @@ namespace sogen::whp
                 {
                     for (auto& [_, hook] : this->interrupt_hooks_)
                     {
-                        hook(std::to_integer<uint8_t>(opcode[1]));
+                        hook(*this, std::to_integer<uint8_t>(opcode[1]));
 
                         if (this->read_instruction_pointer() == rip)
                         {
@@ -3081,7 +3081,7 @@ namespace sogen::whp
                             continue;
                         }
 
-                        if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
+                        if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
                         {
                             skip = true;
                             consumed = true;
@@ -3100,7 +3100,7 @@ namespace sogen::whp
 
                     for (auto& [_, hook] : this->interrupt_hooks_)
                     {
-                        hook(6);
+                        hook(*this, 6);
                         return true;
                     }
 
@@ -3121,7 +3121,7 @@ namespace sogen::whp
                 {
                     for (auto& [_, hook] : this->interrupt_hooks_)
                     {
-                        hook(1);
+                        hook(*this, 1);
                         return true;
                     }
                 }
@@ -3132,7 +3132,7 @@ namespace sogen::whp
                 {
                     for (auto& [_, hook] : this->memory_violation_hooks_)
                     {
-                        const auto result = hook(fault_address, 1, memory_operation::read, memory_violation_type::unmapped);
+                        const auto result = hook(*this, fault_address, 1, memory_operation::read, memory_violation_type::unmapped);
                         if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                         {
                             return true;
@@ -3142,7 +3142,7 @@ namespace sogen::whp
 
                 for (auto& [_, hook] : this->interrupt_hooks_)
                 {
-                    hook(14);
+                    hook(*this, 14);
                     return true;
                 }
 
@@ -3171,7 +3171,7 @@ namespace sogen::whp
 
                 for (const auto& callback : callbacks)
                 {
-                    callback(address);
+                    callback(*this, address);
                 }
 
                 if (this->stop_requested_)
@@ -3259,7 +3259,7 @@ namespace sogen::whp
 
                 for (auto& [_, hook] : this->memory_violation_hooks_)
                 {
-                    const auto result = hook(mmio_address, 1, operation, type);
+                    const auto result = hook(*this, mmio_address, 1, operation, type);
                     if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                     {
                         return true;
@@ -3292,7 +3292,7 @@ namespace sogen::whp
 
                 for (const auto& callback : callbacks)
                 {
-                    callback(address);
+                    callback(*this, address);
                 }
 
                 this->deferred_patched_breakpoint_ = address;
@@ -3321,7 +3321,7 @@ namespace sogen::whp
 
                     for (auto& [_, hook] : this->memory_violation_hooks_)
                     {
-                        const auto result = hook(fault_address, 1, operation, type);
+                        const auto result = hook(*this, fault_address, 1, operation, type);
                         if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                         {
                             return true;
@@ -3330,7 +3330,7 @@ namespace sogen::whp
 
                     for (auto& [_, hook] : this->interrupt_hooks_)
                     {
-                        hook(14);
+                        hook(*this, 14);
                         return true;
                     }
 
@@ -3387,7 +3387,7 @@ namespace sogen::whp
                             continue;
                         }
 
-                        if (hook.callback(0) == instruction_hook_continuation::skip_instruction)
+                        if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
                         {
                             if (this->read_instruction_pointer() == rip)
                             {
@@ -3423,7 +3423,7 @@ namespace sogen::whp
 
                 for (auto& [_, hook] : this->interrupt_hooks_)
                 {
-                    hook(exception.ExceptionType);
+                    hook(*this, exception.ExceptionType);
                     return true;
                 }
 

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1232,6 +1232,11 @@ namespace sogen::whp
             std::atomic_bool stop_requested_{false};
             std::atomic_bool run_active_{false};
             std::atomic_bool pending_tlb_flush_{false};
+
+            // Guards against looping when a fault is repaired but recurs unchanged (a genuine
+            // violation): tracks the last (page, rip) we re-mapped and retried.
+            uint64_t last_repair_page_{unmapped_guest_page};
+            uint64_t last_repair_rip_{};
             std::optional<pending_execution_step> pending_execution_step_{};
             std::optional<pending_mmio_step> pending_mmio_step_{};
             std::optional<uint64_t> deferred_patched_breakpoint_{};
@@ -2996,6 +3001,42 @@ namespace sogen::whp
                 return (pt_entries[pt_index] & page_table_entry_present) != 0;
             }
 
+            // A fault can be spurious under multiple vCPUs: the backend has the page backed
+            // (a peer mapped/committed it, or a protection/COW remap transiently cleared the
+            // guest PTE) but this vCPU's page-table walk missed it. If the page is backed,
+            // re-establish its mapping, flush this vCPU's TLB and retry. A per-vCPU (page,rip)
+            // guard ensures a genuine violation (unbacked page, wrong permissions) is still
+            // delivered rather than looping forever.
+            bool try_repair_spurious_fault(whp_vcpu& vcpu, const uint64_t fault_address)
+            {
+                const auto page_base = align_down_to_page(fault_address);
+                const auto rip = vcpu.read_instruction_pointer();
+
+                if (vcpu.last_repair_page_ == page_base && vcpu.last_repair_rip_ == rip)
+                {
+                    // Already repaired this exact fault and it recurred unchanged: it is real.
+                    vcpu.last_repair_page_ = unmapped_guest_page;
+                    return false;
+                }
+
+                {
+                    std::unique_lock lock(this->partition_mutex_);
+                    const auto it = this->mapped_pages_.find(page_base);
+                    if (it == this->mapped_pages_.end() || !it->second || it->second->host_page == nullptr)
+                    {
+                        return false;
+                    }
+
+                    this->ensure_virtual_mapping(page_base);
+                    this->remap_page(*it->second);
+                }
+
+                vcpu.last_repair_page_ = page_base;
+                vcpu.last_repair_rip_ = rip;
+                vcpu.set_register(WHvX64RegisterCr3, vcpu.get_register(WHvX64RegisterCr3));
+                return true;
+            }
+
             // Assumes partition_mutex_ is held exclusively.
             bool clear_virtual_mapping(const uint64_t guest_address)
             {
@@ -3492,6 +3533,15 @@ namespace sogen::whp
 
                 if (fault_address != 0)
                 {
+                    // Guest page faults escalate here (the guest IDT cannot dispatch them). Under
+                    // multiple vCPUs the faulting page may in fact be backed - a peer mapped/committed
+                    // it, or a protection/remap on another vCPU transiently cleared this vCPU's guest
+                    // PTE. Repair and retry rather than delivering a spurious access violation.
+                    if (this->try_repair_spurious_fault(vcpu, fault_address))
+                    {
+                        return true;
+                    }
+
                     for (const auto& hook : this->copy_memory_violation_hooks())
                     {
                         const auto result = hook(vcpu, fault_address, 1, memory_operation::read, memory_violation_type::unmapped);
@@ -3647,6 +3697,14 @@ namespace sogen::whp
                     return true;
                 }
 
+                // Spurious fault on an actually-backed page whose GPA mapping is momentarily
+                // absent for this vCPU (peer map/commit): repair and retry. Only for unmapped
+                // (not protection) accesses, so guard pages and real violations still reach the hook.
+                if (memory_access.AccessInfo.GpaUnmapped && this->try_repair_spurious_fault(vcpu, resolved_address))
+                {
+                    return true;
+                }
+
                 const auto violation_hooks = this->copy_memory_violation_hooks();
                 if (violation_hooks.empty())
                 {
@@ -3724,19 +3782,15 @@ namespace sogen::whp
                     const auto operation = is_write ? memory_operation::write : memory_operation::read;
                     const auto type = is_present ? memory_violation_type::protection : memory_violation_type::unmapped;
 
-                    // Under multiple vCPUs a peer may have mapped/committed this page after this vCPU
-                    // cached a stale (negative) translation, producing a spurious not-present fault. If
-                    // the page is in fact mapped present, flush this vCPU's TLB and retry instead of
-                    // delivering a bogus access violation to the guest.
-                    if (!is_present)
+                    // Under multiple vCPUs a peer may have mapped/committed this page (or a
+                    // protection/COW remap transiently cleared its guest PTE) after this vCPU faulted,
+                    // producing a spurious not-present fault on an actually-backed page. Repair and
+                    // retry rather than delivering a bogus access violation to the guest. Only for
+                    // not-present faults - protection faults (guard pages, real violations) are left
+                    // to the violation hook.
+                    if (!is_present && this->try_repair_spurious_fault(vcpu, fault_address))
                     {
-                        std::shared_lock lock(this->partition_mutex_);
-                        if (this->is_virtual_mapping_present(fault_address))
-                        {
-                            lock.unlock();
-                            vcpu.set_register(WHvX64RegisterCr3, vcpu.get_register(WHvX64RegisterCr3));
-                            return true;
-                        }
+                        return true;
                     }
 
                     for (const auto& hook : this->copy_memory_violation_hooks())

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1741,6 +1741,14 @@ namespace sogen::whp
                 return true;
             }
 
+            bool supports_multiple_vcpus() const override
+            {
+                // WHP can drive multiple virtual processors per partition, but the
+                // backend still hardcodes VP index 0 everywhere. Flip this once the
+                // multi-vCPU backend work (docs/multi-vcpu-design.md, Phase 1) lands.
+                return false;
+            }
+
             bool supports_global_memory_execution_hooks() const override
             {
                 return false;

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1231,6 +1231,7 @@ namespace sogen::whp
 
             std::atomic_bool stop_requested_{false};
             std::atomic_bool run_active_{false};
+            std::atomic_bool pending_tlb_flush_{false};
             std::optional<pending_execution_step> pending_execution_step_{};
             std::optional<pending_mmio_step> pending_mmio_step_{};
             std::optional<uint64_t> deferred_patched_breakpoint_{};
@@ -2997,13 +2998,18 @@ namespace sogen::whp
                 return true;
             }
 
-            // Assumes partition_mutex_ is held exclusively. Rewriting CR3 flushes the cached
-            // virtual-address translations; every vCPU shares the same page tables.
+            // Assumes partition_mutex_ is held exclusively. Every vCPU shares the same page
+            // tables; each one flushes its own cached translations by reloading CR3 at the
+            // top of its run loop. Registers of a potentially running vCPU cannot be touched
+            // from here, so the flush is requested via a flag plus a cancel: a running vCPU
+            // exits and re-enters through the loop top, an idle one applies the flag before
+            // its next run.
             void flush_virtual_address_mappings()
             {
                 for (const auto& vcpu : this->vcpus_)
                 {
-                    vcpu->set_register(WHvX64RegisterCr3, vcpu->get_register(WHvX64RegisterCr3));
+                    vcpu->pending_tlb_flush_ = true;
+                    (void)WHvCancelRunVirtualProcessor(this->partition_, vcpu->vp_index_, 0);
                 }
             }
 
@@ -3211,6 +3217,13 @@ namespace sogen::whp
 
                 while (!vcpu.stop_requested_)
                 {
+                    if (vcpu.pending_tlb_flush_.exchange(false))
+                    {
+                        // Reload CR3 to flush this vCPU's cached translations. Safe here:
+                        // this vCPU is not inside WHvRunVirtualProcessor.
+                        vcpu.set_register(WHvX64RegisterCr3, vcpu.get_register(WHvX64RegisterCr3));
+                    }
+
                     this->expire_mmio_read_grace_pages(vcpu);
                     WHV_RUN_VP_EXIT_CONTEXT exit_context{};
                     const auto start_rip = vcpu.read_instruction_pointer();

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -3391,8 +3391,8 @@ namespace sogen::whp
                 }
             }
 
-            void apply_default_instruction_exit(whp_vcpu& vcpu, const x86_hookable_instructions type,
-                                                const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
+            static void apply_default_instruction_exit(whp_vcpu& vcpu, const x86_hookable_instructions type,
+                                                       const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
             {
                 switch (type)
                 {
@@ -3439,7 +3439,7 @@ namespace sogen::whp
 
                 if (!handled || !skip)
                 {
-                    this->apply_default_instruction_exit(vcpu, type, exit_context);
+                    apply_default_instruction_exit(vcpu, type, exit_context);
                 }
 
                 vcpu.advance_rip(instruction_size);

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -2934,7 +2934,9 @@ namespace sogen::whp
             }
 
             // Assumes partition_mutex_ is held exclusively.
-            void ensure_virtual_mapping(const uint64_t guest_address)
+            // Returns true if the page transitioned from not-present to present, meaning
+            // other vCPUs may hold a stale (negative) translation and need a TLB flush.
+            bool ensure_virtual_mapping(const uint64_t guest_address)
             {
                 const auto page_base = align_down_to_page(guest_address);
                 const auto mapped_page = this->mapped_pages_.find(page_base);
@@ -2953,8 +2955,45 @@ namespace sogen::whp
                 const auto pt_gpa = this->ensure_child_table(pd_gpa, pd_index);
 
                 auto* const pt_entries = this->get_page_table_entries(pt_gpa);
+                const auto was_present = (pt_entries[pt_index] & page_table_entry_present) != 0;
                 pt_entries[pt_index] = mapped_page->second->guest_physical_address | page_table_entry_present | page_table_entry_writable |
                                        page_table_entry_user;
+                return !was_present;
+            }
+
+            // Assumes partition_mutex_ is held (shared is sufficient). Walks the guest page
+            // tables read-only and reports whether the address is currently mapped present.
+            bool is_virtual_mapping_present(const uint64_t guest_address)
+            {
+                const auto page_base = align_down_to_page(guest_address);
+                const auto pml4_index = static_cast<size_t>((page_base >> 39) & 0x1FF);
+                const auto pdpt_index = static_cast<size_t>((page_base >> 30) & 0x1FF);
+                const auto pd_index = static_cast<size_t>((page_base >> 21) & 0x1FF);
+                const auto pt_index = static_cast<size_t>((page_base >> 12) & 0x1FF);
+
+                auto* pml4_entries = this->get_page_table_entries(this->pml4_gpa_);
+                const auto pml4_entry = pml4_entries[pml4_index];
+                if ((pml4_entry & page_table_entry_present) == 0)
+                {
+                    return false;
+                }
+
+                auto* pdpt_entries = this->get_page_table_entries(pml4_entry & page_table_entry_address_mask);
+                const auto pdpt_entry = pdpt_entries[pdpt_index];
+                if ((pdpt_entry & page_table_entry_present) == 0)
+                {
+                    return false;
+                }
+
+                auto* pd_entries = this->get_page_table_entries(pdpt_entry & page_table_entry_address_mask);
+                const auto pd_entry = pd_entries[pd_index];
+                if ((pd_entry & page_table_entry_present) == 0)
+                {
+                    return false;
+                }
+
+                auto* pt_entries = this->get_page_table_entries(pd_entry & page_table_entry_address_mask);
+                return (pt_entries[pt_index] & page_table_entry_present) != 0;
             }
 
             // Assumes partition_mutex_ is held exclusively.
@@ -3684,6 +3723,21 @@ namespace sogen::whp
                     const bool is_present = (exception.ErrorCode & 0x1u) != 0;
                     const auto operation = is_write ? memory_operation::write : memory_operation::read;
                     const auto type = is_present ? memory_violation_type::protection : memory_violation_type::unmapped;
+
+                    // Under multiple vCPUs a peer may have mapped/committed this page after this vCPU
+                    // cached a stale (negative) translation, producing a spurious not-present fault. If
+                    // the page is in fact mapped present, flush this vCPU's TLB and retry instead of
+                    // delivering a bogus access violation to the guest.
+                    if (!is_present)
+                    {
+                        std::shared_lock lock(this->partition_mutex_);
+                        if (this->is_virtual_mapping_present(fault_address))
+                        {
+                            lock.unlock();
+                            vcpu.set_register(WHvX64RegisterCr3, vcpu.get_register(WHvX64RegisterCr3));
+                            return true;
+                        }
+                    }
 
                     for (const auto& hook : this->copy_memory_violation_hooks())
                     {

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1233,10 +1233,16 @@ namespace sogen::whp
             std::atomic_bool run_active_{false};
             std::atomic_bool pending_tlb_flush_{false};
 
-            // Guards against looping when a fault is repaired but recurs unchanged (a genuine
-            // violation): tracks the last (page, rip) we re-mapped and retried.
+            // Tracks the last (page, rip) we re-mapped and retried, plus how many times in a row.
+            // A backed page whose permissions allow the access can only fault spuriously (a stale
+            // translation or a peer transiently re-clearing/reprotecting it) - never a genuine
+            // violation, which fails the permission check and is delivered without a repair. So we
+            // retry many times to ride out concurrent re-clears at high vCPU counts, but still cap it
+            // to bound the one case that could otherwise loop: an unrecoverable-exit fault whose real
+            // access type we had to guess (see the unrecoverable handler).
             uint64_t last_repair_page_{unmapped_guest_page};
             uint64_t last_repair_rip_{};
+            uint32_t last_repair_count_{};
             std::optional<pending_execution_step> pending_execution_step_{};
             std::optional<pending_mmio_step> pending_mmio_step_{};
             std::optional<uint64_t> deferred_patched_breakpoint_{};
@@ -2939,9 +2945,7 @@ namespace sogen::whp
             }
 
             // Assumes partition_mutex_ is held exclusively.
-            // Returns true if the page transitioned from not-present to present, meaning
-            // other vCPUs may hold a stale (negative) translation and need a TLB flush.
-            bool ensure_virtual_mapping(const uint64_t guest_address)
+            void ensure_virtual_mapping(const uint64_t guest_address)
             {
                 const auto page_base = align_down_to_page(guest_address);
                 const auto mapped_page = this->mapped_pages_.find(page_base);
@@ -2960,45 +2964,8 @@ namespace sogen::whp
                 const auto pt_gpa = this->ensure_child_table(pd_gpa, pd_index);
 
                 auto* const pt_entries = this->get_page_table_entries(pt_gpa);
-                const auto was_present = (pt_entries[pt_index] & page_table_entry_present) != 0;
                 pt_entries[pt_index] = mapped_page->second->guest_physical_address | page_table_entry_present | page_table_entry_writable |
                                        page_table_entry_user;
-                return !was_present;
-            }
-
-            // Assumes partition_mutex_ is held (shared is sufficient). Walks the guest page
-            // tables read-only and reports whether the address is currently mapped present.
-            bool is_virtual_mapping_present(const uint64_t guest_address)
-            {
-                const auto page_base = align_down_to_page(guest_address);
-                const auto pml4_index = static_cast<size_t>((page_base >> 39) & 0x1FF);
-                const auto pdpt_index = static_cast<size_t>((page_base >> 30) & 0x1FF);
-                const auto pd_index = static_cast<size_t>((page_base >> 21) & 0x1FF);
-                const auto pt_index = static_cast<size_t>((page_base >> 12) & 0x1FF);
-
-                auto* pml4_entries = this->get_page_table_entries(this->pml4_gpa_);
-                const auto pml4_entry = pml4_entries[pml4_index];
-                if ((pml4_entry & page_table_entry_present) == 0)
-                {
-                    return false;
-                }
-
-                auto* pdpt_entries = this->get_page_table_entries(pml4_entry & page_table_entry_address_mask);
-                const auto pdpt_entry = pdpt_entries[pdpt_index];
-                if ((pdpt_entry & page_table_entry_present) == 0)
-                {
-                    return false;
-                }
-
-                auto* pd_entries = this->get_page_table_entries(pdpt_entry & page_table_entry_address_mask);
-                const auto pd_entry = pd_entries[pd_index];
-                if ((pd_entry & page_table_entry_present) == 0)
-                {
-                    return false;
-                }
-
-                auto* pt_entries = this->get_page_table_entries(pd_entry & page_table_entry_address_mask);
-                return (pt_entries[pt_index] & page_table_entry_present) != 0;
             }
 
             // A fault can be spurious under multiple vCPUs: the backend has the page backed
@@ -3007,30 +2974,52 @@ namespace sogen::whp
             // re-establish its mapping, flush this vCPU's TLB and retry. A per-vCPU (page,rip)
             // guard ensures a genuine violation (unbacked page, wrong permissions) is still
             // delivered rather than looping forever.
-            bool try_repair_spurious_fault(whp_vcpu& vcpu, const uint64_t fault_address)
+            bool try_repair_spurious_fault(whp_vcpu& vcpu, const uint64_t fault_address, const memory_operation operation)
             {
+                constexpr uint32_t max_consecutive_repairs = 256;
+
                 const auto page_base = align_down_to_page(fault_address);
                 const auto rip = vcpu.read_instruction_pointer();
+                const auto same_as_last = vcpu.last_repair_page_ == page_base && vcpu.last_repair_rip_ == rip;
+                const auto guard_tripped = same_as_last && vcpu.last_repair_count_ >= max_consecutive_repairs;
 
-                if (vcpu.last_repair_page_ == page_base && vcpu.last_repair_rip_ == rip)
-                {
-                    // Already repaired this exact fault and it recurred unchanged: it is real.
-                    vcpu.last_repair_page_ = unmapped_guest_page;
-                    return false;
-                }
+                bool repaired = false;
 
                 {
                     std::unique_lock lock(this->partition_mutex_);
                     const auto it = this->mapped_pages_.find(page_base);
-                    if (it == this->mapped_pages_.end() || !it->second || it->second->host_page == nullptr)
-                    {
-                        return false;
-                    }
+                    const auto backed = it != this->mapped_pages_.end() && it->second && it->second->host_page != nullptr;
 
-                    this->ensure_virtual_mapping(page_base);
-                    this->remap_page(*it->second);
+                    // Only a page that is backed AND whose intended permissions allow the faulting
+                    // operation can be a spurious (stale-translation) fault. Guard and no-access pages
+                    // map with permission 'none', so they still reach the violation hook, as do genuine
+                    // protection violations (write to read-only, etc.).
+                    const auto perms = backed ? it->second->permissions : memory_permission::none;
+                    const auto permitted = (perms & operation) == operation;
+
+                    if (!guard_tripped && backed && permitted)
+                    {
+                        this->ensure_virtual_mapping(page_base);
+                        this->remap_page(*it->second);
+                        repaired = true;
+                    }
                 }
 
+                if (guard_tripped)
+                {
+                    // Repaired this exact fault too many times in a row without progress: give up and
+                    // deliver it (guards the unrecoverable-exit read-assumption from a write-to-RO loop).
+                    vcpu.last_repair_page_ = unmapped_guest_page;
+                    vcpu.last_repair_count_ = 0;
+                    return false;
+                }
+
+                if (!repaired)
+                {
+                    return false;
+                }
+
+                vcpu.last_repair_count_ = same_as_last ? vcpu.last_repair_count_ + 1 : 1;
                 vcpu.last_repair_page_ = page_base;
                 vcpu.last_repair_rip_ = rip;
                 vcpu.set_register(WHvX64RegisterCr3, vcpu.get_register(WHvX64RegisterCr3));
@@ -3534,10 +3523,12 @@ namespace sogen::whp
                 if (fault_address != 0)
                 {
                     // Guest page faults escalate here (the guest IDT cannot dispatch them). Under
-                    // multiple vCPUs the faulting page may in fact be backed - a peer mapped/committed
-                    // it, or a protection/remap on another vCPU transiently cleared this vCPU's guest
-                    // PTE. Repair and retry rather than delivering a spurious access violation.
-                    if (this->try_repair_spurious_fault(vcpu, fault_address))
+                    // multiple vCPUs the faulting page may in fact be backed with permissions that
+                    // allow the access - a peer mapped/committed/reprotected it after this vCPU cached
+                    // a stale translation. Repair and retry rather than delivering a spurious access
+                    // violation. The exit carries no access type, so assume a read; a genuine
+                    // write-to-read-only self-corrects via the per-vCPU retry guard.
+                    if (this->try_repair_spurious_fault(vcpu, fault_address, memory_operation::read))
                     {
                         return true;
                     }
@@ -3697,10 +3688,10 @@ namespace sogen::whp
                     return true;
                 }
 
-                // Spurious fault on an actually-backed page whose GPA mapping is momentarily
-                // absent for this vCPU (peer map/commit): repair and retry. Only for unmapped
-                // (not protection) accesses, so guard pages and real violations still reach the hook.
-                if (memory_access.AccessInfo.GpaUnmapped && this->try_repair_spurious_fault(vcpu, resolved_address))
+                // Spurious fault on an actually-backed page whose mapping is momentarily stale for
+                // this vCPU (peer map/commit/reprotect): repair and retry. Guard/no-access pages
+                // (permission 'none') and genuine violations still reach the hook.
+                if (this->try_repair_spurious_fault(vcpu, resolved_address, operation))
                 {
                     return true;
                 }
@@ -3782,13 +3773,12 @@ namespace sogen::whp
                     const auto operation = is_write ? memory_operation::write : memory_operation::read;
                     const auto type = is_present ? memory_violation_type::protection : memory_violation_type::unmapped;
 
-                    // Under multiple vCPUs a peer may have mapped/committed this page (or a
-                    // protection/COW remap transiently cleared its guest PTE) after this vCPU faulted,
-                    // producing a spurious not-present fault on an actually-backed page. Repair and
-                    // retry rather than delivering a bogus access violation to the guest. Only for
-                    // not-present faults - protection faults (guard pages, real violations) are left
-                    // to the violation hook.
-                    if (!is_present && this->try_repair_spurious_fault(vcpu, fault_address))
+                    // Under multiple vCPUs a peer may have mapped/committed/reprotected this page
+                    // after this vCPU cached a stale translation, producing a spurious fault on an
+                    // actually-backed page whose permissions allow the access. Repair and retry rather
+                    // than delivering a bogus access violation. Guard/no-access pages and genuine
+                    // violations (permission mismatch) still reach the violation hook.
+                    if (this->try_repair_spurious_fault(vcpu, fault_address, operation))
                     {
                         return true;
                     }

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -2974,14 +2974,21 @@ namespace sogen::whp
             // re-establish its mapping, flush this vCPU's TLB and retry. A per-vCPU (page,rip)
             // guard ensures a genuine violation (unbacked page, wrong permissions) is still
             // delivered rather than looping forever.
-            bool try_repair_spurious_fault(whp_vcpu& vcpu, const uint64_t fault_address, const memory_operation operation)
+            // operation_known is false only for the unrecoverable-exit path, whose fault carries no
+            // access type (we assume a read). There a backed+readable page could still be a genuine
+            // write-to-read-only, so consecutive repairs are capped to avoid an endless retry loop.
+            // For the well-typed paths (#PF, memory access) a backed page whose permissions allow the
+            // faulting operation can only fault transiently (a peer's stale-translation re-clear), so
+            // it is retried without a cap - the re-clears are finite and always resolve.
+            bool try_repair_spurious_fault(whp_vcpu& vcpu, const uint64_t fault_address, const memory_operation operation,
+                                           const bool operation_known)
             {
                 constexpr uint32_t max_consecutive_repairs = 256;
 
                 const auto page_base = align_down_to_page(fault_address);
                 const auto rip = vcpu.read_instruction_pointer();
                 const auto same_as_last = vcpu.last_repair_page_ == page_base && vcpu.last_repair_rip_ == rip;
-                const auto guard_tripped = same_as_last && vcpu.last_repair_count_ >= max_consecutive_repairs;
+                const auto guard_tripped = !operation_known && same_as_last && vcpu.last_repair_count_ >= max_consecutive_repairs;
 
                 bool repaired = false;
 
@@ -3528,7 +3535,7 @@ namespace sogen::whp
                     // a stale translation. Repair and retry rather than delivering a spurious access
                     // violation. The exit carries no access type, so assume a read; a genuine
                     // write-to-read-only self-corrects via the per-vCPU retry guard.
-                    if (this->try_repair_spurious_fault(vcpu, fault_address, memory_operation::read))
+                    if (this->try_repair_spurious_fault(vcpu, fault_address, memory_operation::read, false))
                     {
                         return true;
                     }
@@ -3691,7 +3698,7 @@ namespace sogen::whp
                 // Spurious fault on an actually-backed page whose mapping is momentarily stale for
                 // this vCPU (peer map/commit/reprotect): repair and retry. Guard/no-access pages
                 // (permission 'none') and genuine violations still reach the hook.
-                if (this->try_repair_spurious_fault(vcpu, resolved_address, operation))
+                if (this->try_repair_spurious_fault(vcpu, resolved_address, operation, true))
                 {
                     return true;
                 }
@@ -3778,7 +3785,7 @@ namespace sogen::whp
                     // actually-backed page whose permissions allow the access. Repair and retry rather
                     // than delivering a bogus access violation. Guard/no-access pages and genuine
                     // violations (permission mismatch) still reach the violation hook.
-                    if (this->try_repair_spurious_fault(vcpu, fault_address, operation))
+                    if (this->try_repair_spurious_fault(vcpu, fault_address, operation, true))
                     {
                         return true;
                     }

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -6,14 +6,18 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstring>
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -26,7 +30,7 @@ namespace sogen::whp
 {
     namespace
     {
-        constexpr UINT32 vp_index = 0;
+        constexpr size_t maximum_vcpu_count = 64;
         constexpr uint64_t page_size = 0x1000;
         constexpr uint64_t trap_flag_bit = 0x100ull;
         constexpr uint64_t syscall_instruction_size = 2;
@@ -96,10 +100,11 @@ namespace sogen::whp
         class virtual_processor_handle
         {
           public:
-            explicit virtual_processor_handle(const WHV_PARTITION_HANDLE partition)
-                : partition_(partition)
+            virtual_processor_handle(const WHV_PARTITION_HANDLE partition, const UINT32 vp_index)
+                : partition_(partition),
+                  vp_index_(vp_index)
             {
-                WHP_CHECK_HR(WHvCreateVirtualProcessor(this->partition_, vp_index, 0));
+                WHP_CHECK_HR(WHvCreateVirtualProcessor(this->partition_, this->vp_index_, 0));
             }
 
             virtual_processor_handle(const virtual_processor_handle&) = delete;
@@ -109,12 +114,13 @@ namespace sogen::whp
             {
                 if (this->partition_ != nullptr)
                 {
-                    (void)WHvDeleteVirtualProcessor(this->partition_, vp_index);
+                    (void)WHvDeleteVirtualProcessor(this->partition_, this->vp_index_);
                 }
             }
 
           private:
             WHV_PARTITION_HANDLE partition_ = nullptr;
+            UINT32 vp_index_ = 0;
         };
 
         struct mapped_page
@@ -840,180 +846,53 @@ namespace sogen::whp
             throw std::runtime_error("Unsupported WHP register");
         }
 
-        class whp_x86_64_emulator : public x86_64_emulator
+        class whp_x86_64_emulator;
+
+        struct pending_mmio_step
+        {
+            uint64_t page_base{};
+            uint64_t original_rflags{};
+            bool had_trap_flag{};
+            bool allow_debug_delivery{};
+            bool is_write{};
+            std::vector<std::byte> old_page{};
+        };
+
+        struct pending_execution_step
+        {
+            std::optional<uint64_t> page_base{};
+            std::optional<uint64_t> patched_breakpoint{};
+            bool had_trap_flag{};
+            bool stop_after_step{};
+        };
+
+        class whp_vcpu final : public x86_64_cpu
         {
           public:
-            whp_x86_64_emulator()
+            whp_vcpu(whp_x86_64_emulator& emulator, const WHV_PARTITION_HANDLE partition, const UINT32 index)
+                : emulator_(emulator),
+                  partition_(partition),
+                  vp_index_(index),
+                  vp_(partition, index)
             {
-                this->ensure_platform_support();
-                this->configure_partition();
-                this->vp_ = std::make_unique<virtual_processor_handle>(this->partition_);
-                this->initialize_long_mode_page_tables();
-                this->initialize_virtual_processor_state();
-                this->initialize_syscall_intercept_page();
             }
 
-            ~whp_x86_64_emulator() override
+            size_t index() const override
             {
-                utils::reset_object_with_delayed_destruction(this->memory_write_hooks_);
-                utils::reset_object_with_delayed_destruction(this->memory_read_hooks_);
-                utils::reset_object_with_delayed_destruction(this->memory_execution_hooks_);
-                utils::reset_object_with_delayed_destruction(this->memory_violation_hooks_);
-                utils::reset_object_with_delayed_destruction(this->interrupt_hooks_);
-                utils::reset_object_with_delayed_destruction(this->basic_block_hooks_);
-                utils::reset_object_with_delayed_destruction(this->instruction_hooks_);
+                return this->vp_index_;
             }
 
-            void set_memory_execution_hook_mode(const memory_execution_hook_mode mode) override
-            {
-                this->memory_execution_hook_mode_ = mode;
-            }
+            memory_interface& memory() override;
+            const memory_interface& memory() const override;
 
-            void start(const size_t count) override
-            {
-                if (count != 0 && count != 1)
-                {
-                    throw std::runtime_error("WHP backend does not support exact instruction counts yet");
-                }
-
-                this->stop_requested_ = false;
-                bool armed_single_step = false;
-                if (this->deferred_patched_breakpoint_)
-                {
-                    if (this->read_instruction_pointer() == *this->deferred_patched_breakpoint_)
-                    {
-                        if (!this->arm_patched_breakpoint_single_step(*this->deferred_patched_breakpoint_, count == 1))
-                        {
-                            throw std::runtime_error("Nested WHP execution single-step state is not supported");
-                        }
-
-                        armed_single_step = true;
-                    }
-                    else
-                    {
-                        this->set_patched_execution_breakpoint_state(*this->deferred_patched_breakpoint_, true);
-                        this->deferred_patched_breakpoint_.reset();
-                    }
-                }
-
-                if (!armed_single_step && this->deferred_execution_page_)
-                {
-                    if (!this->arm_execution_single_step(*this->deferred_execution_page_, count == 1))
-                    {
-                        throw std::runtime_error("Nested WHP execution single-step state is not supported");
-                    }
-
-                    this->deferred_execution_page_.reset();
-                    armed_single_step = true;
-                }
-
-                if (!armed_single_step && count == 1 && !this->arm_execution_single_step(std::nullopt, true))
-                {
-                    throw std::runtime_error("Nested WHP execution single-step state is not supported");
-                }
-
-                while (!this->stop_requested_)
-                {
-                    this->expire_mmio_read_grace_pages();
-                    WHV_RUN_VP_EXIT_CONTEXT exit_context{};
-                    const auto start_rip = this->read_instruction_pointer();
-                    this->run_active_ = true;
-                    const auto run_hr = WHvRunVirtualProcessor(this->partition_, vp_index, &exit_context, sizeof(exit_context));
-                    this->run_active_ = false;
-                    if (FAILED(run_hr))
-                    {
-                        throw_hr(run_hr, "WHvRunVirtualProcessor");
-                    }
-                    switch (exit_context.ExitReason)
-                    {
-                    case WHvRunVpExitReasonCanceled: {
-                        if (this->stop_requested_)
-                        {
-                            return;
-                        }
-
-                        // If rip has not changed, we _probably_ executed nothing.
-                        // Could be that the execution was cancelled while it was not running.
-                        // Just restart it.
-                        if (start_rip == exit_context.VpContext.Rip)
-                        {
-                            this->stop_requested_ = false;
-                            continue;
-                        }
-
-                        return;
-                    }
-                    case WHvRunVpExitReasonX64Halt:
-                        if (this->syscall_hook_ && exit_context.VpContext.Rip == (this->syscall_hook_page_ + 1))
-                        {
-                            if (this->handle_syscall_halt())
-                            {
-                                continue;
-                            }
-                        }
-                        else
-                        {
-                            return;
-                        }
-
-                        if (this->stop_requested_)
-                        {
-                            return;
-                        }
-
-                        if (this->syscall_hook_)
-                        {
-                            continue;
-                        }
-                        return;
-                    case WHvRunVpExitReasonMemoryAccess:
-                        if (this->handle_memory_access(exit_context.MemoryAccess))
-                        {
-                            continue;
-                        }
-                        return;
-                    case WHvRunVpExitReasonException:
-                        if (this->handle_exception(exit_context))
-                        {
-                            this->clear_pending_exception_state();
-                            continue;
-                        }
-                        return;
-                    case WHvRunVpExitReasonX64Cpuid:
-                        if (this->handle_instruction_exit(x86_hookable_instructions::cpuid, exit_context, 2))
-                        {
-                            continue;
-                        }
-                        throw std::runtime_error("Unhandled CPUID exit");
-                    case WHvRunVpExitReasonX64Rdtsc:
-                        if (this->handle_instruction_exit(exit_context.ReadTsc.RdtscInfo.IsRdtscp ? x86_hookable_instructions::rdtscp
-                                                                                                  : x86_hookable_instructions::rdtsc,
-                                                          exit_context, 2))
-                        {
-                            continue;
-                        }
-                        throw std::runtime_error("Unhandled RDTSC/RDTSCP exit");
-                    case WHvRunVpExitReasonUnrecoverableException:
-                        if (this->handle_unrecoverable_exception())
-                        {
-                            this->clear_pending_exception_state();
-                            continue;
-                        }
-                        throw_unhandled_exit(exit_context);
-                    case WHvRunVpExitReasonUnsupportedFeature:
-                        throw std::runtime_error("Encountered unsupported processor feature");
-                    default:
-                        throw_unhandled_exit(exit_context);
-                    }
-                }
-            }
+            void start(size_t count) override;
 
             void stop() override
             {
                 this->stop_requested_ = true;
                 if (this->run_active_)
                 {
-                    WHP_CHECK_HR(WHvCancelRunVirtualProcessor(this->partition_, vp_index, 0));
+                    WHP_CHECK_HR(WHvCancelRunVirtualProcessor(this->partition_, this->vp_index_, 0));
                 }
             }
 
@@ -1037,314 +916,6 @@ namespace sogen::whp
             {
                 const auto mapping = map_register(base);
                 return this->get_register(mapping.name).Segment.Base;
-            }
-
-            void map_mmio(const uint64_t address, const size_t size, mmio_read_callback read_cb, mmio_write_callback write_cb) override
-            {
-                if (!is_page_aligned(address) || !is_page_aligned(size))
-                {
-                    throw std::runtime_error("WHP MMIO mappings must be page aligned");
-                }
-
-                mmio_region region{
-                    .address = address,
-                    .size = size,
-                    .read_cb = std::move(read_cb),
-                    .write_cb = std::move(write_cb),
-                };
-
-                bool can_batch_map = true;
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    const auto entry = this->mapped_pages_.find(guest_address);
-                    if (entry != this->mapped_pages_.end() && entry->second && entry->second->host_page != nullptr)
-                    {
-                        can_batch_map = false;
-                        break;
-                    }
-                }
-
-                if (can_batch_map)
-                {
-                    auto backing = allocate_backing_memory(size);
-                    auto* backing_base = backing.get();
-
-                    for (size_t offset = 0; offset < size; offset += page_size)
-                    {
-                        const auto guest_address = address + offset;
-                        auto& page = this->mapped_pages_[guest_address];
-                        if (!page)
-                        {
-                            page = std::make_unique<mapped_page>();
-                        }
-
-                        page->owned_page = backing;
-                        page->host_page = backing_base + offset;
-                        this->assign_guest_physical_page(guest_address, *page);
-                        page->permissions = memory_permission::none;
-                        this->apply_patched_execution_breakpoints(guest_address);
-                        this->ensure_virtual_mapping(guest_address);
-                    }
-
-                    this->remap_pages(address, size);
-                    this->mmio_regions_[address] = std::move(region);
-                    return;
-                }
-
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    auto& page = this->mapped_pages_[guest_address];
-                    if (!page)
-                    {
-                        page = std::make_unique<mapped_page>();
-                    }
-
-                    if (page->host_page == nullptr)
-                    {
-                        auto backing = allocate_backing_memory(page_size);
-                        page->owned_page = std::move(backing);
-                        page->host_page = page->owned_page.get();
-                        this->assign_guest_physical_page(guest_address, *page);
-                        this->apply_patched_execution_breakpoints(guest_address);
-                    }
-
-                    page->permissions = memory_permission::none;
-                    this->remap_page(*page);
-                    this->ensure_virtual_mapping(guest_address);
-                }
-
-                this->mmio_regions_[address] = std::move(region);
-            }
-
-            void map_memory(const uint64_t address, const size_t size, const memory_permission permissions) override
-            {
-                if (!is_page_aligned(address) || !is_page_aligned(size))
-                {
-                    throw std::runtime_error("WHP memory mappings must be page aligned");
-                }
-
-                bool can_batch_map = true;
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    const auto entry = this->mapped_pages_.find(guest_address);
-                    if (entry != this->mapped_pages_.end() && entry->second && entry->second->host_page != nullptr)
-                    {
-                        can_batch_map = false;
-                        break;
-                    }
-                }
-
-                if (can_batch_map)
-                {
-                    auto backing = allocate_backing_memory(size);
-                    auto* backing_base = backing.get();
-
-                    for (size_t offset = 0; offset < size; offset += page_size)
-                    {
-                        const auto guest_address = address + offset;
-                        auto& page = this->mapped_pages_[guest_address];
-                        if (!page)
-                        {
-                            page = std::make_unique<mapped_page>();
-                        }
-
-                        page->owned_page = backing;
-                        page->host_page = backing_base + offset;
-                        this->assign_guest_physical_page(guest_address, *page);
-                        page->permissions = permissions;
-                        this->apply_patched_execution_breakpoints(guest_address);
-                        this->ensure_virtual_mapping(guest_address);
-                    }
-
-                    this->remap_pages(address, size);
-                    return;
-                }
-
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    auto& page = this->mapped_pages_[guest_address];
-                    if (!page)
-                    {
-                        page = std::make_unique<mapped_page>();
-                    }
-
-                    if (page->host_page == nullptr)
-                    {
-                        auto backing = allocate_backing_memory(page_size);
-                        page->owned_page = std::move(backing);
-                        page->host_page = page->owned_page.get();
-                        this->assign_guest_physical_page(guest_address, *page);
-                        this->apply_patched_execution_breakpoints(guest_address);
-                    }
-
-                    page->permissions = permissions;
-                    this->remap_page(*page);
-                    this->ensure_virtual_mapping(guest_address);
-                }
-            }
-
-            void map_host_memory(const uint64_t address, const size_t size, void* host_pointer,
-                                 const memory_permission permissions) override
-            {
-                if (!is_page_aligned(address) || !is_page_aligned(size))
-                {
-                    throw std::runtime_error("WHP host memory mappings must be page aligned");
-                }
-                if ((reinterpret_cast<uintptr_t>(host_pointer) % page_size) != 0)
-                {
-                    throw std::runtime_error("WHP host memory mappings require a page-aligned host pointer");
-                }
-
-                // Back each guest page with the caller's host memory (owned_page stays null so unmap never
-                // frees it). WHvMapGpaRange then aliases the guest physical page directly onto that host page,
-                // so guest reads and writes hit it coherently.
-                auto* host_base = static_cast<uint8_t*>(host_pointer);
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    auto& page = this->mapped_pages_[guest_address];
-                    if (!page)
-                    {
-                        page = std::make_unique<mapped_page>();
-                    }
-
-                    page->owned_page = nullptr;
-                    page->host_page = host_base + offset;
-                    this->assign_guest_physical_page(guest_address, *page);
-                    page->permissions = permissions;
-                    this->apply_patched_execution_breakpoints(guest_address);
-                    this->ensure_virtual_mapping(guest_address);
-                }
-
-                this->remap_pages(address, size);
-            }
-
-            void unmap_memory(const uint64_t address, const size_t size) override
-            {
-                if (!is_page_aligned(address) || !is_page_aligned(size))
-                {
-                    throw std::runtime_error("WHP memory unmappings must be page aligned");
-                }
-
-                // Coalesce into one WHvUnmapGpaRange per contiguous guest-physical run: each call is an EPT flush,
-                // so freeing a large region page-by-page stalls the guest for seconds. The LIFO GPA free list
-                // scatters/reverses a region's GPAs, hence the sort. Free high-to-low so the indices pop back
-                // ascending on the next allocation, keeping remap_pages' map-side coalescing effective too.
-                std::vector<uint64_t> unmap_gpas;
-                // Keep each page's host backing alive until after the unmaps below: erasing the mapped_page drops
-                // its (shared) owned_page, which can free memory the WHP partition still maps by GPA.
-                std::vector<std::shared_ptr<uint8_t>> retired_backings;
-                bool flushed_virtual_mappings = false;
-                for (size_t offset = size; offset > 0; offset -= page_size)
-                {
-                    const auto guest_address = address + offset - page_size;
-                    this->revoke_mmio_read_grace(guest_address);
-
-                    const auto entry = this->mapped_pages_.find(guest_address);
-                    if (entry == this->mapped_pages_.end())
-                    {
-                        continue;
-                    }
-
-                    if (entry->second->map_flags != 0)
-                    {
-                        unmap_gpas.push_back(entry->second->guest_physical_address);
-                    }
-
-                    flushed_virtual_mappings = this->clear_virtual_mapping(guest_address) || flushed_virtual_mappings;
-                    this->mark_patched_execution_breakpoints_unmapped(guest_address);
-                    this->release_guest_physical_page(entry->second->guest_physical_address);
-                    retired_backings.push_back(std::move(entry->second->owned_page));
-                    this->mapped_pages_.erase(entry);
-                }
-
-                std::ranges::sort(unmap_gpas);
-                for (size_t i = 0; i < unmap_gpas.size();)
-                {
-                    size_t j = i;
-                    while (j + 1 < unmap_gpas.size() && unmap_gpas[j + 1] == unmap_gpas[j] + page_size)
-                    {
-                        ++j;
-                    }
-
-                    WHP_CHECK_HR(WHvUnmapGpaRange(this->partition_, unmap_gpas[i], (j - i + 1) * page_size));
-                    i = j + 1;
-                }
-
-                if (flushed_virtual_mappings)
-                {
-                    this->flush_virtual_address_mappings();
-                }
-
-                const auto mmio = this->mmio_regions_.find(address);
-                if (mmio != this->mmio_regions_.end() && mmio->second.size == size)
-                {
-                    this->mmio_regions_.erase(mmio);
-                }
-            }
-
-            bool try_read_memory(const uint64_t address, void* data, const size_t size) const override
-            {
-                if (!this->access_memory(address, data, size, false))
-                {
-                    return false;
-                }
-
-                this->overlay_patched_breakpoints(address, data, size);
-                return true;
-            }
-
-            void read_memory(const uint64_t address, void* data, const size_t size) const override
-            {
-                if (!this->try_read_memory(address, data, size))
-                {
-                    throw std::runtime_error("Failed to read WHP guest memory");
-                }
-            }
-
-            bool try_write_memory(const uint64_t address, const void* data, const size_t size) override
-            {
-                if (!this->access_memory(address, const_cast<void*>(data), size, true))
-                {
-                    return false;
-                }
-
-                this->overlay_patched_breakpoints(address, data, size);
-                return true;
-            }
-
-            void write_memory(const uint64_t address, const void* data, const size_t size) override
-            {
-                if (!this->try_write_memory(address, data, size))
-                {
-                    throw std::runtime_error("Failed to write WHP guest memory");
-                }
-            }
-
-            void apply_memory_protection(const uint64_t address, const size_t size, const memory_permission permissions) override
-            {
-                if (!is_page_aligned(address) || !is_page_aligned(size))
-                {
-                    throw std::runtime_error("WHP protection changes must be page aligned");
-                }
-
-                for (size_t offset = 0; offset < size; offset += page_size)
-                {
-                    const auto guest_address = address + offset;
-                    const auto entry = this->mapped_pages_.find(guest_address);
-                    if (entry == this->mapped_pages_.end())
-                    {
-                        continue;
-                    }
-
-                    entry->second->permissions = permissions;
-                }
-
-                this->remap_pages(address, size);
             }
 
             size_t write_raw_register(const int reg, const void* value, const size_t size) override
@@ -1557,8 +1128,543 @@ namespace sogen::whp
                 return true;
             }
 
+            std::vector<std::byte> save_registers() const override
+            {
+                auto names = snapshot_register_names();
+                std::vector<WHV_REGISTER_VALUE> values(names.size());
+                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, this->vp_index_, names.data(),
+                                                             static_cast<UINT32>(names.size()), values.data()));
+
+                std::vector<std::byte> bytes(sizeof(WHV_REGISTER_VALUE) * values.size());
+                std::memcpy(bytes.data(), values.data(), bytes.size());
+                return bytes;
+            }
+
+            void restore_registers(const std::vector<std::byte>& register_data) override
+            {
+                auto names = snapshot_register_names();
+                const auto expected_size = sizeof(WHV_REGISTER_VALUE) * names.size();
+                if (register_data.size() != expected_size)
+                {
+                    throw std::runtime_error("Unexpected WHP register snapshot size");
+                }
+
+                std::vector<WHV_REGISTER_VALUE> values(names.size());
+                std::memcpy(values.data(), register_data.data(), register_data.size());
+
+                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, this->vp_index_, names.data(),
+                                                             static_cast<UINT32>(names.size()), values.data()));
+            }
+
+            bool has_violation() const override
+            {
+                return false;
+            }
+
+            bool supports_instruction_counting() const override
+            {
+                return false;
+            }
+
+            bool is_stop_thread_safe() const override
+            {
+                return true;
+            }
+
+            WHV_REGISTER_VALUE get_register(const WHV_REGISTER_NAME name) const
+            {
+                WHV_REGISTER_VALUE value{};
+                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, this->vp_index_, &name, 1, &value));
+                return value;
+            }
+
+            template <size_t N>
+            std::array<WHV_REGISTER_VALUE, N> get_registers(const std::array<WHV_REGISTER_NAME, N>& names) const
+            {
+                std::array<WHV_REGISTER_VALUE, N> values{};
+                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, this->vp_index_, names.data(),
+                                                             static_cast<UINT32>(names.size()), values.data()));
+                return values;
+            }
+
+            void set_register(const WHV_REGISTER_NAME name, const WHV_REGISTER_VALUE& value)
+            {
+                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, this->vp_index_, &name, 1, &value));
+            }
+
+            template <size_t N>
+            void set_registers(const std::array<WHV_REGISTER_NAME, N>& names, const std::array<WHV_REGISTER_VALUE, N>& values)
+            {
+                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, this->vp_index_, names.data(),
+                                                             static_cast<UINT32>(names.size()), values.data()));
+            }
+
+            void advance_rip(const uint64_t amount)
+            {
+                auto rip = this->get_register(WHvX64RegisterRip);
+                rip.Reg64 += amount;
+                this->set_register(WHvX64RegisterRip, rip);
+            }
+
+            void clear_pending_exception_state()
+            {
+                WHV_REGISTER_VALUE pending_interruption{};
+                pending_interruption.PendingInterruption.AsUINT64 = 0;
+                this->set_register(WHvRegisterPendingInterruption, pending_interruption);
+
+                WHV_REGISTER_VALUE pending_event{};
+                pending_event.ExceptionEvent.AsUINT128 = {};
+                this->set_register(WHvRegisterPendingEvent, pending_event);
+
+                WHV_REGISTER_VALUE pending_debug{};
+                pending_debug.PendingDebugException.AsUINT64 = 0;
+                this->set_register(WHvX64RegisterPendingDebugException, pending_debug);
+            }
+
+          private:
+            friend class whp_x86_64_emulator;
+
+            whp_x86_64_emulator& emulator_;
+            WHV_PARTITION_HANDLE partition_{};
+            UINT32 vp_index_{};
+            virtual_processor_handle vp_;
+
+            std::atomic_bool stop_requested_{false};
+            std::atomic_bool run_active_{false};
+            std::optional<pending_execution_step> pending_execution_step_{};
+            std::optional<pending_mmio_step> pending_mmio_step_{};
+            std::optional<uint64_t> deferred_patched_breakpoint_{};
+            std::optional<uint64_t> deferred_execution_page_{};
+        };
+
+        class whp_x86_64_emulator : public x86_64_emulator
+        {
+          public:
+            explicit whp_x86_64_emulator(const size_t vcpu_count)
+            {
+                this->ensure_platform_support();
+                this->configure_partition(static_cast<UINT32>(vcpu_count));
+                this->initialize_long_mode_page_tables();
+                this->initialize_syscall_intercept_page();
+
+                this->vcpus_.reserve(vcpu_count);
+                for (size_t i = 0; i < vcpu_count; ++i)
+                {
+                    auto vcpu = std::make_unique<whp_vcpu>(*this, this->partition_, static_cast<UINT32>(i));
+                    this->initialize_virtual_processor_state(*vcpu);
+                    this->vcpus_.push_back(std::move(vcpu));
+                }
+            }
+
+            ~whp_x86_64_emulator() override
+            {
+                utils::reset_object_with_delayed_destruction(this->memory_write_hooks_);
+                utils::reset_object_with_delayed_destruction(this->memory_read_hooks_);
+                utils::reset_object_with_delayed_destruction(this->memory_execution_hooks_);
+                utils::reset_object_with_delayed_destruction(this->memory_violation_hooks_);
+                utils::reset_object_with_delayed_destruction(this->interrupt_hooks_);
+                utils::reset_object_with_delayed_destruction(this->basic_block_hooks_);
+                utils::reset_object_with_delayed_destruction(this->instruction_hooks_);
+            }
+
+            void set_memory_execution_hook_mode(const memory_execution_hook_mode mode) override
+            {
+                std::unique_lock lock(this->partition_mutex_);
+                this->memory_execution_hook_mode_ = mode;
+            }
+
+            size_t vcpu_count() const override
+            {
+                return this->vcpus_.size();
+            }
+
+            x86_64_cpu& get_cpu(const size_t index) override
+            {
+                if (index >= this->vcpus_.size())
+                {
+                    throw std::out_of_range("Invalid vCPU index");
+                }
+
+                return *this->vcpus_[index];
+            }
+
+            void start(const size_t count) override
+            {
+                this->vcpus_[0]->start(count);
+            }
+
+            void stop() override
+            {
+                this->vcpus_[0]->stop();
+            }
+
+            size_t write_raw_register(const int reg, const void* value, const size_t size) override
+            {
+                return this->vcpus_[0]->write_raw_register(reg, value, size);
+            }
+
+            size_t read_raw_register(const int reg, void* value, const size_t size) override
+            {
+                return this->vcpus_[0]->read_raw_register(reg, value, size);
+            }
+
+            bool read_descriptor_table(const int reg, descriptor_table_register& table) override
+            {
+                return this->vcpus_[0]->read_descriptor_table(reg, table);
+            }
+
+            std::vector<std::byte> save_registers() const override
+            {
+                return this->vcpus_[0]->save_registers();
+            }
+
+            void restore_registers(const std::vector<std::byte>& register_data) override
+            {
+                this->vcpus_[0]->restore_registers(register_data);
+            }
+
+            void load_gdt(const pointer_type address, const uint32_t limit) override
+            {
+                this->vcpus_[0]->load_gdt(address, limit);
+            }
+
+            void set_segment_base(const x86_register base, const pointer_type value) override
+            {
+                this->vcpus_[0]->set_segment_base(base, value);
+            }
+
+            pointer_type get_segment_base(const x86_register base) override
+            {
+                return this->vcpus_[0]->get_segment_base(base);
+            }
+
+            void map_mmio(const uint64_t address, const size_t size, mmio_read_callback read_cb, mmio_write_callback write_cb) override
+            {
+                if (!is_page_aligned(address) || !is_page_aligned(size))
+                {
+                    throw std::runtime_error("WHP MMIO mappings must be page aligned");
+                }
+
+                std::unique_lock lock(this->partition_mutex_);
+
+                mmio_region region{
+                    .address = address,
+                    .size = size,
+                    .read_cb = std::move(read_cb),
+                    .write_cb = std::move(write_cb),
+                };
+
+                bool can_batch_map = true;
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    const auto entry = this->mapped_pages_.find(guest_address);
+                    if (entry != this->mapped_pages_.end() && entry->second && entry->second->host_page != nullptr)
+                    {
+                        can_batch_map = false;
+                        break;
+                    }
+                }
+
+                if (can_batch_map)
+                {
+                    auto backing = allocate_backing_memory(size);
+                    auto* backing_base = backing.get();
+
+                    for (size_t offset = 0; offset < size; offset += page_size)
+                    {
+                        const auto guest_address = address + offset;
+                        auto& page = this->mapped_pages_[guest_address];
+                        if (!page)
+                        {
+                            page = std::make_unique<mapped_page>();
+                        }
+
+                        page->owned_page = backing;
+                        page->host_page = backing_base + offset;
+                        this->assign_guest_physical_page(guest_address, *page);
+                        page->permissions = memory_permission::none;
+                        this->apply_patched_execution_breakpoints(guest_address);
+                        this->ensure_virtual_mapping(guest_address);
+                    }
+
+                    this->remap_pages(address, size);
+                    this->mmio_regions_[address] = std::move(region);
+                    return;
+                }
+
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    auto& page = this->mapped_pages_[guest_address];
+                    if (!page)
+                    {
+                        page = std::make_unique<mapped_page>();
+                    }
+
+                    if (page->host_page == nullptr)
+                    {
+                        auto backing = allocate_backing_memory(page_size);
+                        page->owned_page = std::move(backing);
+                        page->host_page = page->owned_page.get();
+                        this->assign_guest_physical_page(guest_address, *page);
+                        this->apply_patched_execution_breakpoints(guest_address);
+                    }
+
+                    page->permissions = memory_permission::none;
+                    this->remap_page(*page);
+                    this->ensure_virtual_mapping(guest_address);
+                }
+
+                this->mmio_regions_[address] = std::move(region);
+            }
+
+            void map_memory(const uint64_t address, const size_t size, const memory_permission permissions) override
+            {
+                if (!is_page_aligned(address) || !is_page_aligned(size))
+                {
+                    throw std::runtime_error("WHP memory mappings must be page aligned");
+                }
+
+                std::unique_lock lock(this->partition_mutex_);
+
+                bool can_batch_map = true;
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    const auto entry = this->mapped_pages_.find(guest_address);
+                    if (entry != this->mapped_pages_.end() && entry->second && entry->second->host_page != nullptr)
+                    {
+                        can_batch_map = false;
+                        break;
+                    }
+                }
+
+                if (can_batch_map)
+                {
+                    auto backing = allocate_backing_memory(size);
+                    auto* backing_base = backing.get();
+
+                    for (size_t offset = 0; offset < size; offset += page_size)
+                    {
+                        const auto guest_address = address + offset;
+                        auto& page = this->mapped_pages_[guest_address];
+                        if (!page)
+                        {
+                            page = std::make_unique<mapped_page>();
+                        }
+
+                        page->owned_page = backing;
+                        page->host_page = backing_base + offset;
+                        this->assign_guest_physical_page(guest_address, *page);
+                        page->permissions = permissions;
+                        this->apply_patched_execution_breakpoints(guest_address);
+                        this->ensure_virtual_mapping(guest_address);
+                    }
+
+                    this->remap_pages(address, size);
+                    return;
+                }
+
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    auto& page = this->mapped_pages_[guest_address];
+                    if (!page)
+                    {
+                        page = std::make_unique<mapped_page>();
+                    }
+
+                    if (page->host_page == nullptr)
+                    {
+                        auto backing = allocate_backing_memory(page_size);
+                        page->owned_page = std::move(backing);
+                        page->host_page = page->owned_page.get();
+                        this->assign_guest_physical_page(guest_address, *page);
+                        this->apply_patched_execution_breakpoints(guest_address);
+                    }
+
+                    page->permissions = permissions;
+                    this->remap_page(*page);
+                    this->ensure_virtual_mapping(guest_address);
+                }
+            }
+
+            void map_host_memory(const uint64_t address, const size_t size, void* host_pointer,
+                                 const memory_permission permissions) override
+            {
+                if (!is_page_aligned(address) || !is_page_aligned(size))
+                {
+                    throw std::runtime_error("WHP host memory mappings must be page aligned");
+                }
+                if ((reinterpret_cast<uintptr_t>(host_pointer) % page_size) != 0)
+                {
+                    throw std::runtime_error("WHP host memory mappings require a page-aligned host pointer");
+                }
+
+                std::unique_lock lock(this->partition_mutex_);
+
+                // Back each guest page with the caller's host memory (owned_page stays null so unmap never
+                // frees it). WHvMapGpaRange then aliases the guest physical page directly onto that host page,
+                // so guest reads and writes hit it coherently.
+                auto* host_base = static_cast<uint8_t*>(host_pointer);
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    auto& page = this->mapped_pages_[guest_address];
+                    if (!page)
+                    {
+                        page = std::make_unique<mapped_page>();
+                    }
+
+                    page->owned_page = nullptr;
+                    page->host_page = host_base + offset;
+                    this->assign_guest_physical_page(guest_address, *page);
+                    page->permissions = permissions;
+                    this->apply_patched_execution_breakpoints(guest_address);
+                    this->ensure_virtual_mapping(guest_address);
+                }
+
+                this->remap_pages(address, size);
+            }
+
+            void unmap_memory(const uint64_t address, const size_t size) override
+            {
+                if (!is_page_aligned(address) || !is_page_aligned(size))
+                {
+                    throw std::runtime_error("WHP memory unmappings must be page aligned");
+                }
+
+                std::unique_lock lock(this->partition_mutex_);
+
+                // Coalesce into one WHvUnmapGpaRange per contiguous guest-physical run: each call is an EPT flush,
+                // so freeing a large region page-by-page stalls the guest for seconds. The LIFO GPA free list
+                // scatters/reverses a region's GPAs, hence the sort. Free high-to-low so the indices pop back
+                // ascending on the next allocation, keeping remap_pages' map-side coalescing effective too.
+                std::vector<uint64_t> unmap_gpas;
+                // Keep each page's host backing alive until after the unmaps below: erasing the mapped_page drops
+                // its (shared) owned_page, which can free memory the WHP partition still maps by GPA.
+                std::vector<std::shared_ptr<uint8_t>> retired_backings;
+                bool flushed_virtual_mappings = false;
+                for (size_t offset = size; offset > 0; offset -= page_size)
+                {
+                    const auto guest_address = address + offset - page_size;
+                    this->revoke_mmio_read_grace(guest_address);
+
+                    const auto entry = this->mapped_pages_.find(guest_address);
+                    if (entry == this->mapped_pages_.end())
+                    {
+                        continue;
+                    }
+
+                    if (entry->second->map_flags != 0)
+                    {
+                        unmap_gpas.push_back(entry->second->guest_physical_address);
+                    }
+
+                    flushed_virtual_mappings = this->clear_virtual_mapping(guest_address) || flushed_virtual_mappings;
+                    this->mark_patched_execution_breakpoints_unmapped(guest_address);
+                    this->release_guest_physical_page(entry->second->guest_physical_address);
+                    retired_backings.push_back(std::move(entry->second->owned_page));
+                    this->mapped_pages_.erase(entry);
+                }
+
+                std::ranges::sort(unmap_gpas);
+                for (size_t i = 0; i < unmap_gpas.size();)
+                {
+                    size_t j = i;
+                    while (j + 1 < unmap_gpas.size() && unmap_gpas[j + 1] == unmap_gpas[j] + page_size)
+                    {
+                        ++j;
+                    }
+
+                    WHP_CHECK_HR(WHvUnmapGpaRange(this->partition_, unmap_gpas[i], (j - i + 1) * page_size));
+                    i = j + 1;
+                }
+
+                if (flushed_virtual_mappings)
+                {
+                    this->flush_virtual_address_mappings();
+                }
+
+                const auto mmio = this->mmio_regions_.find(address);
+                if (mmio != this->mmio_regions_.end() && mmio->second.size == size)
+                {
+                    this->mmio_regions_.erase(mmio);
+                }
+            }
+
+            bool try_read_memory(const uint64_t address, void* data, const size_t size) const override
+            {
+                std::shared_lock lock(this->partition_mutex_);
+
+                if (!this->access_memory(address, data, size, false))
+                {
+                    return false;
+                }
+
+                this->overlay_patched_breakpoints(address, data, size);
+                return true;
+            }
+
+            void read_memory(const uint64_t address, void* data, const size_t size) const override
+            {
+                if (!this->try_read_memory(address, data, size))
+                {
+                    throw std::runtime_error("Failed to read WHP guest memory");
+                }
+            }
+
+            bool try_write_memory(const uint64_t address, const void* data, const size_t size) override
+            {
+                // Exclusive: the breakpoint overlay below may update patched-breakpoint bookkeeping.
+                std::unique_lock lock(this->partition_mutex_);
+
+                if (!this->access_memory(address, const_cast<void*>(data), size, true))
+                {
+                    return false;
+                }
+
+                this->overlay_patched_breakpoints(address, data, size);
+                return true;
+            }
+
+            void write_memory(const uint64_t address, const void* data, const size_t size) override
+            {
+                if (!this->try_write_memory(address, data, size))
+                {
+                    throw std::runtime_error("Failed to write WHP guest memory");
+                }
+            }
+
+            void apply_memory_protection(const uint64_t address, const size_t size, const memory_permission permissions) override
+            {
+                if (!is_page_aligned(address) || !is_page_aligned(size))
+                {
+                    throw std::runtime_error("WHP protection changes must be page aligned");
+                }
+
+                std::unique_lock lock(this->partition_mutex_);
+
+                for (size_t offset = 0; offset < size; offset += page_size)
+                {
+                    const auto guest_address = address + offset;
+                    const auto entry = this->mapped_pages_.find(guest_address);
+                    if (entry == this->mapped_pages_.end())
+                    {
+                        continue;
+                    }
+
+                    entry->second->permissions = permissions;
+                }
+
+                this->remap_pages(address, size);
+            }
+
             emulator_hook* hook_instruction(const int instruction_type, instruction_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 auto& entry = this->instruction_hooks_[hook];
                 entry.type = static_cast<x86_hookable_instructions>(instruction_type);
@@ -1574,6 +1680,8 @@ namespace sogen::whp
 
             emulator_hook* hook_basic_block(basic_block_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->basic_block_hooks_[hook] = std::move(callback);
                 return hook;
@@ -1581,6 +1689,8 @@ namespace sogen::whp
 
             emulator_hook* hook_interrupt(interrupt_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->interrupt_hooks_[hook] = std::move(callback);
                 return hook;
@@ -1588,6 +1698,8 @@ namespace sogen::whp
 
             emulator_hook* hook_memory_violation(memory_violation_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->memory_violation_hooks_[hook] = std::move(callback);
                 return hook;
@@ -1596,6 +1708,8 @@ namespace sogen::whp
             emulator_hook* hook_memory_execution(memory_execution_hook_callback callback) override
             {
                 // NOTE: Global memory execution hooks are registered but not currently honored.
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->memory_execution_hooks_[hook] = execution_hook_entry{.address = std::nullopt, .callback = std::move(callback)};
                 return hook;
@@ -1609,6 +1723,8 @@ namespace sogen::whp
                     return this->hook_memory_execution(address, std::move(callback));
                 }
 
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->memory_execution_hooks_[hook] =
                     execution_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
@@ -1619,6 +1735,8 @@ namespace sogen::whp
 
             emulator_hook* hook_memory_execution(const uint64_t address, memory_execution_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
 
                 switch (this->memory_execution_hook_mode_)
@@ -1646,6 +1764,8 @@ namespace sogen::whp
 
             emulator_hook* hook_memory_read(const uint64_t address, const uint64_t size, memory_access_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->memory_read_hooks_[hook] =
                     memory_access_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
@@ -1654,6 +1774,8 @@ namespace sogen::whp
 
             emulator_hook* hook_memory_write(const uint64_t address, const uint64_t size, memory_access_hook_callback callback) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 auto* hook = this->make_hook();
                 this->memory_write_hooks_[hook] =
                     memory_access_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
@@ -1662,6 +1784,8 @@ namespace sogen::whp
 
             void delete_hook(emulator_hook* hook) override
             {
+                std::unique_lock lock(this->partition_mutex_);
+
                 const auto instruction_it = this->instruction_hooks_.find(hook);
                 if (instruction_it != this->instruction_hooks_.end() && &instruction_it->second == this->syscall_hook_)
                 {
@@ -1685,45 +1809,27 @@ namespace sogen::whp
 
             void serialize_state(utils::buffer_serializer& buffer, const bool) const override
             {
-                buffer.write_vector(this->save_registers());
+                if (this->vcpus_.size() > 1)
+                {
+                    throw std::runtime_error("Multi-vCPU snapshots are not supported yet");
+                }
+
+                buffer.write_vector(this->vcpus_[0]->save_registers());
             }
 
             void deserialize_state(utils::buffer_deserializer& buffer, const bool) override
             {
-                this->restore_registers(buffer.read_vector<std::byte>());
-            }
-
-            std::vector<std::byte> save_registers() const override
-            {
-                auto names = snapshot_register_names();
-                std::vector<WHV_REGISTER_VALUE> values(names.size());
-                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, vp_index, names.data(), static_cast<UINT32>(names.size()),
-                                                             values.data()));
-
-                std::vector<std::byte> bytes(sizeof(WHV_REGISTER_VALUE) * values.size());
-                std::memcpy(bytes.data(), values.data(), bytes.size());
-                return bytes;
-            }
-
-            void restore_registers(const std::vector<std::byte>& register_data) override
-            {
-                auto names = snapshot_register_names();
-                const auto expected_size = sizeof(WHV_REGISTER_VALUE) * names.size();
-                if (register_data.size() != expected_size)
+                if (this->vcpus_.size() > 1)
                 {
-                    throw std::runtime_error("Unexpected WHP register snapshot size");
+                    throw std::runtime_error("Multi-vCPU snapshots are not supported yet");
                 }
 
-                std::vector<WHV_REGISTER_VALUE> values(names.size());
-                std::memcpy(values.data(), register_data.data(), register_data.size());
-
-                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, vp_index, names.data(), static_cast<UINT32>(names.size()),
-                                                             values.data()));
+                this->vcpus_[0]->restore_registers(buffer.read_vector<std::byte>());
             }
 
             bool has_violation() const override
             {
-                return false;
+                return this->vcpus_[0]->has_violation();
             }
 
             std::string get_name() const override
@@ -1743,10 +1849,7 @@ namespace sogen::whp
 
             bool supports_multiple_vcpus() const override
             {
-                // WHP can drive multiple virtual processors per partition, but the
-                // backend still hardcodes VP index 0 everywhere. Flip this once the
-                // multi-vCPU backend work (docs/multi-vcpu-design.md, Phase 1) lands.
-                return false;
+                return true;
             }
 
             bool supports_global_memory_execution_hooks() const override
@@ -1755,6 +1858,8 @@ namespace sogen::whp
             }
 
           private:
+            friend class whp_vcpu;
+
             struct instruction_hook_entry
             {
                 x86_hookable_instructions type = x86_hookable_instructions::invalid;
@@ -1784,22 +1889,10 @@ namespace sogen::whp
                 mmio_write_callback write_cb{};
             };
 
-            struct pending_mmio_step
+            struct mmio_write_chunk
             {
-                uint64_t page_base{};
-                uint64_t original_rflags{};
-                bool had_trap_flag{};
-                bool allow_debug_delivery{};
-                bool is_write{};
-                std::vector<std::byte> old_page{};
-            };
-
-            struct pending_execution_step
-            {
-                std::optional<uint64_t> page_base{};
-                std::optional<uint64_t> patched_breakpoint{};
-                bool had_trap_flag{};
-                bool stop_after_step{};
+                size_t offset{};
+                std::vector<std::byte> data{};
             };
 
             struct patched_execution_breakpoint
@@ -1810,10 +1903,17 @@ namespace sogen::whp
             };
 
             partition_handle partition_{};
-            std::unique_ptr<virtual_processor_handle> vp_{};
             WHV_EXTENDED_VM_EXITS supported_exits_{};
             WHV_PROCESSOR_XSAVE_FEATURES supported_xsave_features_{};
             bool has_supported_xsave_features_ = false;
+
+            // Guards all partition-shared state below (page/GPA tables, MMIO regions, hook containers).
+            // Discipline: acquired only at public entry points and at the top-level exit handlers of the
+            // run loop; interior helpers assume it is already held. Non-recursive — never re-acquired.
+            // Never held while invoking a user callback or across WHvRunVirtualProcessor. Construction
+            // runs single-threaded, before any vCPU can execute, and takes no lock.
+            mutable std::shared_mutex partition_mutex_{};
+
             std::unordered_map<uint64_t, std::unique_ptr<mapped_page>> mapped_pages_{};
             std::vector<uint64_t> guest_pages_by_gpa_{};
             // Ordered free list of guest-physical page indices. Allocating the *lowest* free index (rather
@@ -1825,9 +1925,6 @@ namespace sogen::whp
             std::unordered_map<uint64_t, uint64_t*> page_table_views_{};
             uint64_t pml4_gpa_ = 0;
             uint64_t next_internal_gpa_ = internal_page_table_base;
-            std::atomic_bool stop_requested_ = false;
-            std::atomic_bool run_active_ = false;
-            std::optional<pending_execution_step> pending_execution_step_{};
             uint64_t syscall_hook_page_ = 0;
             size_t next_hook_id_ = 1;
 
@@ -1839,13 +1936,15 @@ namespace sogen::whp
             std::unordered_map<emulator_hook*, memory_access_hook_entry> memory_read_hooks_{};
             std::unordered_map<emulator_hook*, memory_access_hook_entry> memory_write_hooks_{};
             std::unordered_map<uint64_t, patched_execution_breakpoint> patched_execution_breakpoints_{};
-            std::optional<uint64_t> deferred_patched_breakpoint_{};
-            std::optional<uint64_t> deferred_execution_page_{};
             std::unordered_map<uint64_t, mmio_region> mmio_regions_{};
-            std::optional<pending_mmio_step> pending_mmio_step_{};
             std::unordered_map<uint64_t, std::chrono::steady_clock::time_point> mmio_read_grace_deadlines_{};
+            // Installed once during setup, before any vCPU runs, and read-only afterwards; the syscall
+            // dispatch hot path deliberately reads it without taking partition_mutex_.
             instruction_hook_entry* syscall_hook_ = nullptr;
             memory_execution_hook_mode memory_execution_hook_mode_ = memory_execution_hook_mode::automatic;
+
+            std::vector<std::unique_ptr<whp_vcpu>> vcpus_{};
+
             void ensure_platform_support()
             {
                 BOOL hypervisor_present = FALSE;
@@ -1869,9 +1968,8 @@ namespace sogen::whp
                                                       this->supported_xsave_features_.XsaveSupport;
             }
 
-            void configure_partition()
+            void configure_partition(const UINT32 processor_count)
             {
-                UINT32 processor_count = 1;
                 WHP_CHECK_HR(WHvSetPartitionProperty(this->partition_, WHvPartitionPropertyCodeProcessorCount, &processor_count,
                                                      sizeof(processor_count)));
 
@@ -1898,7 +1996,7 @@ namespace sogen::whp
                 WHP_CHECK_HR(WHvSetupPartition(this->partition_));
             }
 
-            void initialize_virtual_processor_state()
+            void initialize_virtual_processor_state(whp_vcpu& vcpu)
             {
                 std::vector<WHV_REGISTER_NAME> names = {
                     WHvX64RegisterCs,
@@ -1916,6 +2014,7 @@ namespace sogen::whp
                     WHvX64RegisterSfmask,
                     WHvX64RegisterFpControlStatus,
                     WHvX64RegisterXmmControlStatus,
+                    WHvX64RegisterLstar,
                 };
                 std::vector<WHV_REGISTER_VALUE> values(names.size());
                 values[0].Segment = make_segment(0x33, true);
@@ -1936,6 +2035,7 @@ namespace sogen::whp
                 values[13].FpControlStatus.FpTag = 0xFF;
                 values[14].XmmControlStatus.XmmStatusControl = 0x1F80u;
                 values[14].XmmControlStatus.XmmStatusControlMask = 0xFFFFFFFFu;
+                values[15].Reg64 = this->syscall_hook_page_;
 
                 if (this->has_supported_xsave_features_)
                 {
@@ -1949,8 +2049,8 @@ namespace sogen::whp
                     values.push_back(xcr0);
                 }
 
-                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, vp_index, names.data(), static_cast<UINT32>(names.size()),
-                                                             values.data()));
+                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, vcpu.vp_index_, names.data(),
+                                                             static_cast<UINT32>(names.size()), values.data()));
             }
 
             void initialize_syscall_intercept_page()
@@ -1958,13 +2058,10 @@ namespace sogen::whp
                 this->syscall_hook_page_ = this->allocate_internal_page(true);
                 auto* code = static_cast<uint8_t*>(this->mapped_pages_.at(this->syscall_hook_page_)->host_page);
                 code[0] = 0xF4;
-
-                WHV_REGISTER_VALUE lstar{};
-                lstar.Reg64 = this->syscall_hook_page_;
-                this->set_register(WHvX64RegisterLstar, lstar);
             }
 
-            bool handle_syscall_halt()
+            // Hot path: reads only registers and the setup-frozen syscall hook, so it takes no lock.
+            bool handle_syscall_halt(whp_vcpu& vcpu)
             {
                 if (!this->syscall_hook_)
                 {
@@ -1975,7 +2072,7 @@ namespace sogen::whp
                     WHvX64RegisterRip,    WHvX64RegisterRcx, WHvX64RegisterR10, WHvX64RegisterR11,
                     WHvX64RegisterRflags, WHvX64RegisterCs,  WHvX64RegisterSs,
                 };
-                auto entry_values = this->get_registers(entry_names);
+                auto entry_values = vcpu.get_registers(entry_names);
 
                 const auto post_syscall_rcx = entry_values[1].Reg64;
                 const auto post_syscall_r10 = entry_values[2].Reg64;
@@ -1995,12 +2092,12 @@ namespace sogen::whp
                 const std::array<WHV_REGISTER_VALUE, 5> pre_hook_values = {
                     entry_values[0], entry_values[1], entry_values[4], entry_values[5], entry_values[6],
                 };
-                this->set_registers(pre_hook_names, pre_hook_values);
+                vcpu.set_registers(pre_hook_names, pre_hook_values);
 
-                const auto continuation = this->syscall_hook_->callback(*this, 0);
+                const auto continuation = this->syscall_hook_->callback(vcpu, 0);
 
                 constexpr std::array<WHV_REGISTER_NAME, 1> post_hook_rip_name = {WHvX64RegisterRip};
-                auto post_hook_rip_value = this->get_registers(post_hook_rip_name);
+                auto post_hook_rip_value = vcpu.get_registers(post_hook_rip_name);
                 if (continuation != instruction_hook_continuation::finalized_instruction_pointer)
                 {
                     if (continuation == instruction_hook_continuation::skip_instruction && post_hook_rip_value[0].Reg64 == pre_syscall_rip)
@@ -2025,7 +2122,7 @@ namespace sogen::whp
                 };
                 post_hook_values[1].Segment = make_segment(0x33, true);
                 post_hook_values[2].Segment = make_segment(0x2B, false);
-                this->set_registers(post_hook_names, post_hook_values);
+                vcpu.set_registers(post_hook_names, post_hook_values);
 
                 return true;
             }
@@ -2035,6 +2132,7 @@ namespace sogen::whp
                 this->pml4_gpa_ = this->allocate_internal_page(false, false);
             }
 
+            // Assumes partition_mutex_ is held exclusively (or single-threaded construction).
             uint64_t allocate_internal_page(const bool executable = false, const bool map_into_guest = true)
             {
                 auto backing = allocate_backing_memory(page_size);
@@ -2061,6 +2159,7 @@ namespace sogen::whp
                 return page_gpa;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             uint64_t allocate_guest_physical_page()
             {
                 size_t page_index = 0;
@@ -2089,6 +2188,7 @@ namespace sogen::whp
                 return guest_physical_memory_base + (static_cast<uint64_t>(page_index) * page_size);
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void assign_guest_physical_page(const uint64_t guest_address, mapped_page& page)
             {
                 if (page.guest_physical_address != unmapped_guest_page)
@@ -2106,6 +2206,7 @@ namespace sogen::whp
                 this->guest_pages_by_gpa_[this->guest_physical_page_index(page.guest_physical_address)] = page.guest_page_base;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void release_guest_physical_page(const uint64_t guest_physical_address)
             {
                 if (guest_physical_address == unmapped_guest_page)
@@ -2128,6 +2229,7 @@ namespace sogen::whp
                 this->free_guest_gpa_indices_.insert(page_index);
             }
 
+            // Assumes partition_mutex_ is held (shared is sufficient).
             std::optional<uint64_t> translate_guest_physical_address(const uint64_t guest_physical_address) const
             {
                 if (guest_physical_address < guest_physical_memory_base)
@@ -2167,11 +2269,27 @@ namespace sogen::whp
                 return page_index;
             }
 
+            // Assumes partition_mutex_ is held. All pending-step mutation happens under the exclusive
+            // lock, so scanning the other vCPUs' step state here is safe.
+            bool is_page_being_stepped(const uint64_t page_base) const
+            {
+                for (const auto& vcpu : this->vcpus_)
+                {
+                    const auto& step = vcpu->pending_execution_step_;
+                    if (step && step->page_base == page_base)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            // Assumes partition_mutex_ is held.
             memory_permission effective_page_permissions(const mapped_page& page) const
             {
                 auto permissions = page.permissions;
-                const auto stepped_page = this->pending_execution_step_ ? this->pending_execution_step_->page_base : std::nullopt;
-                if (page.page_execution_hook_count != 0 && stepped_page != page.guest_page_base)
+                if (page.page_execution_hook_count != 0 && !this->is_page_being_stepped(page.guest_page_base))
                 {
                     permissions &= ~memory_permission::exec;
                 }
@@ -2179,6 +2297,7 @@ namespace sogen::whp
                 return permissions;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void remap_page(mapped_page& page)
             {
                 if (page.guest_physical_address == unmapped_guest_page)
@@ -2201,6 +2320,7 @@ namespace sogen::whp
                                             static_cast<WHV_MAP_GPA_RANGE_FLAGS>(page.map_flags)));
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void remap_pages(const uint64_t address, const size_t size)
             {
                 if (size == 0)
@@ -2272,6 +2392,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void remap_hook_page(const uint64_t address)
             {
                 const auto page_base = align_down_to_page(address);
@@ -2282,6 +2403,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void remap_hook_pages(const uint64_t address, const uint64_t size)
             {
                 if (size == 0)
@@ -2298,6 +2420,7 @@ namespace sogen::whp
                 this->remap_pages(start, static_cast<size_t>(end - start));
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void increment_execution_hook_count(const uint64_t address, const uint64_t size)
             {
                 if (size == 0)
@@ -2319,6 +2442,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void decrement_execution_hook_count(const uint64_t address, const uint64_t size)
             {
                 if (size == 0)
@@ -2343,6 +2467,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void deactivate_execution_hook(emulator_hook* hook)
             {
                 const auto execution_it = this->memory_execution_hooks_.find(hook);
@@ -2368,6 +2493,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void try_apply_patched_execution_breakpoint(const uint64_t address, patched_execution_breakpoint& breakpoint)
             {
                 const auto page_base = align_down_to_page(address);
@@ -2390,6 +2516,7 @@ namespace sogen::whp
                 breakpoint.applied = true;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void apply_patched_execution_breakpoints(const uint64_t page_base)
             {
                 for (auto& [address, breakpoint] : this->patched_execution_breakpoints_)
@@ -2401,6 +2528,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void mark_patched_execution_breakpoints_unmapped(const uint64_t page_base)
             {
                 for (auto& [address, breakpoint] : this->patched_execution_breakpoints_)
@@ -2413,6 +2541,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void install_patched_execution_breakpoint(const uint64_t address)
             {
                 auto existing = this->patched_execution_breakpoints_.find(address);
@@ -2431,6 +2560,7 @@ namespace sogen::whp
                 this->patched_execution_breakpoints_[address] = breakpoint;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void uninstall_patched_execution_breakpoint(const uint64_t address)
             {
                 auto existing = this->patched_execution_breakpoints_.find(address);
@@ -2454,6 +2584,7 @@ namespace sogen::whp
                 this->patched_execution_breakpoints_.erase(existing);
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void set_patched_execution_breakpoint_state(const uint64_t address, const bool applied)
             {
                 const auto existing = this->patched_execution_breakpoints_.find(address);
@@ -2484,28 +2615,29 @@ namespace sogen::whp
                 existing->second.applied = applied;
             }
 
-            bool arm_execution_single_step(const std::optional<uint64_t> page_base, const bool stop_after_step)
+            // Assumes partition_mutex_ is held exclusively.
+            bool arm_execution_single_step(whp_vcpu& vcpu, const std::optional<uint64_t> page_base, const bool stop_after_step)
             {
-                if (this->pending_execution_step_)
+                if (vcpu.pending_execution_step_)
                 {
-                    if (!page_base || this->pending_execution_step_->page_base)
+                    if (!page_base || vcpu.pending_execution_step_->page_base)
                     {
                         return false;
                     }
 
-                    this->pending_execution_step_->page_base = page_base;
+                    vcpu.pending_execution_step_->page_base = page_base;
                 }
                 else
                 {
-                    auto rflags = this->get_register(WHvX64RegisterRflags);
+                    auto rflags = vcpu.get_register(WHvX64RegisterRflags);
                     pending_execution_step state{};
                     state.page_base = page_base;
                     state.had_trap_flag = (rflags.Reg64 & trap_flag_bit) != 0;
                     state.stop_after_step = stop_after_step;
 
                     rflags.Reg64 |= trap_flag_bit;
-                    this->set_register(WHvX64RegisterRflags, rflags);
-                    this->pending_execution_step_ = state;
+                    vcpu.set_register(WHvX64RegisterRflags, rflags);
+                    vcpu.pending_execution_step_ = state;
                 }
 
                 if (page_base)
@@ -2520,28 +2652,30 @@ namespace sogen::whp
                 return true;
             }
 
-            bool arm_patched_breakpoint_single_step(const uint64_t address, const bool stop_after_step)
+            // Assumes partition_mutex_ is held exclusively.
+            bool arm_patched_breakpoint_single_step(whp_vcpu& vcpu, const uint64_t address, const bool stop_after_step)
             {
-                if (!this->arm_execution_single_step(std::nullopt, stop_after_step))
+                if (!this->arm_execution_single_step(vcpu, std::nullopt, stop_after_step))
                 {
                     return false;
                 }
 
-                this->pending_execution_step_->patched_breakpoint = address;
-                this->deferred_patched_breakpoint_.reset();
+                vcpu.pending_execution_step_->patched_breakpoint = address;
+                vcpu.deferred_patched_breakpoint_.reset();
                 return true;
             }
 
-            bool complete_execution_step()
+            // Assumes partition_mutex_ is held exclusively.
+            bool complete_execution_step(whp_vcpu& vcpu)
             {
-                if (!this->pending_execution_step_)
+                if (!vcpu.pending_execution_step_)
                 {
                     return false;
                 }
 
-                const auto state = std::exchange(this->pending_execution_step_, std::nullopt);
+                const auto state = std::exchange(vcpu.pending_execution_step_, std::nullopt);
 
-                auto rflags = this->get_register(WHvX64RegisterRflags);
+                auto rflags = vcpu.get_register(WHvX64RegisterRflags);
                 if (state->had_trap_flag)
                 {
                     rflags.Reg64 |= trap_flag_bit;
@@ -2550,7 +2684,7 @@ namespace sogen::whp
                 {
                     rflags.Reg64 &= ~trap_flag_bit;
                 }
-                this->set_register(WHvX64RegisterRflags, rflags);
+                vcpu.set_register(WHvX64RegisterRflags, rflags);
 
                 if (state->page_base)
                 {
@@ -2563,12 +2697,13 @@ namespace sogen::whp
 
                 if (state->stop_after_step)
                 {
-                    this->stop_requested_ = true;
+                    vcpu.stop_requested_ = true;
                 }
 
                 return !state->had_trap_flag;
             }
 
+            // Assumes partition_mutex_ is held.
             mmio_region* find_mmio_region(const uint64_t address)
             {
                 for (auto& [base, region] : this->mmio_regions_)
@@ -2582,6 +2717,7 @@ namespace sogen::whp
                 return nullptr;
             }
 
+            // Assumes partition_mutex_ is held.
             const mmio_region* find_mmio_region(const uint64_t address) const
             {
                 for (const auto& [base, region] : this->mmio_regions_)
@@ -2595,26 +2731,37 @@ namespace sogen::whp
                 return nullptr;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void grant_mmio_read_grace(const uint64_t page_base)
             {
                 constexpr std::chrono::milliseconds mmio_read_grace_period_{4};
                 this->mmio_read_grace_deadlines_[page_base] = std::chrono::steady_clock::now() + mmio_read_grace_period_;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void revoke_mmio_read_grace(const uint64_t page_base)
             {
                 this->mmio_read_grace_deadlines_.erase(page_base);
             }
 
-            void expire_mmio_read_grace_pages()
+            void expire_mmio_read_grace_pages(whp_vcpu& vcpu)
             {
-                if (this->pending_mmio_step_.has_value())
+                if (vcpu.pending_mmio_step_.has_value())
                 {
                     return;
                 }
 
+                {
+                    std::shared_lock lock(this->partition_mutex_);
+                    if (this->mmio_read_grace_deadlines_.empty())
+                    {
+                        return;
+                    }
+                }
+
                 const auto now = std::chrono::steady_clock::now();
 
+                std::unique_lock lock(this->partition_mutex_);
                 for (auto it = this->mmio_read_grace_deadlines_.begin(); it != this->mmio_read_grace_deadlines_.end();)
                 {
                     const auto page_base = it->first;
@@ -2640,61 +2787,15 @@ namespace sogen::whp
                 }
             }
 
-            void refresh_mmio_page(const mmio_region& region, const uint64_t page_base)
+            // Assumes partition_mutex_ is held exclusively.
+            bool arm_mmio_single_step(whp_vcpu& vcpu, const uint64_t page_base, const bool is_write)
             {
-                auto entry = this->mapped_pages_.find(page_base);
-                if (entry == this->mapped_pages_.end() || !entry->second || entry->second->host_page == nullptr)
-                {
-                    throw std::runtime_error("MMIO page backing is missing");
-                }
-
-                auto* page = static_cast<std::byte*>(entry->second->host_page);
-                std::memset(page, 0, page_size);
-
-                const auto region_offset = static_cast<size_t>(page_base - region.address);
-                const auto bytes_to_read = (std::min)(static_cast<size_t>(page_size), region.size - region_offset);
-                region.read_cb(region_offset, page, bytes_to_read);
-            }
-
-            void flush_mmio_write(const mmio_region& region, const uint64_t page_base, const std::vector<std::byte>& old_page)
-            {
-                auto entry = this->mapped_pages_.find(page_base);
-                if (entry == this->mapped_pages_.end() || !entry->second || entry->second->host_page == nullptr)
-                {
-                    throw std::runtime_error("MMIO page backing is missing");
-                }
-
-                const auto* current_page = static_cast<const std::byte*>(entry->second->host_page);
-                const auto region_offset = static_cast<size_t>(page_base - region.address);
-                const auto bytes_in_region = (std::min)(static_cast<size_t>(page_size), region.size - region_offset);
-
-                size_t index = 0;
-                while (index < bytes_in_region)
-                {
-                    if (old_page[index] == current_page[index])
-                    {
-                        ++index;
-                        continue;
-                    }
-
-                    const auto start = index;
-                    while (index < bytes_in_region && old_page[index] != current_page[index])
-                    {
-                        ++index;
-                    }
-
-                    region.write_cb(region_offset + start, current_page + start, index - start);
-                }
-            }
-
-            bool arm_mmio_single_step(const uint64_t page_base, const bool is_write)
-            {
-                if (this->pending_mmio_step_.has_value())
+                if (vcpu.pending_mmio_step_.has_value())
                 {
                     return false;
                 }
 
-                auto rflags = this->get_register(WHvX64RegisterRflags);
+                auto rflags = vcpu.get_register(WHvX64RegisterRflags);
                 const auto original_rflags = rflags.Reg64;
 
                 pending_mmio_step state{};
@@ -2717,40 +2818,84 @@ namespace sogen::whp
                 }
 
                 rflags.Reg64 = original_rflags | 0x100;
-                this->set_register(WHvX64RegisterRflags, rflags);
-                this->pending_mmio_step_ = std::move(state);
+                vcpu.set_register(WHvX64RegisterRflags, rflags);
+                vcpu.pending_mmio_step_ = std::move(state);
                 return true;
             }
 
-            bool complete_pending_mmio_step()
+            // Called without the partition lock held; takes it internally so the MMIO write callback
+            // can be invoked outside of it.
+            bool complete_pending_mmio_step(whp_vcpu& vcpu)
             {
-                if (!this->pending_mmio_step_.has_value())
+                if (!vcpu.pending_mmio_step_.has_value())
                 {
                     return false;
                 }
 
-                const auto state = std::move(*this->pending_mmio_step_);
-                this->pending_mmio_step_.reset();
-                this->revoke_mmio_read_grace(state.page_base);
+                const auto state = std::move(*vcpu.pending_mmio_step_);
+                vcpu.pending_mmio_step_.reset();
 
-                const auto entry = this->mapped_pages_.find(state.page_base);
-                if (entry == this->mapped_pages_.end() || !entry->second)
-                {
-                    throw std::runtime_error("MMIO page backing is missing");
-                }
+                mmio_write_callback write_cb{};
+                std::vector<mmio_write_chunk> write_chunks{};
 
-                if (state.is_write)
                 {
-                    if (const auto* region = this->find_mmio_region(state.page_base))
+                    std::unique_lock lock(this->partition_mutex_);
+                    this->revoke_mmio_read_grace(state.page_base);
+
+                    const auto entry = this->mapped_pages_.find(state.page_base);
+                    if (entry == this->mapped_pages_.end() || !entry->second)
                     {
-                        this->flush_mmio_write(*region, state.page_base, state.old_page);
+                        throw std::runtime_error("MMIO page backing is missing");
                     }
+
+                    if (state.is_write)
+                    {
+                        if (const auto* region = this->find_mmio_region(state.page_base))
+                        {
+                            if (entry->second->host_page == nullptr)
+                            {
+                                throw std::runtime_error("MMIO page backing is missing");
+                            }
+
+                            write_cb = region->write_cb;
+
+                            const auto* current_page = static_cast<const std::byte*>(entry->second->host_page);
+                            const auto region_offset = static_cast<size_t>(state.page_base - region->address);
+                            const auto bytes_in_region = (std::min)(static_cast<size_t>(page_size), region->size - region_offset);
+
+                            size_t index = 0;
+                            while (index < bytes_in_region)
+                            {
+                                if (state.old_page[index] == current_page[index])
+                                {
+                                    ++index;
+                                    continue;
+                                }
+
+                                const auto start = index;
+                                while (index < bytes_in_region && state.old_page[index] != current_page[index])
+                                {
+                                    ++index;
+                                }
+
+                                write_chunks.push_back(mmio_write_chunk{
+                                    .offset = region_offset + start,
+                                    .data = std::vector<std::byte>(current_page + start, current_page + index),
+                                });
+                            }
+                        }
+                    }
+
+                    entry->second->permissions = memory_permission::none;
+                    this->remap_page(*entry->second);
                 }
 
-                entry->second->permissions = memory_permission::none;
-                this->remap_page(*entry->second);
+                for (const auto& chunk : write_chunks)
+                {
+                    write_cb(chunk.offset, chunk.data.data(), chunk.data.size());
+                }
 
-                auto rflags = this->get_register(WHvX64RegisterRflags);
+                auto rflags = vcpu.get_register(WHvX64RegisterRflags);
 
                 if (state.had_trap_flag)
                 {
@@ -2761,7 +2906,7 @@ namespace sogen::whp
                     rflags.Reg64 &= ~0x100ull;
                 }
 
-                this->set_register(WHvX64RegisterRflags, rflags);
+                vcpu.set_register(WHvX64RegisterRflags, rflags);
 
                 return !state.allow_debug_delivery;
             }
@@ -2771,6 +2916,7 @@ namespace sogen::whp
                 return this->page_table_views_.at(page_gpa);
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             uint64_t ensure_child_table(const uint64_t table_gpa, const size_t index)
             {
                 auto* const table_entries = this->get_page_table_entries(table_gpa);
@@ -2786,6 +2932,7 @@ namespace sogen::whp
                 return entry & page_table_entry_address_mask;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void ensure_virtual_mapping(const uint64_t guest_address)
             {
                 const auto page_base = align_down_to_page(guest_address);
@@ -2809,6 +2956,7 @@ namespace sogen::whp
                                        page_table_entry_user;
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             bool clear_virtual_mapping(const uint64_t guest_address)
             {
                 const auto page_base = align_down_to_page(guest_address);
@@ -2849,11 +2997,18 @@ namespace sogen::whp
                 return true;
             }
 
+            // Assumes partition_mutex_ is held exclusively. Rewriting CR3 flushes the cached
+            // virtual-address translations; every vCPU shares the same page tables.
             void flush_virtual_address_mappings()
             {
-                this->set_register(WHvX64RegisterCr3, this->get_register(WHvX64RegisterCr3));
+                for (const auto& vcpu : this->vcpus_)
+                {
+                    vcpu->set_register(WHvX64RegisterCr3, vcpu->get_register(WHvX64RegisterCr3));
+                }
             }
 
+            // Assumes partition_mutex_ is held (shared is sufficient for reads, exclusive for writes
+            // only because callers that write also update breakpoint bookkeeping).
             bool access_memory(const uint64_t address, void* data, size_t size, const bool is_write) const
             {
                 auto current_address = address;
@@ -2889,6 +3044,7 @@ namespace sogen::whp
                 return true;
             }
 
+            // Assumes partition_mutex_ is held (shared).
             void overlay_patched_breakpoints(const uint64_t address, void* data, const size_t size) const
             {
                 auto current_address = address;
@@ -2919,6 +3075,7 @@ namespace sogen::whp
                 }
             }
 
+            // Assumes partition_mutex_ is held exclusively.
             void overlay_patched_breakpoints(const uint64_t address, const void* data, const size_t size)
             {
                 auto current_address = address;
@@ -2957,60 +3114,220 @@ namespace sogen::whp
                 }
             }
 
-            WHV_REGISTER_VALUE get_register(const WHV_REGISTER_NAME name) const
-            {
-                WHV_REGISTER_VALUE value{};
-                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, vp_index, &name, 1, &value));
-                return value;
-            }
-
-            template <size_t N>
-            std::array<WHV_REGISTER_VALUE, N> get_registers(const std::array<WHV_REGISTER_NAME, N>& names) const
-            {
-                std::array<WHV_REGISTER_VALUE, N> values{};
-                WHP_CHECK_HR(WHvGetVirtualProcessorRegisters(this->partition_, vp_index, names.data(), static_cast<UINT32>(names.size()),
-                                                             values.data()));
-                return values;
-            }
-
-            void set_register(const WHV_REGISTER_NAME name, const WHV_REGISTER_VALUE& value)
-            {
-                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, vp_index, &name, 1, &value));
-            }
-
-            template <size_t N>
-            void set_registers(const std::array<WHV_REGISTER_NAME, N>& names, const std::array<WHV_REGISTER_VALUE, N>& values)
-            {
-                WHP_CHECK_HR(WHvSetVirtualProcessorRegisters(this->partition_, vp_index, names.data(), static_cast<UINT32>(names.size()),
-                                                             values.data()));
-            }
-
+            // Assumes partition_mutex_ is held exclusively.
             emulator_hook* make_hook()
             {
                 return reinterpret_cast<emulator_hook*>(this->next_hook_id_++);
             }
 
-            void apply_default_instruction_exit(const x86_hookable_instructions type, const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
+            interrupt_hook_callback copy_first_interrupt_hook() const
+            {
+                std::shared_lock lock(this->partition_mutex_);
+                if (this->interrupt_hooks_.empty())
+                {
+                    return {};
+                }
+
+                return this->interrupt_hooks_.begin()->second;
+            }
+
+            std::vector<instruction_hook_callback> copy_instruction_hooks(const x86_hookable_instructions type) const
+            {
+                std::vector<instruction_hook_callback> callbacks{};
+
+                std::shared_lock lock(this->partition_mutex_);
+                for (const auto& [_, hook] : this->instruction_hooks_)
+                {
+                    if (hook.type == type)
+                    {
+                        callbacks.push_back(hook.callback);
+                    }
+                }
+
+                return callbacks;
+            }
+
+            std::vector<memory_violation_hook_callback> copy_memory_violation_hooks() const
+            {
+                std::vector<memory_violation_hook_callback> callbacks{};
+
+                std::shared_lock lock(this->partition_mutex_);
+                callbacks.reserve(this->memory_violation_hooks_.size());
+                for (const auto& [_, hook] : this->memory_violation_hooks_)
+                {
+                    callbacks.push_back(hook);
+                }
+
+                return callbacks;
+            }
+
+            void run(whp_vcpu& vcpu, const size_t count)
+            {
+                if (count != 0 && count != 1)
+                {
+                    throw std::runtime_error("WHP backend does not support exact instruction counts yet");
+                }
+
+                vcpu.stop_requested_ = false;
+
+                {
+                    std::unique_lock lock(this->partition_mutex_);
+
+                    bool armed_single_step = false;
+                    if (vcpu.deferred_patched_breakpoint_)
+                    {
+                        if (vcpu.read_instruction_pointer() == *vcpu.deferred_patched_breakpoint_)
+                        {
+                            if (!this->arm_patched_breakpoint_single_step(vcpu, *vcpu.deferred_patched_breakpoint_, count == 1))
+                            {
+                                throw std::runtime_error("Nested WHP execution single-step state is not supported");
+                            }
+
+                            armed_single_step = true;
+                        }
+                        else
+                        {
+                            this->set_patched_execution_breakpoint_state(*vcpu.deferred_patched_breakpoint_, true);
+                            vcpu.deferred_patched_breakpoint_.reset();
+                        }
+                    }
+
+                    if (!armed_single_step && vcpu.deferred_execution_page_)
+                    {
+                        if (!this->arm_execution_single_step(vcpu, *vcpu.deferred_execution_page_, count == 1))
+                        {
+                            throw std::runtime_error("Nested WHP execution single-step state is not supported");
+                        }
+
+                        vcpu.deferred_execution_page_.reset();
+                        armed_single_step = true;
+                    }
+
+                    if (!armed_single_step && count == 1 && !this->arm_execution_single_step(vcpu, std::nullopt, true))
+                    {
+                        throw std::runtime_error("Nested WHP execution single-step state is not supported");
+                    }
+                }
+
+                while (!vcpu.stop_requested_)
+                {
+                    this->expire_mmio_read_grace_pages(vcpu);
+                    WHV_RUN_VP_EXIT_CONTEXT exit_context{};
+                    const auto start_rip = vcpu.read_instruction_pointer();
+                    vcpu.run_active_ = true;
+                    const auto run_hr = WHvRunVirtualProcessor(this->partition_, vcpu.vp_index_, &exit_context, sizeof(exit_context));
+                    vcpu.run_active_ = false;
+                    if (FAILED(run_hr))
+                    {
+                        throw_hr(run_hr, "WHvRunVirtualProcessor");
+                    }
+                    switch (exit_context.ExitReason)
+                    {
+                    case WHvRunVpExitReasonCanceled: {
+                        if (vcpu.stop_requested_)
+                        {
+                            return;
+                        }
+
+                        // If rip has not changed, we _probably_ executed nothing.
+                        // Could be that the execution was cancelled while it was not running.
+                        // Just restart it.
+                        if (start_rip == exit_context.VpContext.Rip)
+                        {
+                            vcpu.stop_requested_ = false;
+                            continue;
+                        }
+
+                        return;
+                    }
+                    case WHvRunVpExitReasonX64Halt:
+                        if (this->syscall_hook_ && exit_context.VpContext.Rip == (this->syscall_hook_page_ + 1))
+                        {
+                            if (this->handle_syscall_halt(vcpu))
+                            {
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            return;
+                        }
+
+                        if (vcpu.stop_requested_)
+                        {
+                            return;
+                        }
+
+                        if (this->syscall_hook_)
+                        {
+                            continue;
+                        }
+                        return;
+                    case WHvRunVpExitReasonMemoryAccess:
+                        if (this->handle_memory_access(vcpu, exit_context.MemoryAccess))
+                        {
+                            continue;
+                        }
+                        return;
+                    case WHvRunVpExitReasonException:
+                        if (this->handle_exception(vcpu, exit_context))
+                        {
+                            vcpu.clear_pending_exception_state();
+                            continue;
+                        }
+                        return;
+                    case WHvRunVpExitReasonX64Cpuid:
+                        if (this->handle_instruction_exit(vcpu, x86_hookable_instructions::cpuid, exit_context, 2))
+                        {
+                            continue;
+                        }
+                        throw std::runtime_error("Unhandled CPUID exit");
+                    case WHvRunVpExitReasonX64Rdtsc:
+                        if (this->handle_instruction_exit(vcpu,
+                                                          exit_context.ReadTsc.RdtscInfo.IsRdtscp ? x86_hookable_instructions::rdtscp
+                                                                                                  : x86_hookable_instructions::rdtsc,
+                                                          exit_context, 2))
+                        {
+                            continue;
+                        }
+                        throw std::runtime_error("Unhandled RDTSC/RDTSCP exit");
+                    case WHvRunVpExitReasonUnrecoverableException:
+                        if (this->handle_unrecoverable_exception(vcpu))
+                        {
+                            vcpu.clear_pending_exception_state();
+                            continue;
+                        }
+                        throw_unhandled_exit(exit_context);
+                    case WHvRunVpExitReasonUnsupportedFeature:
+                        throw std::runtime_error("Encountered unsupported processor feature");
+                    default:
+                        throw_unhandled_exit(exit_context);
+                    }
+                }
+            }
+
+            void apply_default_instruction_exit(whp_vcpu& vcpu, const x86_hookable_instructions type,
+                                                const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
             {
                 switch (type)
                 {
                 case x86_hookable_instructions::cpuid: {
                     const auto& cpuid = exit_context.CpuidAccess;
-                    this->reg(x86_register::rax, static_cast<uint64_t>(cpuid.DefaultResultRax));
-                    this->reg(x86_register::rbx, static_cast<uint64_t>(cpuid.DefaultResultRbx));
-                    this->reg(x86_register::rcx, static_cast<uint64_t>(cpuid.DefaultResultRcx));
-                    this->reg(x86_register::rdx, static_cast<uint64_t>(cpuid.DefaultResultRdx));
+                    vcpu.reg(x86_register::rax, static_cast<uint64_t>(cpuid.DefaultResultRax));
+                    vcpu.reg(x86_register::rbx, static_cast<uint64_t>(cpuid.DefaultResultRbx));
+                    vcpu.reg(x86_register::rcx, static_cast<uint64_t>(cpuid.DefaultResultRcx));
+                    vcpu.reg(x86_register::rdx, static_cast<uint64_t>(cpuid.DefaultResultRdx));
                     break;
                 }
                 case x86_hookable_instructions::rdtsc:
                 case x86_hookable_instructions::rdtscp: {
                     const auto tsc = exit_context.ReadTsc.Tsc;
-                    this->reg(x86_register::rax, static_cast<uint32_t>(tsc & 0xFFFFFFFFull));
-                    this->reg(x86_register::rdx, static_cast<uint32_t>(tsc >> 32));
+                    vcpu.reg(x86_register::rax, static_cast<uint32_t>(tsc & 0xFFFFFFFFull));
+                    vcpu.reg(x86_register::rdx, static_cast<uint32_t>(tsc >> 32));
 
                     if (type == x86_hookable_instructions::rdtscp)
                     {
-                        this->reg(x86_register::rcx, static_cast<uint32_t>(exit_context.ReadTsc.TscAux & 0xFFFFFFFFull));
+                        vcpu.reg(x86_register::rcx, static_cast<uint32_t>(exit_context.ReadTsc.TscAux & 0xFFFFFFFFull));
                     }
 
                     break;
@@ -3020,20 +3337,16 @@ namespace sogen::whp
                 }
             }
 
-            bool handle_instruction_exit(const x86_hookable_instructions type, const WHV_RUN_VP_EXIT_CONTEXT& exit_context,
+            bool handle_instruction_exit(whp_vcpu& vcpu, const x86_hookable_instructions type, const WHV_RUN_VP_EXIT_CONTEXT& exit_context,
                                          const uint64_t instruction_size)
             {
-                bool handled = false;
+                const auto callbacks = this->copy_instruction_hooks(type);
+                const bool handled = !callbacks.empty();
                 bool skip = false;
-                for (auto& [_, hook] : this->instruction_hooks_)
-                {
-                    if (hook.type != type)
-                    {
-                        continue;
-                    }
 
-                    handled = true;
-                    if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
+                for (const auto& callback : callbacks)
+                {
+                    if (callback(vcpu, 0) == instruction_hook_continuation::skip_instruction)
                     {
                         skip = true;
                     }
@@ -3041,56 +3354,57 @@ namespace sogen::whp
 
                 if (!handled || !skip)
                 {
-                    this->apply_default_instruction_exit(type, exit_context);
+                    this->apply_default_instruction_exit(vcpu, type, exit_context);
                 }
 
-                this->advance_rip(instruction_size);
+                vcpu.advance_rip(instruction_size);
 
                 return handled || type == x86_hookable_instructions::cpuid || type == x86_hookable_instructions::rdtsc ||
                        type == x86_hookable_instructions::rdtscp;
             }
 
-            bool handle_unrecoverable_exception()
+            bool handle_unrecoverable_exception(whp_vcpu& vcpu)
             {
-                const auto rip = this->read_instruction_pointer();
-                std::array<std::byte, 2> opcode{};
-                if (this->access_memory(rip, opcode.data(), opcode.size(), false) && opcode[0] == std::byte{0xCD})
-                {
-                    for (auto& [_, hook] : this->interrupt_hooks_)
-                    {
-                        hook(*this, std::to_integer<uint8_t>(opcode[1]));
+                const auto rip = vcpu.read_instruction_pointer();
 
-                        if (this->read_instruction_pointer() == rip)
+                std::array<std::byte, 2> opcode{};
+                bool opcode_read = false;
+                {
+                    std::shared_lock lock(this->partition_mutex_);
+                    opcode_read = this->access_memory(rip, opcode.data(), opcode.size(), false);
+                }
+
+                if (opcode_read && opcode[0] == std::byte{0xCD})
+                {
+                    if (const auto hook = this->copy_first_interrupt_hook())
+                    {
+                        hook(vcpu, std::to_integer<uint8_t>(opcode[1]));
+
+                        if (vcpu.read_instruction_pointer() == rip)
                         {
-                            this->advance_rip(2);
+                            vcpu.advance_rip(2);
                         }
 
                         return true;
                     }
                 }
-                else if (this->access_memory(rip, opcode.data(), opcode.size(), false) && opcode[0] == std::byte{0x0F} &&
-                         opcode[1] == std::byte{0x0B})
+                else if (opcode_read && opcode[0] == std::byte{0x0F} && opcode[1] == std::byte{0x0B})
                 {
                     bool skip = false;
                     bool consumed = false;
 
-                    for (auto& [_, hook] : this->instruction_hooks_)
+                    for (const auto& callback : this->copy_instruction_hooks(x86_hookable_instructions::invalid))
                     {
-                        if (hook.type != x86_hookable_instructions::invalid)
-                        {
-                            continue;
-                        }
-
-                        if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
+                        if (callback(vcpu, 0) == instruction_hook_continuation::skip_instruction)
                         {
                             skip = true;
                             consumed = true;
                         }
                     }
 
-                    if (skip && this->read_instruction_pointer() == rip)
+                    if (skip && vcpu.read_instruction_pointer() == rip)
                     {
-                        this->advance_rip(2);
+                        vcpu.advance_rip(2);
                     }
 
                     if (consumed)
@@ -3098,41 +3412,41 @@ namespace sogen::whp
                         return true;
                     }
 
-                    for (auto& [_, hook] : this->interrupt_hooks_)
+                    if (const auto hook = this->copy_first_interrupt_hook())
                     {
-                        hook(*this, 6);
+                        hook(vcpu, 6);
                         return true;
                     }
 
                     return false;
                 }
 
-                if (this->pending_mmio_step_.has_value())
+                if (vcpu.pending_mmio_step_.has_value())
                 {
-                    const auto swallow = this->complete_pending_mmio_step();
+                    const auto swallow = this->complete_pending_mmio_step(vcpu);
                     if (swallow)
                     {
                         return true;
                     }
                 }
 
-                const auto rflags = this->reg<uint64_t>(x86_register::rflags);
+                const auto rflags = vcpu.reg<uint64_t>(x86_register::rflags);
                 if ((rflags & 0x100ull) != 0)
                 {
-                    for (auto& [_, hook] : this->interrupt_hooks_)
+                    if (const auto hook = this->copy_first_interrupt_hook())
                     {
-                        hook(*this, 1);
+                        hook(vcpu, 1);
                         return true;
                     }
                 }
 
-                const auto fault_address = this->reg<uint64_t>(x86_register::cr2);
+                const auto fault_address = vcpu.reg<uint64_t>(x86_register::cr2);
 
-                if (fault_address != 0 && !this->memory_violation_hooks_.empty())
+                if (fault_address != 0)
                 {
-                    for (auto& [_, hook] : this->memory_violation_hooks_)
+                    for (const auto& hook : this->copy_memory_violation_hooks())
                     {
-                        const auto result = hook(*this, fault_address, 1, memory_operation::read, memory_violation_type::unmapped);
+                        const auto result = hook(vcpu, fault_address, 1, memory_operation::read, memory_violation_type::unmapped);
                         if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                         {
                             return true;
@@ -3140,45 +3454,52 @@ namespace sogen::whp
                     }
                 }
 
-                for (auto& [_, hook] : this->interrupt_hooks_)
+                if (const auto hook = this->copy_first_interrupt_hook())
                 {
-                    hook(*this, 14);
+                    hook(vcpu, 14);
                     return true;
                 }
 
                 return false;
             }
 
-            bool handle_execution_hook(const uint64_t address)
+            bool handle_execution_hook(whp_vcpu& vcpu, const uint64_t address)
             {
                 const auto page_base = align_down_to_page(address);
-                const auto entry = this->mapped_pages_.find(page_base);
-                if (entry == this->mapped_pages_.end() || !entry->second || !is_executable(entry->second->permissions) ||
-                    entry->second->page_execution_hook_count == 0)
-                {
-                    return false;
-                }
-
                 std::vector<memory_execution_hook_callback> callbacks{};
-                for (const auto& [_, hook] : this->memory_execution_hooks_)
+
                 {
-                    if (hook.address && !hook.patched_breakpoint && hook.size != 0 &&
-                        is_within_start_and_length(address, *hook.address, hook.size))
+                    std::shared_lock lock(this->partition_mutex_);
+
+                    const auto entry = this->mapped_pages_.find(page_base);
+                    if (entry == this->mapped_pages_.end() || !entry->second || !is_executable(entry->second->permissions) ||
+                        entry->second->page_execution_hook_count == 0)
                     {
-                        callbacks.push_back(hook.callback);
+                        return false;
+                    }
+
+                    for (const auto& [_, hook] : this->memory_execution_hooks_)
+                    {
+                        if (hook.address && !hook.patched_breakpoint && hook.size != 0 &&
+                            is_within_start_and_length(address, *hook.address, hook.size))
+                        {
+                            callbacks.push_back(hook.callback);
+                        }
                     }
                 }
 
                 for (const auto& callback : callbacks)
                 {
-                    callback(*this, address);
+                    callback(vcpu, address);
                 }
 
-                if (this->stop_requested_)
+                if (vcpu.stop_requested_)
                 {
-                    this->deferred_execution_page_ = page_base;
+                    vcpu.deferred_execution_page_ = page_base;
                     return true;
                 }
+
+                std::unique_lock lock(this->partition_mutex_);
 
                 const auto current_entry = this->mapped_pages_.find(page_base);
                 if (current_entry == this->mapped_pages_.end() || !current_entry->second ||
@@ -3187,7 +3508,7 @@ namespace sogen::whp
                     return true;
                 }
 
-                if (!this->arm_execution_single_step(page_base, false))
+                if (!this->arm_execution_single_step(vcpu, page_base, false))
                 {
                     throw std::runtime_error("Nested WHP execution single-step state is not supported");
                 }
@@ -3195,32 +3516,62 @@ namespace sogen::whp
                 return true;
             }
 
-            bool handle_memory_access(const WHV_MEMORY_ACCESS_CONTEXT& memory_access)
+            bool handle_memory_access(whp_vcpu& vcpu, const WHV_MEMORY_ACCESS_CONTEXT& memory_access)
             {
                 const auto access_type = static_cast<WHV_MEMORY_ACCESS_TYPE>(memory_access.AccessInfo.AccessType);
-                const auto resolved_address = memory_access.AccessInfo.GvaValid
-                                                  ? memory_access.Gva
-                                                  : this->translate_guest_physical_address(memory_access.Gpa).value_or(memory_access.Gpa);
 
-                if (access_type == WHvMemoryAccessExecute && this->handle_execution_hook(resolved_address))
+                auto resolved_address = memory_access.Gva;
+                if (!memory_access.AccessInfo.GvaValid)
+                {
+                    std::shared_lock lock(this->partition_mutex_);
+                    resolved_address = this->translate_guest_physical_address(memory_access.Gpa).value_or(memory_access.Gpa);
+                }
+
+                if (access_type == WHvMemoryAccessExecute && this->handle_execution_hook(vcpu, resolved_address))
                 {
                     return true;
                 }
 
                 const auto mmio_address = resolved_address;
-                if (auto* region = this->find_mmio_region(mmio_address))
+                const auto operation = map_memory_operation(access_type);
+
+                bool found_region = false;
+                mmio_read_callback region_read_cb{};
+                uint64_t region_address = 0;
+                size_t region_size = 0;
+
+                {
+                    std::shared_lock lock(this->partition_mutex_);
+                    if (const auto* region = this->find_mmio_region(mmio_address))
+                    {
+                        found_region = true;
+                        region_read_cb = region->read_cb;
+                        region_address = region->address;
+                        region_size = region->size;
+                    }
+                }
+
+                if (found_region)
                 {
                     const auto page_base = align_down_to_page(mmio_address);
-                    const auto operation = map_memory_operation(access_type);
                     const auto is_write = operation == memory_operation::write;
 
-                    this->refresh_mmio_page(*region, page_base);
+                    // Refresh the page content through the region callback outside the lock, then
+                    // publish it into the backing page under it.
+                    std::vector<std::byte> refreshed_page(page_size);
+                    const auto region_offset = static_cast<size_t>(page_base - region_address);
+                    const auto bytes_to_read = (std::min)(static_cast<size_t>(page_size), region_size - region_offset);
+                    region_read_cb(region_offset, refreshed_page.data(), bytes_to_read);
+
+                    std::unique_lock lock(this->partition_mutex_);
 
                     auto page_it = this->mapped_pages_.find(page_base);
-                    if (page_it == this->mapped_pages_.end())
+                    if (page_it == this->mapped_pages_.end() || !page_it->second || page_it->second->host_page == nullptr)
                     {
                         throw std::runtime_error("MMIO page backing is missing");
                     }
+
+                    std::memcpy(page_it->second->host_page, refreshed_page.data(), page_size);
 
                     if (is_write)
                     {
@@ -3240,7 +3591,7 @@ namespace sogen::whp
                         return true;
                     }
 
-                    if (!this->arm_mmio_single_step(page_base, is_write))
+                    if (!this->arm_mmio_single_step(vcpu, page_base, is_write))
                     {
                         throw std::runtime_error("Nested WHP MMIO single-step state is not supported");
                     }
@@ -3248,18 +3599,18 @@ namespace sogen::whp
                     return true;
                 }
 
-                if (this->memory_violation_hooks_.empty())
+                const auto violation_hooks = this->copy_memory_violation_hooks();
+                if (violation_hooks.empty())
                 {
                     throw std::runtime_error("Unhandled WHP memory access violation");
                 }
 
-                const auto operation = map_memory_operation(access_type);
                 const auto type =
                     memory_access.AccessInfo.GpaUnmapped ? memory_violation_type::unmapped : memory_violation_type::protection;
 
-                for (auto& [_, hook] : this->memory_violation_hooks_)
+                for (const auto& hook : violation_hooks)
                 {
-                    const auto result = hook(*this, mmio_address, 1, operation, type);
+                    const auto result = hook(vcpu, mmio_address, 1, operation, type);
                     if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                     {
                         return true;
@@ -3269,36 +3620,42 @@ namespace sogen::whp
                 return false;
             }
 
-            bool handle_patched_execution_breakpoint(const uint64_t address)
+            bool handle_patched_execution_breakpoint(whp_vcpu& vcpu, const uint64_t address)
             {
-                if (!this->patched_execution_breakpoints_.contains(address))
-                {
-                    return false;
-                }
-
-                auto rip_value = this->get_register(WHvX64RegisterRip);
-                rip_value.Reg64 = address;
-                this->set_register(WHvX64RegisterRip, rip_value);
-                this->set_patched_execution_breakpoint_state(address, false);
-
                 std::vector<memory_execution_hook_callback> callbacks{};
-                for (const auto& [_, hook] : this->memory_execution_hooks_)
+
                 {
-                    if (hook.address && hook.patched_breakpoint && *hook.address == address)
+                    std::unique_lock lock(this->partition_mutex_);
+
+                    if (!this->patched_execution_breakpoints_.contains(address))
                     {
-                        callbacks.push_back(hook.callback);
+                        return false;
+                    }
+
+                    auto rip_value = vcpu.get_register(WHvX64RegisterRip);
+                    rip_value.Reg64 = address;
+                    vcpu.set_register(WHvX64RegisterRip, rip_value);
+                    this->set_patched_execution_breakpoint_state(address, false);
+
+                    for (const auto& [_, hook] : this->memory_execution_hooks_)
+                    {
+                        if (hook.address && hook.patched_breakpoint && *hook.address == address)
+                        {
+                            callbacks.push_back(hook.callback);
+                        }
                     }
                 }
 
                 for (const auto& callback : callbacks)
                 {
-                    callback(*this, address);
+                    callback(vcpu, address);
                 }
 
-                this->deferred_patched_breakpoint_ = address;
-                if (!this->stop_requested_)
+                vcpu.deferred_patched_breakpoint_ = address;
+                if (!vcpu.stop_requested_)
                 {
-                    if (!this->arm_patched_breakpoint_single_step(address, false))
+                    std::unique_lock lock(this->partition_mutex_);
+                    if (!this->arm_patched_breakpoint_single_step(vcpu, address, false))
                     {
                         throw std::runtime_error("Nested WHP execution single-step state is not supported");
                     }
@@ -3307,7 +3664,7 @@ namespace sogen::whp
                 return true;
             }
 
-            bool handle_exception(const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
+            bool handle_exception(whp_vcpu& vcpu, const WHV_RUN_VP_EXIT_CONTEXT& exit_context)
             {
                 const auto& exception = exit_context.VpException;
 
@@ -3319,18 +3676,18 @@ namespace sogen::whp
                     const auto operation = is_write ? memory_operation::write : memory_operation::read;
                     const auto type = is_present ? memory_violation_type::protection : memory_violation_type::unmapped;
 
-                    for (auto& [_, hook] : this->memory_violation_hooks_)
+                    for (const auto& hook : this->copy_memory_violation_hooks())
                     {
-                        const auto result = hook(*this, fault_address, 1, operation, type);
+                        const auto result = hook(vcpu, fault_address, 1, operation, type);
                         if (result == memory_violation_continuation::resume || result == memory_violation_continuation::restart)
                         {
                             return true;
                         }
                     }
 
-                    for (auto& [_, hook] : this->interrupt_hooks_)
+                    if (const auto hook = this->copy_first_interrupt_hook())
                     {
-                        hook(*this, 14);
+                        hook(vcpu, 14);
                         return true;
                     }
 
@@ -3339,14 +3696,17 @@ namespace sogen::whp
 
                 if (exception.ExceptionType == WHvX64ExceptionTypeDebugTrapOrFault)
                 {
-                    if (this->complete_execution_step())
                     {
-                        return true;
+                        std::unique_lock lock(this->partition_mutex_);
+                        if (this->complete_execution_step(vcpu))
+                        {
+                            return true;
+                        }
                     }
 
-                    if (this->pending_mmio_step_.has_value())
+                    if (vcpu.pending_mmio_step_.has_value())
                     {
-                        const auto swallow = this->complete_pending_mmio_step();
+                        const auto swallow = this->complete_pending_mmio_step(vcpu);
                         if (swallow)
                         {
                             return true;
@@ -3361,7 +3721,7 @@ namespace sogen::whp
                 if (exception.ExceptionType == WHvX64ExceptionTypeBreakpointTrap)
                 {
                     const auto rip = exit_context.VpContext.Rip;
-                    if (this->handle_patched_execution_breakpoint(rip - 1) || this->handle_patched_execution_breakpoint(rip))
+                    if (this->handle_patched_execution_breakpoint(vcpu, rip - 1) || this->handle_patched_execution_breakpoint(vcpu, rip))
                     {
                         return true;
                     }
@@ -3370,28 +3730,23 @@ namespace sogen::whp
                     {
                         if (rip == this->syscall_hook_page_ || rip == (this->syscall_hook_page_ + 1))
                         {
-                            return this->handle_syscall_halt();
+                            return this->handle_syscall_halt(vcpu);
                         }
                     }
                 }
 
                 if (exception.ExceptionType == WHvX64ExceptionTypeInvalidOpcodeFault)
                 {
-                    const auto rip = this->read_instruction_pointer();
+                    const auto rip = vcpu.read_instruction_pointer();
                     bool consumed = false;
 
-                    for (auto& [_, hook] : this->instruction_hooks_)
+                    for (const auto& callback : this->copy_instruction_hooks(x86_hookable_instructions::invalid))
                     {
-                        if (hook.type != x86_hookable_instructions::invalid)
+                        if (callback(vcpu, 0) == instruction_hook_continuation::skip_instruction)
                         {
-                            continue;
-                        }
-
-                        if (hook.callback(*this, 0) == instruction_hook_continuation::skip_instruction)
-                        {
-                            if (this->read_instruction_pointer() == rip)
+                            if (vcpu.read_instruction_pointer() == rip)
                             {
-                                this->advance_rip(exception.InstructionByteCount);
+                                vcpu.advance_rip(exception.InstructionByteCount);
                             }
                             consumed = true;
                         }
@@ -3410,52 +3765,50 @@ namespace sogen::whp
                     // guest only reaches here with its FP exception masks cleared (a corrupted MXCSR/x87 control
                     // word); restore the masked Windows defaults and re-run the instruction so it completes as it
                     // would natively.
-                    const auto mxcsr = this->reg<uint32_t>(x86_register::mxcsr);
-                    this->reg(x86_register::mxcsr, (mxcsr | 0x1F80u) & ~0x3Fu);
-                    const auto fpcw = this->reg<uint16_t>(x86_register::fpcw);
-                    this->reg(x86_register::fpcw, static_cast<uint16_t>(fpcw | 0x3Fu));
+                    const auto mxcsr = vcpu.reg<uint32_t>(x86_register::mxcsr);
+                    vcpu.reg(x86_register::mxcsr, (mxcsr | 0x1F80u) & ~0x3Fu);
+                    const auto fpcw = vcpu.reg<uint16_t>(x86_register::fpcw);
+                    vcpu.reg(x86_register::fpcw, static_cast<uint16_t>(fpcw | 0x3Fu));
                     // Also clear the x87 status-word exception flags / summary (ES) bit, or an FWAIT or following
                     // x87 op would re-raise #MF on the rerun.
-                    const auto fpsw = this->reg<uint16_t>(x86_register::fpsw);
-                    this->reg(x86_register::fpsw, static_cast<uint16_t>(fpsw & ~0x80FFu));
+                    const auto fpsw = vcpu.reg<uint16_t>(x86_register::fpsw);
+                    vcpu.reg(x86_register::fpsw, static_cast<uint16_t>(fpsw & ~0x80FFu));
                     return true;
                 }
 
-                for (auto& [_, hook] : this->interrupt_hooks_)
+                if (const auto hook = this->copy_first_interrupt_hook())
                 {
-                    hook(*this, exception.ExceptionType);
+                    hook(vcpu, exception.ExceptionType);
                     return true;
                 }
 
                 return false;
             }
-
-            void advance_rip(const uint64_t amount)
-            {
-                auto rip = this->get_register(WHvX64RegisterRip);
-                rip.Reg64 += amount;
-                this->set_register(WHvX64RegisterRip, rip);
-            }
-
-            void clear_pending_exception_state()
-            {
-                WHV_REGISTER_VALUE pending_interruption{};
-                pending_interruption.PendingInterruption.AsUINT64 = 0;
-                this->set_register(WHvRegisterPendingInterruption, pending_interruption);
-
-                WHV_REGISTER_VALUE pending_event{};
-                pending_event.ExceptionEvent.AsUINT128 = {};
-                this->set_register(WHvRegisterPendingEvent, pending_event);
-
-                WHV_REGISTER_VALUE pending_debug{};
-                pending_debug.PendingDebugException.AsUINT64 = 0;
-                this->set_register(WHvX64RegisterPendingDebugException, pending_debug);
-            }
         };
+
+        void whp_vcpu::start(const size_t count)
+        {
+            this->emulator_.run(*this, count);
+        }
+
+        memory_interface& whp_vcpu::memory()
+        {
+            return this->emulator_;
+        }
+
+        const memory_interface& whp_vcpu::memory() const
+        {
+            return this->emulator_;
+        }
     }
 
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator()
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(const size_t vcpu_count)
     {
-        return std::make_unique<whp_x86_64_emulator>();
+        if (vcpu_count < 1 || vcpu_count > maximum_vcpu_count)
+        {
+            throw std::invalid_argument("WHP vCPU count must be between 1 and " + std::to_string(maximum_vcpu_count));
+        }
+
+        return std::make_unique<whp_x86_64_emulator>(vcpu_count);
     }
 } // namespace sogen::whp

--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -3242,16 +3242,12 @@ namespace sogen::whp
                             return;
                         }
 
-                        // If rip has not changed, we _probably_ executed nothing.
-                        // Could be that the execution was cancelled while it was not running.
-                        // Just restart it.
-                        if (start_rip == exit_context.VpContext.Rip)
-                        {
-                            vcpu.stop_requested_ = false;
-                            continue;
-                        }
-
-                        return;
+                        // A cancel without a stop request comes from flush_virtual_address_mappings
+                        // (another vCPU changed the shared page tables) - never from a real stop, which
+                        // always sets stop_requested_ first. Re-enter so the pending TLB flush is applied
+                        // at the loop top; do not treat it as a stop regardless of whether rip advanced.
+                        (void)start_rip;
+                        continue;
                     }
                     case WHvRunVpExitReasonX64Halt:
                         if (this->syscall_hook_ && exit_context.VpContext.Rip == (this->syscall_hook_page_ + 1))

--- a/src/backends/whp-emulator/whp_x86_64_emulator.hpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <arch_emulator.hpp>
 #include "platform/platform.hpp"
@@ -15,5 +16,5 @@ namespace sogen::whp
 #if !SOGEN_BUILD_STATIC
     WHP_EMULATOR_DLL_STORAGE
 #endif
-    std::unique_ptr<x86_64_emulator> create_x86_64_emulator();
+    std::unique_ptr<x86_64_emulator> create_x86_64_emulator(size_t vcpu_count = 1);
 } // namespace sogen::whp

--- a/src/debugger/debug_session.cpp
+++ b/src/debugger/debug_session.cpp
@@ -33,7 +33,7 @@ namespace sogen::debugger
           impl_(std::make_unique<impl>())
     {
         auto& cpu = this->emu_->emu();
-        this->impl_->control_hook = scoped_hook(cpu, cpu.hook_memory_execution([this](const uint64_t address) {
+        this->impl_->control_hook = scoped_hook(cpu, cpu.hook_memory_execution([this](cpu_interface&, const uint64_t address) {
             if (this->should_break(address))
             {
                 enter_breakpoint(*this->emu_, address);

--- a/src/debugger/debug_session.cpp
+++ b/src/debugger/debug_session.cpp
@@ -252,7 +252,7 @@ namespace sogen::debugger
     std::vector<thread_info> debug_session::threads() const
     {
         std::vector<thread_info> result{};
-        const auto* active = this->emu_->process.active_thread;
+        const auto* active = this->emu_->vcpu(0).active_thread;
         for (auto& thread : this->emu_->process.threads | std::views::values)
         {
             result.push_back({.id = thread.id, .instruction_pointer = thread.current_ip, .active = &thread == active});

--- a/src/disassembler/disassembler.cpp
+++ b/src/disassembler/disassembler.cpp
@@ -1,4 +1,4 @@
-#include "disassembler.hpp"
+﻿#include "disassembler.hpp"
 
 #include <utils/finally.hpp>
 
@@ -78,7 +78,7 @@ namespace sogen
         }
     }
 
-    instructions disassembler::disassemble(emulator& cpu, const uint16_t cs_selector, const std::span<const uint8_t> data,
+    instructions disassembler::disassemble(x86_64_cpu& cpu, const uint16_t cs_selector, const std::span<const uint8_t> data,
                                            const size_t count, const uint64_t address) const
     {
         const csh handle_to_use = this->resolve_handle(cpu, cs_selector);
@@ -88,12 +88,12 @@ namespace sogen
         return instructions{std::span(insts, inst_count)};
     }
 
-    std::optional<disassembler::segment_bitness> disassembler::get_segment_bitness(emulator& cpu, const uint16_t cs_selector)
+    std::optional<disassembler::segment_bitness> disassembler::get_segment_bitness(x86_64_cpu& cpu, const uint16_t cs_selector)
     {
         return segment_utils::get_segment_bitness(cpu, cs_selector);
     }
 
-    csh disassembler::resolve_handle(emulator& cpu, const uint16_t cs_selector) const
+    csh disassembler::resolve_handle(x86_64_cpu& cpu, const uint16_t cs_selector) const
     {
         const auto mode = disassembler::get_segment_bitness(cpu, cs_selector);
         if (!mode)

--- a/src/disassembler/disassembler.hpp
+++ b/src/disassembler/disassembler.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <array>
 #include <capstone/capstone.h>
@@ -108,10 +108,10 @@ namespace sogen
 
         using segment_bitness = segment_utils::segment_bitness;
 
-        instructions disassemble(emulator& cpu, uint16_t cs_selector, std::span<const uint8_t> data, size_t count,
+        instructions disassemble(x86_64_cpu& cpu, uint16_t cs_selector, std::span<const uint8_t> data, size_t count,
                                  uint64_t address = 0) const;
-        static std::optional<segment_bitness> get_segment_bitness(emulator& cpu, uint16_t cs_selector);
-        csh resolve_handle(emulator& cpu, uint16_t cs_selector) const;
+        static std::optional<segment_bitness> get_segment_bitness(x86_64_cpu& cpu, uint16_t cs_selector);
+        csh resolve_handle(x86_64_cpu& cpu, uint16_t cs_selector) const;
 
         csh get_handle_64() const
         {
@@ -136,7 +136,7 @@ namespace sogen
         void release();
     };
 
-    inline bool read_x86_register_value(x86_64_emulator& cpu, x86_reg reg, uint64_t& value)
+    inline bool read_x86_register_value(x86_64_cpu& cpu, x86_reg reg, uint64_t& value)
     {
         switch (reg)
         {
@@ -193,7 +193,7 @@ namespace sogen
         }
     }
 
-    inline bool resolve_jump_target(x86_64_emulator& cpu, uint64_t& target)
+    inline bool resolve_jump_target(x86_64_cpu& cpu, uint64_t& target)
     {
         disassembler d{};
         const auto cs_selector = cpu.reg<uint16_t>(x86_register::cs);

--- a/src/emulator-platform/segment_utils.hpp
+++ b/src/emulator-platform/segment_utils.hpp
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include <optional>
 #include <cstdint>
 
-#include "emulator.hpp"
+#include "arch_emulator.hpp"
 #include "x86_register.hpp"
 
 namespace sogen::segment_utils
@@ -38,7 +38,7 @@ namespace sogen::segment_utils
         bool default_op_size{};
     };
 
-    inline std::optional<cpu_interface::descriptor_table_register> read_descriptor_table(emulator& cpu, const x86_register reg)
+    inline std::optional<cpu_interface::descriptor_table_register> read_descriptor_table(x86_64_cpu& cpu, const x86_register reg)
     {
         cpu_interface::descriptor_table_register table{};
         if (!cpu.read_descriptor_table(static_cast<int>(reg), table))
@@ -49,10 +49,10 @@ namespace sogen::segment_utils
         return table;
     }
 
-    inline std::optional<uint16_t> read_selector(emulator& cpu, const x86_register reg)
+    inline std::optional<uint16_t> read_selector(x86_64_cpu& cpu, const x86_register reg)
     {
         uint16_t selector{};
-        const auto bytes_read = cpu.read_raw_register(static_cast<int>(reg), &selector, sizeof(selector));
+        const auto bytes_read = cpu.read_register(reg, &selector, sizeof(selector));
         if (bytes_read < sizeof(selector))
         {
             return std::nullopt;
@@ -61,7 +61,7 @@ namespace sogen::segment_utils
         return selector;
     }
 
-    inline std::optional<descriptor> read_descriptor(emulator& cpu, const cpu_interface::descriptor_table_register& table,
+    inline std::optional<descriptor> read_descriptor(x86_64_cpu& cpu, const cpu_interface::descriptor_table_register& table,
                                                      const uint16_t selector)
     {
         const auto index = selector >> 3;
@@ -115,7 +115,7 @@ namespace sogen::segment_utils
         return desc;
     }
 
-    inline std::optional<cpu_interface::descriptor_table_register> resolve_table(emulator& cpu, const uint16_t selector)
+    inline std::optional<cpu_interface::descriptor_table_register> resolve_table(x86_64_cpu& cpu, const uint16_t selector)
     {
         auto gdt = read_descriptor_table(cpu, x86_register::gdtr);
         if (!gdt)
@@ -147,7 +147,7 @@ namespace sogen::segment_utils
         return ldt;
     }
 
-    inline std::optional<segment_bitness> get_segment_bitness(emulator& cpu, const uint16_t selector)
+    inline std::optional<segment_bitness> get_segment_bitness(x86_64_cpu& cpu, const uint16_t selector)
     {
         if ((selector & ~0x3u) == 0)
         {

--- a/src/emulator/arch_emulator.hpp
+++ b/src/emulator/arch_emulator.hpp
@@ -1,25 +1,30 @@
 /*
 Design notes:
 
-1. emulator:               the root interface (provides CPU, memory, and hook interfaces).
+1. emulator:               the machine interface (provides memory and hook interfaces).
 2. typed_emulator<Traits>: a template that adapts to architecture/bitness via the Traits struct.
 3. arch_emulator<Traits>:  a thin layer for architecture-specific logic, things that are shared by all x86 (32/64), or
                            all ARM (32/64), etc.
 X. x86_emulator<Traits>:   x86_emulator<Traits> are specialisations for
                            x86 and ARM, parameterised by their respective traits (e.g., x86_64_traits) and stuff :)
 
-1. emulator (cpu_interface, memory_interface, hook_interface)
-2.  └── typed_emulator<address_t, register_t, ...>
-3.         └── arch_emulator<arch_traits>
-              ├── x86_emulator<x86_32_traits>
-              ├── x86_emulator<x86_64_traits>
-              ├── arm_emulator<arm_32_traits>
-              └── arm_emulator<arm_64_traits>
+Virtual CPUs are modelled separately (typed_cpu<Traits> -> x86_cpu<Traits>): a CPU owns register
+and run state and delegates memory access to the machine. The machine exposes its CPUs via
+get_cpu()/vcpu_count() and currently acts as its own single CPU (index 0) until backends grow
+real per-vCPU objects (docs/multi-vcpu-design.md).
+
+1. emulator (memory_interface, hook_interface)          typed_cpu<Traits> (cpu_interface)
+2.  └── typed_emulator<address_t, register_t, ...>       └── x86_cpu<x86_64_traits>
+3.         └── arch_emulator<arch_traits>                        │
+              └── x86_emulator<x86_64_traits> ───────────────────┘ (implements its own CPU 0)
 */
 
 #pragma once
 #include "typed_emulator.hpp"
+#include "typed_cpu.hpp"
 #include "x86_register.hpp"
+
+#include <stdexcept>
 
 namespace sogen
 {
@@ -32,7 +37,7 @@ namespace sogen
     };
 
     template <typename Traits>
-    struct x86_emulator : arch_emulator<Traits>
+    struct x86_cpu : typed_cpu<Traits>
     {
         using register_type = Traits::register_type;
         using pointer_type = Traits::pointer_type;
@@ -40,6 +45,53 @@ namespace sogen
         virtual void set_segment_base(register_type base, pointer_type value) = 0;
         virtual pointer_type get_segment_base(register_type base) = 0;
         virtual void load_gdt(pointer_type address, uint32_t limit) = 0;
+    };
+
+    template <typename Traits>
+    struct x86_emulator : arch_emulator<Traits>, x86_cpu<Traits>
+    {
+        using registers = Traits::register_type;
+        using register_type = Traits::register_type;
+        using pointer_type = Traits::pointer_type;
+        using hookable_instructions = Traits::hookable_instructions;
+
+        // Both bases expose a memory surface (the machine's own and the CPU's
+        // delegating one); they resolve to the same backend implementation.
+        using arch_emulator<Traits>::read_memory;
+        using arch_emulator<Traits>::try_read_memory;
+        using arch_emulator<Traits>::write_memory;
+        using arch_emulator<Traits>::try_write_memory;
+        using arch_emulator<Traits>::move_memory;
+
+        virtual size_t vcpu_count() const
+        {
+            return 1;
+        }
+
+        virtual x86_cpu<Traits>& get_cpu(const size_t index)
+        {
+            if (index >= this->vcpu_count())
+            {
+                throw std::out_of_range("Invalid vCPU index");
+            }
+
+            return *this;
+        }
+
+        size_t index() const override
+        {
+            return 0;
+        }
+
+        memory_interface& memory() override
+        {
+            return *this;
+        }
+
+        const memory_interface& memory() const override
+        {
+            return *this;
+        }
     };
 
     template <typename Traits>
@@ -67,6 +119,7 @@ namespace sogen
         using hookable_instructions = x86_hookable_instructions;
     };
 
+    using x86_64_cpu = x86_cpu<x86_64_traits>;
     using x86_64_emulator = x86_emulator<x86_64_traits>;
 
 } // namespace sogen

--- a/src/emulator/cpu_interface.hpp
+++ b/src/emulator/cpu_interface.hpp
@@ -12,6 +12,9 @@ namespace sogen
     {
         virtual ~cpu_interface() = default;
 
+        // Identity of this virtual CPU within its machine, in [0, vcpu_count).
+        virtual size_t index() const = 0;
+
         struct descriptor_table_register
         {
             uint64_t base{};

--- a/src/emulator/emulator.hpp
+++ b/src/emulator/emulator.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "cpu_interface.hpp"
 #include "hook_interface.hpp"
 #include "memory_interface.hpp"
 
@@ -9,7 +8,7 @@
 namespace sogen
 {
 
-    class emulator : public cpu_interface, public memory_interface, public hook_interface
+    class emulator : public memory_interface, public hook_interface
     {
       public:
         emulator() = default;

--- a/src/emulator/emulator.hpp
+++ b/src/emulator/emulator.hpp
@@ -23,6 +23,11 @@ namespace sogen
 
         virtual std::string get_name() const = 0;
 
+        // Whether this backend can drive more than one virtual CPU within a single
+        // emulator instance. Requesting more than one vCPU on a backend that returns
+        // false is an error at construction time.
+        virtual bool supports_multiple_vcpus() const = 0;
+
         virtual void serialize_state(utils::buffer_serializer& buffer, bool is_snapshot) const = 0;
         virtual void deserialize_state(utils::buffer_deserializer& buffer, bool is_snapshot) = 0;
     };

--- a/src/emulator/hook_interface.hpp
+++ b/src/emulator/hook_interface.hpp
@@ -11,6 +11,7 @@ namespace sogen
 {
 
     struct emulator_hook;
+    struct cpu_interface;
 
     using memory_operation = memory_permission;
 
@@ -41,18 +42,21 @@ namespace sogen
         size_t size;
     };
 
-    using edge_generation_hook_callback = std::function<void(const basic_block& current_block, const basic_block& previous_block)>;
-    using basic_block_hook_callback = std::function<void(const basic_block& block)>;
+    // Hook callbacks receive the virtual CPU that triggered them as their first
+    // argument. Callbacks always run on the host thread driving that CPU.
+    using edge_generation_hook_callback =
+        std::function<void(cpu_interface& cpu, const basic_block& current_block, const basic_block& previous_block)>;
+    using basic_block_hook_callback = std::function<void(cpu_interface& cpu, const basic_block& block)>;
 
     using simple_instruction_hook_callback = std::function<instruction_hook_continuation()>;
-    using instruction_hook_callback = std::function<instruction_hook_continuation(uint64_t data)>;
-    using interrupt_hook_callback = std::function<void(int interrupt)>;
+    using instruction_hook_callback = std::function<instruction_hook_continuation(cpu_interface& cpu, uint64_t data)>;
+    using interrupt_hook_callback = std::function<void(cpu_interface& cpu, int interrupt)>;
 
-    using memory_access_hook_callback = std::function<void(uint64_t address, const void* data, size_t size)>;
-    using memory_execution_hook_callback = std::function<void(uint64_t address)>;
+    using memory_access_hook_callback = std::function<void(cpu_interface& cpu, uint64_t address, const void* data, size_t size)>;
+    using memory_execution_hook_callback = std::function<void(cpu_interface& cpu, uint64_t address)>;
 
-    using memory_violation_hook_callback =
-        std::function<memory_violation_continuation(uint64_t address, size_t size, memory_operation operation, memory_violation_type type)>;
+    using memory_violation_hook_callback = std::function<memory_violation_continuation(
+        cpu_interface& cpu, uint64_t address, size_t size, memory_operation operation, memory_violation_type type)>;
 
     class hook_interface
     {

--- a/src/emulator/logger.cpp
+++ b/src/emulator/logger.cpp
@@ -150,6 +150,8 @@ namespace sogen
 
     void logger::print_message(const color c, const std::string_view message, const bool force) const
     {
+        const std::scoped_lock lock(this->print_mutex_);
+
         // Sinks observe all log activity, regardless of disable_output_. That lets
         // consumers capture a full structured log even when they've silenced the
         // terminal (e.g. --silent, or a Python wrapper capturing via callback).

--- a/src/emulator/logger.hpp
+++ b/src/emulator/logger.hpp
@@ -4,6 +4,7 @@
 #include <utils/function.hpp>
 #include <utils/win.hpp>
 
+#include <mutex>
 #include <string_view>
 #include <utility>
 
@@ -56,6 +57,7 @@ namespace sogen
 #endif
         bool disable_output_{false};
         sink sink_{};
+        mutable std::mutex print_mutex_{};
         void print_message(color c, std::string_view message, bool force = false) const;
     };
 

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -70,6 +70,19 @@ namespace sogen
         virtual memory_interface& memory() = 0;
         virtual const memory_interface& memory() const = 0;
 
+        // Guest memory is shared by every vCPU, so a CPU can stand in wherever a
+        // memory_interface is expected (emulator_object, read_string, ...). Only
+        // register state is per-CPU.
+        operator memory_interface&()
+        {
+            return this->memory();
+        }
+
+        operator const memory_interface&() const
+        {
+            return this->memory();
+        }
+
         size_t write_register(registers reg, const void* value, const size_t size)
         {
             return this->write_raw_register(static_cast<int>(reg), value, size);

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -1,0 +1,238 @@
+#pragma once
+
+#include "cpu_interface.hpp"
+#include "memory_interface.hpp"
+#include "serialization.hpp"
+
+#include <cassert>
+#include <utility>
+
+namespace sogen
+{
+
+    struct emulator_stack_allocation
+    {
+        uint64_t address{};
+        size_t size{};
+
+        emulator_stack_allocation() = default;
+
+        ~emulator_stack_allocation()
+        {
+            assert(address == 0 && "Emulator stack leak: allocation was not freed before destruction");
+        }
+
+        emulator_stack_allocation(const emulator_stack_allocation&) = delete;
+        emulator_stack_allocation& operator=(const emulator_stack_allocation&) = delete;
+
+        emulator_stack_allocation(emulator_stack_allocation&& other) noexcept
+            : address(std::exchange(other.address, 0)),
+              size(std::exchange(other.size, 0))
+        {
+        }
+
+        emulator_stack_allocation& operator=(emulator_stack_allocation&& other) noexcept
+        {
+            if (this != &other)
+            {
+                address = std::exchange(other.address, 0);
+                size = std::exchange(other.size, 0);
+            }
+            return *this;
+        }
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(address);
+            buffer.write(size);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(address);
+            buffer.read(size);
+        }
+    };
+
+    // A single virtual CPU's view of the machine: typed register and stack access
+    // native to this CPU, memory access delegated to the shared machine.
+    template <typename Traits>
+    class typed_cpu : public cpu_interface
+    {
+      public:
+        using registers = Traits::register_type;
+        using pointer_type = Traits::pointer_type;
+
+        static constexpr size_t pointer_size = sizeof(pointer_type);
+        static constexpr registers stack_pointer = Traits::stack_pointer;
+        static constexpr registers instruction_pointer = Traits::instruction_pointer;
+
+        virtual size_t index() const = 0;
+
+        virtual memory_interface& memory() = 0;
+        virtual const memory_interface& memory() const = 0;
+
+        size_t write_register(registers reg, const void* value, const size_t size)
+        {
+            return this->write_raw_register(static_cast<int>(reg), value, size);
+        }
+
+        size_t read_register(registers reg, void* value, const size_t size)
+        {
+            return this->read_raw_register(static_cast<int>(reg), value, size);
+        }
+
+        template <typename T = pointer_type>
+        T reg(const registers regid)
+        {
+            T value{};
+            this->read_register(regid, &value, sizeof(value));
+            return value;
+        }
+
+        template <typename T = pointer_type, typename S>
+        void reg(const registers regid, const S& maybe_value)
+        {
+            T value = static_cast<T>(maybe_value);
+            this->write_register(regid, &value, sizeof(value));
+        }
+
+        pointer_type read_instruction_pointer()
+        {
+            return this->reg(instruction_pointer);
+        }
+
+        pointer_type read_stack_pointer()
+        {
+            return this->reg(stack_pointer);
+        }
+
+        void read_memory(const uint64_t address, void* data, const size_t size) const
+        {
+            this->memory().read_memory(address, data, size);
+        }
+
+        bool try_read_memory(const uint64_t address, void* data, const size_t size) const
+        {
+            return this->memory().try_read_memory(address, data, size);
+        }
+
+        void write_memory(const uint64_t address, const void* data, const size_t size)
+        {
+            this->memory().write_memory(address, data, size);
+        }
+
+        bool try_write_memory(const uint64_t address, const void* data, const size_t size)
+        {
+            return this->memory().try_write_memory(address, data, size);
+        }
+
+        template <typename T>
+        T read_memory(const uint64_t address) const
+        {
+            return this->memory().template read_memory<T>(address);
+        }
+
+        template <typename T>
+        T read_memory(const void* address) const
+        {
+            return this->memory().template read_memory<T>(address);
+        }
+
+        std::vector<std::byte> read_memory(const uint64_t address, const size_t size) const
+        {
+            return this->memory().read_memory(address, size);
+        }
+
+        std::vector<std::byte> read_memory(const void* address, const size_t size) const
+        {
+            return this->memory().read_memory(address, size);
+        }
+
+        template <typename T>
+        void write_memory(const uint64_t address, const T& value)
+        {
+            this->memory().write_memory(address, value);
+        }
+
+        template <typename T>
+        void write_memory(void* address, const T& value)
+        {
+            this->memory().write_memory(address, value);
+        }
+
+        void write_memory(void* address, const void* data, const size_t size)
+        {
+            this->memory().write_memory(address, data, size);
+        }
+
+        void move_memory(const uint64_t dst, const uint64_t src, const size_t size)
+        {
+            this->memory().move_memory(dst, src, size);
+        }
+
+        pointer_type read_stack(const size_t index)
+        {
+            pointer_type result{};
+            const auto sp = this->read_stack_pointer();
+
+            this->read_memory(sp + (index * pointer_size), &result, sizeof(result));
+
+            return result;
+        }
+
+        void write_stack(const size_t index, const pointer_type& value)
+        {
+            const auto sp = this->read_stack_pointer();
+            this->write_memory(sp + (index * pointer_size), &value, sizeof(value));
+        }
+
+        void push_stack(const pointer_type& value)
+        {
+            const auto sp = this->read_stack_pointer() - pointer_size;
+            this->reg(stack_pointer, sp);
+            this->write_memory(sp, &value, sizeof(value));
+        }
+
+        pointer_type pop_stack()
+        {
+            pointer_type result{};
+            const auto sp = this->read_stack_pointer();
+            this->read_memory(sp, &result, sizeof(result));
+            this->reg(stack_pointer, sp + pointer_size);
+
+            return result;
+        }
+
+        template <typename T>
+            requires std::is_trivially_copyable_v<T>
+        emulator_stack_allocation push_stack(const T& data)
+        {
+            uint64_t old_rsp = read_stack_pointer();
+            uint64_t new_rsp = (old_rsp - sizeof(T)) & ~0xF;
+
+            reg(stack_pointer, new_rsp);
+            write_memory(new_rsp, &data, sizeof(T));
+
+            emulator_stack_allocation alloc{};
+            alloc.address = new_rsp;
+            alloc.size = static_cast<size_t>(old_rsp - new_rsp);
+
+            return alloc;
+        }
+
+        void pop_stack(emulator_stack_allocation allocation)
+        {
+            uint64_t current_rsp = read_stack_pointer();
+            assert(current_rsp == allocation.address && "Invalid stack deallocation");
+
+            reg(stack_pointer, current_rsp + allocation.size);
+            allocation = {};
+        }
+
+      private:
+        size_t read_raw_register(int reg, void* value, size_t size) override = 0;
+        size_t write_raw_register(int reg, const void* value, size_t size) override = 0;
+    };
+
+} // namespace sogen

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -67,8 +67,6 @@ namespace sogen
         static constexpr registers stack_pointer = Traits::stack_pointer;
         static constexpr registers instruction_pointer = Traits::instruction_pointer;
 
-        virtual size_t index() const = 0;
-
         virtual memory_interface& memory() = 0;
         virtual const memory_interface& memory() const = 0;
 

--- a/src/emulator/typed_emulator.hpp
+++ b/src/emulator/typed_emulator.hpp
@@ -1,54 +1,12 @@
 #pragma once
 
 #include "emulator.hpp"
+#include "typed_cpu.hpp"
+
 #include <utility>
 
 namespace sogen
 {
-
-    struct emulator_stack_allocation
-    {
-        uint64_t address{};
-        size_t size{};
-
-        emulator_stack_allocation() = default;
-
-        ~emulator_stack_allocation()
-        {
-            assert(address == 0 && "Emulator stack leak: allocation was not freed before destruction");
-        }
-
-        emulator_stack_allocation(const emulator_stack_allocation&) = delete;
-        emulator_stack_allocation& operator=(const emulator_stack_allocation&) = delete;
-
-        emulator_stack_allocation(emulator_stack_allocation&& other) noexcept
-            : address(std::exchange(other.address, 0)),
-              size(std::exchange(other.size, 0))
-        {
-        }
-
-        emulator_stack_allocation& operator=(emulator_stack_allocation&& other) noexcept
-        {
-            if (this != &other)
-            {
-                address = std::exchange(other.address, 0);
-                size = std::exchange(other.size, 0);
-            }
-            return *this;
-        }
-
-        void serialize(utils::buffer_serializer& buffer) const
-        {
-            buffer.write(address);
-            buffer.write(size);
-        }
-
-        void deserialize(utils::buffer_deserializer& buffer)
-        {
-            buffer.read(address);
-            buffer.read(size);
-        }
-    };
 
     template <typename Traits>
     class typed_emulator : public emulator
@@ -57,104 +15,6 @@ namespace sogen
         using registers = Traits::register_type;
         using pointer_type = Traits::pointer_type;
         using hookable_instructions = Traits::hookable_instructions;
-
-        static constexpr size_t pointer_size = sizeof(pointer_type);
-        static constexpr registers stack_pointer = Traits::stack_pointer;
-        static constexpr registers instruction_pointer = Traits::instruction_pointer;
-
-        size_t write_register(registers reg, const void* value, const size_t size)
-        {
-            return this->write_raw_register(static_cast<int>(reg), value, size);
-        }
-
-        size_t read_register(registers reg, void* value, const size_t size)
-        {
-            return this->read_raw_register(static_cast<int>(reg), value, size);
-        }
-
-        template <typename T = pointer_type>
-        T reg(const registers regid)
-        {
-            T value{};
-            this->read_register(regid, &value, sizeof(value));
-            return value;
-        }
-
-        template <typename T = pointer_type, typename S>
-        void reg(const registers regid, const S& maybe_value)
-        {
-            T value = static_cast<T>(maybe_value);
-            this->write_register(regid, &value, sizeof(value));
-        }
-
-        pointer_type read_instruction_pointer()
-        {
-            return this->reg(instruction_pointer);
-        }
-
-        pointer_type read_stack_pointer()
-        {
-            return this->reg(stack_pointer);
-        }
-
-        pointer_type read_stack(const size_t index)
-        {
-            pointer_type result{};
-            const auto sp = this->read_stack_pointer();
-
-            this->read_memory(sp + (index * pointer_size), &result, sizeof(result));
-
-            return result;
-        }
-
-        void write_stack(const size_t index, const pointer_type& value)
-        {
-            const auto sp = this->read_stack_pointer();
-            this->write_memory(sp + (index * pointer_size), &value, sizeof(value));
-        }
-
-        void push_stack(const pointer_type& value)
-        {
-            const auto sp = this->read_stack_pointer() - pointer_size;
-            this->reg(stack_pointer, sp);
-            this->write_memory(sp, &value, sizeof(value));
-        }
-
-        pointer_type pop_stack()
-        {
-            pointer_type result{};
-            const auto sp = this->read_stack_pointer();
-            this->read_memory(sp, &result, sizeof(result));
-            this->reg(stack_pointer, sp + pointer_size);
-
-            return result;
-        }
-
-        template <typename T>
-            requires std::is_trivially_copyable_v<T>
-        emulator_stack_allocation push_stack(const T& data)
-        {
-            uint64_t old_rsp = read_stack_pointer();
-            uint64_t new_rsp = (old_rsp - sizeof(T)) & ~0xF;
-
-            reg(stack_pointer, new_rsp);
-            write_memory(new_rsp, &data, sizeof(T));
-
-            emulator_stack_allocation alloc{};
-            alloc.address = new_rsp;
-            alloc.size = static_cast<size_t>(old_rsp - new_rsp);
-
-            return alloc;
-        }
-
-        void pop_stack(emulator_stack_allocation allocation)
-        {
-            uint64_t current_rsp = read_stack_pointer();
-            assert(current_rsp == allocation.address && "Invalid stack deallocation");
-
-            reg(stack_pointer, current_rsp + allocation.size);
-            allocation = {};
-        }
 
         emulator_hook* hook_instruction(hookable_instructions instruction_type, instruction_hook_callback callback)
         {
@@ -168,9 +28,6 @@ namespace sogen
 
       private:
         emulator_hook* hook_instruction(int instruction_type, instruction_hook_callback callback) override = 0;
-
-        size_t read_raw_register(int reg, void* value, size_t size) override = 0;
-        size_t write_raw_register(int reg, const void* value, size_t size) override = 0;
     };
 
 } // namespace sogen

--- a/src/emulator/typed_emulator.hpp
+++ b/src/emulator/typed_emulator.hpp
@@ -23,7 +23,7 @@ namespace sogen
 
         emulator_hook* hook_instruction(hookable_instructions instruction_type, simple_instruction_hook_callback callback)
         {
-            return this->hook_instruction(instruction_type, [c = std::move(callback)](const uint64_t) { return c(); });
+            return this->hook_instruction(instruction_type, [c = std::move(callback)](cpu_interface&, const uint64_t) { return c(); });
         }
 
       private:

--- a/src/fuzzer/main.cpp
+++ b/src/fuzzer/main.cpp
@@ -64,7 +64,7 @@ namespace sogen
         void forward_emulator(windows_emulator& win_emu)
         {
             const auto target = win_emu.mod_manager.executable->find_export("vulnerable");
-            win_emu.emu().hook_memory_execution(target, [&](uint64_t) {
+            win_emu.emu().hook_memory_execution(target, [&](cpu_interface&, uint64_t) {
                 win_emu.emu().stop(); //
             });
 
@@ -81,7 +81,7 @@ namespace sogen
             fuzzer_executer(const std::span<const std::byte> data)
                 : emulator_data(data)
             {
-                emu.emu().hook_basic_block([&](const basic_block& block) {
+                emu.emu().hook_basic_block([&](cpu_interface&, const basic_block& block) {
                     if (this->handler && visited_blocks.emplace(block.address).second)
                     {
                         (*this->handler)(block.address);
@@ -93,7 +93,7 @@ namespace sogen
                 emu.save_snapshot();
 
                 const auto return_address = emu.emu().read_stack(0);
-                emu.emu().hook_memory_execution(return_address, [&](const uint64_t) {
+                emu.emu().hook_memory_execution(return_address, [&](cpu_interface&, const uint64_t) {
                     emu.emu().stop(); //
                 });
             }

--- a/src/linux-emulator/linux_emulator.cpp
+++ b/src/linux-emulator/linux_emulator.cpp
@@ -628,9 +628,10 @@ namespace sogen
     void linux_emulator::setup_hooks()
     {
         // Hook the syscall instruction
-        this->emu().hook_instruction(x86_hookable_instructions::syscall, [this](uint64_t) { return this->dispatcher.dispatch(*this); });
+        this->emu().hook_instruction(x86_hookable_instructions::syscall,
+                                     [this](cpu_interface&, uint64_t) { return this->dispatcher.dispatch(*this); });
 
-        this->emu().hook_interrupt([this](const int interrupt) {
+        this->emu().hook_interrupt([this](cpu_interface&, const int interrupt) {
             this->notify_interrupt_observers(interrupt);
             if (this->should_stop)
             {
@@ -647,57 +648,57 @@ namespace sogen
 
         // Hook memory violations — first give Linux-managed observers a chance
         // to handle the fault, then fall back to SIGSEGV/default termination.
-        this->emu().hook_memory_violation(
-            [this](const uint64_t address, const size_t size, const memory_operation operation, const memory_violation_type type) {
-                if (!this->memory_violation_observers_.empty())
-                {
-                    return this->notify_memory_violation_observers(address, size, operation, type);
-                }
+        this->emu().hook_memory_violation([this](cpu_interface&, const uint64_t address, const size_t size,
+                                                 const memory_operation operation, const memory_violation_type type) {
+            if (!this->memory_violation_observers_.empty())
+            {
+                return this->notify_memory_violation_observers(address, size, operation, type);
+            }
 
-                const char* type_str = (type == memory_violation_type::unmapped) ? "unmapped" : "protection";
-                const char* op_str = "unknown";
+            const char* type_str = (type == memory_violation_type::unmapped) ? "unmapped" : "protection";
+            const char* op_str = "unknown";
 
-                if (operation == memory_permission::read)
-                {
-                    op_str = "read";
-                }
-                else if (operation == memory_permission::write)
-                {
-                    op_str = "write";
-                }
-                else if (operation == memory_permission::exec)
-                {
-                    op_str = "exec";
-                }
+            if (operation == memory_permission::read)
+            {
+                op_str = "read";
+            }
+            else if (operation == memory_permission::write)
+            {
+                op_str = "write";
+            }
+            else if (operation == memory_permission::exec)
+            {
+                op_str = "exec";
+            }
 
-                const auto rip = this->emu().read_instruction_pointer();
+            const auto rip = this->emu().read_instruction_pointer();
 
-                // Determine si_code: SEGV_MAPERR for unmapped, SEGV_ACCERR for protection violation
-                const int si_code =
-                    (type == memory_violation_type::unmapped) ? linux_signals::LINUX_SEGV_MAPERR : linux_signals::LINUX_SEGV_ACCERR;
+            // Determine si_code: SEGV_MAPERR for unmapped, SEGV_ACCERR for protection violation
+            const int si_code =
+                (type == memory_violation_type::unmapped) ? linux_signals::LINUX_SEGV_MAPERR : linux_signals::LINUX_SEGV_ACCERR;
 
-                // Try to deliver SIGSEGV to the emulated program's signal handler
-                if (this->signals.deliver_signal(*this, linux_signals::LINUX_SIGSEGV, address, si_code))
-                {
-                    // Signal handler was set up — continue execution (it will run the handler)
-                    return memory_violation_continuation::resume;
-                }
+            // Try to deliver SIGSEGV to the emulated program's signal handler
+            if (this->signals.deliver_signal(*this, linux_signals::LINUX_SIGSEGV, address, si_code))
+            {
+                // Signal handler was set up — continue execution (it will run the handler)
+                return memory_violation_continuation::resume;
+            }
 
-                // No handler — default action: terminate
-                if (!this->log.is_output_disabled())
-                {
-                    this->log.error("Memory violation at 0x%" PRIx64 ": %s %s (size=%zu, rip=0x%" PRIx64 ")\n", address, type_str, op_str,
-                                    size, rip);
-                }
+            // No handler — default action: terminate
+            if (!this->log.is_output_disabled())
+            {
+                this->log.error("Memory violation at 0x%" PRIx64 ": %s %s (size=%zu, rip=0x%" PRIx64 ")\n", address, type_str, op_str, size,
+                                rip);
+            }
 
-                this->record_stop(stop_reason::unhandled_memory_violation, format_memory_violation_stop_detail(address, size));
-                this->process.exit_status.reset();
-                this->stop();
-                return memory_violation_continuation::stop;
-            });
+            this->record_stop(stop_reason::unhandled_memory_violation, format_memory_violation_stop_detail(address, size));
+            this->process.exit_status.reset();
+            this->stop();
+            return memory_violation_continuation::stop;
+        });
 
         // Hook instruction execution (for counting)
-        this->emu().hook_memory_execution([this](const uint64_t address) { this->on_instruction_execution(address); });
+        this->emu().hook_memory_execution([this](cpu_interface&, const uint64_t address) { this->on_instruction_execution(address); });
     }
 
     void linux_emulator::on_instruction_execution(const uint64_t address)

--- a/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
+++ b/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
@@ -261,7 +261,7 @@ namespace sogen
 
             for (size_t i = 0; i < size; ++i)
             {
-                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](const uint64_t) {
+                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](cpu_interface&, const uint64_t) {
                     this->on_interrupt(); //
                 });
 
@@ -273,7 +273,7 @@ namespace sogen
 
         std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_read(addr, size, [this](const uint64_t, const void*, const size_t) {
+            auto* hook = this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
 
@@ -282,7 +282,7 @@ namespace sogen
 
         std::vector<emulator_hook*> create_write_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_write(addr, size, [this](const uint64_t, const void*, const size_t) {
+            auto* hook = this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
 

--- a/src/python-bindings/sogen_api_hooks.cpp
+++ b/src/python-bindings/sogen_api_hooks.cpp
@@ -277,7 +277,7 @@ namespace sogen::py
             return;
         }
 
-        auto* hook = this->win_emu->emu().hook_memory_execution([this](uint64_t address) {
+        auto* hook = this->win_emu->emu().hook_memory_execution([this](cpu_interface&, uint64_t address) {
             try
             {
                 this->dispatch_address(address);

--- a/src/python-bindings/sogen_internal.hpp
+++ b/src/python-bindings/sogen_internal.hpp
@@ -209,11 +209,12 @@ namespace sogen::py
 
     struct sogen_process_context
     {
+        windows_emulator* emu{};
         process_context* ctx{};
         std::shared_ptr<callback_registry> callbacks{};
         nb::object owner = nb::none();
 
-        sogen_process_context(process_context& context, std::shared_ptr<callback_registry> callback_registry, nb::object owner);
+        sogen_process_context(windows_emulator& win_emu, std::shared_ptr<callback_registry> callback_registry, nb::object owner);
 
         bool is_wow64_process() const;
         std::optional<NTSTATUS> exit_status() const;

--- a/src/python-bindings/sogen_linux_wrappers.cpp
+++ b/src/python-bindings/sogen_linux_wrappers.cpp
@@ -1,4 +1,4 @@
-#include "sogen_internal.hpp"
+﻿#include "sogen_internal.hpp"
 
 #include <linux_emulator.hpp>
 #include <disassembler.hpp>
@@ -738,7 +738,7 @@ namespace sogen::py
                 continue;
             }
 
-            auto* hook = this->emu->emu().hook_memory_execution(symbol.address, [this, key, symbol](uint64_t address) {
+            auto* hook = this->emu->emu().hook_memory_execution(symbol.address, [this, key, symbol](cpu_interface&, uint64_t address) {
                 auto& backend = this->emu->emu();
                 uint64_t return_address{};
                 if (!backend.try_read_memory(backend.reg<uint64_t>(x86_register::rsp), &return_address, sizeof(return_address)))
@@ -787,7 +787,8 @@ namespace sogen::py
             return true;
         }
 
-        auto* hook = this->emu->emu().hook_memory_execution(address, [this, address](uint64_t) { this->handle_breakpoint(address); });
+        auto* hook = this->emu->emu().hook_memory_execution(
+            address, [this, address](cpu_interface&, uint64_t) { this->handle_breakpoint(address); });
         this->breakpoints.emplace(address, hook_handle{this->emu->emu(), hook, nb::none()});
         return true;
     }
@@ -834,12 +835,14 @@ namespace sogen::py
         }
         catch (...)
         {
-            auto* hook = this->emu->emu().hook_memory_execution(address, [this, address](uint64_t) { this->handle_breakpoint(address); });
+            auto* hook = this->emu->emu().hook_memory_execution(
+                address, [this, address](cpu_interface&, uint64_t) { this->handle_breakpoint(address); });
             it->second = hook_handle{this->emu->emu(), hook, nb::none()};
             throw;
         }
 
-        auto* hook = this->emu->emu().hook_memory_execution(address, [this, address](uint64_t) { this->handle_breakpoint(address); });
+        auto* hook = this->emu->emu().hook_memory_execution(
+            address, [this, address](cpu_interface&, uint64_t) { this->handle_breakpoint(address); });
         it->second = hook_handle{this->emu->emu(), hook, nb::none()};
         return true;
     }
@@ -890,7 +893,8 @@ namespace sogen::py
 
     void linux_debug_facade::run_to(const uint64_t address)
     {
-        auto* hook = this->emu->emu().hook_memory_execution(address, [this, address](uint64_t) { this->handle_breakpoint(address); });
+        auto* hook = this->emu->emu().hook_memory_execution(
+            address, [this, address](cpu_interface&, uint64_t) { this->handle_breakpoint(address); });
         hook_handle temporary{this->emu->emu(), hook, nb::none()};
         try
         {
@@ -1092,7 +1096,7 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::memory_execution(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_memory_execution([cb = std::move(callback)](uint64_t address) {
+        auto* hook = this->emu->emu().hook_memory_execution([cb = std::move(callback)](cpu_interface&, uint64_t address) {
             nb::gil_scoped_acquire gil{};
             cb(address);
         });
@@ -1101,7 +1105,7 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::memory_execution_at(uint64_t address, nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_memory_execution(address, [cb = std::move(callback)](uint64_t addr) {
+        auto* hook = this->emu->emu().hook_memory_execution(address, [cb = std::move(callback)](cpu_interface&, uint64_t addr) {
             nb::gil_scoped_acquire gil{};
             cb(addr);
         });
@@ -1110,8 +1114,8 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::memory_read(uint64_t address, uint64_t size, nb::object callback)
     {
-        auto* hook =
-            this->emu->emu().hook_memory_read(address, size, [cb = std::move(callback)](uint64_t addr, const void* data, size_t length) {
+        auto* hook = this->emu->emu().hook_memory_read(
+            address, size, [cb = std::move(callback)](cpu_interface&, uint64_t addr, const void* data, size_t length) {
                 nb::gil_scoped_acquire gil{};
                 cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
             });
@@ -1120,8 +1124,8 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::memory_write(uint64_t address, uint64_t size, nb::object callback)
     {
-        auto* hook =
-            this->emu->emu().hook_memory_write(address, size, [cb = std::move(callback)](uint64_t addr, const void* data, size_t length) {
+        auto* hook = this->emu->emu().hook_memory_write(
+            address, size, [cb = std::move(callback)](cpu_interface&, uint64_t addr, const void* data, size_t length) {
                 nb::gil_scoped_acquire gil{};
                 cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
             });
@@ -1130,7 +1134,7 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::instruction(x86_hookable_instructions instruction_type, nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_instruction(instruction_type, [cb = std::move(callback)](uint64_t data) {
+        auto* hook = this->emu->emu().hook_instruction(instruction_type, [cb = std::move(callback)](cpu_interface&, uint64_t data) {
             nb::gil_scoped_acquire gil{};
             return coerce_instruction_continuation(cb(data));
         });
@@ -1162,7 +1166,7 @@ namespace sogen::py
 
     hook_handle linux_hook_registry::basic_block(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_basic_block([cb = std::move(callback)](const sogen::basic_block& block) {
+        auto* hook = this->emu->emu().hook_basic_block([cb = std::move(callback)](cpu_interface&, const sogen::basic_block& block) {
             nb::gil_scoped_acquire gil{};
             cb(block);
         });

--- a/src/python-bindings/sogen_wrappers.cpp
+++ b/src/python-bindings/sogen_wrappers.cpp
@@ -1,4 +1,4 @@
-#include "sogen_internal.hpp"
+﻿#include "sogen_internal.hpp"
 
 #include <windows_emulator.hpp>
 
@@ -24,7 +24,7 @@ namespace sogen::py
 
     hook_handle hook_registry::memory_execution(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_memory_execution([cb = std::move(callback)](uint64_t address) {
+        auto* hook = this->emu->emu().hook_memory_execution([cb = std::move(callback)](cpu_interface&, uint64_t address) {
             nb::gil_scoped_acquire gil{};
             cb(address);
         });
@@ -33,7 +33,7 @@ namespace sogen::py
 
     hook_handle hook_registry::memory_execution_at(uint64_t address, nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_memory_execution(address, [cb = std::move(callback)](uint64_t addr) {
+        auto* hook = this->emu->emu().hook_memory_execution(address, [cb = std::move(callback)](cpu_interface&, uint64_t addr) {
             nb::gil_scoped_acquire gil{};
             cb(addr);
         });
@@ -42,8 +42,8 @@ namespace sogen::py
 
     hook_handle hook_registry::memory_read(uint64_t address, uint64_t size, nb::object callback)
     {
-        auto* hook =
-            this->emu->emu().hook_memory_read(address, size, [cb = std::move(callback)](uint64_t addr, const void* data, size_t length) {
+        auto* hook = this->emu->emu().hook_memory_read(
+            address, size, [cb = std::move(callback)](cpu_interface&, uint64_t addr, const void* data, size_t length) {
                 nb::gil_scoped_acquire gil{};
                 cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
             });
@@ -52,8 +52,8 @@ namespace sogen::py
 
     hook_handle hook_registry::memory_write(uint64_t address, uint64_t size, nb::object callback)
     {
-        auto* hook =
-            this->emu->emu().hook_memory_write(address, size, [cb = std::move(callback)](uint64_t addr, const void* data, size_t length) {
+        auto* hook = this->emu->emu().hook_memory_write(
+            address, size, [cb = std::move(callback)](cpu_interface&, uint64_t addr, const void* data, size_t length) {
                 nb::gil_scoped_acquire gil{};
                 cb(addr, nb::bytes(static_cast<const char*>(data), static_cast<nb::ssize_t>(length)));
             });
@@ -62,7 +62,7 @@ namespace sogen::py
 
     hook_handle hook_registry::instruction(x86_hookable_instructions instruction_type, nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_instruction(instruction_type, [cb = std::move(callback)](uint64_t data) {
+        auto* hook = this->emu->emu().hook_instruction(instruction_type, [cb = std::move(callback)](cpu_interface&, uint64_t data) {
             nb::gil_scoped_acquire gil{};
             return coerce_instruction_continuation(cb(data));
         });
@@ -71,7 +71,7 @@ namespace sogen::py
 
     hook_handle hook_registry::interrupt(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_interrupt([cb = std::move(callback)](int interrupt) {
+        auto* hook = this->emu->emu().hook_interrupt([cb = std::move(callback)](cpu_interface&, int interrupt) {
             nb::gil_scoped_acquire gil{};
             cb(interrupt);
         });
@@ -80,8 +80,9 @@ namespace sogen::py
 
     hook_handle hook_registry::memory_violation(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_memory_violation(
-            [cb = std::move(callback)](uint64_t address, size_t size, memory_operation operation, memory_violation_type type) {
+        auto* hook =
+            this->emu->emu().hook_memory_violation([cb = std::move(callback)](cpu_interface&, uint64_t address, size_t size,
+                                                                              memory_operation operation, memory_violation_type type) {
                 nb::gil_scoped_acquire gil{};
                 return coerce_memory_violation_continuation(cb(address, size, operation, type));
             });
@@ -90,7 +91,7 @@ namespace sogen::py
 
     hook_handle hook_registry::basic_block(nb::object callback)
     {
-        auto* hook = this->emu->emu().hook_basic_block([cb = std::move(callback)](const sogen::basic_block& block) {
+        auto* hook = this->emu->emu().hook_basic_block([cb = std::move(callback)](cpu_interface&, const sogen::basic_block& block) {
             nb::gil_scoped_acquire gil{};
             cb(block);
         });

--- a/src/python-bindings/sogen_wrappers.cpp
+++ b/src/python-bindings/sogen_wrappers.cpp
@@ -100,9 +100,10 @@ namespace sogen::py
 
     // ----- sogen_process_context -----
 
-    sogen_process_context::sogen_process_context(process_context& context, std::shared_ptr<callback_registry> callback_registry,
+    sogen_process_context::sogen_process_context(windows_emulator& win_emu, std::shared_ptr<callback_registry> callback_registry,
                                                  nb::object owner)
-        : ctx(&context),
+        : emu(&win_emu),
+          ctx(&win_emu.process),
           callbacks(std::move(callback_registry)),
           owner(std::move(owner))
     {
@@ -130,7 +131,7 @@ namespace sogen::py
 
     emulator_thread* sogen_process_context::active_thread() const
     {
-        return this->ctx->active_thread;
+        return this->emu->vcpu(0).active_thread;
     }
 
     callback_registry& sogen_process_context::callback_view() const
@@ -195,17 +196,17 @@ namespace sogen::py
 
     void sogen_windows_emulator::yield_thread(const bool alertable) const
     {
-        this->emu->yield_thread(alertable);
+        this->emu->yield_thread(this->emu->vcpu(0), alertable);
     }
 
     bool sogen_windows_emulator::perform_thread_switch() const
     {
-        return this->emu->perform_thread_switch();
+        return this->emu->perform_thread_switch(this->emu->vcpu(0));
     }
 
     bool sogen_windows_emulator::activate_thread(const uint32_t id) const
     {
-        return this->emu->activate_thread(id);
+        return this->emu->activate_thread(this->emu->vcpu(0), id);
     }
 
     memory_manager& sogen_windows_emulator::memory() const
@@ -215,7 +216,7 @@ namespace sogen::py
 
     emulator_thread* sogen_windows_emulator::current_thread() const
     {
-        return this->emu->process.active_thread;
+        return this->emu->vcpu(0).active_thread;
     }
 
     nb::bytes sogen_windows_emulator::read_memory(const uint64_t address, const size_t size) const
@@ -255,16 +256,17 @@ namespace sogen::py
 
     sogen_process_context sogen_windows_emulator::process()
     {
-        return {this->emu->process, this->callbacks, nb::cast(this, nb::rv_policy::reference_internal)};
+        return {*this->emu, this->callbacks, nb::cast(this, nb::rv_policy::reference_internal)};
     }
 
     std::optional<uint32_t> sogen_windows_emulator::current_thread_id() const
     {
-        if (!this->emu->process.active_thread)
+        const auto* active_thread = this->emu->vcpu(0).active_thread;
+        if (!active_thread)
         {
             return std::nullopt;
         }
 
-        return this->emu->process.active_thread->id;
+        return active_thread->id;
     }
 }

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(manual-messagebox-sample)
 add_subdirectory(manual-controls-sample)
 add_subdirectory(custom-paint-sample)
 add_subdirectory(test-sample)
+add_subdirectory(stress-sample)
 add_subdirectory(vulkan-shim)
 add_subdirectory(vulkan-shim-test)
 

--- a/src/samples/stress-sample/CMakeLists.txt
+++ b/src/samples/stress-sample/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
+  *.cpp
+  *.hpp
+)
+
+list(SORT SRC_FILES)
+
+add_executable(stress-sample ${SRC_FILES})
+
+sogen_assign_source_group(${SRC_FILES})

--- a/src/samples/stress-sample/stress.cpp
+++ b/src/samples/stress-sample/stress.cpp
@@ -66,10 +66,12 @@ namespace
             {
                 EnterCriticalSection(&cs);
                 const LONG value = guarded;
-                // Widen the race window without yielding the vCPU (a syscall would serialize us). Simple
-                // assignment rather than ++ because increment of a volatile is deprecated in C++20.
-                for (volatile int spin = 0; spin < 64; spin = spin + 1)
+                // Widen the race window without yielding the vCPU (a syscall would serialize us). An atomic
+                // delay loop keeps the compiler from eliding it; a volatile counter is deprecated in C++20.
+                std::atomic<int> spin{0};
+                for (int i = 0; i < 64; ++i)
                 {
+                    spin.fetch_add(1, std::memory_order_relaxed);
                 }
                 guarded = value + 1;
                 LeaveCriticalSection(&cs);

--- a/src/samples/stress-sample/stress.cpp
+++ b/src/samples/stress-sample/stress.cpp
@@ -66,8 +66,9 @@ namespace
             {
                 EnterCriticalSection(&cs);
                 const LONG value = guarded;
-                // Widen the race window without yielding the vCPU (a syscall would serialize us).
-                for (volatile int spin = 0; spin < 64; ++spin)
+                // Widen the race window without yielding the vCPU (a syscall would serialize us). Simple
+                // assignment rather than ++ because increment of a volatile is deprecated in C++20.
+                for (volatile int spin = 0; spin < 64; spin = spin + 1)
                 {
                 }
                 guarded = value + 1;

--- a/src/samples/stress-sample/stress.cpp
+++ b/src/samples/stress-sample/stress.cpp
@@ -58,14 +58,14 @@ namespace
         CRITICAL_SECTION cs;
         InitializeCriticalSection(&cs);
 
-        volatile long guarded = 0;
+        volatile LONG guarded = 0;
         const unsigned iters = scaled(2000);
 
         run_threads(kThreads, [&](unsigned) {
             for (unsigned i = 0; i < iters; ++i)
             {
                 EnterCriticalSection(&cs);
-                const long value = guarded;
+                const LONG value = guarded;
                 // Widen the race window without yielding the vCPU (a syscall would serialize us).
                 for (volatile int spin = 0; spin < 64; ++spin)
                 {
@@ -77,7 +77,7 @@ namespace
 
         DeleteCriticalSection(&cs);
 
-        const long expected = static_cast<long>(kThreads * iters);
+        const LONG expected = static_cast<LONG>(kThreads) * static_cast<LONG>(iters);
         if (guarded != expected)
         {
             printf("  critical section: lost updates, got %ld expected %ld\n", guarded, expected);
@@ -90,7 +90,7 @@ namespace
     // prefix must stay atomic across host threads. A torn increment shows up as a short total.
     bool test_interlocked()
     {
-        volatile long counter = 0;
+        volatile LONG counter = 0;
         const unsigned iters = scaled(20000);
 
         run_threads(kThreads, [&](unsigned) {
@@ -100,7 +100,7 @@ namespace
             }
         });
 
-        const long expected = static_cast<long>(kThreads * iters);
+        const LONG expected = static_cast<LONG>(kThreads) * static_cast<LONG>(iters);
         if (counter != expected)
         {
             printf("  interlocked: torn increment, got %ld expected %ld\n", counter, expected);
@@ -116,7 +116,7 @@ namespace
         const unsigned producers = kThreads / 2;
         const unsigned consumers = kThreads - producers;
         const unsigned per_producer = scaled(1000);
-        const long total = static_cast<long>(producers * per_producer);
+        const LONG total = static_cast<LONG>(producers) * static_cast<LONG>(per_producer);
 
         HANDLE sem = CreateSemaphoreW(nullptr, 0, total, nullptr);
         if (!sem)
@@ -125,8 +125,8 @@ namespace
             return false;
         }
 
-        std::atomic<long> claim{0};
-        std::atomic<long> acquired{0};
+        std::atomic<LONG> claim{0};
+        std::atomic<LONG> acquired{0};
         std::atomic<bool> ok{true};
 
         std::vector<std::thread> threads;
@@ -251,7 +251,7 @@ namespace
                 }
 
                 const uint32_t stamp = (tid << 24) ^ (i * 2654435761u);
-                constexpr unsigned words = 0x1000 / sizeof(uint32_t);
+                constexpr auto words = static_cast<unsigned>(0x1000 / sizeof(uint32_t));
                 for (unsigned w = 0; w < words; ++w)
                 {
                     page[w] = stamp + w;
@@ -291,7 +291,7 @@ int main(const int argc, const char* argv[])
 {
     if (argc >= 2)
     {
-        const int parsed = atoi(argv[1]);
+        const auto parsed = std::strtol(argv[1], nullptr, 10);
         if (parsed > 0)
         {
             g_scale = static_cast<unsigned>(parsed);

--- a/src/samples/stress-sample/stress.cpp
+++ b/src/samples/stress-sample/stress.cpp
@@ -1,0 +1,312 @@
+// Multi-threaded stress sample for the multi-vCPU emulator (docs/multi-vcpu-design.md, Phase 4).
+//
+// Every workload below asserts a deterministic invariant that only holds when the emulator's
+// cross-vCPU synchronization and memory are correct: broken mutual exclusion loses counter
+// updates, a lost wakeup stalls a wait until it times out, and a memory-manager race corrupts a
+// freshly written page. Run it at --vcpus 1..8; exit code 0 means every invariant held.
+//
+// The workload scale can be tuned with argv[1] (a positive multiplier, default 1) to trade run
+// time for contention when iterating.
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <atomic>
+#include <thread>
+#include <vector>
+#include <functional>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace
+{
+    unsigned g_scale = 1;
+
+    unsigned scaled(const unsigned base)
+    {
+        return base * g_scale;
+    }
+
+    // Number of guest worker threads. Fixed above any realistic --vcpus so guest threads always
+    // outnumber vCPUs and genuinely contend, even at --vcpus 2.
+    constexpr unsigned kThreads = 8;
+
+    void run_threads(const unsigned count, const std::function<void(unsigned)>& body)
+    {
+        std::vector<std::thread> threads;
+        threads.reserve(count);
+        for (unsigned i = 0; i < count; ++i)
+        {
+            threads.emplace_back(body, i);
+        }
+        for (auto& t : threads)
+        {
+            t.join();
+        }
+    }
+
+    // Workload 1 - mutual exclusion. Threads take a CRITICAL_SECTION and do a non-atomic
+    // read-modify-write on a shared counter with a deliberately widened window between the read and
+    // the write. If the emulator ever lets two vCPUs hold the section at once, updates are lost and
+    // the final value falls short of the expected total.
+    bool test_critical_section()
+    {
+        CRITICAL_SECTION cs;
+        InitializeCriticalSection(&cs);
+
+        volatile long guarded = 0;
+        const unsigned iters = scaled(2000);
+
+        run_threads(kThreads, [&](unsigned) {
+            for (unsigned i = 0; i < iters; ++i)
+            {
+                EnterCriticalSection(&cs);
+                const long value = guarded;
+                // Widen the race window without yielding the vCPU (a syscall would serialize us).
+                for (volatile int spin = 0; spin < 64; ++spin)
+                {
+                }
+                guarded = value + 1;
+                LeaveCriticalSection(&cs);
+            }
+        });
+
+        DeleteCriticalSection(&cs);
+
+        const long expected = static_cast<long>(kThreads * iters);
+        if (guarded != expected)
+        {
+            printf("  critical section: lost updates, got %ld expected %ld\n", guarded, expected);
+            return false;
+        }
+        return true;
+    }
+
+    // Workload 2 - interlocked atomics across vCPUs. On WHP these run on real cores, so the lock
+    // prefix must stay atomic across host threads. A torn increment shows up as a short total.
+    bool test_interlocked()
+    {
+        volatile long counter = 0;
+        const unsigned iters = scaled(20000);
+
+        run_threads(kThreads, [&](unsigned) {
+            for (unsigned i = 0; i < iters; ++i)
+            {
+                InterlockedIncrement(&counter);
+            }
+        });
+
+        const long expected = static_cast<long>(kThreads * iters);
+        if (counter != expected)
+        {
+            printf("  interlocked: torn increment, got %ld expected %ld\n", counter, expected);
+            return false;
+        }
+        return true;
+    }
+
+    // Workload 3 - semaphore producer/consumer. Producers release exactly `total` permits; consumers
+    // claim exactly `total` waits. Every wait must succeed - a lost wakeup surfaces as a timeout.
+    bool test_semaphore()
+    {
+        const unsigned producers = kThreads / 2;
+        const unsigned consumers = kThreads - producers;
+        const unsigned per_producer = scaled(1000);
+        const long total = static_cast<long>(producers * per_producer);
+
+        HANDLE sem = CreateSemaphoreW(nullptr, 0, total, nullptr);
+        if (!sem)
+        {
+            puts("  semaphore: CreateSemaphore failed");
+            return false;
+        }
+
+        std::atomic<long> claim{0};
+        std::atomic<long> acquired{0};
+        std::atomic<bool> ok{true};
+
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+
+        for (unsigned p = 0; p < producers; ++p)
+        {
+            threads.emplace_back([&] {
+                for (unsigned i = 0; i < per_producer; ++i)
+                {
+                    ReleaseSemaphore(sem, 1, nullptr);
+                }
+            });
+        }
+
+        for (unsigned c = 0; c < consumers; ++c)
+        {
+            threads.emplace_back([&] {
+                while (claim.fetch_add(1) < total)
+                {
+                    if (WaitForSingleObject(sem, 15000) != WAIT_OBJECT_0)
+                    {
+                        ok.store(false);
+                        return;
+                    }
+                    acquired.fetch_add(1);
+                }
+            });
+        }
+
+        for (auto& t : threads)
+        {
+            t.join();
+        }
+
+        CloseHandle(sem);
+
+        if (!ok.load())
+        {
+            puts("  semaphore: a consumer wait timed out (lost wakeup)");
+            return false;
+        }
+        if (acquired.load() != total)
+        {
+            printf("  semaphore: consumed %ld expected %ld\n", acquired.load(), total);
+            return false;
+        }
+        return true;
+    }
+
+    // Workload 4 - auto-reset event ping-pong. Two threads hand a token back and forth through a tight
+    // set/wait loop. This is the densest wait/wake path; a single dropped signal deadlocks one side,
+    // caught by the finite wait timeout.
+    bool test_event_pingpong()
+    {
+        HANDLE e_a = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        HANDLE e_b = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!e_a || !e_b)
+        {
+            puts("  ping-pong: CreateEvent failed");
+            return false;
+        }
+
+        const unsigned rounds = scaled(1500);
+        std::atomic<bool> ok{true};
+
+        std::thread a([&] {
+            for (unsigned i = 0; i < rounds; ++i)
+            {
+                SetEvent(e_a);
+                if (WaitForSingleObject(e_b, 15000) != WAIT_OBJECT_0)
+                {
+                    ok.store(false);
+                    return;
+                }
+            }
+        });
+
+        std::thread b([&] {
+            for (unsigned i = 0; i < rounds; ++i)
+            {
+                if (WaitForSingleObject(e_a, 15000) != WAIT_OBJECT_0)
+                {
+                    ok.store(false);
+                    return;
+                }
+                SetEvent(e_b);
+            }
+        });
+
+        a.join();
+        b.join();
+
+        CloseHandle(e_a);
+        CloseHandle(e_b);
+
+        if (!ok.load())
+        {
+            puts("  ping-pong: a wait timed out (lost wakeup)");
+            return false;
+        }
+        return true;
+    }
+
+    // Workload 5 - VirtualAlloc churn with write/read verification. Each thread repeatedly commits a
+    // page, stamps it with a value unique to (thread, iteration), reads it back, and frees it. Under a
+    // memory-manager race two threads could receive overlapping backing pages, so the readback would
+    // not match what this thread wrote.
+    bool test_memory_churn()
+    {
+        const unsigned iters = scaled(800);
+        std::atomic<bool> ok{true};
+
+        run_threads(kThreads, [&](unsigned tid) {
+            for (unsigned i = 0; i < iters && ok.load(); ++i)
+            {
+                auto* page = static_cast<uint32_t*>(VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+                if (!page)
+                {
+                    ok.store(false);
+                    return;
+                }
+
+                const uint32_t stamp = (tid << 24) ^ (i * 2654435761u);
+                constexpr unsigned words = 0x1000 / sizeof(uint32_t);
+                for (unsigned w = 0; w < words; ++w)
+                {
+                    page[w] = stamp + w;
+                }
+                for (unsigned w = 0; w < words; ++w)
+                {
+                    if (page[w] != stamp + w)
+                    {
+                        ok.store(false);
+                        break;
+                    }
+                }
+
+                VirtualFree(page, 0, MEM_RELEASE);
+            }
+        });
+
+        if (!ok.load())
+        {
+            puts("  memory churn: allocation failed or page contents corrupted");
+            return false;
+        }
+        return true;
+    }
+}
+
+#define RUN(func, name)                        \
+    {                                          \
+        printf("Running stress '" name "': "); \
+        fflush(stdout);                        \
+        const bool res = func();               \
+        valid &= res;                          \
+        puts(res ? "Success" : "Fail");        \
+    }
+
+int main(const int argc, const char* argv[])
+{
+    if (argc >= 2)
+    {
+        const int parsed = atoi(argv[1]);
+        if (parsed > 0)
+        {
+            g_scale = static_cast<unsigned>(parsed);
+        }
+    }
+
+    printf("stress-sample: %u threads, scale %u\n", kThreads, g_scale);
+
+    bool valid = true;
+    RUN(test_interlocked, "Interlocked")
+    RUN(test_critical_section, "Critical Section")
+    RUN(test_semaphore, "Semaphore")
+    RUN(test_event_pingpong, "Event Ping-Pong")
+    RUN(test_memory_churn, "Memory Churn")
+
+    puts(valid ? "ALL STRESS TESTS PASSED" : "STRESS TESTS FAILED");
+    return valid ? 0 : 1;
+}

--- a/src/samples/stress-sample/stress.cpp
+++ b/src/samples/stress-sample/stress.cpp
@@ -69,7 +69,7 @@ namespace
                 // Widen the race window without yielding the vCPU (a syscall would serialize us). An atomic
                 // delay loop keeps the compiler from eliding it; a volatile counter is deprecated in C++20.
                 std::atomic<int> spin{0};
-                for (int i = 0; i < 64; ++i)
+                for (int k = 0; k < 64; ++k)
                 {
                     spin.fetch_add(1, std::memory_order_relaxed);
                 }

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -10,6 +10,7 @@
 
 #include <CLI/CLI.hpp>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstdio>
@@ -18,6 +19,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace sogen::sandbox
@@ -62,7 +64,16 @@ namespace sogen::sandbox
                 .arguments = parse_arguments(args),
             };
 
+#ifdef _WIN32
+            // One vCPU per host core; WHP supports at most 64 per partition.
+            const auto vcpu_count = std::clamp(std::thread::hardware_concurrency(), 1u, 64u);
+#else
+            // The KVM backend does not support multiple vCPUs yet.
+            constexpr uint32_t vcpu_count = 1;
+#endif
+
             emulator_settings settings{
+                .vcpu_count = vcpu_count,
                 .registry_directory = get_current_binary_dir() / "registry",
             };
 
@@ -79,7 +90,7 @@ namespace sogen::sandbox
             };
 
 #ifdef _WIN32
-            auto emulator = whp::create_x86_64_emulator();
+            auto emulator = whp::create_x86_64_emulator(vcpu_count);
 #else
             auto emulator = kvm::create_x86_64_emulator();
 #endif

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -65,8 +65,12 @@ namespace sogen::sandbox
             };
 
 #ifdef _WIN32
-            // One vCPU per host core; WHP supports at most 64 per partition.
-            const auto vcpu_count = std::clamp(std::thread::hardware_concurrency(), 1u, 64u);
+            // One vCPU per host core; WHP supports at most 64 per partition. EMULATOR_VCPU_COUNT overrides.
+            auto vcpu_count = std::clamp(std::thread::hardware_concurrency(), 1u, 64u);
+            if (const char* env = std::getenv("EMULATOR_VCPU_COUNT"); env != nullptr && env[0] != '\0')
+            {
+                vcpu_count = std::clamp(static_cast<uint32_t>(std::strtoul(env, nullptr, 10)), 1u, 64u);
+            }
 #else
             // The KVM backend does not support multiple vCPUs yet.
             constexpr uint32_t vcpu_count = 1;

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -71,13 +71,9 @@ namespace sogen::sandbox
             {
                 vcpu_count = std::clamp(static_cast<uint32_t>(std::strtoul(env, nullptr, 10)), 1u, 64u);
             }
-#else
-            // The KVM backend does not support multiple vCPUs yet.
-            constexpr uint32_t vcpu_count = 1;
 #endif
 
             emulator_settings settings{
-                .vcpu_count = vcpu_count,
                 .registry_directory = get_current_binary_dir() / "registry",
             };
 

--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -745,30 +745,31 @@ namespace sogen
                 max = std::max(import_thunk, max);
             }
 
-            c.win_emu->emu().hook_memory_write(min, max - min, [&c](const uint64_t address, const void* value, size_t size) {
-                const auto& watched_module = *c.win_emu->mod_manager.executable;
+            c.win_emu->emu().hook_memory_write(min, max - min,
+                                               [&c](cpu_interface&, const uint64_t address, const void* value, size_t size) {
+                                                   const auto& watched_module = *c.win_emu->mod_manager.executable;
 
-                const auto sym = watched_module.imports.find(address);
-                if (sym == watched_module.imports.end())
-                {
-                    // TODO: Print unaligned write accesses?
-                    return;
-                }
+                                                   const auto sym = watched_module.imports.find(address);
+                                                   if (sym == watched_module.imports.end())
+                                                   {
+                                                       // TODO: Print unaligned write accesses?
+                                                       return;
+                                                   }
 
-                uint64_t int_value{};
-                memcpy(&int_value, value, std::min(size, sizeof(int_value)));
+                                                   uint64_t int_value{};
+                                                   memcpy(&int_value, value, std::min(size, sizeof(int_value)));
 
-                const auto import_module = watched_module.imported_modules.at(sym->second.module_index);
+                                                   const auto import_module = watched_module.imported_modules.at(sym->second.module_index);
 
-                c.emit_observation<import_write_event>([&](auto& event) {
-                    event.size = size;
-                    event.value = int_value;
-                    event.import_name = sym->second.name;
-                    event.import_module = import_module;
-                });
-            });
+                                                   c.emit_observation<import_write_event>([&](auto& event) {
+                                                       event.size = size;
+                                                       event.value = int_value;
+                                                       event.import_name = sym->second.name;
+                                                       event.import_module = import_module;
+                                                   });
+                                               });
 
-            c.win_emu->emu().hook_memory_read(min, max - min, [&c](const uint64_t address, const void*, size_t) {
+            c.win_emu->emu().hook_memory_read(min, max - min, [&c](cpu_interface&, const uint64_t address, const void*, size_t) {
                 const auto rip = c.win_emu->emu().read_instruction_pointer();
                 const auto& watched_module = *c.win_emu->mod_manager.executable;
                 const auto accessor_module = get_module_if_interesting(c.win_emu->mod_manager, c.settings->modules, rip);

--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -36,7 +36,7 @@ namespace sogen
             };
         }
 
-        std::string get_instruction_string(const disassembler& d, const emulator& emu, const uint64_t address)
+        std::string get_instruction_string(const disassembler& d, x86_64_cpu& emu, const uint64_t address)
         {
             std::array<uint8_t, MAX_INSTRUCTION_BYTES> instruction_bytes{};
             const auto result = emu.try_read_memory(address, instruction_bytes.data(), instruction_bytes.size());
@@ -45,10 +45,8 @@ namespace sogen
                 return {};
             }
 
-            uint16_t reg_cs = 0;
-            auto& emu_ref = const_cast<emulator&>(emu);
-            emu_ref.read_raw_register(static_cast<int>(x86_register::cs), &reg_cs, sizeof(reg_cs));
-            const auto instructions = d.disassemble(emu_ref, reg_cs, instruction_bytes, 1, address);
+            const auto reg_cs = emu.reg<uint16_t>(x86_register::cs);
+            const auto instructions = d.disassemble(emu, reg_cs, instruction_bytes, 1, address);
             if (instructions.empty())
             {
                 return {};
@@ -399,7 +397,7 @@ namespace sogen
             }
         }
 
-        bool is_return(const disassembler& d, const emulator& emu, const uint64_t address)
+        bool is_return(const disassembler& d, x86_64_cpu& emu, const uint64_t address)
         {
             std::array<uint8_t, MAX_INSTRUCTION_BYTES> instruction_bytes{};
             const auto result = emu.try_read_memory(address, instruction_bytes.data(), instruction_bytes.size());
@@ -408,16 +406,14 @@ namespace sogen
                 return false;
             }
 
-            uint16_t reg_cs = 0;
-            auto& emu_ref = const_cast<emulator&>(emu);
-            emu_ref.read_raw_register(static_cast<int>(x86_register::cs), &reg_cs, sizeof(reg_cs));
-            const auto instructions = d.disassemble(emu_ref, reg_cs, instruction_bytes, 1, address);
+            const auto reg_cs = emu.reg<uint16_t>(x86_register::cs);
+            const auto instructions = d.disassemble(emu, reg_cs, instruction_bytes, 1, address);
             if (instructions.empty())
             {
                 return false;
             }
 
-            const auto handle = d.resolve_handle(emu_ref, reg_cs);
+            const auto handle = d.resolve_handle(emu, reg_cs);
             return cs_insn_group(handle, instructions.data(), CS_GRP_RET);
         }
 

--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -630,7 +630,7 @@ namespace sogen
             }
 
             auto& win_emu = *c.win_emu;
-            auto& emu = win_emu.emu();
+            auto& emu = win_emu.active_cpu();
 
             const auto address = emu.read_instruction_pointer();
             if (c.syscall_to_resume_after_break)

--- a/src/windows-analyzer/analysis.cpp
+++ b/src/windows-analyzer/analysis.cpp
@@ -593,7 +593,7 @@ namespace sogen
         void handle_rdtsc(analysis_context& c)
         {
             auto& win_emu = *c.win_emu;
-            auto& emu = win_emu.emu();
+            auto& emu = win_emu.active_cpu();
 
             const auto rip = emu.read_instruction_pointer();
             const auto mod = get_module_if_interesting(win_emu.mod_manager, c.settings->modules, rip);
@@ -609,7 +609,7 @@ namespace sogen
         void handle_rdtscp(analysis_context& c)
         {
             auto& win_emu = *c.win_emu;
-            auto& emu = win_emu.emu();
+            auto& emu = win_emu.active_cpu();
 
             const auto rip = emu.read_instruction_pointer();
             const auto mod = get_module_if_interesting(win_emu.mod_manager, c.settings->modules, rip);
@@ -809,7 +809,7 @@ namespace sogen
 
     execution_context analysis_context::make_execution_context() const
     {
-        auto& emu = this->win_emu->emu();
+        auto& emu = this->win_emu->active_cpu();
         const auto rip = emu.read_instruction_pointer();
         const auto* rip_module = this->win_emu->mod_manager.find_name(rip);
 

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -174,30 +174,32 @@ namespace sogen
                     return;
                 }
 
-                auto hook_handler = [state, env_ptr](cpu_interface&, const uint64_t address, const void*, const size_t size) {
-                    const auto rip = state->win_emu_.emu().read_instruction_pointer();
-                    const auto* mod = state->win_emu_.mod_manager.find_by_address(rip);
-                    const auto is_main_access =
-                        !mod || (mod == state->win_emu_.mod_manager.executable || state->modules_.contains(mod->name));
+                auto hook_handler = [state, env_ptr](cpu_interface& cpu, const uint64_t address, const void*, const size_t size) {
+                    state->win_emu_.dispatch_on_cpu(cpu, [&] {
+                        const auto rip = state->win_emu_.active_cpu().read_instruction_pointer();
+                        const auto* mod = state->win_emu_.mod_manager.find_by_address(rip);
+                        const auto is_main_access =
+                            !mod || (mod == state->win_emu_.mod_manager.executable || state->modules_.contains(mod->name));
 
-                    if (!is_main_access && !state->verbose_)
-                    {
-                        return;
-                    }
-
-                    if (state->concise_)
-                    {
-                        const auto count = ++state->env_module_cache_[mod ? mod->name : "<N/A>"];
-                        if (count > 30 && count % 1000 != 0)
+                        if (!is_main_access && !state->verbose_)
                         {
                             return;
                         }
-                    }
 
-                    state->context_.emit_observation<environment_access_event>([&](auto& event) {
-                        event.main_access = is_main_access;
-                        event.offset = address - env_ptr;
-                        event.size = size;
+                        if (state->concise_)
+                        {
+                            const auto count = ++state->env_module_cache_[mod ? mod->name : "<N/A>"];
+                            if (count > 30 && count % 1000 != 0)
+                            {
+                                return;
+                            }
+                        }
+
+                        state->context_.emit_observation<environment_access_event>([&](auto& event) {
+                            event.main_access = is_main_access;
+                            event.offset = address - env_ptr;
+                            event.size = size;
+                        });
                     });
                 };
 
@@ -702,37 +704,39 @@ namespace sogen
             {
                 auto module_cache = std::make_shared<std::map<std::string, uint64_t>>();
                 win_emu->emu().hook_memory_read(0, std::numeric_limits<uint64_t>::max(),
-                                                [&, module_cache](cpu_interface&, const uint64_t address, const void*, size_t size) {
-                                                    const auto rip = win_emu->emu().read_instruction_pointer();
-                                                    const auto accessor =
-                                                        get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
+                                                [&, module_cache](cpu_interface& cpu, const uint64_t address, const void*, size_t size) {
+                                                    win_emu->dispatch_on_cpu(cpu, [&] {
+                                                        const auto rip = win_emu->active_cpu().read_instruction_pointer();
+                                                        const auto accessor =
+                                                            get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
 
-                                                    if (!accessor.has_value())
-                                                    {
-                                                        return;
-                                                    }
-
-                                                    const auto* mod = win_emu->mod_manager.find_by_address(address);
-                                                    if (!mod || mod == *accessor)
-                                                    {
-                                                        return;
-                                                    }
-
-                                                    if (concise_logging)
-                                                    {
-                                                        const auto count = ++(*module_cache)[mod->name];
-                                                        if (count > 30 && count % 100000 != 0)
+                                                        if (!accessor.has_value())
                                                         {
                                                             return;
                                                         }
-                                                    }
 
-                                                    const auto* region_name = get_module_memory_region_name(*mod, address);
-                                                    context.emit_observation<foreign_module_read_event>([&](auto& event) {
-                                                        event.address = address;
-                                                        event.size = size;
-                                                        event.module_name = mod->name;
-                                                        event.region_name = region_name;
+                                                        const auto* mod = win_emu->mod_manager.find_by_address(address);
+                                                        if (!mod || mod == *accessor)
+                                                        {
+                                                            return;
+                                                        }
+
+                                                        if (concise_logging)
+                                                        {
+                                                            const auto count = ++(*module_cache)[mod->name];
+                                                            if (count > 30 && count % 100000 != 0)
+                                                            {
+                                                                return;
+                                                            }
+                                                        }
+
+                                                        const auto* region_name = get_module_memory_region_name(*mod, address);
+                                                        context.emit_observation<foreign_module_read_event>([&](auto& event) {
+                                                            event.address = address;
+                                                            event.size = size;
+                                                            event.module_name = mod->name;
+                                                            event.region_name = region_name;
+                                                        });
                                                     });
                                                 });
             }

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -894,6 +894,11 @@ namespace sogen
 
             try
             {
+                if (options.use_gdb && options.vcpu_count > 1)
+                {
+                    throw std::runtime_error("GDB debugging requires --vcpus 1");
+                }
+
                 if (!backend_name.empty())
                 {
                     static const std::map<std::string, backend_type> backends{

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -472,7 +472,6 @@ namespace sogen
             return {
                 .use_relative_time = options.reproducible,
                 .use_instruction_precision = !options.disable_instruction_precision,
-                .vcpu_count = options.vcpu_count,
                 .emulation_root = options.emulation_root,
                 .registry_directory = options.registry_path,
                 .path_mappings = options.path_mappings,

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -174,7 +174,7 @@ namespace sogen
                     return;
                 }
 
-                auto hook_handler = [state, env_ptr](const uint64_t address, const void*, const size_t size) {
+                auto hook_handler = [state, env_ptr](cpu_interface&, const uint64_t address, const void*, const size_t size) {
                     const auto rip = state->win_emu_.emu().read_instruction_pointer();
                     const auto* mod = state->win_emu_.mod_manager.find_by_address(rip);
                     const auto is_main_access =
@@ -209,7 +209,7 @@ namespace sogen
             auto& win_emu = state->win_emu_;
             return state->win_emu_.emu().hook_memory_write(
                 process_params.value() + offsetof(RTL_USER_PROCESS_PARAMETERS64, Environment), 0x8,
-                [&win_emu, install = std::move(install_env_access_hook)](const uint64_t address, const void*, size_t) {
+                [&win_emu, install = std::move(install_env_access_hook)](cpu_interface&, const uint64_t address, const void*, size_t) {
                     const auto new_process_params = get_process_params(win_emu);
 
                     const auto target_address = new_process_params.value() + offsetof(RTL_USER_PROCESS_PARAMETERS64, Environment);
@@ -256,7 +256,7 @@ namespace sogen
 
             win_emu.emu().hook_memory_write(
                 win_emu.process.peb64.value() + offsetof(PEB64, ProcessParameters), 0x8,
-                [state, emit_object_access, update_env = std::move(update_env_hook)](const uint64_t, const void*, size_t) {
+                [state, emit_object_access, update_env = std::move(update_env_hook)](cpu_interface&, const uint64_t, const void*, size_t) {
                     const auto new_ptr = state->win_emu_.process.peb64.read().ProcessParameters;
                     state->params_hook_ = watch_object<RTL_USER_PROCESS_PARAMETERS64>(
                         state->win_emu_, state->modules_, new_ptr, state->verbose_, emit_object_access, state->params_state_);
@@ -264,7 +264,7 @@ namespace sogen
                 });
 
             win_emu.emu().hook_memory_write(win_emu.process.peb64.value() + offsetof(PEB64, Ldr), 0x8,
-                                            [state, emit_object_access](const uint64_t, const void*, size_t) {
+                                            [state, emit_object_access](cpu_interface&, const uint64_t, const void*, size_t) {
                                                 const auto new_ptr = state->win_emu_.process.peb64.read().Ldr;
                                                 state->ldr_hook_ =
                                                     watch_object<PEB_LDR_DATA64>(state->win_emu_, state->modules_, new_ptr, state->verbose_,
@@ -698,39 +698,40 @@ namespace sogen
             if (options.log_foreign_module_access)
             {
                 auto module_cache = std::make_shared<std::map<std::string, uint64_t>>();
-                win_emu->emu().hook_memory_read(
-                    0, std::numeric_limits<uint64_t>::max(), [&, module_cache](const uint64_t address, const void*, size_t size) {
-                        const auto rip = win_emu->emu().read_instruction_pointer();
-                        const auto accessor = get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
+                win_emu->emu().hook_memory_read(0, std::numeric_limits<uint64_t>::max(),
+                                                [&, module_cache](cpu_interface&, const uint64_t address, const void*, size_t size) {
+                                                    const auto rip = win_emu->emu().read_instruction_pointer();
+                                                    const auto accessor =
+                                                        get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
 
-                        if (!accessor.has_value())
-                        {
-                            return;
-                        }
+                                                    if (!accessor.has_value())
+                                                    {
+                                                        return;
+                                                    }
 
-                        const auto* mod = win_emu->mod_manager.find_by_address(address);
-                        if (!mod || mod == *accessor)
-                        {
-                            return;
-                        }
+                                                    const auto* mod = win_emu->mod_manager.find_by_address(address);
+                                                    if (!mod || mod == *accessor)
+                                                    {
+                                                        return;
+                                                    }
 
-                        if (concise_logging)
-                        {
-                            const auto count = ++(*module_cache)[mod->name];
-                            if (count > 30 && count % 100000 != 0)
-                            {
-                                return;
-                            }
-                        }
+                                                    if (concise_logging)
+                                                    {
+                                                        const auto count = ++(*module_cache)[mod->name];
+                                                        if (count > 30 && count % 100000 != 0)
+                                                        {
+                                                            return;
+                                                        }
+                                                    }
 
-                        const auto* region_name = get_module_memory_region_name(*mod, address);
-                        context.emit_observation<foreign_module_read_event>([&](auto& event) {
-                            event.address = address;
-                            event.size = size;
-                            event.module_name = mod->name;
-                            event.region_name = region_name;
-                        });
-                    });
+                                                    const auto* region_name = get_module_memory_region_name(*mod, address);
+                                                    context.emit_observation<foreign_module_read_event>([&](auto& event) {
+                                                        event.address = address;
+                                                        event.size = size;
+                                                        event.module_name = mod->name;
+                                                        event.region_name = region_name;
+                                                    });
+                                                });
             }
 
             if (options.log_executable_access)
@@ -745,7 +746,8 @@ namespace sogen
                     const auto read_count = std::make_shared<uint64_t>(0);
                     const auto write_count = std::make_shared<uint64_t>(0);
 
-                    auto read_handler = [&, section, concise_logging, read_count](const uint64_t address, const void*, size_t size) {
+                    auto read_handler = [&, section, concise_logging, read_count](cpu_interface&, const uint64_t address, const void*,
+                                                                                  size_t size) {
                         const auto rip = win_emu->emu().read_instruction_pointer();
                         const auto accessor = get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
 
@@ -770,8 +772,8 @@ namespace sogen
                         });
                     };
 
-                    auto write_handler = [&, section, concise_logging, write_count](const uint64_t address, const void* value,
-                                                                                    size_t size) {
+                    auto write_handler = [&, section, concise_logging, write_count](cpu_interface&, const uint64_t address,
+                                                                                    const void* value, size_t size) {
                         if (concise_logging)
                         {
                             const auto count = ++*write_count;

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -494,7 +494,8 @@ namespace sogen
 
         std::unique_ptr<x86_64_emulator> create_configured_backend(const analysis_options& options)
         {
-            auto emu = options.backend ? create_x86_64_emulator(*options.backend) : create_x86_64_emulator_from_environment();
+            auto emu = options.backend ? create_x86_64_emulator(*options.backend, options.vcpu_count)
+                                       : create_x86_64_emulator_from_environment(options.vcpu_count);
             emu->set_memory_execution_hook_mode(parse_memory_execution_hook_mode(options.whp_execution_hook_mode));
             return emu;
         }

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -67,6 +67,7 @@ namespace sogen
             std::string whp_execution_hook_mode{"auto"};
             std::optional<backend_type> backend{};
             bool disable_instruction_precision{false};
+            uint32_t vcpu_count{1};
             std::filesystem::path registry_path{get_current_binary_dir() / "registry"};
             std::filesystem::path emulation_root{};
             std::unordered_map<windows_path, std::filesystem::path> path_mappings{};
@@ -469,6 +470,7 @@ namespace sogen
             return {
                 .use_relative_time = options.reproducible,
                 .use_instruction_precision = !options.disable_instruction_precision,
+                .vcpu_count = options.vcpu_count,
                 .emulation_root = options.emulation_root,
                 .registry_directory = options.registry_path,
                 .path_mappings = options.path_mappings,
@@ -859,6 +861,9 @@ namespace sogen
                 ->capture_default_str()
                 ->check(CLI::IsMember({"auto", "int3"}));
             app.add_option("-r,--registry", options.registry_path, "Set registry path");
+
+            app.add_option("--vcpus", options.vcpu_count, "Number of virtual CPUs (requires a backend with multi-vCPU support)")
+                ->capture_default_str();
 
             std::string backend_name{};
             app.add_option("--backend", backend_name, "Select CPU backend: unicorn, icicle, whp or kvm (overrides env)")

--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -648,52 +648,54 @@ namespace sogen
             const auto& exe = *win_emu->mod_manager.executable;
             const auto is_whp = win_emu->emu().get_name() == "Windows Hypervisor Platform";
 
-            win_emu->emu().hook_instruction(x86_hookable_instructions::cpuid, [&] {
-                auto& emu = win_emu->emu();
+            win_emu->emu().hook_instruction(x86_hookable_instructions::cpuid, [&](cpu_interface& cpu, uint64_t) {
+                return win_emu->dispatch_on_cpu(cpu, [&] {
+                    auto& emu = win_emu->active_cpu();
 
-                const auto rip = emu.read_instruction_pointer();
-                const auto leaf = emu.reg<uint32_t>(x86_register::eax);
-                const auto mod = get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
+                    const auto rip = emu.read_instruction_pointer();
+                    const auto leaf = emu.reg<uint32_t>(x86_register::eax);
+                    const auto mod = get_module_if_interesting(win_emu->mod_manager, options.modules, rip);
 
-                if (mod.has_value() && (!concise_logging || context.cpuid_cache.insert({rip, leaf}).second))
-                {
-                    context.emit_observation<cpuid_event>([&](auto& event) { event.leaf = leaf; });
-                }
+                    if (mod.has_value() && (!concise_logging || context.cpuid_cache.insert({rip, leaf}).second))
+                    {
+                        context.emit_observation<cpuid_event>([&](auto& event) { event.leaf = leaf; });
+                    }
 
-                if (leaf == 1 && !is_whp)
-                {
-                    // NOTE: We hard-code these values to disable SSE4.x and AVX
-                    //       See: https://github.com/momo5502/sogen/issues/560
-                    emu.reg<uint32_t>(x86_register::eax, 0x000906EA);
-                    emu.reg<uint32_t>(x86_register::ebx, 0x00100800);
-                    emu.reg<uint32_t>(x86_register::ecx, 0xEFE2F38F);
-                    emu.reg<uint32_t>(x86_register::edx, 0xBFEBFBFF);
+                    if (leaf == 1 && !is_whp)
+                    {
+                        // NOTE: We hard-code these values to disable SSE4.x and AVX
+                        //       See: https://github.com/momo5502/sogen/issues/560
+                        emu.reg<uint32_t>(x86_register::eax, 0x000906EA);
+                        emu.reg<uint32_t>(x86_register::ebx, 0x00100800);
+                        emu.reg<uint32_t>(x86_register::ecx, 0xEFE2F38F);
+                        emu.reg<uint32_t>(x86_register::edx, 0xBFEBFBFF);
 
-                    return instruction_hook_continuation::skip_instruction;
-                }
+                        return instruction_hook_continuation::skip_instruction;
+                    }
 
-                if (leaf == 0x40000000 && !is_whp)
-                {
-                    // Microsoft Hv vendor string
-                    emu.reg<uint32_t>(x86_register::eax, 0x40000003);
-                    emu.reg<uint32_t>(x86_register::ebx, 0x7263694d);
-                    emu.reg<uint32_t>(x86_register::ecx, 0x666f736f);
-                    emu.reg<uint32_t>(x86_register::edx, 0x76482074);
+                    if (leaf == 0x40000000 && !is_whp)
+                    {
+                        // Microsoft Hv vendor string
+                        emu.reg<uint32_t>(x86_register::eax, 0x40000003);
+                        emu.reg<uint32_t>(x86_register::ebx, 0x7263694d);
+                        emu.reg<uint32_t>(x86_register::ecx, 0x666f736f);
+                        emu.reg<uint32_t>(x86_register::edx, 0x76482074);
 
-                    return instruction_hook_continuation::skip_instruction;
-                }
+                        return instruction_hook_continuation::skip_instruction;
+                    }
 
-                if (leaf == 0x40000003 && !is_whp)
-                {
-                    emu.reg<uint32_t>(x86_register::eax, 0x00000000);
-                    emu.reg<uint32_t>(x86_register::ebx, 0x00000001);
-                    emu.reg<uint32_t>(x86_register::ecx, 0x00000000);
-                    emu.reg<uint32_t>(x86_register::edx, 0x00000000);
+                    if (leaf == 0x40000003 && !is_whp)
+                    {
+                        emu.reg<uint32_t>(x86_register::eax, 0x00000000);
+                        emu.reg<uint32_t>(x86_register::ebx, 0x00000001);
+                        emu.reg<uint32_t>(x86_register::ecx, 0x00000000);
+                        emu.reg<uint32_t>(x86_register::edx, 0x00000000);
 
-                    return instruction_hook_continuation::skip_instruction;
-                }
+                        return instruction_hook_continuation::skip_instruction;
+                    }
 
-                return instruction_hook_continuation::run_instruction;
+                    return instruction_hook_continuation::run_instruction;
+                });
             });
 
             if (options.log_foreign_module_access)

--- a/src/windows-analyzer/object_watching.hpp
+++ b/src/windows-analyzer/object_watching.hpp
@@ -36,7 +36,7 @@ namespace sogen
         return emu.emu().hook_memory_read(
             object.value(), static_cast<size_t>(object.size()),
             [i = std::move(info), object, &emu, verbose, modules, state = std::move(shared_state),
-             on_access = std::forward<Callback>(on_access)](const uint64_t address, const void*, const size_t size) {
+             on_access = std::forward<Callback>(on_access)](cpu_interface&, const uint64_t address, const void*, const size_t size) {
                 const auto rip = emu.emu().read_instruction_pointer();
                 const auto* mod = emu.mod_manager.find_by_address(rip);
                 const auto is_main_access = !mod || (mod == emu.mod_manager.executable || modules.contains(mod->name));

--- a/src/windows-analyzer/tenet_tracer.cpp
+++ b/src/windows-analyzer/tenet_tracer.cpp
@@ -62,17 +62,17 @@ namespace sogen
 
         auto& emu = win_emu_.emu();
 
-        auto* read_hook = emu.hook_memory_read(0, 0xFFFFFFFFFFFFFFFF, [this](uint64_t a, const void* d, size_t s) {
+        auto* read_hook = emu.hook_memory_read(0, 0xFFFFFFFFFFFFFFFF, [this](cpu_interface&, uint64_t a, const void* d, size_t s) {
             this->log_memory_read(a, d, s); //
         });
         read_hook_ = scoped_hook(emu, read_hook);
 
-        auto* write_hook = emu.hook_memory_write(0, 0xFFFFFFFFFFFFFFFF, [this](uint64_t a, const void* d, size_t s) {
+        auto* write_hook = emu.hook_memory_write(0, 0xFFFFFFFFFFFFFFFF, [this](cpu_interface&, uint64_t a, const void* d, size_t s) {
             this->log_memory_write(a, d, s); //
         });
         write_hook_ = scoped_hook(emu, write_hook);
 
-        auto* execute_hook = emu.hook_memory_execution([&](uint64_t address) {
+        auto* execute_hook = emu.hook_memory_execution([&](cpu_interface&, uint64_t address) {
             this->process_instruction(address); //
         });
         execute_hook_ = scoped_hook(emu, execute_hook);

--- a/src/windows-emulator/cpu_context.cpp
+++ b/src/windows-emulator/cpu_context.cpp
@@ -6,7 +6,7 @@ namespace sogen
 
     namespace cpu_context
     {
-        void restore(x86_64_emulator& emu, const CONTEXT64& context)
+        void restore(x86_64_cpu& emu, const CONTEXT64& context)
         {
             if ((context.ContextFlags & CONTEXT_DEBUG_REGISTERS_64) == CONTEXT_DEBUG_REGISTERS_64)
             {
@@ -81,7 +81,7 @@ namespace sogen
             }
         }
 
-        void save(x86_64_emulator& emu, CONTEXT64& context)
+        void save(x86_64_cpu& emu, CONTEXT64& context)
         {
             if ((context.ContextFlags & CONTEXT_DEBUG_REGISTERS_64) == CONTEXT_DEBUG_REGISTERS_64)
             {

--- a/src/windows-emulator/cpu_context.hpp
+++ b/src/windows-emulator/cpu_context.hpp
@@ -6,8 +6,8 @@ namespace sogen
 
     namespace cpu_context
     {
-        void save(x86_64_emulator& emu, CONTEXT64& context);
-        void restore(x86_64_emulator& emu, const CONTEXT64& context);
+        void save(x86_64_cpu& emu, CONTEXT64& context);
+        void restore(x86_64_cpu& emu, const CONTEXT64& context);
     }
 
 } // namespace sogen

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -969,8 +969,7 @@ namespace sogen
                 }
 
                 auto* vulkan = &this->vulkan_;
-                win_emu.current_thread().await_host_condition = [vulkan, &win_emu, context, device, flags, entries = std::move(entries),
-                                                                 count]() {
+                context.thread().await_host_condition = [vulkan, &win_emu, context, device, flags, entries = std::move(entries), count]() {
                     const int32_t result = vulkan->wait_semaphores(device, flags, entries.data(), count, 0);
                     if (result == vk_timeout)
                     {
@@ -980,7 +979,7 @@ namespace sogen
                     write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
                     return true;
                 };
-                win_emu.yield_thread(false);
+                win_emu.yield_thread(*context.vcpu, false);
                 return STATUS_SUCCESS;
             }
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -18,7 +18,7 @@ namespace sogen
             abandoned,
         };
 
-        void setup_wow64_fs_segment(memory_manager& memory, uint64_t teb32_addr)
+        void setup_wow64_fs_segment(memory_manager& memory, uint64_t teb32_addr, uint64_t gdt_base)
         {
             const uint64_t base = teb32_addr;
             const uint32_t limit = 0xFFF; // 4KB - size of TEB32 (matching Windows)
@@ -34,8 +34,8 @@ namespace sogen
             descriptor |= (0x40ULL << 48);                                        // G=0 (byte), D=1 (32-bit), L=0, AVL=0
             descriptor |= ((base & 0xFF000000) << 32);                            // Base[31:24]
 
-            // Write the updated descriptor to GDT index 10 (selector 0x53)
-            constexpr uint64_t fs_gdt_offset = GDT_ADDR + 10 * sizeof(uint64_t);
+            // Write the updated descriptor to GDT index 10 (selector 0x53) of this vCPU's own GDT.
+            const uint64_t fs_gdt_offset = gdt_base + 10 * sizeof(uint64_t);
             memory.write_memory(fs_gdt_offset, &descriptor, sizeof(descriptor));
         }
 
@@ -1226,12 +1226,17 @@ namespace sogen
 
     void emulator_thread::refresh_execution_context(x86_64_cpu& emu) const
     {
-        (void)emu;
+        // Point this vCPU's GDTR at its own per-vCPU GDT. The saved thread context restores whatever
+        // GDTR the thread last ran with (possibly another vCPU's GDT), so re-assert it here on every
+        // switch. Cheap and keeps each vCPU reading its own descriptors.
+        const auto gdt_base = gdt_base_for_vcpu(emu.index());
+        emu.load_gdt(gdt_base, GDT_LIMIT);
 
         if (this->teb32.has_value())
         {
-            // Refresh GDT entry for FS selector on context switch
-            setup_wow64_fs_segment(*this->memory_ptr, this->teb32->value());
+            // Refresh this vCPU's WOW64 FS descriptor with this thread's 32-bit TEB base, so a 64<->32
+            // transition that reloads FS reads the correct base regardless of which vCPU runs the thread.
+            setup_wow64_fs_segment(*this->memory_ptr, this->teb32->value(), gdt_base);
         }
     }
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -40,22 +40,22 @@ namespace sogen
         }
 
         template <typename T>
-        emulator_object<T> allocate_object_on_stack(x86_64_emulator& emu)
+        emulator_object<T> allocate_object_on_stack(x86_64_cpu& emu)
         {
             const auto old_sp = emu.reg(x86_register::rsp);
-            const auto new_sp = align_down(old_sp - sizeof(T), std::max(alignof(T), alignof(x86_64_emulator::pointer_type)));
+            const auto new_sp = align_down(old_sp - sizeof(T), std::max(alignof(T), alignof(x86_64_cpu::pointer_type)));
             emu.reg(x86_register::rsp, new_sp);
-            return {emu, new_sp};
+            return {emu.memory(), new_sp};
         }
 
-        void unalign_stack(x86_64_emulator& emu)
+        void unalign_stack(x86_64_cpu& emu)
         {
             auto sp = emu.reg(x86_register::rsp);
             sp = align_down(sp - 0x10, 0x10) + 8;
             emu.reg(x86_register::rsp, sp);
         }
 
-        void setup_stack(x86_64_emulator& emu, const process_context& context, const uint64_t stack_base, const size_t stack_size)
+        void setup_stack(x86_64_cpu& emu, const process_context& context, const uint64_t stack_base, const size_t stack_size)
         {
             if (!context.is_wow64_process)
             {
@@ -1172,7 +1172,7 @@ namespace sogen
         return true;
     }
 
-    void emulator_thread::setup_registers(x86_64_emulator& emu, const process_context& context) const
+    void emulator_thread::setup_registers(x86_64_cpu& emu, const process_context& context) const
     {
         if (!this->gs_segment)
         {
@@ -1224,7 +1224,7 @@ namespace sogen
         emu.reg(x86_register::rip, context.ldr_initialize_thunk);
     }
 
-    void emulator_thread::refresh_execution_context(x86_64_emulator& emu) const
+    void emulator_thread::refresh_execution_context(x86_64_cpu& emu) const
     {
         (void)emu;
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+﻿#include "std_include.hpp"
 #include "emulator_thread.hpp"
 
 #include "cpu_context.hpp"
@@ -1248,7 +1248,7 @@ namespace sogen
 
     callback_frame::~callback_frame() = default;
 
-    void callback_frame::save_registers(x86_64_emulator& emu)
+    void callback_frame::save_registers(x86_64_cpu& emu)
     {
         if (this->rip != 0)
         {
@@ -1280,7 +1280,7 @@ namespace sogen
         this->gs = emu.reg<uint16_t>(x86_register::gs);
     }
 
-    void callback_frame::restore_registers(x86_64_emulator& emu) const
+    void callback_frame::restore_registers(x86_64_cpu& emu) const
     {
         if (this->rip == 0)
         {

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -230,8 +230,8 @@ namespace sogen
 
         ~callback_frame();
 
-        void save_registers(x86_64_emulator& emu);
-        void restore_registers(x86_64_emulator& emu) const;
+        void save_registers(x86_64_cpu& emu);
+        void restore_registers(x86_64_cpu& emu) const;
 
         void serialize(utils::buffer_serializer& buffer) const;
         void deserialize(utils::buffer_deserializer& buffer);

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -376,18 +376,18 @@ namespace sogen
 
         bool is_thread_ready(windows_emulator& win_emu);
 
-        void save(x86_64_emulator& emu)
+        void save(x86_64_cpu& emu)
         {
             this->last_registers = emu.save_registers();
         }
 
-        void restore(x86_64_emulator& emu) const
+        void restore(x86_64_cpu& emu) const
         {
             emu.restore_registers(this->last_registers);
             this->refresh_execution_context(emu);
         }
 
-        void setup_if_necessary(x86_64_emulator& emu, const process_context& context)
+        void setup_if_necessary(x86_64_cpu& emu, const process_context& context)
         {
             if (!this->setup_done)
             {
@@ -553,8 +553,8 @@ namespace sogen
       private:
         bool can_coalesce_message(const msg& msg) const;
 
-        void setup_registers(x86_64_emulator& emu, const process_context& context) const;
-        void refresh_execution_context(x86_64_emulator& emu) const;
+        void setup_registers(x86_64_cpu& emu, const process_context& context) const;
+        void refresh_execution_context(x86_64_cpu& emu) const;
 
         void release()
         {

--- a/src/windows-emulator/emulator_utils.hpp
+++ b/src/windows-emulator/emulator_utils.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <arch_emulator.hpp>
 #include <function_calling_convention.hpp>
@@ -386,7 +386,7 @@ namespace sogen
         return result;
     }
 
-    inline std::u16string read_unicode_string(const emulator& emu, const UNICODE_STRING<EmulatorTraits<Emu64>> ucs)
+    inline std::u16string read_unicode_string(const memory_interface& emu, const UNICODE_STRING<EmulatorTraits<Emu64>> ucs)
     {
         static_assert(offsetof(UNICODE_STRING<EmulatorTraits<Emu64>>, Length) == 0);
         static_assert(offsetof(UNICODE_STRING<EmulatorTraits<Emu64>>, MaximumLength) == 2);
@@ -401,14 +401,15 @@ namespace sogen
         return result;
     }
 
-    inline std::u16string read_unicode_string(const emulator& emu, const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> uc_string,
+    inline std::u16string read_unicode_string(const memory_interface& emu,
+                                              const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> uc_string,
                                               const size_t index = 0)
     {
         const auto ucs = uc_string.read(index);
         return read_unicode_string(emu, ucs);
     }
 
-    inline std::u16string read_unicode_string(emulator& emu, const uint64_t uc_string, const size_t index = 0)
+    inline std::u16string read_unicode_string(memory_interface& emu, const uint64_t uc_string, const size_t index = 0)
     {
         return read_unicode_string(emu, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>>{emu, uc_string}, index);
     }
@@ -430,7 +431,7 @@ namespace sogen
         return cp1252_to_u16(ansi_string);
     }
 
-    inline uint64_t get_function_argument_x64_fastcall(x86_64_emulator& emu, const size_t index)
+    inline uint64_t get_function_argument_x64_fastcall(x86_64_cpu& emu, const size_t index)
     {
         switch (index)
         {
@@ -447,7 +448,7 @@ namespace sogen
         }
     }
 
-    inline uint64_t get_function_argument_x64_syscall(x86_64_emulator& emu, const size_t index)
+    inline uint64_t get_function_argument_x64_syscall(x86_64_cpu& emu, const size_t index)
     {
         if (index == 0)
         {
@@ -457,21 +458,21 @@ namespace sogen
         return get_function_argument_x64_fastcall(emu, index);
     }
 
-    inline bool is_32bit_code_segment(x86_64_emulator& emu)
+    inline bool is_32bit_code_segment(x86_64_cpu& emu)
     {
         const auto cs_selector = emu.reg<uint16_t>(x86_register::cs);
         const auto bitness = segment_utils::get_segment_bitness(emu, cs_selector);
         return bitness && *bitness == segment_utils::segment_bitness::bit32;
     }
 
-    inline uint64_t get_function_argument_x86_stack(x86_64_emulator& emu, const size_t index)
+    inline uint64_t get_function_argument_x86_stack(x86_64_cpu& emu, const size_t index)
     {
         const auto esp = emu.reg<uint32_t>(x86_register::esp);
         const auto address = static_cast<uint64_t>(esp) + static_cast<uint64_t>((index + 1) * sizeof(uint32_t));
         return static_cast<uint64_t>(emu.read_memory<uint32_t>(address));
     }
 
-    inline uint64_t get_function_argument(x86_64_emulator& emu, const function_calling_convention cc, const size_t index)
+    inline uint64_t get_function_argument(x86_64_cpu& emu, const function_calling_convention cc, const size_t index)
     {
         using enum function_calling_convention;
 
@@ -489,7 +490,7 @@ namespace sogen
         }
     }
 
-    inline uint64_t get_function_argument(x86_64_emulator& emu, const size_t index, const bool is_syscall = false)
+    inline uint64_t get_function_argument(x86_64_cpu& emu, const size_t index, const bool is_syscall = false)
     {
         if (is_syscall)
         {
@@ -504,7 +505,7 @@ namespace sogen
         return get_function_argument_x64_fastcall(emu, index);
     }
 
-    inline std::vector<uint64_t> get_function_arguments(x86_64_emulator& emu, const function_calling_convention cc, const size_t count)
+    inline std::vector<uint64_t> get_function_arguments(x86_64_cpu& emu, const function_calling_convention cc, const size_t count)
     {
         std::vector<uint64_t> args{};
         args.reserve(count);
@@ -517,7 +518,7 @@ namespace sogen
         return args;
     }
 
-    inline void set_function_argument_x64_fastcall(x86_64_emulator& emu, const size_t index, const uint64_t value)
+    inline void set_function_argument_x64_fastcall(x86_64_cpu& emu, const size_t index, const uint64_t value)
     {
         switch (index)
         {
@@ -539,7 +540,7 @@ namespace sogen
         }
     }
 
-    inline void set_function_argument_x64_syscall(x86_64_emulator& emu, const size_t index, const uint64_t value)
+    inline void set_function_argument_x64_syscall(x86_64_cpu& emu, const size_t index, const uint64_t value)
     {
         if (index == 0)
         {
@@ -550,14 +551,14 @@ namespace sogen
         set_function_argument_x64_fastcall(emu, index, value);
     }
 
-    inline void set_function_argument_x86_stack(x86_64_emulator& emu, const size_t index, const uint64_t value)
+    inline void set_function_argument_x86_stack(x86_64_cpu& emu, const size_t index, const uint64_t value)
     {
         const auto esp = emu.reg<uint32_t>(x86_register::esp);
         const auto address = static_cast<uint64_t>(esp) + static_cast<uint64_t>((index + 1) * sizeof(uint32_t));
         emu.write_memory<uint32_t>(address, static_cast<uint32_t>(value));
     }
 
-    inline void set_function_argument(x86_64_emulator& emu, const function_calling_convention cc, const size_t index, const uint64_t value)
+    inline void set_function_argument(x86_64_cpu& emu, const function_calling_convention cc, const size_t index, const uint64_t value)
     {
         using enum function_calling_convention;
 
@@ -578,7 +579,7 @@ namespace sogen
         }
     }
 
-    inline void set_function_argument(x86_64_emulator& emu, const size_t index, const uint64_t value, const bool is_syscall = false)
+    inline void set_function_argument(x86_64_cpu& emu, const size_t index, const uint64_t value, const bool is_syscall = false)
     {
         if (is_32bit_code_segment(emu))
         {
@@ -595,7 +596,7 @@ namespace sogen
         set_function_argument_x64_fastcall(emu, index, value);
     }
 
-    inline void set_function_arguments(x86_64_emulator& emu, const function_calling_convention cc, const std::span<const uint64_t> values)
+    inline void set_function_arguments(x86_64_cpu& emu, const function_calling_convention cc, const std::span<const uint64_t> values)
     {
         for (size_t i = 0; i < values.size(); ++i)
         {

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -94,7 +94,7 @@ namespace sogen
             uint64_t ss;
         };
 
-        void dispatch_exception_pointers(x86_64_emulator& emu, const uint64_t dispatcher,
+        void dispatch_exception_pointers(x86_64_cpu& emu, const uint64_t dispatcher,
                                          const EMU_EXCEPTION_POINTERS<EmulatorTraits<Emu64>> pointers)
         {
             constexpr auto mach_frame_size = 0x40;
@@ -199,14 +199,14 @@ namespace sogen
             return result;
         }
 
-        void sync_wow64_cpu_reserved_context(windows_emulator& win_emu, emulator_thread& thread, const CONTEXT64& ctx)
+        void sync_wow64_cpu_reserved_context(windows_emulator& win_emu, x86_64_cpu& emu, emulator_thread& thread, const CONTEXT64& ctx)
         {
             if (!win_emu.process.is_wow64_process)
             {
                 return;
             }
 
-            const auto bitness = segment_utils::get_segment_bitness(win_emu.emu(), ctx.SegCs);
+            const auto bitness = segment_utils::get_segment_bitness(emu, ctx.SegCs);
             if (!bitness || *bitness != segment_utils::segment_bitness::bit32)
             {
                 return;
@@ -286,12 +286,12 @@ namespace sogen
 
         record.ExceptionAddress = ctx.Rip;
 
-        sync_wow64_cpu_reserved_context(win_emu, thread, ctx);
+        sync_wow64_cpu_reserved_context(win_emu, vcpu.cpu, thread, ctx);
 
         EMU_EXCEPTION_POINTERS<EmulatorTraits<Emu64>> pointers{};
         pointers.ContextRecord = reinterpret_cast<EmulatorTraits<Emu64>::PVOID>(&ctx);
         pointers.ExceptionRecord = reinterpret_cast<EmulatorTraits<Emu64>::PVOID>(&record);
-        dispatch_exception_pointers(win_emu.emu(), win_emu.process.ki_user_exception_dispatcher, pointers);
+        dispatch_exception_pointers(vcpu.cpu, win_emu.process.ki_user_exception_dispatcher, pointers);
     }
 
     void dispatch_access_violation(windows_emulator& win_emu, vcpu_context& vcpu, const uint64_t address, const memory_operation operation)

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -249,6 +249,14 @@ namespace sogen
     {
         auto& thread = vcpu.thread();
 
+        win_emu.record_exception_trace({
+            .status = static_cast<uint32_t>(status),
+            .tid = thread.id,
+            .vcpu = static_cast<uint32_t>(vcpu.cpu.index()),
+            .rip = vcpu.cpu.read_instruction_pointer(),
+            .info = parameters.size() > 1 ? static_cast<uint64_t>(parameters[1]) : 0,
+        });
+
         CONTEXT64 ctx{};
         ctx.ContextFlags = CONTEXT64_ALL;
         cpu_context::save(vcpu.cpu, ctx);

--- a/src/windows-emulator/exception_dispatch.cpp
+++ b/src/windows-emulator/exception_dispatch.cpp
@@ -199,7 +199,7 @@ namespace sogen
             return result;
         }
 
-        void sync_wow64_cpu_reserved_context(windows_emulator& win_emu, const CONTEXT64& ctx)
+        void sync_wow64_cpu_reserved_context(windows_emulator& win_emu, emulator_thread& thread, const CONTEXT64& ctx)
         {
             if (!win_emu.process.is_wow64_process)
             {
@@ -214,7 +214,7 @@ namespace sogen
 
             // Wow64PassExceptionToGuest rebuilds the 32-bit context from WOW64_CPURESERVED
             // (TEB64 TLS slot 1), not from the native exception ContextRecord below.
-            win_emu.current_thread().wow64_cpu_reserved->access([&](WOW64_CPURESERVED& cpu) {
+            thread.wow64_cpu_reserved->access([&](WOW64_CPURESERVED& cpu) {
                 cpu.Flags |= WOW64_CPURESERVED_FLAG_RESET_STATE;
                 cpu.Context = make_wow64_context(ctx);
             });
@@ -244,14 +244,17 @@ namespace sogen
         return false;
     }
 
-    void dispatch_exception(windows_emulator& win_emu, const DWORD status, const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters)
+    void dispatch_exception(windows_emulator& win_emu, vcpu_context& vcpu, const DWORD status,
+                            const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters)
     {
+        auto& thread = vcpu.thread();
+
         CONTEXT64 ctx{};
         ctx.ContextFlags = CONTEXT64_ALL;
-        cpu_context::save(win_emu.emu(), ctx);
+        cpu_context::save(vcpu.cpu, ctx);
         ctx.Rip = win_emu.uses_instruction_precision() //
-                      ? win_emu.current_thread().current_ip
-                      : win_emu.emu().read_instruction_pointer();
+                      ? thread.current_ip
+                      : vcpu.cpu.read_instruction_pointer();
 
         exception_record record{};
         memset(&record, 0, sizeof(record));
@@ -283,7 +286,7 @@ namespace sogen
 
         record.ExceptionAddress = ctx.Rip;
 
-        sync_wow64_cpu_reserved_context(win_emu, ctx);
+        sync_wow64_cpu_reserved_context(win_emu, thread, ctx);
 
         EMU_EXCEPTION_POINTERS<EmulatorTraits<Emu64>> pointers{};
         pointers.ContextRecord = reinterpret_cast<EmulatorTraits<Emu64>::PVOID>(&ctx);
@@ -291,42 +294,43 @@ namespace sogen
         dispatch_exception_pointers(win_emu.emu(), win_emu.process.ki_user_exception_dispatcher, pointers);
     }
 
-    void dispatch_access_violation(windows_emulator& win_emu, const uint64_t address, const memory_operation operation)
+    void dispatch_access_violation(windows_emulator& win_emu, vcpu_context& vcpu, const uint64_t address, const memory_operation operation)
     {
-        dispatch_exception(win_emu, STATUS_ACCESS_VIOLATION,
+        dispatch_exception(win_emu, vcpu, STATUS_ACCESS_VIOLATION,
                            {
                                map_violation_operation_to_parameter(operation),
                                address,
                            });
     }
 
-    void dispatch_guard_page_violation(windows_emulator& win_emu, const uint64_t address, const memory_operation operation)
+    void dispatch_guard_page_violation(windows_emulator& win_emu, vcpu_context& vcpu, const uint64_t address,
+                                       const memory_operation operation)
     {
-        dispatch_exception(win_emu, STATUS_GUARD_PAGE_VIOLATION,
+        dispatch_exception(win_emu, vcpu, STATUS_GUARD_PAGE_VIOLATION,
                            {
                                map_violation_operation_to_parameter(operation),
                                address,
                            });
     }
 
-    void dispatch_illegal_instruction_violation(windows_emulator& win_emu)
+    void dispatch_illegal_instruction_violation(windows_emulator& win_emu, vcpu_context& vcpu)
     {
-        dispatch_exception(win_emu, STATUS_ILLEGAL_INSTRUCTION, {});
+        dispatch_exception(win_emu, vcpu, STATUS_ILLEGAL_INSTRUCTION, {});
     }
 
-    void dispatch_integer_division_by_zero(windows_emulator& win_emu)
+    void dispatch_integer_division_by_zero(windows_emulator& win_emu, vcpu_context& vcpu)
     {
-        dispatch_exception(win_emu, STATUS_INTEGER_DIVIDE_BY_ZERO, {});
+        dispatch_exception(win_emu, vcpu, STATUS_INTEGER_DIVIDE_BY_ZERO, {});
     }
 
-    void dispatch_single_step(windows_emulator& win_emu)
+    void dispatch_single_step(windows_emulator& win_emu, vcpu_context& vcpu)
     {
-        dispatch_exception(win_emu, STATUS_SINGLE_STEP, {});
+        dispatch_exception(win_emu, vcpu, STATUS_SINGLE_STEP, {});
     }
 
-    void dispatch_breakpoint(windows_emulator& win_emu)
+    void dispatch_breakpoint(windows_emulator& win_emu, vcpu_context& vcpu)
     {
-        dispatch_exception(win_emu, STATUS_BREAKPOINT, {});
+        dispatch_exception(win_emu, vcpu, STATUS_BREAKPOINT, {});
     }
 
 } // namespace sogen

--- a/src/windows-emulator/exception_dispatch.hpp
+++ b/src/windows-emulator/exception_dispatch.hpp
@@ -19,21 +19,24 @@ namespace sogen
 {
 
     class windows_emulator;
+    struct vcpu_context;
 
-    void dispatch_exception(windows_emulator& win_emu, DWORD status, const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters);
+    void dispatch_exception(windows_emulator& win_emu, vcpu_context& vcpu, DWORD status,
+                            const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters);
     template <typename T>
         requires(std::is_integral_v<T> && !std::is_same_v<T, DWORD>)
-    void dispatch_exception(windows_emulator& win_emu, const T status, const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters)
+    void dispatch_exception(windows_emulator& win_emu, vcpu_context& vcpu, const T status,
+                            const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters)
     {
-        dispatch_exception(win_emu, static_cast<DWORD>(status), parameters);
+        dispatch_exception(win_emu, vcpu, static_cast<DWORD>(status), parameters);
     }
 
     bool dispatch_debug_exception(windows_emulator& win_emu, CONTEXT64& ctx, EMU_EXCEPTION_RECORD<EmulatorTraits<Emu64>>& record);
-    void dispatch_access_violation(windows_emulator& win_emu, uint64_t address, memory_operation operation);
-    void dispatch_guard_page_violation(windows_emulator& win_emu, uint64_t address, memory_operation operation);
-    void dispatch_illegal_instruction_violation(windows_emulator& win_emu);
-    void dispatch_integer_division_by_zero(windows_emulator& win_emu);
-    void dispatch_single_step(windows_emulator& win_emu);
-    void dispatch_breakpoint(windows_emulator& win_emu);
+    void dispatch_access_violation(windows_emulator& win_emu, vcpu_context& vcpu, uint64_t address, memory_operation operation);
+    void dispatch_guard_page_violation(windows_emulator& win_emu, vcpu_context& vcpu, uint64_t address, memory_operation operation);
+    void dispatch_illegal_instruction_violation(windows_emulator& win_emu, vcpu_context& vcpu);
+    void dispatch_integer_division_by_zero(windows_emulator& win_emu, vcpu_context& vcpu);
+    void dispatch_single_step(windows_emulator& win_emu, vcpu_context& vcpu);
+    void dispatch_breakpoint(windows_emulator& win_emu, vcpu_context& vcpu);
 
 } // namespace sogen

--- a/src/windows-emulator/io_completion_wait.cpp
+++ b/src/windows-emulator/io_completion_wait.cpp
@@ -126,7 +126,8 @@ namespace sogen
             }
         }
 
-        bool retain_handle_reference(process_context& process, const handle source_handle, handle& retained_handle)
+        bool retain_handle_reference(process_context& process, const emulator_thread* active_thread, const handle source_handle,
+                                     handle& retained_handle)
         {
             if (source_handle.bits == 0)
             {
@@ -134,7 +135,7 @@ namespace sogen
                 return true;
             }
 
-            const auto resolved_source_handle = process.resolve_object_pseudo_handle(source_handle);
+            const auto resolved_source_handle = process.resolve_object_pseudo_handle(source_handle, active_thread);
 
             if (resolved_source_handle.value.is_pseudo)
             {

--- a/src/windows-emulator/io_completion_wait.hpp
+++ b/src/windows-emulator/io_completion_wait.hpp
@@ -9,7 +9,8 @@ namespace sogen
     {
         bool is_wait_completion_target_type(handle target_object_handle);
 
-        bool retain_handle_reference(process_context& process, handle source_handle, handle& retained_handle);
+        bool retain_handle_reference(process_context& process, const emulator_thread* active_thread, handle source_handle,
+                                     handle& retained_handle);
         void release_handle_reference(process_context& process, handle& retained_handle);
 
         void cleanup_wait_packet_on_close(process_context& process, handle wait_packet_handle);

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -104,6 +104,16 @@ namespace sogen
         throw std::runtime_error("Unsupported device: " + u16_to_u8(device));
     }
 
+    emulator_thread& io_device_context::thread() const
+    {
+        if (!this->vcpu)
+        {
+            throw std::runtime_error("I/O request has no issuing vCPU");
+        }
+
+        return this->vcpu->thread();
+    }
+
     NTSTATUS io_device::execute_ioctl(windows_emulator& win_emu, const io_device_context& c)
     {
         if (c.io_status_block)

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -12,6 +12,8 @@ namespace sogen
 
     class windows_emulator;
     struct process_context;
+    struct vcpu_context;
+    class emulator_thread;
 
     struct io_device_context
     {
@@ -24,6 +26,13 @@ namespace sogen
         ULONG input_buffer_length{};
         emulator_pointer output_buffer{};
         ULONG output_buffer_length{};
+
+        // The vCPU whose thread issued this I/O request. Set on syscall-originated ioctls;
+        // null (and not serialized) for deserialized delayed ioctls re-executed from the
+        // scheduler's device pump, which must not depend on an issuing thread.
+        vcpu_context* vcpu{};
+
+        emulator_thread& thread() const;
 
         io_device_context(x86_64_emulator& emu)
             : io_status_block(emu)

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -34,7 +34,7 @@ namespace sogen
 
         emulator_thread& thread() const;
 
-        io_device_context(x86_64_emulator& emu)
+        io_device_context(memory_interface& emu)
             : io_status_block(emu)
         {
         }

--- a/src/windows-emulator/kernel_lock.hpp
+++ b/src/windows-emulator/kernel_lock.hpp
@@ -2,6 +2,9 @@
 
 #include <atomic>
 #include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
 #include <mutex>
 #include <thread>
 
@@ -17,16 +20,47 @@ namespace sogen
     class kernel_lock
     {
       public:
+        struct profile_stats
+        {
+            uint64_t acquisitions; // total successful lock() calls
+            uint64_t contended;    // acquisitions that had to block because another thread held it
+            uint64_t wait_nanos;   // cumulative time spent blocked on contended acquisitions
+            uint64_t held_nanos;   // cumulative time the lock was held (BEL "busy" time)
+        };
+
+        // Env-gated so a normal run pays nothing: the instrumented path (a try_lock plus two
+        // steady_clock reads per acquisition) only runs when SOGEN_LOCK_PROFILE is set.
+        static bool profiling_enabled()
+        {
+            static const bool enabled = std::getenv("SOGEN_LOCK_PROFILE") != nullptr;
+            return enabled;
+        }
+
         void lock()
         {
             assert(!this->is_held_by_current_thread() && "The kernel lock is not recursive");
-            this->mutex_.lock();
+
+            if (profiling_enabled())
+            {
+                this->lock_profiled();
+            }
+            else
+            {
+                this->mutex_.lock();
+            }
+
             this->owner_.store(std::this_thread::get_id(), std::memory_order_relaxed);
         }
 
         void unlock()
         {
             this->owner_.store({}, std::memory_order_relaxed);
+
+            if (profiling_enabled())
+            {
+                this->held_nanos_.fetch_add(nanos_since(this->held_since_), std::memory_order_relaxed);
+            }
+
             this->mutex_.unlock();
         }
 
@@ -40,9 +74,48 @@ namespace sogen
             assert(this->is_held_by_current_thread() && "The kernel lock must be held");
         }
 
+        profile_stats profile() const
+        {
+            return {
+                this->acquisitions_.load(std::memory_order_relaxed),
+                this->contended_.load(std::memory_order_relaxed),
+                this->wait_nanos_.load(std::memory_order_relaxed),
+                this->held_nanos_.load(std::memory_order_relaxed),
+            };
+        }
+
       private:
+        using clock = std::chrono::steady_clock;
+
+        static uint64_t nanos_since(const clock::time_point start)
+        {
+            return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(clock::now() - start).count());
+        }
+
+        void lock_profiled()
+        {
+            if (!this->mutex_.try_lock())
+            {
+                const auto start = clock::now();
+                this->mutex_.lock();
+                this->wait_nanos_.fetch_add(nanos_since(start), std::memory_order_relaxed);
+                this->contended_.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            this->acquisitions_.fetch_add(1, std::memory_order_relaxed);
+            this->held_since_ = clock::now();
+        }
+
         std::mutex mutex_{};
         std::atomic<std::thread::id> owner_{};
+
+        // Guarded by mutex_ (written/read only by the current holder).
+        clock::time_point held_since_{};
+
+        std::atomic<uint64_t> acquisitions_{};
+        std::atomic<uint64_t> contended_{};
+        std::atomic<uint64_t> wait_nanos_{};
+        std::atomic<uint64_t> held_nanos_{};
     };
 
 } // namespace sogen

--- a/src/windows-emulator/kernel_lock.hpp
+++ b/src/windows-emulator/kernel_lock.hpp
@@ -71,16 +71,19 @@ namespace sogen
 
         void assert_held() const
         {
-            assert(this->is_held_by_current_thread() && "The kernel lock must be held");
+            // Evaluated outside assert() so the member access survives in NDEBUG builds (where assert
+            // expands to nothing); the relaxed load is otherwise dead and elided by the optimizer.
+            [[maybe_unused]] const bool held = this->is_held_by_current_thread();
+            assert(held && "The kernel lock must be held");
         }
 
         profile_stats profile() const
         {
             return {
-                this->acquisitions_.load(std::memory_order_relaxed),
-                this->contended_.load(std::memory_order_relaxed),
-                this->wait_nanos_.load(std::memory_order_relaxed),
-                this->held_nanos_.load(std::memory_order_relaxed),
+                .acquisitions = this->acquisitions_.load(std::memory_order_relaxed),
+                .contended = this->contended_.load(std::memory_order_relaxed),
+                .wait_nanos = this->wait_nanos_.load(std::memory_order_relaxed),
+                .held_nanos = this->held_nanos_.load(std::memory_order_relaxed),
             };
         }
 

--- a/src/windows-emulator/kernel_lock.hpp
+++ b/src/windows-emulator/kernel_lock.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <mutex>
+#include <thread>
+
+namespace sogen
+{
+
+    // The emulator kernel lock (docs/multi-vcpu-design.md, sections 2 and 7).
+    // Serializes all emulator code that touches shared kernel state: acquired at
+    // every entry point (VM-exit hook callbacks, UI event delivery, scheduler
+    // iterations) and released while guest code executes. Interior code asserts
+    // ownership instead of re-acquiring; the lock is deliberately not recursive,
+    // so nested acquisition is caught immediately in debug builds.
+    class kernel_lock
+    {
+      public:
+        void lock()
+        {
+            assert(!this->is_held_by_current_thread() && "The kernel lock is not recursive");
+            this->mutex_.lock();
+            this->owner_.store(std::this_thread::get_id(), std::memory_order_relaxed);
+        }
+
+        void unlock()
+        {
+            this->owner_.store({}, std::memory_order_relaxed);
+            this->mutex_.unlock();
+        }
+
+        bool is_held_by_current_thread() const
+        {
+            return this->owner_.load(std::memory_order_relaxed) == std::this_thread::get_id();
+        }
+
+        void assert_held() const
+        {
+            assert(this->is_held_by_current_thread() && "The kernel lock must be held");
+        }
+
+      private:
+        std::mutex mutex_{};
+        std::atomic<std::thread::id> owner_{};
+    };
+
+} // namespace sogen

--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -156,6 +156,8 @@ namespace sogen
 
     void kusd_mmio::read(const uint64_t addr, void* data, const size_t size)
     {
+        const std::scoped_lock lock(this->mutex_);
+
         this->update();
 
         if (addr >= KUSD_SIZE)

--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -65,11 +65,11 @@ namespace sogen
             kusd.QpcInterruptTimeIncrement = 0x8000000000000000;
             kusd.QpcSystemTimeIncrementShift = 0x01;
             kusd.QpcInterruptTimeIncrementShift = 0x01;
-            kusd.UnparkedProcessorCount = 0x000c;
+            kusd.UnparkedProcessorCount = static_cast<uint16_t>(fake_env.number_of_processors);
             kusd.TelemetryCoverageRound = 0x00000001;
             kusd.LangGenerationCount = 0x00000003;
             kusd.InterruptTimeBias = 0x00000015a5d56406;
-            kusd.ActiveProcessorCount = 0x00000004;
+            kusd.ActiveProcessorCount = fake_env.number_of_processors;
             kusd.ActiveGroupCount = 0x01;
             kusd.TimeZoneBiasEffectiveStart.QuadPart = 0x01db276e654cb2ff;
             kusd.TimeZoneBiasEffectiveEnd.QuadPart = 0x01db280b8c3b2800;

--- a/src/windows-emulator/kusd_mmio.hpp
+++ b/src/windows-emulator/kusd_mmio.hpp
@@ -5,6 +5,7 @@
 
 #include "arch_emulator.hpp"
 
+#include <mutex>
 #include <utils/time.hpp>
 
 namespace sogen
@@ -50,6 +51,11 @@ namespace sogen
         utils::clock* clock_{};
 
         bool registered_{};
+
+        // The MMIO read callback runs on the WHP worker thread during guest execution
+        // (outside the kernel lock), so multiple vCPUs can read KUSD concurrently. This
+        // guards update() + the read snapshot so kusd_ is never torn.
+        mutable std::mutex mutex_{};
 
         // NOLINTNEXTLINE(bugprone-invalid-enum-default-initialization)
         KUSER_SHARED_DATA64 kusd_{};

--- a/src/windows-emulator/kusd_mmio.hpp
+++ b/src/windows-emulator/kusd_mmio.hpp
@@ -32,14 +32,20 @@ namespace sogen
         void serialize(utils::buffer_serializer& buffer) const;
         void deserialize(utils::buffer_deserializer& buffer);
 
-        KUSER_SHARED_DATA64& get()
+        // Locked access to the KUSD block: the MMIO read callback mutates kusd_ under mutex_ on the WHP
+        // worker thread, so callers must not touch it unsynchronized. The functor's result is forwarded.
+        template <typename F>
+        decltype(auto) access(const F& functor)
         {
-            return this->kusd_;
+            const std::lock_guard lock{this->mutex_};
+            return functor(this->kusd_);
         }
 
-        const KUSER_SHARED_DATA64& get() const
+        template <typename F>
+        decltype(auto) access(const F& functor) const
         {
-            return this->kusd_;
+            const std::lock_guard lock{this->mutex_};
+            return functor(this->kusd_);
         }
 
         static uint64_t address();

--- a/src/windows-emulator/minidump_loader.cpp
+++ b/src/windows-emulator/minidump_loader.cpp
@@ -466,15 +466,16 @@ namespace sogen
 
                 win_emu.log.info("Setting up KUSER_SHARED_DATA from dump system info\n");
 
-                auto& kusd = win_emu.process.kusd.get();
-                kusd.NtMajorVersion = sys_info->major_version;
-                kusd.NtMinorVersion = sys_info->minor_version;
-                kusd.NtBuildNumber = sys_info->build_number;
-                kusd.NativeProcessorArchitecture = sys_info->processor_architecture;
-                kusd.ActiveProcessorCount = sys_info->number_of_processors;
-                kusd.UnparkedProcessorCount = sys_info->number_of_processors;
-                kusd.NtProductType = static_cast<NT_PRODUCT_TYPE>(sys_info->product_type);
-                kusd.ProductTypeIsValid = 1;
+                win_emu.process.kusd.access([&](KUSER_SHARED_DATA64& kusd) {
+                    kusd.NtMajorVersion = sys_info->major_version;
+                    kusd.NtMinorVersion = sys_info->minor_version;
+                    kusd.NtBuildNumber = sys_info->build_number;
+                    kusd.NativeProcessorArchitecture = sys_info->processor_architecture;
+                    kusd.ActiveProcessorCount = sys_info->number_of_processors;
+                    kusd.UnparkedProcessorCount = sys_info->number_of_processors;
+                    kusd.NtProductType = static_cast<NT_PRODUCT_TYPE>(sys_info->product_type);
+                    kusd.ProductTypeIsValid = 1;
+                });
 
                 win_emu.log.info("KUSD updated: Windows %u.%u.%u, %u processors, product type %u\n", sys_info->major_version,
                                  sys_info->minor_version, sys_info->build_number, sys_info->number_of_processors, sys_info->product_type);

--- a/src/windows-emulator/minidump_loader.cpp
+++ b/src/windows-emulator/minidump_loader.cpp
@@ -556,7 +556,7 @@ namespace sogen
                 if (success_count > 0)
                 {
                     auto& first_thread = win_emu.process.threads.begin()->second;
-                    win_emu.process.active_thread = &first_thread;
+                    win_emu.vcpu(0).active_thread = &first_thread;
                 }
 
                 win_emu.log.info("Thread reconstruction: %zu/%zu threads created, %zu with context\n", success_count, threads.size(),

--- a/src/windows-emulator/port.hpp
+++ b/src/windows-emulator/port.hpp
@@ -156,7 +156,7 @@ namespace sogen
         emulator_object<PORT_MESSAGE64> receive_message;
         EmulatorTraits<Emu64>::SIZE_T receive_buffer_length{};
 
-        lpc_message_context(x86_64_emulator& emu)
+        lpc_message_context(memory_interface& emu)
             : send_message(emu),
               receive_message(emu)
         {

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -562,7 +562,7 @@ namespace sogen
         });
     }
 
-    void process_context::serialize(utils::buffer_serializer& buffer) const
+    void process_context::serialize(utils::buffer_serializer& buffer, const emulator_thread* active_thread) const
     {
         buffer.write_vector(this->sid);
         buffer.write(this->shared_section_address);
@@ -648,10 +648,10 @@ namespace sogen
         buffer.write(this->spawned_thread_count);
         buffer.write(this->threads);
 
-        buffer.write(this->threads.find_handle(this->active_thread).bits);
+        buffer.write(this->threads.find_handle(active_thread).bits);
     }
 
-    void process_context::deserialize(utils::buffer_deserializer& buffer)
+    void process_context::deserialize(utils::buffer_deserializer& buffer, emulator_thread*& active_thread)
     {
         buffer.read_vector(this->sid);
         buffer.read(this->shared_section_address);
@@ -748,7 +748,7 @@ namespace sogen
             this->thread_handles_by_id[thread.id] = this->threads.make_handle(index);
         }
 
-        this->active_thread = this->threads.get(buffer.read<uint64_t>());
+        active_thread = this->threads.get(buffer.read<uint64_t>());
     }
 
     generic_handle_store* process_context::get_handle_store(const handle handle)
@@ -840,10 +840,10 @@ namespace sogen
         return handle == CURRENT_PROCESS || handle == GUEST_PROCESS_HANDLE;
     }
 
-    bool process_context::is_current_thread_handle(const handle handle) const
+    bool process_context::is_current_thread_handle(const handle handle, const emulator_thread* active_thread) const
     {
-        return handle == CURRENT_THREAD || (handle.value.type == handle_types::thread && this->active_thread &&
-                                            this->threads.find_handle(this->active_thread) == handle);
+        return handle == CURRENT_THREAD ||
+               (handle.value.type == handle_types::thread && active_thread && this->threads.find_handle(active_thread) == handle);
     }
 
     // NOLINTNEXTLINE(cert-dcl50-cpp,readability-convert-member-functions-to-static)
@@ -852,7 +852,7 @@ namespace sogen
         return handle == CURRENT_PROCESS || handle == CURRENT_THREAD;
     }
 
-    handle process_context::resolve_object_pseudo_handle(const handle handle) const
+    handle process_context::resolve_object_pseudo_handle(const handle handle, const emulator_thread* active_thread) const
     {
         if (handle == CURRENT_PROCESS)
         {
@@ -861,7 +861,7 @@ namespace sogen
 
         if (handle == CURRENT_THREAD)
         {
-            return this->threads.find_handle(this->active_thread);
+            return this->threads.find_handle(active_thread);
         }
 
         return handle;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -89,7 +89,15 @@ namespace sogen
         {
             // Allocate GDT with read-write permissions for segment descriptor setup
             memory.allocate_memory(GDT_ADDR, static_cast<size_t>(page_align_up(GDT_LIMIT)), memory_permission::read_write);
-            emu.load_gdt(GDT_ADDR, GDT_LIMIT);
+
+            // The GDT table lives in shared guest memory, but the GDTR register is per-vCPU. Every vCPU
+            // needs it loaded: normal 64-bit execution restores segment caches from the saved thread
+            // context, but a runtime segment load - notably the WOW64 32<->64 heaven's-gate transition -
+            // reads descriptors through the GDTR, which would be invalid on a vCPU that never loaded it.
+            for (size_t i = 0; i < emu.vcpu_count(); ++i)
+            {
+                emu.get_cpu(i).load_gdt(GDT_ADDR, GDT_LIMIT);
+            }
 
             // Index 1 (selector 0x08) - 64-bit kernel code segment (Ring 0)
             // P=1, DPL=0, S=1, Type=0xA (Code, Execute/Read), L=1 (Long mode)

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -87,54 +87,41 @@ namespace sogen
 
         void setup_gdt(x86_64_emulator& emu, memory_manager& memory)
         {
-            // Allocate GDT with read-write permissions for segment descriptor setup
-            memory.allocate_memory(GDT_ADDR, static_cast<size_t>(page_align_up(GDT_LIMIT)), memory_permission::read_write);
+            const auto vcpu_count = emu.vcpu_count();
 
-            // The GDT table lives in shared guest memory, but the GDTR register is per-vCPU. Every vCPU
-            // needs it loaded: normal 64-bit execution restores segment caches from the saved thread
-            // context, but a runtime segment load - notably the WOW64 32<->64 heaven's-gate transition -
-            // reads descriptors through the GDTR, which would be invalid on a vCPU that never loaded it.
-            for (size_t i = 0; i < emu.vcpu_count(); ++i)
+            // One GDT page per vCPU (see gdt_base_for_vcpu): the WOW64 FS descriptor holds a per-thread
+            // TEB base, so a shared GDT cannot serve WOW64 threads on different vCPUs at the same time.
+            memory.allocate_memory(GDT_ADDR, static_cast<size_t>(page_align_up(vcpu_count * GDT_LIMIT)), memory_permission::read_write);
+
+            for (size_t i = 0; i < vcpu_count; ++i)
             {
-                emu.get_cpu(i).load_gdt(GDT_ADDR, GDT_LIMIT);
+                const auto gdt_base = gdt_base_for_vcpu(i);
+
+                // Index 1 (0x08) - 64-bit kernel code (Ring 0): P=1, DPL=0, S=1, Type=0xA, L=1
+                emu.write_memory<uint64_t>(gdt_base + (1 * sizeof(uint64_t)), 0x00AF9B000000FFFF);
+                // Index 2 (0x10) - 64-bit kernel data (Ring 0): P=1, DPL=0, S=1, Type=0x2, L=1
+                emu.write_memory<uint64_t>(gdt_base + (2 * sizeof(uint64_t)), 0x00CF93000000FFFF);
+                // Index 3 (0x18) - 32-bit compatibility code (Ring 0): P=1, DPL=0, S=1, Type=0xA, DB=1, G=1
+                emu.write_memory<uint64_t>(gdt_base + (3 * sizeof(uint64_t)), 0x00CF9B000000FFFF);
+                // Index 4 (0x23) - 32-bit WOW64 code (Ring 3): P=1, DPL=3, S=1, Type=0xA, DB=1, G=1
+                emu.write_memory<uint64_t>(gdt_base + (4 * sizeof(uint64_t)), 0x00CFFB000000FFFF);
+                // Index 5 (0x2B) - user data (Ring 3): P=1, DPL=3, S=1, Type=0x2, G=1
+                emu.write_memory<uint64_t>(gdt_base + (5 * sizeof(uint64_t)), 0x00CFF3000000FFFF);
+                // Index 6 (0x33) - 64-bit user code (Ring 3): P=1, DPL=3, S=1, Type=0xA, L=1
+                emu.write_memory<uint64_t>(gdt_base + (6 * sizeof(uint64_t)), 0x00AFFB000000FFFF);
+                // Index 10 (0x53) - WOW64 FS/TEB (Ring 3, byte granularity). The base is filled in
+                // per-thread by emulator_thread::refresh_execution_context.
+                emu.write_memory<uint64_t>(gdt_base + (10 * sizeof(uint64_t)), 0x0040F3000000FFFF);
+
+                emu.get_cpu(i).load_gdt(gdt_base, GDT_LIMIT);
             }
 
-            // Index 1 (selector 0x08) - 64-bit kernel code segment (Ring 0)
-            // P=1, DPL=0, S=1, Type=0xA (Code, Execute/Read), L=1 (Long mode)
-            emu.write_memory<uint64_t>(GDT_ADDR + (1 * sizeof(uint64_t)), 0x00AF9B000000FFFF);
-
-            // Index 2 (selector 0x10) - 64-bit kernel data segment (Ring 0)
-            // P=1, DPL=0, S=1, Type=0x2 (Data, Read/Write), L=1 (64-bit)
-            emu.write_memory<uint64_t>(GDT_ADDR + (2 * sizeof(uint64_t)), 0x00CF93000000FFFF);
-
-            // Index 3 (selector 0x18) - 32-bit compatibility mode segment (Ring 0)
-            // P=1, DPL=0, S=1, Type=0xA (Code, Execute/Read), DB=1, G=1
-            emu.write_memory<uint64_t>(GDT_ADDR + (3 * sizeof(uint64_t)), 0x00CF9B000000FFFF);
-
-            // Index 4 (selector 0x23) - 32-bit code segment for WOW64 (Ring 3)
-            // Real Windows: Code RE Ac 3 Bg Pg P Nl 00000cfb
-            // P=1, DPL=3, S=1, Type=0xA (Code, Execute/Read), DB=1, G=1
-            emu.write_memory<uint64_t>(GDT_ADDR + (4 * sizeof(uint64_t)), 0x00CFFB000000FFFF);
-
-            // Index 5 (selector 0x2B) - Data segment for user mode (Ring 3)
-            // Real Windows: Data RW Ac 3 Bg Pg P Nl 00000cf3
-            // P=1, DPL=3, S=1, Type=0x2 (Data, Read/Write), G=1
-            emu.write_memory<uint64_t>(GDT_ADDR + (5 * sizeof(uint64_t)), 0x00CFF3000000FFFF);
+            // Initial selectors for the primary thread on the primary vCPU (per-thread bases applied later).
             emu.reg<uint16_t>(x86_register::ss, 0x2B);
             emu.reg<uint16_t>(x86_register::ds, 0x2B);
             emu.reg<uint16_t>(x86_register::es, 0x2B);
-            emu.reg<uint16_t>(x86_register::gs, 0x2B); // Initial GS value, will be overridden with proper base later
-
-            // Index 6 (selector 0x33) - 64-bit code segment (Ring 3)
-            // P=1, DPL=3, S=1, Type=0xA (Code, Execute/Read), L=1 (Long mode)
-            emu.write_memory<uint64_t>(GDT_ADDR + (6 * sizeof(uint64_t)), 0x00AFFB000000FFFF);
+            emu.reg<uint16_t>(x86_register::gs, 0x2B);
             emu.reg<uint16_t>(x86_register::cs, 0x33);
-
-            // Index 10 (selector 0x53) - FS segment for WOW64 TEB access
-            // Real Windows: Data RW Ac 3 Bg By P Nl 000004f3 (base=0x002c1000, limit=0xfff)
-            // Initially set with base=0, will be updated during thread creation
-            // P=1, DPL=3, S=1, Type=0x3 (Data, Read/Write, Accessed), G=0 (byte granularity), DB=1
-            emu.write_memory<uint64_t>(GDT_ADDR + (10 * sizeof(uint64_t)), 0x0040F3000000FFFF);
             emu.reg<uint16_t>(x86_register::fs, 0x53);
         }
 

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -345,16 +345,16 @@ namespace sogen
         void add_knowndll_section(const std::u16string& name, const section& section, bool is_32bit);
         bool has_knowndll_section(const std::u16string& name, bool is_32bit) const;
 
-        void serialize(utils::buffer_serializer& buffer) const;
-        void deserialize(utils::buffer_deserializer& buffer);
+        void serialize(utils::buffer_serializer& buffer, const emulator_thread* active_thread) const;
+        void deserialize(utils::buffer_deserializer& buffer, emulator_thread*& active_thread);
 
         generic_handle_store* get_handle_store(handle handle);
         emulator_thread* find_thread_by_id(uint32_t thread_id);
         const emulator_thread* find_thread_by_id(uint32_t thread_id) const;
         bool is_current_process_handle(handle handle) const;
-        bool is_current_thread_handle(handle handle) const;
+        bool is_current_thread_handle(handle handle, const emulator_thread* active_thread) const;
         bool is_object_pseudo_handle(handle handle) const;
-        handle resolve_object_pseudo_handle(handle handle) const;
+        handle resolve_object_pseudo_handle(handle handle, const emulator_thread* active_thread) const;
 
         size_t get_live_thread_count() const;
 
@@ -481,7 +481,6 @@ namespace sogen
         static constexpr uint32_t process_id = 4;
         uint32_t spawned_thread_count{0};
         handle_store<handle_types::thread, emulator_thread> threads{};
-        emulator_thread* active_thread{nullptr};
 
         // Extended parameters from last NtMapViewOfSectionEx call
         // These can be used by other syscalls like NtAllocateVirtualMemoryEx

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -23,14 +23,22 @@ namespace sogen
 
     struct fake_environment_config;
 
-#define PEB_SEGMENT_SIZE        (20 << 20) // 20 MB
-#define GS_SEGMENT_SIZE         (1 << 20)  // 1 MB
+#define PEB_SEGMENT_SIZE (20 << 20) // 20 MB
+#define GS_SEGMENT_SIZE  (1 << 20)  // 1 MB
 
-#define STACK_SIZE              0x40000ULL // 256KB
+#define STACK_SIZE       0x40000ULL // 256KB
 
-#define GDT_ADDR                0x35000
-#define GDT_LIMIT               0x1000
-#define GDT_ENTRY_SIZE          0x8
+#define GDT_ADDR         0x35000
+#define GDT_LIMIT        0x1000
+#define GDT_ENTRY_SIZE   0x8
+
+    // Each vCPU gets its own GDT page. Most descriptors are identical, but the WOW64 FS descriptor
+    // (selector 0x53) holds a per-thread 32-bit TEB base that the guest reloads on every 64<->32
+    // transition, so a shared GDT would let a WOW64 thread on one vCPU read another vCPU's TEB base.
+    constexpr uint64_t gdt_base_for_vcpu(const size_t vcpu_index) noexcept
+    {
+        return GDT_ADDR + vcpu_index * GDT_LIMIT;
+    }
 
 // TODO: Get rid of that
 #define WOW64_NATIVE_STACK_SIZE 0x8000

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -66,7 +66,7 @@ namespace sogen
         }
     }
 
-    void syscall_dispatcher::dispatch(windows_emulator& win_emu)
+    void syscall_dispatcher::dispatch(windows_emulator& win_emu, vcpu_context& vcpu)
     {
         auto& emu = win_emu.emu();
         auto& context = win_emu.process;
@@ -81,6 +81,7 @@ namespace sogen
         const syscall_context c{
             .win_emu = win_emu,
             .emu = emu,
+            .vcpu = vcpu,
             .proc = context,
             .write_status = true,
         };
@@ -151,13 +152,14 @@ namespace sogen
         }
     }
 
-    dispatch_result syscall_dispatcher::dispatch_completion(windows_emulator& win_emu, callback_id callback_id,
+    dispatch_result syscall_dispatcher::dispatch_completion(windows_emulator& win_emu, vcpu_context& vcpu, callback_id callback_id,
                                                             completion_state* completion_state, uint64_t callback_result)
     {
         auto& emu = win_emu.emu();
 
         const syscall_context c{.win_emu = win_emu,
                                 .emu = emu,
+                                .vcpu = vcpu,
                                 .proc = win_emu.process,
                                 .write_status = true,
                                 .is_callback_completion = true,

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -68,7 +68,7 @@ namespace sogen
 
     void syscall_dispatcher::dispatch(windows_emulator& win_emu, vcpu_context& vcpu)
     {
-        auto& emu = win_emu.emu();
+        auto& emu = vcpu.cpu;
         auto& context = win_emu.process;
 
         const auto address = emu.read_instruction_pointer();
@@ -155,7 +155,7 @@ namespace sogen
     dispatch_result syscall_dispatcher::dispatch_completion(windows_emulator& win_emu, vcpu_context& vcpu, callback_id callback_id,
                                                             completion_state* completion_state, uint64_t callback_result)
     {
-        auto& emu = win_emu.emu();
+        auto& emu = vcpu.cpu;
 
         const syscall_context c{.win_emu = win_emu,
                                 .emu = emu,

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -136,7 +136,9 @@ namespace sogen
 
     void syscall_dispatcher::dispatch_callback(windows_emulator& win_emu, std::string& syscall_name)
     {
-        auto& emu = win_emu.emu();
+        // active_cpu(), not emu(): this runs under the syscall's scoped_dispatch, and with more than one
+        // vCPU the instrumentation-callback redirect must rewrite the acting vCPU's RIP/r10, not vCPU 0's.
+        auto& emu = win_emu.active_cpu();
         auto& context = win_emu.process;
 
         if (context.instrumentation_callback != 0 && syscall_name != "NtContinue")

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -191,6 +191,7 @@ namespace sogen
     };
 
     class windows_emulator;
+    struct vcpu_context;
 
     class syscall_dispatcher
     {
@@ -199,10 +200,10 @@ namespace sogen
         syscall_dispatcher(const exported_symbols& ntdll_exports, std::span<const std::byte> ntdll_data,
                            const exported_symbols& win32u_exports, std::span<const std::byte> win32u_data);
 
-        void dispatch(windows_emulator& win_emu);
+        void dispatch(windows_emulator& win_emu, vcpu_context& vcpu);
         static void dispatch_callback(windows_emulator& win_emu, std::string& syscall_name);
-        dispatch_result dispatch_completion(windows_emulator& win_emu, callback_id callback_id, completion_state* completion_state,
-                                            uint64_t callback_result);
+        dispatch_result dispatch_completion(windows_emulator& win_emu, vcpu_context& vcpu, callback_id callback_id,
+                                            completion_state* completion_state, uint64_t callback_result);
 
         void serialize(utils::buffer_serializer& buffer) const;
         void deserialize(utils::buffer_deserializer& buffer);

--- a/src/windows-emulator/syscall_utils.hpp
+++ b/src/windows-emulator/syscall_utils.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "windows_emulator.hpp"
 #include <ctime>
@@ -13,7 +13,9 @@ namespace sogen
     struct syscall_context
     {
         windows_emulator& win_emu;
-        x86_64_emulator& emu;
+        // The virtual CPU that issued this syscall. Register and memory access must go
+        // through this CPU, not windows_emulator::emu() (which always resolves vCPU 0).
+        x86_64_cpu& emu;
         vcpu_context& vcpu;
         process_context& proc;
         mutable bool write_status{true};
@@ -54,7 +56,7 @@ namespace sogen
         }
     };
 
-    inline uint64_t get_syscall_argument(x86_64_emulator& emu, const size_t index)
+    inline uint64_t get_syscall_argument(x86_64_cpu& emu, const size_t index)
     {
         return get_function_argument(emu, index, true);
     }
@@ -144,7 +146,7 @@ namespace sogen
 
     template <typename T>
         requires(std::is_integral_v<T> || std::is_enum_v<T>)
-    T resolve_argument(x86_64_emulator& emu, const size_t index)
+    T resolve_argument(x86_64_cpu& emu, const size_t index)
     {
         const auto arg = get_syscall_argument(emu, index);
         return static_cast<T>(arg);
@@ -152,7 +154,7 @@ namespace sogen
 
     template <typename T>
         requires(std::is_same_v<std::remove_cvref_t<T>, handle>)
-    handle resolve_argument(x86_64_emulator& emu, const size_t index)
+    handle resolve_argument(x86_64_cpu& emu, const size_t index)
     {
         handle h{};
         h.bits = resolve_argument<uint64_t>(emu, index);
@@ -161,14 +163,14 @@ namespace sogen
 
     template <typename T>
         requires(std::is_same_v<T, emulator_object<typename T::value_type>>)
-    T resolve_argument(x86_64_emulator& emu, const size_t index)
+    T resolve_argument(x86_64_cpu& emu, const size_t index)
     {
         const auto arg = get_syscall_argument(emu, index);
         return T(emu, arg);
     }
 
     template <typename T>
-    T resolve_indexed_argument(x86_64_emulator& emu, size_t& index)
+    T resolve_indexed_argument(x86_64_cpu& emu, size_t& index)
     {
         return resolve_argument<T>(emu, index++);
     }
@@ -218,7 +220,7 @@ namespace sogen
     }
 
     template <typename T, typename Traits>
-    void write_attribute(emulator& emu, const PS_ATTRIBUTE<Traits>& attribute, const T& value)
+    void write_attribute(memory_interface& emu, const PS_ATTRIBUTE<Traits>& attribute, const T& value)
     {
         if (attribute.ReturnLength)
         {
@@ -232,7 +234,7 @@ namespace sogen
     }
 
     template <typename ResponseType, typename Action, typename ReturnLengthSetter>
-    NTSTATUS handle_query_internal(x86_64_emulator& emu, const uint64_t buffer, const uint32_t length,
+    NTSTATUS handle_query_internal(x86_64_cpu& emu, const uint64_t buffer, const uint32_t length,
                                    const ReturnLengthSetter& return_length_setter, const Action& action)
     {
         constexpr auto required_size = sizeof(ResponseType);
@@ -267,8 +269,8 @@ namespace sogen
 
     template <typename ResponseType, typename Action, typename LengthType>
         requires(std::is_integral_v<LengthType>)
-    NTSTATUS handle_query(x86_64_emulator& emu, const uint64_t buffer, const uint32_t length,
-                          const emulator_object<LengthType> return_length, const Action& action)
+    NTSTATUS handle_query(x86_64_cpu& emu, const uint64_t buffer, const uint32_t length, const emulator_object<LengthType> return_length,
+                          const Action& action)
     {
         const auto length_setter = [&](const size_t required_size) {
             if (return_length)
@@ -281,7 +283,7 @@ namespace sogen
     }
 
     template <typename ResponseType, typename Action>
-    NTSTATUS handle_query(x86_64_emulator& emu, const uint64_t buffer, const uint32_t length,
+    NTSTATUS handle_query(x86_64_cpu& emu, const uint64_t buffer, const uint32_t length,
                           const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block, const Action& action)
     {
         IO_STATUS_BLOCK<EmulatorTraits<Emu64>> status_block{};

--- a/src/windows-emulator/syscall_utils.hpp
+++ b/src/windows-emulator/syscall_utils.hpp
@@ -14,6 +14,7 @@ namespace sogen
     {
         windows_emulator& win_emu;
         x86_64_emulator& emu;
+        vcpu_context& vcpu;
         process_context& proc;
         mutable bool write_status{true};
         mutable bool retrigger_syscall{false};
@@ -22,6 +23,11 @@ namespace sogen
         bool is_callback_completion{false};
         completion_state* current_completion_state{};
         uint64_t previous_callback_result{};
+
+        emulator_thread& thread() const
+        {
+            return this->vcpu.thread();
+        }
 
         template <typename T>
         T get_callback_result() const

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -924,6 +924,7 @@ namespace sogen
             context.input_buffer_length = input_buffer_length;
             context.output_buffer = output_buffer;
             context.output_buffer_length = output_buffer_length;
+            context.vcpu = &c.vcpu;
 
             return device->execute_ioctl(c.win_emu, context);
         }
@@ -942,7 +943,7 @@ namespace sogen
 
         NTSTATUS handle_NtTestAlert(const syscall_context& c)
         {
-            c.win_emu.yield_thread(true);
+            c.win_emu.yield_thread(c.vcpu, true);
             return STATUS_SUCCESS;
         }
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -874,7 +874,7 @@ namespace sogen
                 if (performance_frequency)
                 {
                     performance_frequency.access([&](LARGE_INTEGER& value) {
-                        value.QuadPart = c.proc.kusd.get().QpcFrequency; //
+                        value.QuadPart = c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.QpcFrequency; }); //
                     });
                 }
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -387,7 +387,7 @@ namespace sogen
                                          EmulatorTraits<Emu64>::SIZE_T maximum_stack_size,
                                          emulator_object<PS_ATTRIBUTE_LIST<EmulatorTraits<Emu64>>> attribute_list);
         NTSTATUS handle_NtGetCurrentProcessorNumberEx(const syscall_context&, emulator_object<PROCESSOR_NUMBER> processor_number);
-        ULONG handle_NtGetCurrentProcessorNumber();
+        ULONG handle_NtGetCurrentProcessorNumber(const syscall_context& c);
         NTSTATUS handle_NtQueueApcThreadEx2(const syscall_context& c, handle thread_handle, handle reserve_handle, uint32_t apc_flags,
                                             uint64_t apc_routine, uint64_t apc_argument1, uint64_t apc_argument2, uint64_t apc_argument3);
         NTSTATUS handle_NtQueueApcThreadEx(const syscall_context& c, handle thread_handle, handle reserve_handle, uint64_t apc_routine,

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -344,7 +344,7 @@ namespace sogen
             auto& enum_state = *f->enumeration_state;
 
             uint64_t current_offset{0};
-            emulator_object<T> object{c.emu};
+            emulator_object<T> object{c.emu.memory()};
 
             size_t current_index = enum_state.current_index;
 
@@ -1053,7 +1053,7 @@ namespace sogen
             return ret(STATUS_NOT_SUPPORTED);
         }
 
-        void commit_file_data(const std::string_view data, emulator& emu,
+        void commit_file_data(const std::string_view data, memory_interface& emu,
                               const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block, const uint64_t buffer)
         {
             if (io_status_block)
@@ -1996,8 +1996,8 @@ namespace sogen
                                    const emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block, const ULONG share_access,
                                    const ULONG open_options)
         {
-            return handle_NtCreateFile(c, file_handle, desired_access, object_attributes, io_status_block, {c.emu}, 0, share_access,
-                                       FILE_OPEN, open_options, 0, 0);
+            return handle_NtCreateFile(c, file_handle, desired_access, object_attributes, io_status_block, {c.emu.memory()}, 0,
+                                       share_access, FILE_OPEN, open_options, 0, 0);
         }
 
         NTSTATUS handle_NtOpenDirectoryObject(const syscall_context& c, const emulator_object<handle> directory_handle,

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1134,7 +1134,7 @@ namespace sogen
                     c.emu.write_memory(io_status_block.value() + sizeof(status32), &information32, sizeof(information32));
                 }
 
-                c.win_emu.current_thread().pending_apcs.push_back({
+                c.thread().pending_apcs.push_back({
                     .flags = 0,
                     .apc_routine = apc_routine,
                     .apc_argument1 = apc_context,
@@ -2193,6 +2193,7 @@ namespace sogen
             context.input_buffer_length = input_buffer_length;
             context.output_buffer = output_buffer;
             context.output_buffer_length = output_buffer_length;
+            context.vcpu = &c.vcpu;
 
             return device->execute_ioctl(c.win_emu, context);
         }

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1761,7 +1761,7 @@ namespace sogen
 
         BOOL handle_NtGdiFlush(const syscall_context& c)
         {
-            auto& thread = c.win_emu.current_thread();
+            auto& thread = c.thread();
             if (thread.teb64)
             {
                 BOOL result = TRUE;

--- a/src/windows-emulator/syscalls/io_completion.cpp
+++ b/src/windows-emulator/syscalls/io_completion.cpp
@@ -100,12 +100,14 @@ namespace sogen
                 }
 
                 handle retained_io_completion_handle{};
-                if (!io_completion_wait::retain_handle_reference(c.proc, io_completion_handle, retained_io_completion_handle))
+                if (!io_completion_wait::retain_handle_reference(c.proc, c.vcpu.active_thread, io_completion_handle,
+                                                                 retained_io_completion_handle))
                 {
                     return STATUS_INVALID_HANDLE;
                 }
 
-                if (!io_completion_wait::retain_handle_reference(c.proc, io_completion_packet_handle, wait_packet_handle))
+                if (!io_completion_wait::retain_handle_reference(c.proc, c.vcpu.active_thread, io_completion_packet_handle,
+                                                                 wait_packet_handle))
                 {
                     io_completion_wait::release_handle_reference(c.proc, retained_io_completion_handle);
                     return STATUS_INVALID_HANDLE;
@@ -159,7 +161,7 @@ namespace sogen
                 return STATUS_TIMEOUT;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
             t.await_time = {};
@@ -186,7 +188,7 @@ namespace sogen
                 }
             }
 
-            c.win_emu.yield_thread(false);
+            c.win_emu.yield_thread(c.vcpu, false);
             return STATUS_SUCCESS;
         }
 
@@ -219,7 +221,7 @@ namespace sogen
                 return STATUS_TIMEOUT;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
             t.await_time = {};
@@ -247,7 +249,7 @@ namespace sogen
                 }
             }
 
-            c.win_emu.yield_thread(alertable);
+            c.win_emu.yield_thread(c.vcpu, alertable);
             return STATUS_SUCCESS;
         }
 
@@ -304,7 +306,7 @@ namespace sogen
                 return STATUS_INVALID_HANDLE;
             }
 
-            const auto resolved_target_handle = c.proc.resolve_object_pseudo_handle(target_object_handle);
+            const auto resolved_target_handle = c.proc.resolve_object_pseudo_handle(target_object_handle, c.vcpu.active_thread);
 
             if (!io_completion_wait::is_wait_completion_target_type(resolved_target_handle))
             {
@@ -345,13 +347,14 @@ namespace sogen
             }
 
             handle retained_io_completion_handle{};
-            if (!io_completion_wait::retain_handle_reference(c.proc, io_completion_handle, retained_io_completion_handle))
+            if (!io_completion_wait::retain_handle_reference(c.proc, c.vcpu.active_thread, io_completion_handle,
+                                                             retained_io_completion_handle))
             {
                 return STATUS_INVALID_HANDLE;
             }
 
             handle retained_target_handle{};
-            if (!io_completion_wait::retain_handle_reference(c.proc, resolved_target_handle, retained_target_handle))
+            if (!io_completion_wait::retain_handle_reference(c.proc, c.vcpu.active_thread, resolved_target_handle, retained_target_handle))
             {
                 io_completion_wait::release_handle_reference(c.proc, retained_io_completion_handle);
                 return STATUS_INVALID_HANDLE;

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -518,7 +518,7 @@ namespace sogen
                                                 const uint32_t page_protection)
         {
             return handle_NtAllocateVirtualMemoryEx(c, process_handle, base_address, bytes_to_allocate, allocation_type, page_protection,
-                                                    emulator_object<MEM_EXTENDED_PARAMETER64>{c.emu}, 0);
+                                                    emulator_object<MEM_EXTENDED_PARAMETER64>{c.emu.memory()}, 0);
         }
 
         NTSTATUS handle_NtFreeVirtualMemory(const syscall_context& c, const handle process_handle,

--- a/src/windows-emulator/syscalls/mutant.cpp
+++ b/src/windows-emulator/syscalls/mutant.cpp
@@ -24,7 +24,7 @@ namespace sogen
                 return STATUS_INVALID_HANDLE;
             }
 
-            const auto [old_count, succeeded] = mutant->release(c.win_emu.current_thread().id);
+            const auto [old_count, succeeded] = mutant->release(c.thread().id);
 
             if (previous_count)
             {
@@ -101,7 +101,7 @@ namespace sogen
 
             if (initial_owner)
             {
-                e.try_lock(c.win_emu.current_thread().id);
+                e.try_lock(c.thread().id);
             }
 
             const auto handle = c.proc.mutants.store(std::move(e));

--- a/src/windows-emulator/syscalls/object.cpp
+++ b/src/windows-emulator/syscalls/object.cpp
@@ -95,7 +95,7 @@ namespace sogen
                 return STATUS_NOT_SUPPORTED;
             }
 
-            const auto resolved_source_handle = c.proc.resolve_object_pseudo_handle(source_handle);
+            const auto resolved_source_handle = c.proc.resolve_object_pseudo_handle(source_handle, c.vcpu.active_thread);
 
             if (resolved_source_handle.value.is_pseudo)
             {
@@ -172,7 +172,7 @@ namespace sogen
                                       const OBJECT_INFORMATION_CLASS object_information_class, const emulator_pointer object_information,
                                       const ULONG object_information_length, const emulator_object<ULONG> return_length)
         {
-            const auto effective_handle = c.proc.resolve_object_pseudo_handle(handle);
+            const auto effective_handle = c.proc.resolve_object_pseudo_handle(handle, c.vcpu.active_thread);
 
             if (object_information_class == ObjectNameInformation)
             {
@@ -471,7 +471,7 @@ namespace sogen
         // same recovery the wait32 path does. WoW64 and some callers hand us handles without type bits.
         handle resolve_wait_handle(const syscall_context& c, const handle h)
         {
-            const auto resolved = c.proc.resolve_object_pseudo_handle(h);
+            const auto resolved = c.proc.resolve_object_pseudo_handle(h, c.vcpu.active_thread);
             if (resolved.value.type != handle_types::reserved || resolved.value.is_pseudo)
             {
                 return resolved;
@@ -549,8 +549,8 @@ namespace sogen
 
         NTSTATUS handle_NtCompareObjects(const syscall_context& c, const handle first, const handle second)
         {
-            const auto first_resolved = c.proc.resolve_object_pseudo_handle(first);
-            const auto second_resolved = c.proc.resolve_object_pseudo_handle(second);
+            const auto first_resolved = c.proc.resolve_object_pseudo_handle(first, c.vcpu.active_thread);
+            const auto second_resolved = c.proc.resolve_object_pseudo_handle(second, c.vcpu.active_thread);
             return (first_resolved == second_resolved) ? STATUS_SUCCESS : STATUS_NOT_SAME_OBJECT;
         }
 
@@ -567,7 +567,7 @@ namespace sogen
             }
 
             const bool wait_all = (flags & mwmo_waitall) != 0;
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
             t.await_msg_mask = {};
@@ -604,7 +604,7 @@ namespace sogen
                 t.await_time = c.win_emu.clock().steady_now() + std::chrono::milliseconds{timeout};
             }
 
-            c.win_emu.yield_thread(false);
+            c.win_emu.yield_thread(c.vcpu, false);
             return {};
         }
 
@@ -624,7 +624,7 @@ namespace sogen
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
 
@@ -663,7 +663,7 @@ namespace sogen
                 t.await_time = utils::convert_delay_interval_to_time_point(c.win_emu.clock(), timeout.read());
             }
 
-            c.win_emu.yield_thread(alertable);
+            c.win_emu.yield_thread(c.vcpu, alertable);
             return STATUS_SUCCESS;
         }
 
@@ -683,7 +683,7 @@ namespace sogen
                 return STATUS_INVALID_PARAMETER;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
 
@@ -724,7 +724,7 @@ namespace sogen
                 t.await_time = utils::convert_delay_interval_to_time_point(c.win_emu.clock(), timeout.read());
             }
 
-            c.win_emu.yield_thread(alertable);
+            c.win_emu.yield_thread(c.vcpu, alertable);
             return STATUS_SUCCESS;
         }
 
@@ -738,7 +738,7 @@ namespace sogen
                 return validation_status;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {resolved_handle};
             t.await_any = false;
 
@@ -747,7 +747,7 @@ namespace sogen
                 t.await_time = utils::convert_delay_interval_to_time_point(c.win_emu.clock(), timeout.read());
             }
 
-            c.win_emu.yield_thread(alertable);
+            c.win_emu.yield_thread(c.vcpu, alertable);
             return STATUS_SUCCESS;
         }
 

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -492,7 +492,7 @@ namespace sogen
             {
                 for (auto& thread : c.proc.threads | std::views::values)
                 {
-                    if (&thread != c.proc.active_thread)
+                    if (&thread != c.vcpu.active_thread)
                     {
                         c.proc.terminate_thread(thread, exit_status);
                     }

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -295,7 +295,8 @@ namespace sogen
                 const auto shared_section_size = c.proc.shared_section_size;
                 const auto address = c.proc.shared_section_address;
 
-                const std::u16string_view windows_dir = c.proc.kusd.get().NtSystemRoot.arr;
+                const auto windows_dir =
+                    c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return std::u16string{kusd.NtSystemRoot.arr}; });
 
                 uint64_t obj_address{};
                 if (const auto status =

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -568,7 +568,7 @@ namespace sogen
                         basic_info.MaximumUserModeAddress = MAX_ALLOCATION_ADDRESS;
                         const auto processor_count = c.proc.kusd.get().ActiveProcessorCount;
                         basic_info.ActiveProcessorsAffinityMask = (processor_count >= 64) ? ~0ull : ((1ull << processor_count) - 1);
-                        basic_info.NumberOfProcessors = static_cast<uint8_t>(processor_count);
+                        basic_info.NumberOfProcessors = static_cast<char>(processor_count);
                     });
 
             case SystemDeviceInformation:

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -277,9 +277,9 @@ namespace sogen
 
             uint64_t process_id = process_context::process_id;
             uint64_t active_tid = 0;
-            if (c.proc.active_thread && c.proc.active_thread->teb64)
+            if (c.vcpu.active_thread && c.vcpu.active_thread->teb64)
             {
-                c.proc.active_thread->teb64->access([&](const TEB64& teb) {
+                c.vcpu.active_thread->teb64->access([&](const TEB64& teb) {
                     process_id = teb.ClientId.UniqueProcess;
                     active_tid = teb.ClientId.UniqueThread;
                 });

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -556,19 +556,20 @@ namespace sogen
 
             case SystemBasicInformation:
             case SystemEmulationBasicInformation:
-                return handle_query<SYSTEM_BASIC_INFORMATION64>(c.emu, system_information, system_information_length, return_length,
-                                                                [&](SYSTEM_BASIC_INFORMATION64& basic_info) {
-                                                                    basic_info.Reserved = 0;
-                                                                    basic_info.TimerResolution = 0x0002625a;
-                                                                    basic_info.PageSize = 0x1000;
-                                                                    basic_info.LowestPhysicalPageNumber = 0x00000001;
-                                                                    basic_info.HighestPhysicalPageNumber = 0x00c9c7ff;
-                                                                    basic_info.AllocationGranularity = ALLOCATION_GRANULARITY;
-                                                                    basic_info.MinimumUserModeAddress = MIN_ALLOCATION_ADDRESS;
-                                                                    basic_info.MaximumUserModeAddress = MAX_ALLOCATION_ADDRESS;
-                                                                    basic_info.ActiveProcessorsAffinityMask = 0x0000000000000f;
-                                                                    basic_info.NumberOfProcessors = 4;
-                                                                });
+                return handle_query<SYSTEM_BASIC_INFORMATION64>(
+                    c.emu, system_information, system_information_length, return_length, [&](SYSTEM_BASIC_INFORMATION64& basic_info) {
+                        basic_info.Reserved = 0;
+                        basic_info.TimerResolution = 0x0002625a;
+                        basic_info.PageSize = 0x1000;
+                        basic_info.LowestPhysicalPageNumber = 0x00000001;
+                        basic_info.HighestPhysicalPageNumber = 0x00c9c7ff;
+                        basic_info.AllocationGranularity = ALLOCATION_GRANULARITY;
+                        basic_info.MinimumUserModeAddress = MIN_ALLOCATION_ADDRESS;
+                        basic_info.MaximumUserModeAddress = MAX_ALLOCATION_ADDRESS;
+                        const auto processor_count = c.proc.kusd.get().ActiveProcessorCount;
+                        basic_info.ActiveProcessorsAffinityMask = (processor_count >= 64) ? ~0ull : ((1ull << processor_count) - 1);
+                        basic_info.NumberOfProcessors = static_cast<uint8_t>(processor_count);
+                    });
 
             case SystemDeviceInformation:
                 return handle_query<SYSTEM_DEVICE_INFORMATION>(c.emu, system_information, system_information_length, return_length,

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -105,7 +105,8 @@ namespace sogen
                     group.MaximumGroupCount = 1;
 
                     auto& group_info = group.GroupInfo[0];
-                    group_info.ActiveProcessorCount = static_cast<uint8_t>(c.proc.kusd.get().ActiveProcessorCount);
+                    group_info.ActiveProcessorCount =
+                        static_cast<uint8_t>(c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; }));
                     group_info.ActiveProcessorMask = (1ULL << group_info.ActiveProcessorCount) - 1;
                     group_info.MaximumProcessorCount = group_info.ActiveProcessorCount;
 
@@ -468,7 +469,7 @@ namespace sogen
                 // IdleTime == KernelTime (Windows kernel time includes idle), UserTime == 0. Use the
                 // executed-instruction tick as a monotonic clock so consecutive samples differ and callers
                 // computing usage from deltas don't divide by zero.
-                const auto processor_count = c.proc.kusd.get().ActiveProcessorCount;
+                const auto processor_count = c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; });
                 constexpr auto entry_size = sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION);
                 const auto required = static_cast<uint32_t>(processor_count * entry_size);
 
@@ -548,7 +549,8 @@ namespace sogen
                     if (processor_group == 0)
                     {
                         using mask_type = decltype(info.ProcessorMask);
-                        const auto active_processor_count = c.proc.kusd.get().ActiveProcessorCount;
+                        const auto active_processor_count =
+                            c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; });
                         info.ProcessorMask = (static_cast<mask_type>(1) << active_processor_count) - 1;
                     }
                 });
@@ -566,7 +568,8 @@ namespace sogen
                         basic_info.AllocationGranularity = ALLOCATION_GRANULARITY;
                         basic_info.MinimumUserModeAddress = MIN_ALLOCATION_ADDRESS;
                         basic_info.MaximumUserModeAddress = MAX_ALLOCATION_ADDRESS;
-                        const auto processor_count = c.proc.kusd.get().ActiveProcessorCount;
+                        const auto processor_count =
+                            c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; });
                         basic_info.ActiveProcessorsAffinityMask = (processor_count >= 64) ? ~0ull : ((1ull << processor_count) - 1);
                         basic_info.NumberOfProcessors = static_cast<char>(processor_count);
                     });

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -913,16 +913,17 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtGetCurrentProcessorNumberEx(const syscall_context&, const emulator_object<PROCESSOR_NUMBER> processor_number)
+        NTSTATUS handle_NtGetCurrentProcessorNumberEx(const syscall_context& c, const emulator_object<PROCESSOR_NUMBER> processor_number)
         {
-            constexpr PROCESSOR_NUMBER number{};
+            PROCESSOR_NUMBER number{};
+            number.Number = static_cast<uint8_t>(c.vcpu.cpu.index());
             processor_number.write(number);
             return STATUS_SUCCESS;
         }
 
-        ULONG handle_NtGetCurrentProcessorNumber()
+        ULONG handle_NtGetCurrentProcessorNumber(const syscall_context& c)
         {
-            return 0;
+            return static_cast<ULONG>(c.vcpu.cpu.index());
         }
 
         NTSTATUS handle_NtQueueApcThreadEx2(const syscall_context& c, const handle thread_handle, const handle /*reserve_handle*/,

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -14,7 +14,7 @@ namespace sogen
         NTSTATUS handle_NtSetInformationThread(const syscall_context& c, const handle thread_handle, const THREADINFOCLASS info_class,
                                                const uint64_t thread_information, const uint32_t thread_information_length)
         {
-            auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
@@ -115,10 +115,10 @@ namespace sogen
                 // (e.g. t6r's CEG single-step trick) never arms and never fires.
                 if ((new_wow64_context.ContextFlags & CONTEXT_DEBUG_REGISTERS_32) == CONTEXT_DEBUG_REGISTERS_32)
                 {
-                    const bool needs_switch = thread != c.proc.active_thread;
+                    const bool needs_switch = thread != c.vcpu.active_thread;
                     if (needs_switch)
                     {
-                        c.proc.active_thread->save(c.emu);
+                        c.vcpu.active_thread->save(c.emu);
                         thread->restore(c.emu);
                     }
 
@@ -132,7 +132,7 @@ namespace sogen
                     if (needs_switch)
                     {
                         thread->save(c.emu);
-                        c.proc.active_thread->restore(c.emu);
+                        c.vcpu.active_thread->restore(c.emu);
                     }
                 }
 
@@ -164,7 +164,7 @@ namespace sogen
                         }
                     }
 
-                    c.win_emu.current_thread().debugger_hide = hide;
+                    c.thread().debugger_hide = hide;
                     c.win_emu.callbacks.on_suspicious_activity("Hiding thread from debugger");
                     return STATUS_SUCCESS;
                 }
@@ -264,14 +264,14 @@ namespace sogen
                                                  const uint64_t thread_information, const uint32_t thread_information_length,
                                                  const emulator_object<uint32_t> return_length)
         {
-            const auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            const auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
                 return STATUS_INVALID_HANDLE;
             }
 
-            emulator_thread& cur_emulator_thread = c.win_emu.current_thread();
+            emulator_thread& cur_emulator_thread = c.thread();
 
             if (info_class == ThreadWow64Context)
             {
@@ -502,7 +502,7 @@ namespace sogen
         NTSTATUS handle_NtOpenThreadToken(const syscall_context& c, const handle thread_handle, const ACCESS_MASK /*desired_access*/,
                                           const BOOLEAN /*open_as_self*/, const emulator_object<handle> token_handle)
         {
-            if (!c.proc.is_current_thread_handle(thread_handle))
+            if (!c.proc.is_current_thread_handle(thread_handle, c.vcpu.active_thread))
             {
                 return STATUS_NOT_SUPPORTED;
             }
@@ -521,7 +521,7 @@ namespace sogen
 
         NTSTATUS handle_NtTerminateThread(const syscall_context& c, const handle thread_handle, const NTSTATUS exit_status)
         {
-            auto* thread = !thread_handle.bits ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            auto* thread = !thread_handle.bits ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
@@ -531,9 +531,9 @@ namespace sogen
             c.proc.terminate_thread(*thread, exit_status);
             c.win_emu.callbacks.on_thread_terminated(thread_handle, *thread);
 
-            if (thread == c.proc.active_thread)
+            if (thread == c.vcpu.active_thread)
             {
-                c.win_emu.yield_thread();
+                c.win_emu.yield_thread(c.vcpu);
             }
 
             return STATUS_SUCCESS;
@@ -542,12 +542,12 @@ namespace sogen
         NTSTATUS handle_NtDelayExecution(const syscall_context& c, const BOOLEAN alertable,
                                          const emulator_object<LARGE_INTEGER> delay_interval)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             if (delay_interval.value())
             {
                 t.await_time = utils::convert_delay_interval_to_time_point(c.win_emu.clock(), delay_interval.read());
             }
-            c.win_emu.yield_thread(alertable);
+            c.win_emu.yield_thread(c.vcpu, alertable);
 
             return STATUS_SUCCESS;
         }
@@ -585,7 +585,7 @@ namespace sogen
 
         NTSTATUS handle_NtWaitForAlertByThreadId(const syscall_context& c, const uint64_t, const emulator_object<LARGE_INTEGER> timeout)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
 
             if (t.alerted)
             {
@@ -601,14 +601,14 @@ namespace sogen
                 t.await_time = utils::convert_delay_interval_to_time_point(c.win_emu.clock(), timeout.read());
             }
 
-            c.win_emu.yield_thread();
+            c.win_emu.yield_thread(c.vcpu);
 
             return STATUS_SUCCESS;
         }
 
         NTSTATUS handle_NtYieldExecution(const syscall_context& c)
         {
-            c.win_emu.yield_thread();
+            c.win_emu.yield_thread(c.vcpu);
             return STATUS_SUCCESS;
         }
 
@@ -624,7 +624,7 @@ namespace sogen
         NTSTATUS handle_NtSuspendThread(const syscall_context& c, const handle thread_handle,
                                         const emulator_object<ULONG> previous_suspend_count)
         {
-            auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
@@ -644,9 +644,9 @@ namespace sogen
 
             thread->suspended += 1;
 
-            if (thread == c.proc.active_thread)
+            if (thread == c.vcpu.active_thread)
             {
-                c.win_emu.yield_thread();
+                c.win_emu.yield_thread(c.vcpu);
             }
 
             return STATUS_SUCCESS;
@@ -655,7 +655,7 @@ namespace sogen
         NTSTATUS handle_NtResumeThread(const syscall_context& c, const handle thread_handle,
                                        const emulator_object<ULONG> previous_suspend_count)
         {
-            auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
             if (!thread)
             {
                 return STATUS_INVALID_HANDLE;
@@ -695,7 +695,7 @@ namespace sogen
 
             if (argument.ContinueFlags & KCONTINUE_FLAG_TEST_ALERT)
             {
-                c.win_emu.yield_thread(true);
+                c.win_emu.yield_thread(c.vcpu, true);
             }
 
             return STATUS_SUCCESS;
@@ -715,7 +715,7 @@ namespace sogen
                 return STATUS_INVALID_HANDLE;
             }
 
-            const auto resolved_thread_handle = c.proc.resolve_object_pseudo_handle(thread_handle);
+            const auto resolved_thread_handle = c.proc.resolve_object_pseudo_handle(thread_handle, c.vcpu.active_thread);
 
             if (resolved_thread_handle != NULL_HANDLE && resolved_thread_handle.value.type != handle_types::thread)
             {
@@ -752,16 +752,16 @@ namespace sogen
         NTSTATUS handle_NtGetContextThread(const syscall_context& c, const handle thread_handle,
                                            const emulator_object<CONTEXT64> thread_context)
         {
-            const auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            const auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
                 return STATUS_INVALID_HANDLE;
             }
 
-            c.proc.active_thread->save(c.emu);
+            c.vcpu.active_thread->save(c.emu);
             const auto _ = utils::finally([&] {
-                c.proc.active_thread->restore(c.emu); //
+                c.vcpu.active_thread->restore(c.emu); //
             });
 
             thread->restore(c.emu);
@@ -781,25 +781,25 @@ namespace sogen
         NTSTATUS handle_NtSetContextThread(const syscall_context& c, const handle thread_handle,
                                            const emulator_object<CONTEXT64> thread_context)
         {
-            const auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            const auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
                 return STATUS_INVALID_HANDLE;
             }
 
-            const auto needs_swich = thread != c.proc.active_thread;
+            const auto needs_swich = thread != c.vcpu.active_thread;
 
             if (needs_swich)
             {
-                c.proc.active_thread->save(c.emu);
+                c.vcpu.active_thread->save(c.emu);
                 thread->restore(c.emu);
             }
 
             const auto _ = utils::finally([&] {
                 if (needs_swich)
                 {
-                    c.proc.active_thread->restore(c.emu); //
+                    c.vcpu.active_thread->restore(c.emu); //
                 }
             });
 
@@ -929,7 +929,7 @@ namespace sogen
                                             const uint32_t apc_flags, const uint64_t apc_routine, const uint64_t apc_argument1,
                                             const uint64_t apc_argument2, const uint64_t apc_argument3)
         {
-            auto* thread = thread_handle == CURRENT_THREAD ? c.proc.active_thread : c.proc.threads.get(thread_handle);
+            auto* thread = thread_handle == CURRENT_THREAD ? c.vcpu.active_thread : c.proc.threads.get(thread_handle);
 
             if (!thread)
             {
@@ -980,7 +980,7 @@ namespace sogen
         NTSTATUS handle_NtCallbackReturn(const syscall_context& c, const emulator_pointer callback_result_ptr,
                                          const ULONG callback_result_length, const NTSTATUS /*callback_status*/)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
 
             if (t.callback_stack.empty())
             {
@@ -1006,7 +1006,7 @@ namespace sogen
             frame.restore_registers(c.emu);
 
             auto dispatch_result =
-                c.win_emu.dispatcher.dispatch_completion(c.win_emu, frame.handler_id, frame.state.get(), callback_result);
+                c.win_emu.dispatcher.dispatch_completion(c.win_emu, c.vcpu, frame.handler_id, frame.state.get(), callback_result);
 
             if (dispatch_result != dispatch_result::new_callback)
             {

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -136,7 +136,7 @@ namespace sogen
 
         void set_guest_last_error(const syscall_context& c, uint32_t last_error)
         {
-            c.proc.active_thread->teb64->access([&](TEB64& teb) {
+            c.vcpu.active_thread->teb64->access([&](TEB64& teb) {
                 teb.LastErrorValue = static_cast<ULONG>(last_error); //
             });
         }
@@ -273,15 +273,15 @@ namespace sogen
 
         void set_thread_window_context(const syscall_context& c, const uint64_t active_handle, const uint64_t active_window_ptr)
         {
-            if (c.proc.active_thread && c.proc.active_thread->teb64)
+            if (c.vcpu.active_thread && c.vcpu.active_thread->teb64)
             {
-                c.proc.active_thread->teb64->access([&](TEB64& teb) {
+                c.vcpu.active_thread->teb64->access([&](TEB64& teb) {
                     teb.Win32ClientInfo.arr[8] = active_handle;
                     teb.Win32ClientInfo.arr[9] = active_window_ptr;
                 });
             }
 
-            if (c.proc.is_wow64_process && c.proc.active_thread && c.proc.active_thread->teb32)
+            if (c.proc.is_wow64_process && c.vcpu.active_thread && c.vcpu.active_thread->teb32)
             {
                 uint32_t active_handle32{};
                 uint32_t active_window_ptr32{};
@@ -296,7 +296,7 @@ namespace sogen
                     active_window_ptr32 = static_cast<uint32_t>(active_window_ptr);
                 }
 
-                c.proc.active_thread->teb32->access([&](TEB32& teb) {
+                c.vcpu.active_thread->teb32->access([&](TEB32& teb) {
                     teb.Win32ClientInfo[8] = active_handle32;
                     teb.Win32ClientInfo[9] = active_window_ptr32;
                 });
@@ -911,7 +911,7 @@ namespace sogen
 
         uint64_t ensure_win32_thread_info(const syscall_context& c)
         {
-            auto* thread = c.proc.active_thread;
+            auto* thread = c.vcpu.active_thread;
             if (!thread || !thread->teb64)
             {
                 return 0;
@@ -940,7 +940,7 @@ namespace sogen
 
         void publish_win32_thread_info(const syscall_context& c, const uint64_t thread_info)
         {
-            auto* thread = c.proc.active_thread;
+            auto* thread = c.vcpu.active_thread;
             if (!thread || !thread->teb64 || thread_info == 0)
             {
                 return;
@@ -1347,12 +1347,12 @@ namespace sogen
         {
             if (routine == k_thread_state_message_time)
             {
-                return c.proc.active_thread ? c.proc.active_thread->current_message_time : 0;
+                return c.vcpu.active_thread ? c.vcpu.active_thread->current_message_time : 0;
             }
 
             if (routine == k_thread_state_dialog_state)
             {
-                return c.proc.active_thread ? c.proc.active_thread->win32k_thread_state : 0;
+                return c.vcpu.active_thread ? c.vcpu.active_thread->win32k_thread_state : 0;
             }
 
             if (routine != k_thread_state_win32_thread_info)
@@ -1368,10 +1368,10 @@ namespace sogen
 
             publish_win32_thread_info(c, thread_info);
 
-            if (c.proc.is_wow64_process && c.proc.active_thread && !c.proc.active_thread->win32k_thread_setup_done &&
-                !c.proc.active_thread->win32k_thread_setup_pending)
+            if (c.proc.is_wow64_process && c.vcpu.active_thread && !c.vcpu.active_thread->win32k_thread_setup_done &&
+                !c.vcpu.active_thread->win32k_thread_setup_pending)
             {
-                c.proc.active_thread->win32k_thread_setup_pending = true;
+                c.vcpu.active_thread->win32k_thread_setup_pending = true;
                 dispatch_user_callback(c, callback_id::NtUserGetThreadState, k_client_setup_callback_id);
                 return 0;
             }
@@ -1381,7 +1381,7 @@ namespace sogen
 
         uint64_t handle_NtUserSetThreadState(const syscall_context& c, const uint64_t value, const uint64_t mask)
         {
-            auto* thread = c.proc.active_thread;
+            auto* thread = c.vcpu.active_thread;
             if (!thread)
             {
                 return 0;
@@ -1444,10 +1444,10 @@ namespace sogen
                 }
             }
 
-            if (c.proc.active_thread)
+            if (c.vcpu.active_thread)
             {
-                c.proc.active_thread->win32k_thread_setup_pending = false;
-                c.proc.active_thread->win32k_thread_setup_done = true;
+                c.vcpu.active_thread->win32k_thread_setup_pending = false;
+                c.vcpu.active_thread->win32k_thread_setup_done = true;
             }
 
             return STATUS_SUCCESS;
@@ -1457,10 +1457,10 @@ namespace sogen
                                                         const emulator_pointer apfn_client_w, const emulator_pointer apfn_client_worker,
                                                         const emulator_pointer /*hmod_user*/)
         {
-            if (c.proc.active_thread)
+            if (c.vcpu.active_thread)
             {
-                c.proc.active_thread->win32k_thread_setup_pending = false;
-                c.proc.active_thread->win32k_thread_setup_done = true;
+                c.vcpu.active_thread->win32k_thread_setup_pending = false;
+                c.vcpu.active_thread->win32k_thread_setup_done = true;
             }
 
             if (!win32k_userconnect::try_update_client_pfn_arrays_from_addresses(c.win_emu.memory, c.proc, apfn_client_a, apfn_client_w,
@@ -1480,9 +1480,9 @@ namespace sogen
         hdesk handle_NtUserGetThreadDesktop(const syscall_context& c, const ULONG thread_id)
         {
             emulator_thread* target = nullptr;
-            if (thread_id == 0 || (c.proc.active_thread && c.proc.active_thread->id == thread_id))
+            if (thread_id == 0 || (c.vcpu.active_thread && c.vcpu.active_thread->id == thread_id))
             {
-                target = c.proc.active_thread;
+                target = c.vcpu.active_thread;
             }
             else
             {
@@ -2667,7 +2667,7 @@ namespace sogen
             win.y = y;
             win.width = width;
             win.height = height;
-            win.thread_id = c.win_emu.current_thread().id;
+            win.thread_id = c.thread().id;
             win.handle = handle.bits;
             if (!is_message_only)
             {
@@ -2953,7 +2953,7 @@ namespace sogen
                 return FALSE;
             }
 
-            if (win->thread_id != c.proc.active_thread->id)
+            if (win->thread_id != c.vcpu.active_thread->id)
             {
                 return FALSE;
             }
@@ -3070,7 +3070,7 @@ namespace sogen
                 return FALSE;
             }
 
-            if (win->thread_id != c.proc.active_thread->id)
+            if (win->thread_id != c.vcpu.active_thread->id)
             {
                 // TODO: Wait?
                 return FALSE;
@@ -3185,7 +3185,7 @@ namespace sogen
                 return write_message_call_result(c, result_info, result) ? TRUE : FALSE;
             }
 
-            if (win->thread_id != c.proc.active_thread->id)
+            if (win->thread_id != c.vcpu.active_thread->id)
             {
                 // TODO: This is a bit incorrect. We're supposed to wait until the message is received, but this is fine for a first
                 //       minimal version.
@@ -3328,7 +3328,7 @@ namespace sogen
                 return 0;
             }
 
-            if (win && win->thread_id != c.proc.active_thread->id)
+            if (win && win->thread_id != c.vcpu.active_thread->id)
             {
                 return 0;
             }
@@ -3372,7 +3372,7 @@ namespace sogen
         BOOL handle_NtUserGetMessage(const syscall_context& c, const emulator_object<msg> message, const hwnd hwnd,
                                      const UINT msg_filter_min, const UINT msg_filter_max)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
 
             if (auto pending_msg = t.peek_pending_message(c.win_emu, hwnd, msg_filter_min, msg_filter_max, true))
             {
@@ -3384,14 +3384,14 @@ namespace sogen
 
             t.await_msg = {message, hwnd, msg_filter_min, msg_filter_max};
 
-            c.win_emu.yield_thread(false);
+            c.win_emu.yield_thread(c.vcpu, false);
             return {};
         }
 
         BOOL handle_NtUserPeekMessage(const syscall_context& c, const emulator_object<msg> message, const hwnd hwnd,
                                       const UINT msg_filter_min, const UINT msg_filter_max, const UINT remove_message)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
 
             const bool should_remove = (remove_message & PM_REMOVE) != 0;
             std::optional<msg> pending_msg = t.peek_pending_message(c.win_emu, hwnd, msg_filter_min, msg_filter_max, should_remove);
@@ -3409,14 +3409,14 @@ namespace sogen
 
         BOOL handle_NtUserWaitMessage(const syscall_context& c)
         {
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             if (t.peek_pending_message(c.win_emu))
             {
                 return TRUE;
             }
 
-            c.proc.active_thread->await_msg_mask = QS_ALLINPUT;
-            c.win_emu.yield_thread(false);
+            c.vcpu.active_thread->await_msg_mask = QS_ALLINPUT;
+            c.win_emu.yield_thread(c.vcpu, false);
             return {};
         }
 
@@ -3452,7 +3452,7 @@ namespace sogen
 
         void collect_pending_paint_tree(const syscall_context& c, window& win, std::vector<uint64_t>& order)
         {
-            if (win.update_pending && win.thread_id == c.proc.active_thread->id)
+            if (win.update_pending && win.thread_id == c.vcpu.active_thread->id)
             {
                 order.push_back(static_cast<uint64_t>(win.handle));
             }
@@ -3495,7 +3495,7 @@ namespace sogen
             // rely on this to display content without running a message loop, so a merely queued WM_PAINT would
             // never be pumped. Dispatch WM_PAINT now to the window and its invalid visible child controls.
             // Cross-thread windows cannot be painted on this thread, so fall back to posting the paint.
-            if (win->thread_id != c.proc.active_thread->id)
+            if (win->thread_id != c.vcpu.active_thread->id)
             {
                 if (win->update_pending)
                 {
@@ -3546,7 +3546,7 @@ namespace sogen
                 return FALSE;
             }
 
-            uint32_t target_thread_id = hwnd != 0 ? win->thread_id : c.win_emu.current_thread().id;
+            uint32_t target_thread_id = hwnd != 0 ? win->thread_id : c.thread().id;
 
             if (auto* thread = c.proc.find_thread_by_id(target_thread_id))
             {
@@ -3586,7 +3586,7 @@ namespace sogen
             qmsg.message = WM_QUIT;
             qmsg.wParam = exit_code;
 
-            c.proc.active_thread->post_message(c.win_emu, qmsg);
+            c.vcpu.active_thread->post_message(c.win_emu, qmsg);
             return TRUE;
         }
 
@@ -4764,7 +4764,7 @@ namespace sogen
                 interval = k_user_timer_minimum;
             }
 
-            auto* target_thread = c.proc.active_thread;
+            auto* target_thread = c.vcpu.active_thread;
 
             if (hwnd != 0)
             {
@@ -4811,7 +4811,7 @@ namespace sogen
 
         BOOL handle_NtUserKillTimer(const syscall_context& c, const hwnd hwnd, const uint64_t timer_id)
         {
-            auto* target_thread = c.proc.active_thread;
+            auto* target_thread = c.vcpu.active_thread;
 
             if (hwnd != 0)
             {
@@ -4862,7 +4862,7 @@ namespace sogen
 
         uint32_t handle_NtUserGetQueueStatusReadonly(const syscall_context& c, const UINT flags)
         {
-            auto* thread = c.proc.active_thread;
+            auto* thread = c.vcpu.active_thread;
             const auto current_bits = thread->get_message_queue_status(c.win_emu) & flags;
             const auto changed_bits = thread->queue_status_changed_bits & flags;
             return current_bits | (changed_bits << 16);
@@ -4871,7 +4871,7 @@ namespace sogen
         uint32_t handle_NtUserGetQueueStatus(const syscall_context& c, const UINT flags)
         {
             const auto result = handle_NtUserGetQueueStatusReadonly(c, flags);
-            c.proc.active_thread->queue_status_changed_bits &= ~flags;
+            c.vcpu.active_thread->queue_status_changed_bits &= ~flags;
             return result;
         }
 

--- a/src/windows-emulator/syscalls/worker_factory.cpp
+++ b/src/windows-emulator/syscalls/worker_factory.cpp
@@ -188,7 +188,8 @@ namespace sogen
             factory.name = name;
 
             handle retained_io_completion_handle{};
-            if (!io_completion_wait::retain_handle_reference(c.proc, io_completion_handle, retained_io_completion_handle))
+            if (!io_completion_wait::retain_handle_reference(c.proc, c.vcpu.active_thread, io_completion_handle,
+                                                             retained_io_completion_handle))
             {
                 return STATUS_INVALID_HANDLE;
             }
@@ -454,7 +455,7 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            auto& t = c.win_emu.current_thread();
+            auto& t = c.thread();
             t.await_objects = {};
             t.await_any = false;
             t.await_time = {};
@@ -484,7 +485,7 @@ namespace sogen
                 }
             }
 
-            c.win_emu.yield_thread(false);
+            c.win_emu.yield_thread(c.vcpu, false);
             return STATUS_SUCCESS;
         }
     }

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -549,10 +549,21 @@ namespace sogen
 
             void pump_events() override
             {
+                {
+                    const std::lock_guard lock(this->command_mutex_);
+                    if (!this->ui_thread_known_)
+                    {
+                        this->ui_thread_id_ = std::this_thread::get_id();
+                        this->ui_thread_known_ = true;
+                    }
+                }
+
                 if (!this->ensure_initialized())
                 {
                     return;
                 }
+
+                this->drain_commands();
 
                 SDL_Event event{};
                 while (SDL_PollEvent(&event))
@@ -730,6 +741,11 @@ namespace sogen
 
             void create_window(const ui_window_desc& desc) override
             {
+                this->queue_or_run([this, desc] { this->create_window_impl(desc); });
+            }
+
+            void create_window_impl(const ui_window_desc& desc)
+            {
                 if (!this->ensure_initialized())
                 {
                     return;
@@ -800,128 +816,191 @@ namespace sogen
 
             void destroy_window(const hwnd window) override
             {
-                if (const auto it = this->windows_.find(window); it != this->windows_.end())
-                {
-                    // Child (non-top-level) windows have no SDL window; only top-level windows do.
-                    if (it->second.window)
+                this->queue_or_run([this, window] {
+                    if (const auto it = this->windows_.find(window); it != this->windows_.end())
                     {
-                        SDL_StopTextInput(it->second.window);
-                        this->guest_by_window_id_.erase(SDL_GetWindowID(it->second.window));
+                        // Child (non-top-level) windows have no SDL window; only top-level windows do.
+                        if (it->second.window)
+                        {
+                            SDL_StopTextInput(it->second.window);
+                            this->guest_by_window_id_.erase(SDL_GetWindowID(it->second.window));
+                        }
+                        destroy_window_resources(it->second);
+                        this->windows_.erase(it);
                     }
-                    destroy_window_resources(it->second);
-                    this->windows_.erase(it);
-                }
+                });
             }
 
             void set_window_rect(const hwnd window, const RECT& rect) override
             {
-                if (auto* state = this->resolve_window(window))
-                {
-                    state->desc.rect = rect;
-                    if (state->desc.top_level)
+                this->queue_or_run([this, window, rect] {
+                    if (auto* state = this->resolve_window(window))
                     {
-                        const auto& insets = state->desc.client_insets;
-                        SDL_SetWindowPosition(state->window, rect.left, rect.top);
-                        SDL_SetWindowSize(state->window, std::max<int>(1, (rect.right - rect.left) - insets.left - insets.right),
-                                          std::max<int>(1, (rect.bottom - rect.top) - insets.top - insets.bottom));
+                        state->desc.rect = rect;
+                        if (state->desc.top_level)
+                        {
+                            const auto& insets = state->desc.client_insets;
+                            SDL_SetWindowPosition(state->window, rect.left, rect.top);
+                            SDL_SetWindowSize(state->window, std::max<int>(1, (rect.right - rect.left) - insets.left - insets.right),
+                                              std::max<int>(1, (rect.bottom - rect.top) - insets.top - insets.bottom));
+                        }
+                        this->redraw_related(window);
                     }
-                    this->redraw_related(window);
-                }
+                });
             }
 
             void set_window_visible(const hwnd window, const bool visible) override
             {
-                if (auto* state = this->resolve_window(window))
-                {
-                    state->desc.visible = visible;
-                    if (state->desc.top_level)
+                this->queue_or_run([this, window, visible] {
+                    if (auto* state = this->resolve_window(window))
                     {
-                        if (visible)
+                        state->desc.visible = visible;
+                        if (state->desc.top_level)
                         {
-                            SDL_ShowWindow(state->window);
+                            if (visible)
+                            {
+                                SDL_ShowWindow(state->window);
+                            }
+                            else
+                            {
+                                SDL_HideWindow(state->window);
+                            }
                         }
-                        else
-                        {
-                            SDL_HideWindow(state->window);
-                        }
+                        this->redraw_related(window);
                     }
-                    this->redraw_related(window);
-                }
+                });
             }
 
             void set_window_enabled(const hwnd window, const bool enabled) override
             {
-                if (auto* state = this->resolve_window(window))
-                {
-                    state->desc.enabled = enabled;
-                    this->redraw_related(window);
-                }
+                this->queue_or_run([this, window, enabled] {
+                    if (auto* state = this->resolve_window(window))
+                    {
+                        state->desc.enabled = enabled;
+                        this->redraw_related(window);
+                    }
+                });
             }
 
             void set_window_title(const hwnd window, std::u16string_view title) override
             {
-                if (auto* state = this->resolve_window(window))
-                {
-                    state->desc.title = std::u16string{title};
-                    if (state->desc.top_level)
+                this->queue_or_run([this, window, title = std::u16string{title}] {
+                    if (auto* state = this->resolve_window(window))
                     {
-                        const auto utf8 = u16_to_u8(title);
-                        SDL_SetWindowTitle(state->window, utf8.c_str());
+                        state->desc.title = title;
+                        if (state->desc.top_level)
+                        {
+                            const auto utf8 = u16_to_u8(title);
+                            SDL_SetWindowTitle(state->window, utf8.c_str());
+                        }
+                        this->redraw_related(window);
                     }
-                    this->redraw_related(window);
-                }
+                });
             }
 
             void present_surface(const hwnd window, const ui_surface_desc& surface) override
             {
-                // The render target is frequently a child window (e.g. a D3D/Vulkan swap-chain child),
-                // which has no SDL renderer of its own. Composite its surface onto the top-level
-                // ancestor -- the window that actually owns the on-screen SDL window and renderer.
-                auto* state = this->resolve_window(window);
-                if (state && !state->renderer)
+                // The queued command runs on the pump thread after this call returns, by which point the
+                // guest's pixel buffer may be gone, so take a private copy of it now.
+                std::vector<uint8_t> pixels;
+                auto copy = surface;
+                if (surface.pixels && surface.stride > 0 && surface.height > 0)
                 {
-                    state = this->resolve_window(this->get_top_level_ancestor(window));
+                    const auto size = static_cast<size_t>(surface.stride) * static_cast<size_t>(surface.height);
+                    pixels.resize(size);
+                    std::memcpy(pixels.data(), surface.pixels, size);
                 }
-                if (state && state->renderer)
-                {
-                    update_surface_texture(*state, surface);
-                    render_window(*state);
-                }
+
+                this->queue_or_run([this, window, copy, pixels = std::move(pixels)]() mutable {
+                    copy.pixels = pixels.empty() ? nullptr : pixels.data();
+
+                    // The render target is frequently a child window (e.g. a D3D/Vulkan swap-chain child),
+                    // which has no SDL renderer of its own. Composite its surface onto the top-level
+                    // ancestor -- the window that actually owns the on-screen SDL window and renderer.
+                    auto* state = this->resolve_window(window);
+                    if (state && !state->renderer)
+                    {
+                        state = this->resolve_window(this->get_top_level_ancestor(window));
+                    }
+                    if (state && state->renderer)
+                    {
+                        update_surface_texture(*state, copy);
+                        render_window(*state);
+                    }
+                });
             }
 
             void set_cursor_position(const hwnd window, const int32_t screen_x, const int32_t screen_y) override
             {
-                // Top-levels are positioned at their emulated rect (SDL_SetWindowPosition), so emulated screen
-                // coordinates map to guest client pixels by subtracting that origin.
-                const auto top = this->get_top_level_ancestor(window);
-                if (auto* state = this->resolve_window(top); state && state->window)
-                {
-                    auto window_x = static_cast<float>(screen_x - state->desc.rect.left);
-                    auto window_y = static_cast<float>(screen_y - state->desc.rect.top);
-                    // The frame is letterboxed into the window, so guest pixels are not at the same position in
-                    // the host window; map through the same transform map_window_point inverts.
-                    if (state->renderer)
+                this->queue_or_run([this, window, screen_x, screen_y] {
+                    // Top-levels are positioned at their emulated rect (SDL_SetWindowPosition), so emulated screen
+                    // coordinates map to guest client pixels by subtracting that origin.
+                    const auto top = this->get_top_level_ancestor(window);
+                    if (auto* state = this->resolve_window(top); state && state->window)
                     {
-                        SDL_RenderCoordinatesToWindow(state->renderer, window_x, window_y, &window_x, &window_y);
+                        auto window_x = static_cast<float>(screen_x - state->desc.rect.left);
+                        auto window_y = static_cast<float>(screen_y - state->desc.rect.top);
+                        // The frame is letterboxed into the window, so guest pixels are not at the same position in
+                        // the host window; map through the same transform map_window_point inverts.
+                        if (state->renderer)
+                        {
+                            SDL_RenderCoordinatesToWindow(state->renderer, window_x, window_y, &window_x, &window_y);
+                        }
+                        SDL_WarpMouseInWindow(state->window, window_x, window_y);
                     }
-                    SDL_WarpMouseInWindow(state->window, window_x, window_y);
-                }
+                });
             }
 
             void set_cursor_visibility(const bool visible) override
             {
-                // SDL cursor visibility is process-global, which matches the single foreground guest game.
-                if (visible)
-                {
-                    SDL_ShowCursor();
-                }
-                else
-                {
-                    SDL_HideCursor();
-                }
+                this->queue_or_run([visible] {
+                    // SDL cursor visibility is process-global, which matches the single foreground guest game.
+                    if (visible)
+                    {
+                        SDL_ShowCursor();
+                    }
+                    else
+                    {
+                        SDL_HideCursor();
+                    }
+                });
             }
 
           private:
+            // SDL windows are thread-affine: only their owning thread's message pump services the
+            // cross-thread SendMessage that host calls such as SDL_ShowWindow issue, so every SDL
+            // operation must run on the one thread that calls pump_events. With multiple vCPUs the
+            // syscall handlers run on different worker threads, so operations they trigger are queued
+            // here and executed on the pump thread. Every ui_backend method returns void, so the
+            // callers never need a result and this can stay fully asynchronous.
+            void queue_or_run(std::function<void()> task)
+            {
+                {
+                    const std::lock_guard lock(this->command_mutex_);
+                    if (this->ui_thread_known_ && this->ui_thread_id_ != std::this_thread::get_id())
+                    {
+                        this->commands_.emplace_back(std::move(task));
+                        return;
+                    }
+                }
+
+                task();
+            }
+
+            void drain_commands()
+            {
+                std::vector<std::function<void()>> pending;
+                {
+                    const std::lock_guard lock(this->command_mutex_);
+                    pending.swap(this->commands_);
+                }
+
+                for (auto& task : pending)
+                {
+                    task();
+                }
+            }
+
             bool ensure_initialized()
             {
                 if (!this->initialized_)
@@ -1168,6 +1247,11 @@ namespace sogen
             std::array<bool, SDL_SCANCODE_COUNT> key_down_{};
             std::unordered_map<hwnd, window_state> windows_{};
             std::unordered_map<SDL_WindowID, hwnd> guest_by_window_id_{};
+
+            std::mutex command_mutex_{};
+            std::vector<std::function<void()>> commands_{};
+            std::thread::id ui_thread_id_{};
+            bool ui_thread_known_{false};
         };
     }
 

--- a/src/windows-emulator/user_callback_dispatch.hpp
+++ b/src/windows-emulator/user_callback_dispatch.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "syscall_utils.hpp"
 
@@ -14,7 +14,7 @@ namespace sogen
     }
 
     template <typename T>
-    void write_user_callback_arg(x86_64_emulator& emu, const uint64_t arg_buffer, size_t& offset, const T& arg)
+    void write_user_callback_arg(x86_64_cpu& emu, const uint64_t arg_buffer, size_t& offset, const T& arg)
     {
         offset = static_cast<size_t>(align_up(offset, alignof(T)));
         emu.write_memory(arg_buffer + offset, &arg, sizeof(arg));
@@ -51,7 +51,7 @@ namespace sogen
     }
 
     template <typename... Args>
-    void prepare_call_stack(x86_64_emulator& emu, const uint32_t callback_index, const Args&... args)
+    void prepare_call_stack(x86_64_cpu& emu, const uint32_t callback_index, const Args&... args)
     {
         const uint32_t arg_length = user_callback_args_size<Args...>();
         const uint64_t stack_args_size = align_up(arg_length, 0x10);

--- a/src/windows-emulator/user_callback_dispatch.hpp
+++ b/src/windows-emulator/user_callback_dispatch.hpp
@@ -44,8 +44,10 @@ namespace sogen
 
         callback_frame frame(completion_id, std::move(state));
         frame.save_registers(c.emu);
-        c.proc.active_thread->callback_return_rax.reset();
-        c.proc.active_thread->callback_stack.emplace_back(std::move(frame));
+
+        auto& thread = c.thread();
+        thread.callback_return_rax.reset();
+        thread.callback_stack.emplace_back(std::move(frame));
     }
 
     template <typename... Args>

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -9,6 +9,7 @@ namespace sogen
         : state_(state),
           emu_(c.emu),
           proc_(c.proc),
+          thread_(c.thread()),
           ui_(c.win_emu.ui())
     {
     }
@@ -24,7 +25,7 @@ namespace sogen
         {
             auto& frame = this->state_.frames.back();
             auto* win = this->proc_.windows.get(frame.handle);
-            if (!win || win->thread_id != this->proc_.active_thread->id)
+            if (!win || win->thread_id != this->thread_.id)
             {
                 this->pop_frame_allocation(frame);
                 this->state_.frames.pop_back();

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -38,7 +38,7 @@ namespace sogen
         void finalize_frame(window_destroy_frame& frame, const window& win) const;
 
         window_destroy_state& state_;
-        x86_64_emulator& emu_;
+        x86_64_cpu& emu_;
         process_context& proc_;
         const emulator_thread& thread_;
         ui_backend& ui_;

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -12,6 +12,7 @@ namespace sogen
     struct syscall_context;
     class ui_backend;
     struct process_context;
+    class emulator_thread;
 
     struct window_destroy_step
     {
@@ -39,6 +40,7 @@ namespace sogen
         window_destroy_state& state_;
         x86_64_emulator& emu_;
         process_context& proc_;
+        const emulator_thread& thread_;
         ui_backend& ui_;
     };
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -269,10 +269,10 @@ namespace sogen
             return false;
         }
 
-        void perform_context_switch_work(windows_emulator& win_emu)
+        void perform_context_switch_work(windows_emulator& win_emu, vcpu_context& vcpu)
         {
             auto& threads = win_emu.process.threads;
-            auto*& active = win_emu.process.active_thread;
+            auto*& active = vcpu.active_thread;
 
             for (auto it = threads.begin(); it != threads.end();)
             {
@@ -323,18 +323,18 @@ namespace sogen
             return nullptr;
         }
 
-        void dispatch_next_apc(windows_emulator& win_emu, emulator_thread& thread)
+        void dispatch_next_apc(windows_emulator& win_emu, vcpu_context& vcpu, emulator_thread& thread)
         {
-            assert(&win_emu.current_thread() == &thread);
+            assert(vcpu.active_thread == &thread);
 
-            auto& emu = win_emu.emu();
+            auto& emu = vcpu.cpu;
             auto& apcs = thread.pending_apcs;
             if (apcs.empty())
             {
                 return;
             }
 
-            thread.setup_if_necessary(win_emu.emu(), win_emu.process);
+            thread.setup_if_necessary(vcpu.cpu, win_emu.process);
 
             win_emu.callbacks.on_generic_activity("APC Dispatch");
 
@@ -382,14 +382,14 @@ namespace sogen
             emu.reg(x86_register::rip, win_emu.process.ki_user_apc_dispatcher);
         }
 
-        bool switch_to_thread(windows_emulator& win_emu, emulator_thread& thread, const bool force = false)
+        bool switch_to_thread(windows_emulator& win_emu, vcpu_context& vcpu, emulator_thread& thread, const bool force = false)
         {
             if (thread.is_terminated())
             {
                 return false;
             }
 
-            auto& emu = win_emu.emu();
+            auto& emu = vcpu.cpu;
             auto& context = win_emu.process;
 
             const auto is_ready = thread.is_thread_ready(win_emu);
@@ -401,7 +401,7 @@ namespace sogen
                 return false;
             }
 
-            auto* active_thread = context.active_thread;
+            auto* active_thread = vcpu.active_thread;
 
             if (active_thread != &thread)
             {
@@ -411,7 +411,7 @@ namespace sogen
                     active_thread->save(emu);
                 }
 
-                context.active_thread = &thread;
+                vcpu.active_thread = &thread;
 
                 thread.restore(emu);
             }
@@ -421,14 +421,14 @@ namespace sogen
             if (can_dispatch_apcs && !has_pending_status)
             {
                 thread.mark_as_ready(STATUS_USER_APC);
-                dispatch_next_apc(win_emu, thread);
+                dispatch_next_apc(win_emu, vcpu, thread);
             }
 
             thread.apc_alertable = false;
             return true;
         }
 
-        bool switch_to_thread(windows_emulator& win_emu, const handle thread_handle)
+        bool switch_to_thread(windows_emulator& win_emu, vcpu_context& vcpu, const handle thread_handle)
         {
             auto* thread = win_emu.process.threads.get(thread_handle);
             if (!thread)
@@ -436,12 +436,12 @@ namespace sogen
                 throw std::runtime_error("Bad thread handle");
             }
 
-            return switch_to_thread(win_emu, *thread);
+            return switch_to_thread(win_emu, vcpu, *thread);
         }
 
-        bool switch_to_next_thread(windows_emulator& win_emu)
+        bool switch_to_next_thread(windows_emulator& win_emu, vcpu_context& vcpu)
         {
-            perform_context_switch_work(win_emu);
+            perform_context_switch_work(win_emu, vcpu);
 
             auto& context = win_emu.process;
 
@@ -451,7 +451,7 @@ namespace sogen
             {
                 if (next_thread)
                 {
-                    if (switch_to_thread(win_emu, t))
+                    if (switch_to_thread(win_emu, vcpu, t))
                     {
                         return true;
                     }
@@ -459,7 +459,7 @@ namespace sogen
                     continue;
                 }
 
-                if (&t == context.active_thread)
+                if (&t == vcpu.active_thread)
                 {
                     next_thread = true;
                 }
@@ -467,7 +467,7 @@ namespace sogen
 
             for (auto& t : context.threads | std::views::values)
             {
-                if (switch_to_thread(win_emu, t))
+                if (switch_to_thread(win_emu, vcpu, t))
                 {
                     return true;
                 }
@@ -584,6 +584,12 @@ namespace sogen
             throw std::invalid_argument("The emulator backend was created with fewer vCPUs than requested");
         }
 
+        this->vcpus_.reserve(this->vcpu_count_);
+        for (uint32_t i = 0; i < this->vcpu_count_; ++i)
+        {
+            this->vcpus_.push_back(std::make_unique<vcpu_context>(this->emu_->get_cpu(i)));
+        }
+
         this->ui_backend_->set_event_sink([this](const ui_event& event) { this->handle_ui_event(event); });
 #ifndef OS_WINDOWS
         if (this->emulation_root.empty())
@@ -646,22 +652,22 @@ namespace sogen
         const auto main_thread_id = context.create_thread(this->memory, this->mod_manager.executable->entry_point, 0,
                                                           this->mod_manager.executable->size_of_stack_reserve, 0, true);
 
-        switch_to_thread(*this, main_thread_id);
+        switch_to_thread(*this, this->vcpu(0), main_thread_id);
     }
 
-    void windows_emulator::yield_thread(const bool alertable)
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    void windows_emulator::yield_thread(vcpu_context& vcpu, const bool alertable)
     {
-        this->switch_thread_ = true;
-        this->current_thread().apc_alertable = alertable;
-        this->emu().stop();
+        vcpu.switch_thread = true;
+        vcpu.thread().apc_alertable = alertable;
+        vcpu.cpu.stop();
     }
 
-    bool windows_emulator::perform_thread_switch()
+    bool windows_emulator::perform_thread_switch(vcpu_context& vcpu)
     {
-        const auto needed_switch = this->switch_thread_.exchange(false);
+        const auto needed_switch = vcpu.switch_thread.exchange(false);
 
-        this->switch_thread_ = false;
-        while (!switch_to_next_thread(*this))
+        while (!switch_to_next_thread(*this, vcpu))
         {
             this->ui_backend_->pump_events();
 
@@ -682,7 +688,7 @@ namespace sogen
 
             if (this->should_stop)
             {
-                this->switch_thread_ = needed_switch;
+                vcpu.switch_thread = needed_switch;
                 return false;
             }
         }
@@ -690,7 +696,7 @@ namespace sogen
         return true;
     }
 
-    bool windows_emulator::activate_thread(const uint32_t id)
+    bool windows_emulator::activate_thread(vcpu_context& vcpu, const uint32_t id)
     {
         auto* thread = get_thread_by_id(this->process, id);
         if (!thread)
@@ -698,27 +704,27 @@ namespace sogen
             return false;
         }
 
-        return switch_to_thread(*this, *thread, true);
+        return switch_to_thread(*this, vcpu, *thread, true);
     }
 
-    void windows_emulator::on_instruction_execution(const uint64_t address)
+    void windows_emulator::on_instruction_execution(vcpu_context& vcpu, const uint64_t address)
     {
-        auto& thread = this->current_thread();
+        auto& thread = vcpu.thread();
 
         if (!thread.callback_stack.empty() && address == this->process.zw_callback_return)
         {
-            thread.callback_return_rax = this->emu().reg<uint64_t>(x86_register::rax);
+            thread.callback_return_rax = vcpu.cpu.reg<uint64_t>(x86_register::rax);
         }
 
         ++this->executed_instructions_;
         const auto thread_insts = ++thread.executed_instructions;
         if (thread_insts % MAX_INSTRUCTIONS_PER_TIME_SLICE == 0)
         {
-            this->yield_thread();
+            this->yield_thread(vcpu);
         }
 
         thread.previous_ip = thread.current_ip;
-        thread.current_ip = this->emu().read_instruction_pointer();
+        thread.current_ip = vcpu.cpu.read_instruction_pointer();
 
         if (!this->uses_section_first_execution_hooks())
         {
@@ -859,8 +865,8 @@ namespace sogen
             }
         });
 
-        this->emu().hook_instruction(x86_hookable_instructions::syscall, [&] {
-            this->dispatcher.dispatch(*this);
+        this->emu().hook_instruction(x86_hookable_instructions::syscall, [&](cpu_interface& cpu, uint64_t) {
+            this->dispatcher.dispatch(*this, this->vcpu(cpu.index()));
             return instruction_hook_continuation::skip_instruction;
         });
 
@@ -889,20 +895,21 @@ namespace sogen
         });
 
         // TODO: Unicorn needs this - This should be handled in the backend
-        this->emu().hook_instruction(x86_hookable_instructions::invalid, [&] {
+        this->emu().hook_instruction(x86_hookable_instructions::invalid, [&](cpu_interface& cpu, uint64_t) {
             // TODO: Unify icicle & unicorn handling
-            dispatch_illegal_instruction_violation(*this);
+            dispatch_illegal_instruction_violation(*this, this->vcpu(cpu.index()));
             return instruction_hook_continuation::skip_instruction; //
         });
 
-        this->emu().hook_interrupt([&](cpu_interface&, const int interrupt) {
+        this->emu().hook_interrupt([&](cpu_interface& cpu, const int interrupt) {
+            auto& vcpu = this->vcpu(cpu.index());
             this->callbacks.on_exception();
             const auto eflags = this->emu().reg<uint32_t>(x86_register::eflags);
 
             switch (interrupt)
             {
             case 0:
-                dispatch_integer_division_by_zero(*this);
+                dispatch_integer_division_by_zero(*this, vcpu);
                 return;
             case 1:
                 if ((eflags & 0x100) != 0)
@@ -911,15 +918,15 @@ namespace sogen
                 }
 
                 this->callbacks.on_suspicious_activity("Singlestep");
-                dispatch_single_step(*this);
+                dispatch_single_step(*this, vcpu);
                 return;
             case 3:
                 this->callbacks.on_suspicious_activity("Breakpoint");
-                dispatch_breakpoint(*this);
+                dispatch_breakpoint(*this, vcpu);
                 return;
             case 6:
                 this->callbacks.on_suspicious_activity("Illegal instruction");
-                dispatch_illegal_instruction_violation(*this);
+                dispatch_illegal_instruction_violation(*this, vcpu);
                 return;
             case 41:
                 this->callbacks.on_fast_fail(this->emu().reg<uint32_t>(x86_register::ecx));
@@ -938,13 +945,13 @@ namespace sogen
                          service == BREAKPOINT_COMMAND_STRING))
                     {
                         const auto ip = this->uses_instruction_precision() //
-                                            ? this->current_thread().current_ip
+                                            ? vcpu.thread().current_ip
                                             : this->emu().read_instruction_pointer();
                         this->emu().reg(x86_register::rip, ip + 3);
                     }
                     else
                     {
-                        dispatch_breakpoint(*this);
+                        dispatch_breakpoint(*this, vcpu);
                     }
                 }
                 return;
@@ -958,12 +965,13 @@ namespace sogen
             }
         });
 
-        this->emu().hook_memory_violation([&](cpu_interface&, const uint64_t address, const size_t size, const memory_operation operation,
-                                              const memory_violation_type type) {
+        this->emu().hook_memory_violation([&](cpu_interface& cpu, const uint64_t address, const size_t size,
+                                              const memory_operation operation, const memory_violation_type type) {
+            auto& vcpu = this->vcpu(cpu.index());
             if (this->emu().reg<uint16_t>(x86_register::cs) == 0x33)
             {
                 // loading gs selector only works in 64-bit mode
-                const auto required_gs_base = this->current_thread().gs_segment->get_base();
+                const auto required_gs_base = vcpu.thread().gs_segment->get_base();
                 const auto actual_gs_base = this->emu().get_segment_base(x86_register::gs);
                 if (actual_gs_base != required_gs_base)
                 {
@@ -977,7 +985,7 @@ namespace sogen
             {
                 // Unset the GUARD_PAGE flag and dispatch a STATUS_GUARD_PAGE_VIOLATION
                 this->memory.protect_memory(region.allocation_base, region.length, region.permissions & ~memory_permission_ext::guard);
-                dispatch_guard_page_violation(*this, address, operation);
+                dispatch_guard_page_violation(*this, vcpu, address, operation);
             }
             else
             {
@@ -998,7 +1006,7 @@ namespace sogen
                 }
 
                 this->callbacks.on_memory_violate(address, size, operation, type);
-                dispatch_access_violation(*this, address, operation);
+                dispatch_access_violation(*this, vcpu, address, operation);
             }
 
             return memory_violation_continuation::resume;
@@ -1006,8 +1014,8 @@ namespace sogen
 
         if (this->uses_instruction_precision())
         {
-            this->emu().hook_memory_execution([&](cpu_interface&, const uint64_t address) {
-                this->on_instruction_execution(address); //
+            this->emu().hook_memory_execution([&](cpu_interface& cpu, const uint64_t address) {
+                this->on_instruction_execution(this->vcpu(cpu.index()), address); //
             });
         }
         else if (!this->emu().is_stop_thread_safe())
@@ -1015,15 +1023,15 @@ namespace sogen
             // The backend cannot be stopped safely from another thread, so the interrupt thread in start()
             // is not available for time-slicing. Preempt cooperatively from the CPU thread via a basic-block
             // hook instead.
-            this->emu().hook_basic_block([&](cpu_interface&, const basic_block& block) {
-                this->on_basic_block_execution(block); //
+            this->emu().hook_basic_block([&](cpu_interface& cpu, const basic_block& block) {
+                this->on_basic_block_execution(this->vcpu(cpu.index()), block); //
             });
         }
     }
 
-    void windows_emulator::on_basic_block_execution(const basic_block&)
+    void windows_emulator::on_basic_block_execution(vcpu_context& vcpu, const basic_block&)
     {
-        auto& thread = this->current_thread();
+        auto& thread = vcpu.thread();
 
         // This path deliberately trades instruction precision for speed (one callback per block instead of
         // one per instruction), so we cannot account for individual instructions. Time-slice on a fixed number
@@ -1032,7 +1040,7 @@ namespace sogen
 
         if (++thread.executed_blocks % MAX_BASIC_BLOCKS_PER_TIME_SLICE == 0)
         {
-            this->yield_thread();
+            this->yield_thread(vcpu);
         }
     }
 
@@ -1065,6 +1073,9 @@ namespace sogen
             }
         });
 
+        // The scheduler only drives vCPU 0 until Phase 2 introduces per-vCPU worker loops.
+        auto& vcpu = this->vcpu(0);
+
         if (!this->uses_instruction_precision() && this->emu().is_stop_thread_safe())
         {
             interrupt_thread = std::thread([&] {
@@ -1077,8 +1088,8 @@ namespace sogen
 
                     if (!this->should_stop)
                     {
-                        this->switch_thread_ = true;
-                        this->emu().stop();
+                        vcpu.switch_thread = true;
+                        vcpu.cpu.stop();
                     }
                 }
             });
@@ -1087,17 +1098,17 @@ namespace sogen
         while (!this->should_stop)
         {
             this->ui_backend_->pump_events();
-            if (this->switch_thread_ || !this->current_thread().is_thread_ready(*this))
+            if (vcpu.switch_thread || !vcpu.thread().is_thread_ready(*this))
             {
-                if (!this->perform_thread_switch())
+                if (!this->perform_thread_switch(vcpu))
                 {
                     break;
                 }
             }
 
-            this->emu().start(count);
+            vcpu.cpu.start(count);
 
-            if (!this->switch_thread_ && !this->emu().has_violation())
+            if (!vcpu.switch_thread && !vcpu.cpu.has_violation())
             {
                 break;
             }
@@ -1281,15 +1292,16 @@ namespace sogen
         if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN || event.message == WM_LBUTTONDOWN ||
             event.message == WM_LBUTTONUP)
         {
-            this->switch_thread_ = true;
-            this->emu().stop();
+            auto& vcpu = this->vcpu(0);
+            vcpu.switch_thread = true;
+            vcpu.cpu.stop();
         }
     }
 
     void windows_emulator::stop()
     {
         this->should_stop = true;
-        this->emu().stop();
+        this->vcpu(0).cpu.stop();
     }
 
     void windows_emulator::register_factories(utils::buffer_deserializer& buffer)
@@ -1328,7 +1340,7 @@ namespace sogen
         buffer.write(this->application_settings_);
         buffer.write(this->setup_completed_);
         buffer.write(this->executed_instructions_);
-        buffer.write_atomic(this->switch_thread_);
+        buffer.write_atomic(this->vcpus_[0]->switch_thread);
         buffer.write(this->use_relative_time_);
 
         this->version.serialize(buffer);
@@ -1339,7 +1351,7 @@ namespace sogen
         this->memory.serialize_memory_state(buffer, false);
         this->mod_manager.serialize(buffer);
         this->dispatcher.serialize(buffer);
-        this->process.serialize(buffer);
+        this->process.serialize(buffer, this->vcpus_[0]->active_thread);
     }
 
     void windows_emulator::deserialize(utils::buffer_deserializer& buffer)
@@ -1349,7 +1361,7 @@ namespace sogen
         buffer.read(this->application_settings_);
         buffer.read(this->setup_completed_);
         buffer.read(this->executed_instructions_);
-        buffer.read_atomic(this->switch_thread_);
+        buffer.read_atomic(this->vcpus_[0]->switch_thread);
 
         const auto old_relative_time = this->use_relative_time_;
         buffer.read(this->use_relative_time_);
@@ -1371,7 +1383,7 @@ namespace sogen
         this->mod_manager.deserialize(buffer);
         this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
-        this->process.deserialize(buffer);
+        this->process.deserialize(buffer, this->vcpus_[0]->active_thread);
         this->restore_ui_backend();
     }
 
@@ -1487,7 +1499,7 @@ namespace sogen
 
         buffer.write(this->setup_completed_);
         buffer.write(this->executed_instructions_);
-        buffer.write_atomic(this->switch_thread_);
+        buffer.write_atomic(this->vcpus_[0]->switch_thread);
 
         this->version.serialize(buffer);
         this->registry.serialize_runtime_state(buffer);
@@ -1498,7 +1510,7 @@ namespace sogen
         this->memory.serialize_memory_state(buffer, false);
         this->mod_manager.serialize(buffer);
         this->dispatcher.serialize(buffer);
-        this->process.serialize(buffer);
+        this->process.serialize(buffer, this->vcpus_[0]->active_thread);
 
         this->process_snapshot_ = buffer.move_buffer();
     }
@@ -1516,7 +1528,7 @@ namespace sogen
 
         buffer.read(this->setup_completed_);
         buffer.read(this->executed_instructions_);
-        buffer.read_atomic(this->switch_thread_);
+        buffer.read_atomic(this->vcpus_[0]->switch_thread);
 
         this->version.deserialize(buffer);
         this->registry.deserialize_runtime_state(buffer);
@@ -1529,7 +1541,7 @@ namespace sogen
         this->mod_manager.deserialize(buffer);
         this->install_section_first_execution_hooks();
         this->dispatcher.deserialize(buffer);
-        this->process.deserialize(buffer);
+        this->process.deserialize(buffer, this->vcpus_[0]->active_thread);
         this->restore_ui_backend();
     }
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -269,10 +269,11 @@ namespace sogen
             return false;
         }
 
+        vcpu_context* find_vcpu_running_thread(windows_emulator& win_emu, const emulator_thread& thread);
+
         void perform_context_switch_work(windows_emulator& win_emu, vcpu_context& vcpu)
         {
             auto& threads = win_emu.process.threads;
-            auto*& active = vcpu.active_thread;
 
             for (auto it = threads.begin(); it != threads.end();)
             {
@@ -282,9 +283,16 @@ namespace sogen
                     continue;
                 }
 
-                if (active == &it->second)
+                if (auto* running_on = find_vcpu_running_thread(win_emu, it->second))
                 {
-                    active = nullptr;
+                    if (running_on != &vcpu)
+                    {
+                        // Another vCPU still has this thread loaded; it will detach it soon.
+                        ++it;
+                        continue;
+                    }
+
+                    running_on->active_thread = nullptr;
                 }
 
                 const auto [new_it, deleted] = threads.erase(it);
@@ -382,9 +390,29 @@ namespace sogen
             emu.reg(x86_register::rip, win_emu.process.ki_user_apc_dispatcher);
         }
 
+        vcpu_context* find_vcpu_running_thread(windows_emulator& win_emu, const emulator_thread& thread)
+        {
+            for (uint32_t i = 0; i < win_emu.vcpu_count(); ++i)
+            {
+                auto& vcpu = win_emu.vcpu(i);
+                if (vcpu.active_thread == &thread)
+                {
+                    return &vcpu;
+                }
+            }
+
+            return nullptr;
+        }
+
         bool switch_to_thread(windows_emulator& win_emu, vcpu_context& vcpu, emulator_thread& thread, const bool force = false)
         {
             if (thread.is_terminated())
+            {
+                return false;
+            }
+
+            // A thread that is loaded on another vCPU can only run there.
+            if (auto* running_on = find_vcpu_running_thread(win_emu, thread); running_on && running_on != &vcpu)
             {
                 return false;
             }
@@ -686,17 +714,31 @@ namespace sogen
 
         while (!switch_to_next_thread(*this, vcpu))
         {
+            if (this->vcpu_count_ > 1 && vcpu.active_thread)
+            {
+                // Nothing runnable for this vCPU: detach the stale thread so another
+                // vCPU can pick it up once it becomes ready.
+                vcpu.active_thread->save(vcpu.cpu);
+                vcpu.active_thread = nullptr;
+            }
+
+            const auto host_wait_pending = has_pending_host_wait(this->process);
+
             // Idle: nothing is ready. Release the kernel lock while pumping UI events
-            // and sleeping so other threads (UI delivery, future vCPU workers) can run.
+            // and sleeping so other threads (UI delivery, vCPU workers) can run.
             lock.unlock();
 
-            this->ui_backend_->pump_events();
+            if (this->vcpu_count_ == 1)
+            {
+                // With workers, the thread calling start() pumps UI events instead.
+                this->ui_backend_->pump_events();
+            }
 
             if (this->use_relative_time_)
             {
                 this->executed_instructions_ += MAX_INSTRUCTIONS_PER_TIME_SLICE;
             }
-            else if (has_pending_host_wait(this->process))
+            else if (host_wait_pending)
             {
                 // A host wait (e.g. a GPU semaphore) is parked - re-poll immediately to wake it promptly.
                 std::this_thread::yield();
@@ -717,6 +759,38 @@ namespace sogen
         }
 
         return true;
+    }
+
+    void windows_emulator::vcpu_worker(vcpu_context& vcpu)
+    {
+        std::unique_lock lock(this->kernel_lock_);
+
+        while (!this->should_stop)
+        {
+            if (vcpu.switch_thread || !vcpu.active_thread || !vcpu.thread().is_thread_ready(*this))
+            {
+                if (!this->perform_thread_switch(vcpu, lock))
+                {
+                    break;
+                }
+            }
+
+            // Guest code executes with the kernel lock released; hook callbacks
+            // (syscalls, exceptions, exec hooks) re-acquire it on VM exit.
+            lock.unlock();
+            vcpu.cpu.start();
+            lock.lock();
+
+            if (!vcpu.switch_thread && !vcpu.cpu.has_violation())
+            {
+                break;
+            }
+        }
+
+        lock.unlock();
+
+        // One vCPU winding down (process exit, fatal error) ends the whole run.
+        this->stop();
     }
 
     bool windows_emulator::activate_thread(vcpu_context& vcpu, const uint32_t id)
@@ -1097,6 +1171,8 @@ namespace sogen
         std::mutex interrupt_mutex{};
         std::condition_variable interrupt_cond{};
         std::thread interrupt_thread{};
+        std::vector<std::thread> workers{};
+        std::atomic<uint32_t> active_workers{0};
 
         const auto _ = utils::finally([&] {
             {
@@ -1106,14 +1182,24 @@ namespace sogen
 
             interrupt_cond.notify_all();
 
+            for (uint32_t i = 0; i < this->vcpu_count_; ++i)
+            {
+                this->vcpu(i).cpu.stop();
+            }
+
+            for (auto& worker : workers)
+            {
+                if (worker.joinable())
+                {
+                    worker.join();
+                }
+            }
+
             if (interrupt_thread.joinable())
             {
                 interrupt_thread.join();
             }
         });
-
-        // The scheduler only drives vCPU 0 until Phase 2 introduces per-vCPU worker loops.
-        auto& vcpu = this->vcpu(0);
 
         if (!this->uses_instruction_precision() && this->emu().is_stop_thread_safe())
         {
@@ -1127,12 +1213,50 @@ namespace sogen
 
                     if (!this->should_stop)
                     {
-                        vcpu.switch_thread = true;
-                        vcpu.cpu.stop();
+                        for (uint32_t i = 0; i < this->vcpu_count_; ++i)
+                        {
+                            auto& v = this->vcpu(i);
+                            v.switch_thread = true;
+                            v.cpu.stop();
+                        }
                     }
                 }
             });
         }
+
+        if (this->vcpu_count_ > 1)
+        {
+            // One worker thread per vCPU; this thread pumps UI events until the run ends.
+            active_workers = this->vcpu_count_;
+            workers.reserve(this->vcpu_count_);
+
+            for (uint32_t i = 0; i < this->vcpu_count_; ++i)
+            {
+                workers.emplace_back([this, i, &active_workers] {
+                    try
+                    {
+                        this->vcpu_worker(this->vcpu(i));
+                    }
+                    catch (const std::exception& e)
+                    {
+                        this->log.error("vCPU %u worker terminated: %s\n", i, e.what());
+                        this->stop();
+                    }
+
+                    --active_workers;
+                });
+            }
+
+            while (active_workers.load() > 0)
+            {
+                this->ui_backend_->pump_events();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+
+            return;
+        }
+
+        auto& vcpu = this->vcpu(0);
 
         std::unique_lock lock(this->kernel_lock_);
 
@@ -1351,7 +1475,11 @@ namespace sogen
     void windows_emulator::stop()
     {
         this->should_stop = true;
-        this->vcpu(0).cpu.stop();
+
+        for (uint32_t i = 0; i < this->vcpu_count_; ++i)
+        {
+            this->vcpu(i).cpu.stop();
+        }
     }
 
     void windows_emulator::register_factories(utils::buffer_deserializer& buffer)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -566,8 +566,19 @@ namespace sogen
           mod_manager(memory, file_sys, this->callbacks),
           process(*this->emu_, memory, *this->clock_, this->callbacks),
           use_relative_time_(settings.use_relative_time),
-          instruction_precision_(settings.use_instruction_precision && this->emu_->supports_instruction_counting())
+          instruction_precision_(settings.use_instruction_precision && this->emu_->supports_instruction_counting()),
+          vcpu_count_(settings.vcpu_count)
     {
+        if (this->vcpu_count_ == 0)
+        {
+            throw std::invalid_argument("At least one vCPU is required");
+        }
+
+        if (this->vcpu_count_ > 1 && !this->emu_->supports_multiple_vcpus())
+        {
+            throw std::invalid_argument("The " + this->emu_->get_name() + " backend does not support multiple vCPUs");
+        }
+
         this->ui_backend_->set_event_sink([this](const ui_event& event) { this->handle_ui_event(event); });
 #ifndef OS_WINDOWS
         if (this->emulation_root.empty())

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1263,6 +1263,7 @@ namespace sogen
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
 
+            this->dump_exception_trace();
             return;
         }
 
@@ -1479,6 +1480,44 @@ namespace sogen
             auto& vcpu = this->vcpu(0);
             vcpu.switch_thread = true;
             vcpu.cpu.stop();
+        }
+    }
+
+    void windows_emulator::dump_exception_trace()
+    {
+        // Opt-in post-mortem aid for multi-vCPU debugging (see docs/multi-vcpu-design.md).
+        const auto* enabled = std::getenv("SOGEN_TRACE_EXCEPTIONS");
+        if (!enabled || enabled[0] != '1')
+        {
+            return;
+        }
+
+        const auto count = std::min(this->exception_trace_index_, this->exception_trace_.size());
+        if (count == 0)
+        {
+            return;
+        }
+
+        const auto total = this->exception_trace_index_;
+        const auto start = total - count;
+        this->log.error("--- exception trace (last %zu of %zu) ---\n", count, total);
+
+        const auto describe = [this](const uint64_t address) -> std::string {
+            const auto* mod = this->mod_manager.find_by_address(address);
+            const auto region = this->memory.get_region_info(address);
+            char buffer[256];
+            std::snprintf(buffer, sizeof(buffer), "%s+0x%llx [%s]", mod ? mod->name.c_str() : "?",
+                          mod ? static_cast<unsigned long long>(address - mod->image_base) : address,
+                          region.is_committed ? "committed" : "FREE/reserved");
+            return buffer;
+        };
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            const auto& e = this->exception_trace_[(start + i) % this->exception_trace_.size()];
+            this->log.error("  [%zu] status 0x%08x vcpu %u tid %u\n      rip  0x%llx %s\n      addr 0x%llx %s\n", start + i, e.status,
+                            e.vcpu, e.tid, static_cast<unsigned long long>(e.rip), describe(e.rip).c_str(),
+                            static_cast<unsigned long long>(e.info), describe(e.info).c_str());
         }
     }
 

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -809,10 +809,10 @@ namespace sogen
             return;
         }
 
-        hooks[section_index] =
-            this->emu().hook_memory_range_execution(section.region.start, section.region.length, [this](const uint64_t address) {
-                this->track_section_first_execution(address); //
-            });
+        hooks[section_index] = this->emu().hook_memory_range_execution(section.region.start, section.region.length,
+                                                                       [this](cpu_interface&, const uint64_t address) {
+                                                                           this->track_section_first_execution(address); //
+                                                                       });
     }
 
     void windows_emulator::install_section_first_execution_hooks()
@@ -890,7 +890,7 @@ namespace sogen
             return instruction_hook_continuation::skip_instruction; //
         });
 
-        this->emu().hook_interrupt([&](const int interrupt) {
+        this->emu().hook_interrupt([&](cpu_interface&, const int interrupt) {
             this->callbacks.on_exception();
             const auto eflags = this->emu().reg<uint32_t>(x86_register::eflags);
 
@@ -953,55 +953,55 @@ namespace sogen
             }
         });
 
-        this->emu().hook_memory_violation(
-            [&](const uint64_t address, const size_t size, const memory_operation operation, const memory_violation_type type) {
-                if (this->emu().reg<uint16_t>(x86_register::cs) == 0x33)
+        this->emu().hook_memory_violation([&](cpu_interface&, const uint64_t address, const size_t size, const memory_operation operation,
+                                              const memory_violation_type type) {
+            if (this->emu().reg<uint16_t>(x86_register::cs) == 0x33)
+            {
+                // loading gs selector only works in 64-bit mode
+                const auto required_gs_base = this->current_thread().gs_segment->get_base();
+                const auto actual_gs_base = this->emu().get_segment_base(x86_register::gs);
+                if (actual_gs_base != required_gs_base)
                 {
-                    // loading gs selector only works in 64-bit mode
-                    const auto required_gs_base = this->current_thread().gs_segment->get_base();
-                    const auto actual_gs_base = this->emu().get_segment_base(x86_register::gs);
-                    if (actual_gs_base != required_gs_base)
+                    this->emu().set_segment_base(x86_register::gs, required_gs_base);
+                    return memory_violation_continuation::restart;
+                }
+            }
+
+            auto region = this->memory.get_region_info(address);
+            if (region.permissions.is_guarded())
+            {
+                // Unset the GUARD_PAGE flag and dispatch a STATUS_GUARD_PAGE_VIOLATION
+                this->memory.protect_memory(region.allocation_base, region.length, region.permissions & ~memory_permission_ext::guard);
+                dispatch_guard_page_violation(*this, address, operation);
+            }
+            else
+            {
+                // A fault on a null/near-null address is almost always a call through a null function
+                // pointer (e.g. a Vulkan entry point the shim doesn't implement). Log the caller's
+                // return address so the missing function's call site can be identified.
+                if (address < 0x1000)
+                {
+                    const auto sp = this->emu().reg<uint32_t>(x86_register::esp);
+                    uint32_t return_address = 0;
+                    if (this->emu().try_read_memory(sp, &return_address, sizeof(return_address)))
                     {
-                        this->emu().set_segment_base(x86_register::gs, required_gs_base);
-                        return memory_violation_continuation::restart;
+                        const auto* mod = this->mod_manager.find_by_address(return_address);
+                        this->log.error("Null-pointer call to 0x%llx; caller return address 0x%x (%s+0x%llx)\n",
+                                        static_cast<unsigned long long>(address), return_address, mod ? mod->name.c_str() : "?",
+                                        mod ? static_cast<unsigned long long>(return_address - mod->image_base) : return_address);
                     }
                 }
 
-                auto region = this->memory.get_region_info(address);
-                if (region.permissions.is_guarded())
-                {
-                    // Unset the GUARD_PAGE flag and dispatch a STATUS_GUARD_PAGE_VIOLATION
-                    this->memory.protect_memory(region.allocation_base, region.length, region.permissions & ~memory_permission_ext::guard);
-                    dispatch_guard_page_violation(*this, address, operation);
-                }
-                else
-                {
-                    // A fault on a null/near-null address is almost always a call through a null function
-                    // pointer (e.g. a Vulkan entry point the shim doesn't implement). Log the caller's
-                    // return address so the missing function's call site can be identified.
-                    if (address < 0x1000)
-                    {
-                        const auto sp = this->emu().reg<uint32_t>(x86_register::esp);
-                        uint32_t return_address = 0;
-                        if (this->emu().try_read_memory(sp, &return_address, sizeof(return_address)))
-                        {
-                            const auto* mod = this->mod_manager.find_by_address(return_address);
-                            this->log.error("Null-pointer call to 0x%llx; caller return address 0x%x (%s+0x%llx)\n",
-                                            static_cast<unsigned long long>(address), return_address, mod ? mod->name.c_str() : "?",
-                                            mod ? static_cast<unsigned long long>(return_address - mod->image_base) : return_address);
-                        }
-                    }
+                this->callbacks.on_memory_violate(address, size, operation, type);
+                dispatch_access_violation(*this, address, operation);
+            }
 
-                    this->callbacks.on_memory_violate(address, size, operation, type);
-                    dispatch_access_violation(*this, address, operation);
-                }
-
-                return memory_violation_continuation::resume;
-            });
+            return memory_violation_continuation::resume;
+        });
 
         if (this->uses_instruction_precision())
         {
-            this->emu().hook_memory_execution([&](const uint64_t address) {
+            this->emu().hook_memory_execution([&](cpu_interface&, const uint64_t address) {
                 this->on_instruction_execution(address); //
             });
         }
@@ -1010,7 +1010,7 @@ namespace sogen
             // The backend cannot be stopped safely from another thread, so the interrupt thread in start()
             // is not available for time-slicing. Preempt cooperatively from the CPU thread via a basic-block
             // hook instead.
-            this->emu().hook_basic_block([&](const basic_block& block) {
+            this->emu().hook_basic_block([&](cpu_interface&, const basic_block& block) {
                 this->on_basic_block_execution(block); //
             });
         }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -717,6 +717,12 @@ namespace sogen
         vcpu.cpu.stop();
     }
 
+    bool windows_emulator::perform_thread_switch(vcpu_context& vcpu)
+    {
+        std::unique_lock lock(this->kernel_lock_);
+        return this->perform_thread_switch(vcpu, lock);
+    }
+
     bool windows_emulator::perform_thread_switch(vcpu_context& vcpu, std::unique_lock<kernel_lock>& lock)
     {
         this->kernel_lock_.assert_held();
@@ -1325,6 +1331,7 @@ namespace sogen
             }
         }
 
+        this->dump_exception_trace();
         this->dump_lock_profile();
     }
 
@@ -1495,7 +1502,11 @@ namespace sogen
         if (event.message == WM_CLOSE || event.message == WM_COMMAND || event.message == WM_KEYDOWN || event.message == WM_LBUTTONDOWN ||
             event.message == WM_LBUTTONUP)
         {
-            auto& vcpu = this->vcpu(0);
+            // Kick the vCPU currently running the target thread so it promptly re-checks its message
+            // queue; if the thread is not running on any vCPU right now, fall back to vCPU 0 to force a
+            // reschedule that can pick up the now-ready thread.
+            auto* running_on = find_vcpu_running_thread(*this, *thread);
+            auto& vcpu = running_on ? *running_on : this->vcpu(0);
             vcpu.switch_thread = true;
             vcpu.cpu.stop();
         }
@@ -1523,11 +1534,11 @@ namespace sogen
         const auto describe = [this](const uint64_t address) -> std::string {
             const auto* mod = this->mod_manager.find_by_address(address);
             const auto region = this->memory.get_region_info(address);
-            char buffer[256];
-            std::snprintf(buffer, sizeof(buffer), "%s+0x%llx [%s]", mod ? mod->name.c_str() : "?",
+            std::array<char, 256> buffer{};
+            std::snprintf(buffer.data(), buffer.size(), "%s+0x%llx [%s]", mod ? mod->name.c_str() : "?",
                           mod ? static_cast<unsigned long long>(address - mod->image_base) : address,
                           region.is_committed ? "committed" : "FREE/reserved");
-            return buffer;
+            return buffer.data();
         };
 
         for (size_t i = 0; i < count; ++i)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -986,7 +986,9 @@ namespace sogen
 
         this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&](cpu_interface& cpu, uint64_t) {
             const std::scoped_lock lock(this->kernel_lock_);
-            auto& acting = this->vcpu(cpu.index()).cpu;
+            auto& vcpu = this->vcpu(cpu.index());
+            const scoped_dispatch dispatch(*this, vcpu);
+            auto& acting = vcpu.cpu;
             this->callbacks.on_rdtscp();
 
             const auto ticks = this->clock_->timestamp_counter();
@@ -1002,7 +1004,9 @@ namespace sogen
 
         this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&](cpu_interface& cpu, uint64_t) {
             const std::scoped_lock lock(this->kernel_lock_);
-            auto& acting = this->vcpu(cpu.index()).cpu;
+            auto& vcpu = this->vcpu(cpu.index());
+            const scoped_dispatch dispatch(*this, vcpu);
+            auto& acting = vcpu.cpu;
             this->callbacks.on_rdtsc();
 
             const auto ticks = this->clock_->timestamp_counter();

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -568,6 +568,17 @@ namespace sogen
 
             return create_default_ui_backend();
         }
+
+        // The guest must see at least as many logical processors as there are vCPUs, otherwise a
+        // thread running on a higher-indexed vCPU would report a processor number the guest
+        // considers out of range. The configured fake value still wins when it is larger (e.g. the
+        // anti-analysis default of 4 with a single vCPU).
+        fake_environment_config effective_fake_env(const emulator_settings& settings)
+        {
+            auto fake_env = settings.fake_env;
+            fake_env.number_of_processors = std::max(fake_env.number_of_processors, settings.vcpu_count);
+            return fake_env;
+        }
     }
 
     windows_emulator::windows_emulator(std::unique_ptr<x86_64_emulator> emu, application_settings app_settings,
@@ -586,7 +597,7 @@ namespace sogen
           socket_factory_(get_socket_factory(interfaces)),
           ui_backend_(get_ui_backend(interfaces)),
           emulation_root{settings.emulation_root.empty() ? settings.emulation_root : absolute(settings.emulation_root)},
-          fake_env(settings.fake_env),
+          fake_env(effective_fake_env(settings)),
           callbacks(std::move(callbacks)),
           file_sys(emulation_root.empty() ? emulation_root : emulation_root / "filesys"),
           memory(*this->emu_),

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1279,6 +1279,7 @@ namespace sogen
             }
 
             this->dump_exception_trace();
+            this->dump_lock_profile();
             return;
         }
 
@@ -1323,6 +1324,8 @@ namespace sogen
                 count = static_cast<size_t>(target_instructions - current_instructions);
             }
         }
+
+        this->dump_lock_profile();
     }
 
     void windows_emulator::deliver_raw_input(const process_context::raw_input_payload& payload, const hwnd explicit_target)
@@ -1534,6 +1537,29 @@ namespace sogen
                             e.vcpu, e.tid, static_cast<unsigned long long>(e.rip), describe(e.rip).c_str(),
                             static_cast<unsigned long long>(e.info), describe(e.info).c_str());
         }
+    }
+
+    void windows_emulator::dump_lock_profile()
+    {
+        if (!kernel_lock::profiling_enabled())
+        {
+            return;
+        }
+
+        const auto stats = this->kernel_lock_.profile();
+        const auto held_ms = static_cast<double>(stats.held_nanos) / 1e6;
+        const auto wait_ms = static_cast<double>(stats.wait_nanos) / 1e6;
+        const auto contended_pct =
+            stats.acquisitions ? (100.0 * static_cast<double>(stats.contended) / static_cast<double>(stats.acquisitions)) : 0.0;
+
+        this->log.print(color::cyan,
+                        "--- kernel lock (BEL) profile ---\n"
+                        "  acquisitions:   %llu\n"
+                        "  contended:      %llu (%.1f%%)\n"
+                        "  wait time:      %.1f ms (blocked on a busy BEL)\n"
+                        "  held time:      %.1f ms (BEL busy across all threads)\n",
+                        static_cast<unsigned long long>(stats.acquisitions), static_cast<unsigned long long>(stats.contended),
+                        contended_pct, wait_ms, held_ms);
     }
 
     void windows_emulator::stop()

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -573,10 +573,10 @@ namespace sogen
         // thread running on a higher-indexed vCPU would report a processor number the guest
         // considers out of range. The configured fake value still wins when it is larger (e.g. the
         // anti-analysis default of 4 with a single vCPU).
-        fake_environment_config effective_fake_env(const emulator_settings& settings)
+        fake_environment_config effective_fake_env(const emulator_settings& settings, const uint32_t vcpu_count)
         {
             auto fake_env = settings.fake_env;
-            fake_env.number_of_processors = std::max(fake_env.number_of_processors, settings.vcpu_count);
+            fake_env.number_of_processors = std::max(fake_env.number_of_processors, vcpu_count);
             return fake_env;
         }
     }
@@ -597,7 +597,7 @@ namespace sogen
           socket_factory_(get_socket_factory(interfaces)),
           ui_backend_(get_ui_backend(interfaces)),
           emulation_root{settings.emulation_root.empty() ? settings.emulation_root : absolute(settings.emulation_root)},
-          fake_env(effective_fake_env(settings)),
+          fake_env(effective_fake_env(settings, static_cast<uint32_t>(this->emu_->vcpu_count()))),
           callbacks(std::move(callbacks)),
           file_sys(emulation_root.empty() ? emulation_root : emulation_root / "filesys"),
           memory(*this->emu_),
@@ -606,7 +606,7 @@ namespace sogen
           process(*this->emu_, memory, *this->clock_, this->callbacks),
           use_relative_time_(settings.use_relative_time),
           instruction_precision_(settings.use_instruction_precision && this->emu_->supports_instruction_counting()),
-          vcpu_count_(settings.vcpu_count)
+          vcpu_count_(static_cast<uint32_t>(this->emu_->vcpu_count()))
     {
         if (this->vcpu_count_ == 0)
         {
@@ -616,11 +616,6 @@ namespace sogen
         if (this->vcpu_count_ > 1 && !this->emu_->supports_multiple_vcpus())
         {
             throw std::invalid_argument("The " + this->emu_->get_name() + " backend does not support multiple vCPUs");
-        }
-
-        if (this->vcpu_count_ > this->emu_->vcpu_count())
-        {
-            throw std::invalid_argument("The emulator backend was created with fewer vCPUs than requested");
         }
 
         if (this->vcpu_count_ > 1)

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -967,32 +967,36 @@ namespace sogen
 
         this->emu().hook_instruction(x86_hookable_instructions::syscall, [&](cpu_interface& cpu, uint64_t) {
             const std::scoped_lock lock(this->kernel_lock_);
-            this->dispatcher.dispatch(*this, this->vcpu(cpu.index()));
+            auto& vcpu = this->vcpu(cpu.index());
+            const scoped_dispatch dispatch(*this, vcpu);
+            this->dispatcher.dispatch(*this, vcpu);
             return instruction_hook_continuation::skip_instruction;
         });
 
-        this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&] {
+        this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&](cpu_interface& cpu, uint64_t) {
             const std::scoped_lock lock(this->kernel_lock_);
+            auto& acting = this->vcpu(cpu.index()).cpu;
             this->callbacks.on_rdtscp();
 
             const auto ticks = this->clock_->timestamp_counter();
-            this->emu().reg(x86_register::rax, static_cast<uint32_t>(ticks));
-            this->emu().reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
+            acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
+            acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
 
             // Return the IA32_TSC_AUX value in RCX (low 32 bits)
             auto tsc_aux = 0; // Need to replace this with proper CPUID later
-            this->emu().reg(x86_register::rcx, tsc_aux);
+            acting.reg(x86_register::rcx, tsc_aux);
 
             return instruction_hook_continuation::skip_instruction;
         });
 
-        this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&] {
+        this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&](cpu_interface& cpu, uint64_t) {
             const std::scoped_lock lock(this->kernel_lock_);
+            auto& acting = this->vcpu(cpu.index()).cpu;
             this->callbacks.on_rdtsc();
 
             const auto ticks = this->clock_->timestamp_counter();
-            this->emu().reg(x86_register::rax, static_cast<uint32_t>(ticks));
-            this->emu().reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
+            acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
+            acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
 
             return instruction_hook_continuation::skip_instruction;
         });
@@ -1008,8 +1012,10 @@ namespace sogen
         this->emu().hook_interrupt([&](cpu_interface& cpu, const int interrupt) {
             const std::scoped_lock lock(this->kernel_lock_);
             auto& vcpu = this->vcpu(cpu.index());
+            const scoped_dispatch dispatch(*this, vcpu);
+            auto& acting = vcpu.cpu;
             this->callbacks.on_exception();
-            const auto eflags = this->emu().reg<uint32_t>(x86_register::eflags);
+            const auto eflags = acting.reg<uint32_t>(x86_register::eflags);
 
             switch (interrupt)
             {
@@ -1019,7 +1025,7 @@ namespace sogen
             case 1:
                 if ((eflags & 0x100) != 0)
                 {
-                    this->emu().reg(x86_register::eflags, eflags & ~0x100);
+                    acting.reg(x86_register::eflags, eflags & ~0x100);
                 }
 
                 this->callbacks.on_suspicious_activity("Singlestep");
@@ -1034,16 +1040,16 @@ namespace sogen
                 dispatch_illegal_instruction_violation(*this, vcpu);
                 return;
             case 41:
-                this->callbacks.on_fast_fail(this->emu().reg<uint32_t>(x86_register::ecx));
+                this->callbacks.on_fast_fail(acting.reg<uint32_t>(x86_register::ecx));
                 this->process.exit_status = STATUS_FAIL_FAST_EXCEPTION;
                 this->stop();
                 return;
             case 45:
                 this->callbacks.on_suspicious_activity("DbgPrint");
                 {
-                    const auto cs_selector = this->emu().reg<uint16_t>(x86_register::cs);
-                    const auto bitness = segment_utils::get_segment_bitness(this->emu(), cs_selector);
-                    const auto service = this->emu().reg<uint32_t>(x86_register::eax);
+                    const auto cs_selector = acting.reg<uint16_t>(x86_register::cs);
+                    const auto bitness = segment_utils::get_segment_bitness(acting, cs_selector);
+                    const auto service = acting.reg<uint32_t>(x86_register::eax);
 
                     if (bitness && *bitness == segment_utils::segment_bitness::bit64 &&
                         (service == BREAKPOINT_PRINT || service == BREAKPOINT_LOAD_SYMBOLS || service == BREAKPOINT_UNLOAD_SYMBOLS ||
@@ -1051,8 +1057,8 @@ namespace sogen
                     {
                         const auto ip = this->uses_instruction_precision() //
                                             ? vcpu.thread().current_ip
-                                            : this->emu().read_instruction_pointer();
-                        this->emu().reg(x86_register::rip, ip + 3);
+                                            : acting.read_instruction_pointer();
+                        acting.reg(x86_register::rip, ip + 3);
                     }
                     else
                     {
@@ -1074,14 +1080,16 @@ namespace sogen
                                               const memory_operation operation, const memory_violation_type type) {
             const std::scoped_lock lock(this->kernel_lock_);
             auto& vcpu = this->vcpu(cpu.index());
-            if (this->emu().reg<uint16_t>(x86_register::cs) == 0x33)
+            const scoped_dispatch dispatch(*this, vcpu);
+            auto& acting = vcpu.cpu;
+            if (acting.reg<uint16_t>(x86_register::cs) == 0x33)
             {
                 // loading gs selector only works in 64-bit mode
                 const auto required_gs_base = vcpu.thread().gs_segment->get_base();
-                const auto actual_gs_base = this->emu().get_segment_base(x86_register::gs);
+                const auto actual_gs_base = acting.get_segment_base(x86_register::gs);
                 if (actual_gs_base != required_gs_base)
                 {
-                    this->emu().set_segment_base(x86_register::gs, required_gs_base);
+                    acting.set_segment_base(x86_register::gs, required_gs_base);
                     return memory_violation_continuation::restart;
                 }
             }
@@ -1100,9 +1108,9 @@ namespace sogen
                 // return address so the missing function's call site can be identified.
                 if (address < 0x1000)
                 {
-                    const auto sp = this->emu().reg<uint32_t>(x86_register::esp);
+                    const auto sp = acting.reg<uint32_t>(x86_register::esp);
                     uint32_t return_address = 0;
-                    if (this->emu().try_read_memory(sp, &return_address, sizeof(return_address)))
+                    if (acting.try_read_memory(sp, &return_address, sizeof(return_address)))
                     {
                         const auto* mod = this->mod_manager.find_by_address(return_address);
                         this->log.error("Null-pointer call to 0x%llx; caller return address 0x%x (%s+0x%llx)\n",
@@ -1122,7 +1130,9 @@ namespace sogen
         {
             this->emu().hook_memory_execution([&](cpu_interface& cpu, const uint64_t address) {
                 const std::scoped_lock lock(this->kernel_lock_);
-                this->on_instruction_execution(this->vcpu(cpu.index()), address); //
+                auto& vcpu = this->vcpu(cpu.index());
+                const scoped_dispatch dispatch(*this, vcpu);
+                this->on_instruction_execution(vcpu, address); //
             });
         }
         else if (!this->emu().is_stop_thread_safe())

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -584,6 +584,20 @@ namespace sogen
             throw std::invalid_argument("The emulator backend was created with fewer vCPUs than requested");
         }
 
+        if (this->vcpu_count_ > 1)
+        {
+            // Deliberate hard errors instead of silent clamping (docs/multi-vcpu-design.md).
+            if (this->instruction_precision_)
+            {
+                throw std::invalid_argument("Instruction precision requires a single vCPU");
+            }
+
+            if (this->use_relative_time_)
+            {
+                throw std::invalid_argument("Relative time requires a single vCPU");
+            }
+        }
+
         this->vcpus_.reserve(this->vcpu_count_);
         for (uint32_t i = 0; i < this->vcpu_count_; ++i)
         {
@@ -655,20 +669,27 @@ namespace sogen
         switch_to_thread(*this, this->vcpu(0), main_thread_id);
     }
 
-    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void windows_emulator::yield_thread(vcpu_context& vcpu, const bool alertable)
     {
+        this->kernel_lock_.assert_held();
+
         vcpu.switch_thread = true;
         vcpu.thread().apc_alertable = alertable;
         vcpu.cpu.stop();
     }
 
-    bool windows_emulator::perform_thread_switch(vcpu_context& vcpu)
+    bool windows_emulator::perform_thread_switch(vcpu_context& vcpu, std::unique_lock<kernel_lock>& lock)
     {
+        this->kernel_lock_.assert_held();
+
         const auto needed_switch = vcpu.switch_thread.exchange(false);
 
         while (!switch_to_next_thread(*this, vcpu))
         {
+            // Idle: nothing is ready. Release the kernel lock while pumping UI events
+            // and sleeping so other threads (UI delivery, future vCPU workers) can run.
+            lock.unlock();
+
             this->ui_backend_->pump_events();
 
             if (this->use_relative_time_)
@@ -686,6 +707,8 @@ namespace sogen
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
 
+            lock.lock();
+
             if (this->should_stop)
             {
                 vcpu.switch_thread = needed_switch;
@@ -698,6 +721,8 @@ namespace sogen
 
     bool windows_emulator::activate_thread(vcpu_context& vcpu, const uint32_t id)
     {
+        const std::scoped_lock lock(this->kernel_lock_);
+
         auto* thread = get_thread_by_id(this->process, id);
         if (!thread)
         {
@@ -822,6 +847,7 @@ namespace sogen
 
         hooks[section_index] = this->emu().hook_memory_range_execution(section.region.start, section.region.length,
                                                                        [this](cpu_interface&, const uint64_t address) {
+                                                                           const std::scoped_lock lock(this->kernel_lock_);
                                                                            this->track_section_first_execution(address); //
                                                                        });
     }
@@ -866,11 +892,13 @@ namespace sogen
         });
 
         this->emu().hook_instruction(x86_hookable_instructions::syscall, [&](cpu_interface& cpu, uint64_t) {
+            const std::scoped_lock lock(this->kernel_lock_);
             this->dispatcher.dispatch(*this, this->vcpu(cpu.index()));
             return instruction_hook_continuation::skip_instruction;
         });
 
         this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&] {
+            const std::scoped_lock lock(this->kernel_lock_);
             this->callbacks.on_rdtscp();
 
             const auto ticks = this->clock_->timestamp_counter();
@@ -885,6 +913,7 @@ namespace sogen
         });
 
         this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&] {
+            const std::scoped_lock lock(this->kernel_lock_);
             this->callbacks.on_rdtsc();
 
             const auto ticks = this->clock_->timestamp_counter();
@@ -896,12 +925,14 @@ namespace sogen
 
         // TODO: Unicorn needs this - This should be handled in the backend
         this->emu().hook_instruction(x86_hookable_instructions::invalid, [&](cpu_interface& cpu, uint64_t) {
+            const std::scoped_lock lock(this->kernel_lock_);
             // TODO: Unify icicle & unicorn handling
             dispatch_illegal_instruction_violation(*this, this->vcpu(cpu.index()));
             return instruction_hook_continuation::skip_instruction; //
         });
 
         this->emu().hook_interrupt([&](cpu_interface& cpu, const int interrupt) {
+            const std::scoped_lock lock(this->kernel_lock_);
             auto& vcpu = this->vcpu(cpu.index());
             this->callbacks.on_exception();
             const auto eflags = this->emu().reg<uint32_t>(x86_register::eflags);
@@ -967,6 +998,7 @@ namespace sogen
 
         this->emu().hook_memory_violation([&](cpu_interface& cpu, const uint64_t address, const size_t size,
                                               const memory_operation operation, const memory_violation_type type) {
+            const std::scoped_lock lock(this->kernel_lock_);
             auto& vcpu = this->vcpu(cpu.index());
             if (this->emu().reg<uint16_t>(x86_register::cs) == 0x33)
             {
@@ -1015,6 +1047,7 @@ namespace sogen
         if (this->uses_instruction_precision())
         {
             this->emu().hook_memory_execution([&](cpu_interface& cpu, const uint64_t address) {
+                const std::scoped_lock lock(this->kernel_lock_);
                 this->on_instruction_execution(this->vcpu(cpu.index()), address); //
             });
         }
@@ -1024,6 +1057,7 @@ namespace sogen
             // is not available for time-slicing. Preempt cooperatively from the CPU thread via a basic-block
             // hook instead.
             this->emu().hook_basic_block([&](cpu_interface& cpu, const basic_block& block) {
+                const std::scoped_lock lock(this->kernel_lock_);
                 this->on_basic_block_execution(this->vcpu(cpu.index()), block); //
             });
         }
@@ -1050,6 +1084,11 @@ namespace sogen
         this->last_stop_reason_ = stop_reason::none;
         this->last_stop_detail_.clear();
         this->setup_process_if_necessary();
+
+        if (count > 0 && this->vcpu_count_ > 1)
+        {
+            throw std::invalid_argument("Instruction-count budgets require a single vCPU");
+        }
 
         const auto use_count = count > 0;
         const auto start_instructions = this->executed_instructions_;
@@ -1095,18 +1134,27 @@ namespace sogen
             });
         }
 
+        std::unique_lock lock(this->kernel_lock_);
+
         while (!this->should_stop)
         {
+            lock.unlock();
             this->ui_backend_->pump_events();
+            lock.lock();
+
             if (vcpu.switch_thread || !vcpu.thread().is_thread_ready(*this))
             {
-                if (!this->perform_thread_switch(vcpu))
+                if (!this->perform_thread_switch(vcpu, lock))
                 {
                     break;
                 }
             }
 
+            // Guest code executes with the kernel lock released; hook callbacks
+            // (syscalls, exceptions, exec hooks) re-acquire it on VM exit.
+            lock.unlock();
             vcpu.cpu.start(count);
+            lock.lock();
 
             if (!vcpu.switch_thread && !vcpu.cpu.has_violation())
             {
@@ -1178,6 +1226,8 @@ namespace sogen
 
     void windows_emulator::handle_ui_event(const ui_event& event)
     {
+        const std::scoped_lock lock(this->kernel_lock_);
+
         const auto* win = this->process.windows.get(event.window);
         if (!win)
         {

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -579,6 +579,11 @@ namespace sogen
             throw std::invalid_argument("The " + this->emu_->get_name() + " backend does not support multiple vCPUs");
         }
 
+        if (this->vcpu_count_ > this->emu_->vcpu_count())
+        {
+            throw std::invalid_argument("The emulator backend was created with fewer vCPUs than requested");
+        }
+
         this->ui_backend_->set_event_sink([this](const ui_event& event) { this->handle_ui_event(event); });
 #ifndef OS_WINDOWS
         if (this->emulation_root.empty())

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -113,6 +113,26 @@ namespace sogen
         std::unique_ptr<ui_backend> ui{};
     };
 
+    // Per-vCPU scheduler state: the guest thread a virtual CPU is currently executing
+    // and its yield request. Replaces the previous global "active thread" notion
+    // (docs/multi-vcpu-design.md, section 5.1).
+    struct vcpu_context
+    {
+        x86_64_cpu& cpu;
+        emulator_thread* active_thread{};
+        std::atomic_bool switch_thread{false};
+
+        emulator_thread& thread() const
+        {
+            if (!this->active_thread)
+            {
+                throw std::runtime_error("No active thread!");
+            }
+
+            return *this->active_thread;
+        }
+    };
+
     class windows_emulator
     {
         uint64_t executed_instructions_{0};
@@ -204,14 +224,17 @@ namespace sogen
         void deliver_raw_mouse_input(int32_t dx, int32_t dy, uint16_t button_flags);
         void deliver_raw_keyboard_input(uint16_t vkey, uint16_t scan_code, bool release);
 
+        // Single-vCPU observer convenience for external consumers (gdb stub, analyzer,
+        // python bindings). Internal execution paths must use the explicit vcpu_context
+        // instead. Remains correct until Phase 2, since the scheduler only drives vCPU 0.
         emulator_thread& current_thread() const
         {
-            if (!this->process.active_thread)
-            {
-                throw std::runtime_error("No active thread!");
-            }
+            return this->vcpus_[0]->thread();
+        }
 
-            return *this->process.active_thread;
+        vcpu_context& vcpu(const size_t index)
+        {
+            return *this->vcpus_.at(index);
         }
 
         uint64_t get_executed_instructions() const
@@ -298,16 +321,18 @@ namespace sogen
             }
         }
 
-        void yield_thread(bool alertable = false);
-        bool perform_thread_switch();
-        bool activate_thread(uint32_t id);
+        void yield_thread(vcpu_context& vcpu, bool alertable = false);
+        bool perform_thread_switch(vcpu_context& vcpu);
+        bool activate_thread(vcpu_context& vcpu, uint32_t id);
 
       private:
-        std::atomic_bool switch_thread_{false};
         bool use_relative_time_{false}; // TODO: Get rid of that
         bool instruction_precision_{true};
         uint32_t vcpu_count_{1};
         std::atomic_bool should_stop{false};
+
+        // unique_ptr because vcpu_context contains an atomic and must stay address-stable.
+        std::vector<std::unique_ptr<vcpu_context>> vcpus_{};
 
         std::unordered_map<uint16_t, uint16_t> port_mappings_{};
 
@@ -321,8 +346,8 @@ namespace sogen
 
         void setup_hooks();
         void setup_process();
-        void on_instruction_execution(uint64_t address);
-        void on_basic_block_execution(const basic_block& block);
+        void on_instruction_execution(vcpu_context& vcpu, uint64_t address);
+        void on_basic_block_execution(vcpu_context& vcpu, const basic_block& block);
 
         bool uses_section_first_execution_hooks() const;
         void clear_section_first_execution_hooks();

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -397,6 +397,7 @@ namespace sogen
 
         void yield_thread(vcpu_context& vcpu, bool alertable = false);
         bool perform_thread_switch(vcpu_context& vcpu, std::unique_lock<kernel_lock>& lock);
+        bool perform_thread_switch(vcpu_context& vcpu);
         bool activate_thread(vcpu_context& vcpu, uint32_t id);
 
       private:

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -235,6 +235,14 @@ namespace sogen
             return (this->dispatch_vcpu_ ? this->dispatch_vcpu_ : this->vcpus_[0].get())->thread();
         }
 
+        // The CPU of the vCPU currently dispatching a handler on the calling host thread (see
+        // scoped_dispatch). emu() is only the facade/vCPU 0, so handlers that inspect the faulting
+        // register state must go through here to observe the right vCPU when vcpu_count > 1.
+        x86_64_cpu& active_cpu() const
+        {
+            return (this->dispatch_vcpu_ ? this->dispatch_vcpu_ : this->vcpus_[0].get())->cpu;
+        }
+
         vcpu_context& vcpu(const size_t index)
         {
             return *this->vcpus_.at(index);

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -308,6 +308,9 @@ namespace sogen
 
         void dump_exception_trace();
 
+        // Prints BEL contention stats when SOGEN_LOCK_PROFILE is set (see kernel_lock).
+        void dump_lock_profile();
+
         uint64_t get_executed_instructions() const
         {
             return this->executed_instructions_;

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -93,10 +93,6 @@ namespace sogen
         bool use_relative_time{false};
         bool use_instruction_precision{true};
 
-        // Number of virtual CPUs to run guest threads on. Values above 1 require a
-        // backend where supports_multiple_vcpus() is true (see docs/multi-vcpu-design.md).
-        uint32_t vcpu_count{1};
-
         std::filesystem::path emulation_root{};
         std::filesystem::path registry_directory{"./registry"};
 

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -351,6 +351,7 @@ namespace sogen
 
         void setup_hooks();
         void setup_process();
+        void vcpu_worker(vcpu_context& vcpu);
         void on_instruction_execution(vcpu_context& vcpu, uint64_t address);
         void on_basic_block_execution(vcpu_context& vcpu, const basic_block& block);
 

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -268,6 +268,26 @@ namespace sogen
             vcpu_context* previous_{};
         };
 
+        // Post-mortem exception capture for multi-vCPU debugging. Recorded under the
+        // kernel lock (no I/O, no extra locking), dumped after the run ends, so it does
+        // not perturb the timing-sensitive races it is meant to catch.
+        struct exception_trace_entry
+        {
+            uint32_t status{};
+            uint32_t tid{};
+            uint32_t vcpu{};
+            uint64_t rip{};
+            uint64_t info{};
+        };
+
+        void record_exception_trace(const exception_trace_entry& entry)
+        {
+            this->exception_trace_[this->exception_trace_index_ % this->exception_trace_.size()] = entry;
+            ++this->exception_trace_index_;
+        }
+
+        void dump_exception_trace();
+
         uint64_t get_executed_instructions() const
         {
             return this->executed_instructions_;
@@ -369,6 +389,9 @@ namespace sogen
         // The vCPU currently running a handler under the kernel lock; drives
         // current_thread(). See scoped_dispatch.
         vcpu_context* dispatch_vcpu_{};
+
+        std::array<exception_trace_entry, 32> exception_trace_{};
+        size_t exception_trace_index_{0};
 
         // unique_ptr because vcpu_context contains an atomic and must stay address-stable.
         std::vector<std::unique_ptr<vcpu_context>> vcpus_{};

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -243,6 +243,18 @@ namespace sogen
             return (this->dispatch_vcpu_ ? this->dispatch_vcpu_ : this->vcpus_[0].get())->cpu;
         }
 
+        // Run fn as a dispatched handler for the CPU that triggered a hook: takes the kernel lock and
+        // marks that vCPU as the dispatching one, so active_cpu()/current_thread() resolve to it. Meant
+        // for hooks installed outside setup_hooks (e.g. the analyzer's cpuid hook) which otherwise run
+        // lock-free and would observe only the facade/vCPU 0 when vcpu_count > 1.
+        template <typename Function>
+        auto dispatch_on_cpu(cpu_interface& cpu, Function&& fn)
+        {
+            const std::scoped_lock lock(this->kernel_lock_);
+            const scoped_dispatch dispatch(*this, this->vcpu(cpu.index()));
+            return std::forward<Function>(fn)();
+        }
+
         vcpu_context& vcpu(const size_t index)
         {
             return *this->vcpus_.at(index);

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -92,6 +92,10 @@ namespace sogen
         bool use_relative_time{false};
         bool use_instruction_precision{true};
 
+        // Number of virtual CPUs to run guest threads on. Values above 1 require a
+        // backend where supports_multiple_vcpus() is true (see docs/multi-vcpu-design.md).
+        uint32_t vcpu_count{1};
+
         std::filesystem::path emulation_root{};
         std::filesystem::path registry_directory{"./registry"};
 
@@ -220,6 +224,11 @@ namespace sogen
             return this->instruction_precision_;
         }
 
+        uint32_t vcpu_count() const
+        {
+            return this->vcpu_count_;
+        }
+
         stop_reason last_stop_reason() const
         {
             return this->last_stop_reason_;
@@ -297,6 +306,7 @@ namespace sogen
         std::atomic_bool switch_thread_{false};
         bool use_relative_time_{false}; // TODO: Get rid of that
         bool instruction_precision_{true};
+        uint32_t vcpu_count_{1};
         std::atomic_bool should_stop{false};
 
         std::unordered_map<uint16_t, uint16_t> port_mappings_{};

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -8,6 +8,7 @@
 
 #include "syscall_dispatcher.hpp"
 #include "process_context.hpp"
+#include "kernel_lock.hpp"
 #include "logger.hpp"
 #include "file_system.hpp"
 #include "memory_manager.hpp"
@@ -322,7 +323,7 @@ namespace sogen
         }
 
         void yield_thread(vcpu_context& vcpu, bool alertable = false);
-        bool perform_thread_switch(vcpu_context& vcpu);
+        bool perform_thread_switch(vcpu_context& vcpu, std::unique_lock<kernel_lock>& lock);
         bool activate_thread(vcpu_context& vcpu, uint32_t id);
 
       private:
@@ -330,6 +331,10 @@ namespace sogen
         bool instruction_precision_{true};
         uint32_t vcpu_count_{1};
         std::atomic_bool should_stop{false};
+
+        // The emulator kernel lock: held by all code touching shared kernel state,
+        // released while guest code executes (docs/multi-vcpu-design.md, section 7).
+        kernel_lock kernel_lock_{};
 
         // unique_ptr because vcpu_context contains an atomic and must stay address-stable.
         std::vector<std::unique_ptr<vcpu_context>> vcpus_{};

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -225,18 +225,48 @@ namespace sogen
         void deliver_raw_mouse_input(int32_t dx, int32_t dy, uint16_t button_flags);
         void deliver_raw_keyboard_input(uint16_t vkey, uint16_t scan_code, bool release);
 
-        // Single-vCPU observer convenience for external consumers (gdb stub, analyzer,
-        // python bindings). Internal execution paths must use the explicit vcpu_context
-        // instead. Remains correct until Phase 2, since the scheduler only drives vCPU 0.
+        // Observer convenience for external consumers (gdb stub, analyzer, python
+        // bindings) and legacy paths that don't thread a vcpu_context through. Resolves
+        // to the vCPU whose handler is currently running: all handler/observer code runs
+        // under the kernel lock, so exactly one vCPU dispatches at a time and this is
+        // race-free. Falls back to vCPU 0 when no handler is active (e.g. setup).
         emulator_thread& current_thread() const
         {
-            return this->vcpus_[0]->thread();
+            return (this->dispatch_vcpu_ ? this->dispatch_vcpu_ : this->vcpus_[0].get())->thread();
         }
 
         vcpu_context& vcpu(const size_t index)
         {
             return *this->vcpus_.at(index);
         }
+
+        // Marks vcpu as the one currently dispatching a handler on the calling host
+        // thread, so current_thread() resolves correctly. RAII; must be held only while
+        // the kernel lock is held.
+        class scoped_dispatch
+        {
+          public:
+            scoped_dispatch(windows_emulator& emu, vcpu_context& vcpu)
+                : emu_(&emu),
+                  previous_(emu.dispatch_vcpu_)
+            {
+                emu.dispatch_vcpu_ = &vcpu;
+            }
+
+            ~scoped_dispatch()
+            {
+                this->emu_->dispatch_vcpu_ = this->previous_;
+            }
+
+            scoped_dispatch(const scoped_dispatch&) = delete;
+            scoped_dispatch& operator=(const scoped_dispatch&) = delete;
+            scoped_dispatch(scoped_dispatch&&) = delete;
+            scoped_dispatch& operator=(scoped_dispatch&&) = delete;
+
+          private:
+            windows_emulator* emu_{};
+            vcpu_context* previous_{};
+        };
 
         uint64_t get_executed_instructions() const
         {
@@ -335,6 +365,10 @@ namespace sogen
         // The emulator kernel lock: held by all code touching shared kernel state,
         // released while guest code executes (docs/multi-vcpu-design.md, section 7).
         kernel_lock kernel_lock_{};
+
+        // The vCPU currently running a handler under the kernel lock; drives
+        // current_thread(). See scoped_dispatch.
+        vcpu_context* dispatch_vcpu_{};
 
         // unique_ptr because vcpu_context contains an atomic and must stay address-stable.
         std::vector<std::unique_ptr<vcpu_context>> vcpus_{};

--- a/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
@@ -103,7 +103,7 @@ namespace sogen
 
         bool switch_to_thread(const uint32_t thread_id) override
         {
-            return this->win_emu_->activate_thread(thread_id);
+            return this->win_emu_->activate_thread(this->win_emu_->vcpu(0), thread_id);
         }
 
         std::optional<uint32_t> get_exit_code() override

--- a/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
@@ -300,7 +300,7 @@ namespace sogen
 
             for (size_t i = 0; i < size; ++i)
             {
-                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](const uint64_t) {
+                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](cpu_interface&, const uint64_t) {
                     this->on_interrupt(); //
                 });
 
@@ -312,7 +312,7 @@ namespace sogen
 
         std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_read(addr, size, [this](const uint64_t, const void*, const size_t) {
+            auto* hook = this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
 
@@ -321,7 +321,7 @@ namespace sogen
 
         std::vector<emulator_hook*> create_write_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_write(addr, size, [this](const uint64_t, const void*, const size_t) {
+            auto* hook = this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
 


### PR DESCRIPTION
Closes #828

Runs guest threads **truly in parallel** — one host thread drives one vCPU — instead of cooperatively multiplexing every guest thread onto a single vCPU. WHP backend first; design in `docs/multi-vcpu-design.md`.

## Architecture

- **N vCPUs + scheduler.** One `vcpu_worker` host thread per vCPU; guest threads are multiplexed over the vCPUs via the existing `last_registers` save/restore. `--vcpus N` selects the count (defaults to 1; `N > 1` on a backend without `supports_multiple_vcpus()` is a hard error).
- **Big Emulator Lock (BEL).** A single `kernel_lock` serializes everything that touches shared kernel state; it is released while guest code runs and re-acquired on every VM-exit (syscall/exception/hook). Interior code asserts ownership rather than re-locking.
- **No globals / no `thread_local`.** The per-vCPU CPU view (`x86_64_cpu`) and scheduler state (`vcpu_context`) are passed explicitly; hook callbacks receive the triggering CPU.
- **Backend scope.** WHP flips `supports_multiple_vcpus()` to true; unicorn/icicle stay single-vCPU; KVM is deferred.

## Status by phase

- **0–2 (done):** capability query + `--vcpus` + validation; `x86_64_cpu` split out and explicit `vcpu_context` plumbing; WHP drives N virtual processors; BEL + per-vCPU worker scheduler (N=1 runs through the same scheduler, byte-identical).
- **3 — cross-vCPU correctness (converged):** 64-bit and WoW64 (32-bit) run at `--vcpus 1..8`, and a real game (open-iw5 / MW3) runs to self-exit at `--vcpus 2`. Notable fixes:
  - **Per-vCPU GDTs** — the WoW64 FS/TEB descriptor (selector `0x53`) is per-thread; a single shared GDT let a WoW64 thread on one vCPU read another's TEB base → call through a garbage pointer. Each vCPU now owns its GDT page.
  - **SDL UI marshaling** — SDL windows are thread-affine; UI syscalls ran on arbitrary vCPU workers, so a cross-thread `ShowWindow` blocked forever while holding the BEL (deadlock). All SDL work is now queued onto the pump thread.
  - **Acting-vCPU attribution** — syscall classification and rdtsc/rdtscp/cpuid + the debug read hooks read the RIP/thread through the facade (vCPU 0); they now resolve the dispatching vCPU (`active_cpu()` / `dispatch_on_cpu()`), which also closes a data race on the analyzer's cpuid hook.
- **4 — validation + profiling (done):**
  - `src/samples/stress-sample`: 8 threads hammering interlocked ops, a `CRITICAL_SECTION`-guarded counter, a semaphore producer/consumer, event ping-pong, and `VirtualAlloc` churn with write/read verification — each asserting a deterministic invariant. Passes at `--vcpus 1..8` (x64 and WoW64).
  - `SOGEN_LOCK_PROFILE` instruments the BEL (acquisitions / contended / wait / held). Measured contention: **1.4 %** (open-iw5, N=2) / 2.6 % (N=4) for a real game vs 43–54 % for a pure-synchronization worst case → the BEL is not a bottleneck for the target workloads, so **no lock refinement is warranted** (documented in the design doc).
- **5 — KVM parity / linux-emulator:** not in this PR.

## Testing

- `analyzer -s test-sample.exe` passes on unicorn (N=1) and WHP (N=1..4), x64 and WoW64.
- `stress-sample` passes at `--vcpus 1..8` for both bitnesses.
- open-iw5 / MW3 boots to menu and self-exits at `--vcpus 2`.
- `N=1` path is unchanged (runs through the new scheduler with an uncontended BEL).

## Known limitations

- Phase 3 is *converged, not closed* — more workloads will surface more cross-vCPU edge cases; the stress sample + BEL profiler are the nets for catching them.
- KVM remains single-vCPU (`supports_multiple_vcpus()` is false) until Phase 5.
