### PR TITLE
Improve memory queries and file syscall handling

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -349,6 +349,23 @@ namespace
             return false;
         }
 
+        constexpr DWORD negative_length_low = 0xFFFFFFFFUL;
+        constexpr DWORD negative_length_high = 0xFFFFFFFFUL;
+
+        OVERLAPPED negative_lock{};
+        if (!LockFileEx(first, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, negative_length_low, negative_length_high,
+                        &negative_lock))
+        {
+            puts("Failed to acquire negative-length file lock");
+            return false;
+        }
+
+        if (!UnlockFileEx(first, 0, negative_length_low, negative_length_high, &negative_lock))
+        {
+            puts("Failed to unlock negative-length file lock");
+            return false;
+        }
+
         return true;
     }
 

--- a/src/windows-emulator/memory_manager.hpp
+++ b/src/windows-emulator/memory_manager.hpp
@@ -195,6 +195,26 @@ namespace sogen
             }
         }
 
+        constexpr uint32_t to_memory_region_information_type(const memory_region_kind kind)
+        {
+            switch (kind)
+            {
+            case memory_region_kind::private_allocation:
+                return 1 << 0;
+            case memory_region_kind::file_section_view:
+                return 1 << 1;
+            case memory_region_kind::section_image:
+                return 1 << 2;
+            case memory_region_kind::pagefile_section_view:
+                return 1 << 3;
+            case memory_region_kind::mmio:
+                return 1 << 4;
+            case memory_region_kind::free:
+            default:
+                return 0;
+            }
+        }
+
         constexpr NTSTATUS nt_free_virtual_memory_denied_status(const memory_region_kind kind)
         {
             if (is_section_kind(kind))

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1944,6 +1944,11 @@ namespace sogen
                 return STATUS_OBJECT_NAME_INVALID;
             }
 
+            if (filepath.is_relative())
+            {
+                return STATUS_OBJECT_NAME_NOT_FOUND;
+            }
+
             const auto local_filename = c.win_emu.file_sys.translate(filepath);
 
             struct compat_stat file_stat{};

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -26,6 +26,36 @@ namespace sogen
                 return path.find_first_of(invalid_characters) == std::u16string_view::npos;
             }
 
+            std::u16string resolve_system_root_path(const syscall_context& c, std::u16string filename)
+            {
+                auto filename_upper = filename;
+                std::ranges::transform(filename_upper, filename_upper.begin(), ::towupper);
+
+                constexpr std::u16string_view system_root_prefix = u"\\SYSTEMROOT";
+                if (filename_upper != system_root_prefix &&
+                    !(filename_upper.size() > system_root_prefix.size() && filename_upper.starts_with(system_root_prefix) &&
+                      windows_path_detail::is_slash(filename_upper[system_root_prefix.size()])))
+                {
+                    return filename;
+                }
+
+                const auto system_root =
+                    c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return std::u16string{kusd.NtSystemRoot.arr}; });
+                const auto suffix = std::u16string_view{filename}.substr(system_root_prefix.size());
+                filename = system_root;
+
+                if (!suffix.empty() && windows_path_detail::is_slash(filename.back()) && windows_path_detail::is_slash(suffix.front()))
+                {
+                    filename.append(suffix.substr(1));
+                }
+                else
+                {
+                    filename.append(suffix);
+                }
+
+                return filename;
+            }
+
             std::pair<utils::file_handle, NTSTATUS> open_file(const file_system& file_sys, const windows_path& path,
                                                               const std::u16string& mode)
             {
@@ -1669,24 +1699,7 @@ namespace sogen
             std::u16string filename_upper = filename;
             std::ranges::transform(filename_upper, filename_upper.begin(), ::towupper);
 
-            constexpr std::u16string_view system_root_prefix = u"\\SYSTEMROOT";
-            if (filename_upper == system_root_prefix ||
-                (filename_upper.size() > system_root_prefix.size() && filename_upper.starts_with(system_root_prefix) &&
-                 windows_path_detail::is_slash(filename_upper[system_root_prefix.size()])))
-            {
-                const std::u16string_view system_root = c.proc.kusd.get().NtSystemRoot.arr;
-                const auto suffix = std::u16string_view{filename}.substr(system_root_prefix.size());
-                filename = std::u16string(system_root);
-
-                if (!suffix.empty() && windows_path_detail::is_slash(filename.back()) && windows_path_detail::is_slash(suffix.front()))
-                {
-                    filename.append(suffix.substr(1));
-                }
-                else
-                {
-                    filename.append(suffix);
-                }
-            }
+            filename = resolve_system_root_path(c, std::move(filename));
 
             // Handle console output device
             if (filename_upper == u"\\??\\CONOUT$" || filename_upper == u"\\DEVICE\\CONOUT$" || filename_upper == u"CONOUT$" ||
@@ -1941,6 +1954,8 @@ namespace sogen
                 filename = root->name + (has_separator ? u"" : u"\\") + filename;
             }
 
+            filename = resolve_system_root_path(c, std::move(filename));
+
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 
             const windows_path filepath(filename);
@@ -2004,6 +2019,8 @@ namespace sogen
                 const auto has_separator = root->name.ends_with(u"\\") || root->name.ends_with(u"/");
                 filename = root->name + (has_separator ? u"" : u"\\") + filename;
             }
+
+            filename = resolve_system_root_path(c, std::move(filename));
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -503,7 +503,12 @@ namespace sogen
                 return STATUS_ACCESS_VIOLATION;
             }
 
-            const auto _ = utils::finally([&] { io_status_block.write(block.value()); });
+            const auto _ = utils::finally([&] {
+                if (io_status_block)
+                {
+                    (void)io_status_block.try_write(block.value());
+                }
+            });
 
             const auto ret = [&](const NTSTATUS status, size_t size = 0) {
                 block->Status = status;
@@ -999,7 +1004,7 @@ namespace sogen
             const auto _ = utils::finally([&] {
                 if (io_status_block)
                 {
-                    io_status_block.write(block);
+                    (void)io_status_block.try_write(block);
                 }
             });
 

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1664,6 +1664,25 @@ namespace sogen
             std::u16string filename_upper = filename;
             std::ranges::transform(filename_upper, filename_upper.begin(), ::towupper);
 
+            constexpr std::u16string_view system_root_prefix = u"\\SYSTEMROOT";
+            if (filename_upper == system_root_prefix ||
+                (filename_upper.size() > system_root_prefix.size() && filename_upper.starts_with(system_root_prefix) &&
+                 windows_path_detail::is_slash(filename_upper[system_root_prefix.size()])))
+            {
+                const std::u16string_view system_root = c.proc.kusd.get().NtSystemRoot.arr;
+                const auto suffix = std::u16string_view{filename}.substr(system_root_prefix.size());
+                filename = std::u16string(system_root);
+
+                if (!suffix.empty() && windows_path_detail::is_slash(filename.back()) && windows_path_detail::is_slash(suffix.front()))
+                {
+                    filename.append(suffix.substr(1));
+                }
+                else
+                {
+                    filename.append(suffix);
+                }
+            }
+
             // Handle console output device
             if (filename_upper == u"\\??\\CONOUT$" || filename_upper == u"\\DEVICE\\CONOUT$" || filename_upper == u"CONOUT$" ||
                 filename_upper == u"\\??\\CON" || filename_upper == u"\\DEVICE\\CONSOLE" || filename_upper == u"CON")

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -20,6 +20,12 @@ namespace sogen
     {
         namespace
         {
+            bool has_valid_filename_characters(const std::u16string_view path)
+            {
+                constexpr std::u16string_view invalid_characters = u"\"<>|*?";
+                return path.find_first_of(invalid_characters) == std::u16string_view::npos;
+            }
+
             std::pair<utils::file_handle, NTSTATUS> open_file(const file_system& file_sys, const windows_path& path,
                                                               const std::u16string& mode)
             {
@@ -1913,7 +1919,13 @@ namespace sogen
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 
-            const auto local_filename = c.win_emu.file_sys.translate(filename);
+            const windows_path filepath(filename);
+            if (!has_valid_filename_characters(filepath.u16string()))
+            {
+                return STATUS_OBJECT_NAME_INVALID;
+            }
+
+            const auto local_filename = c.win_emu.file_sys.translate(filepath);
 
             struct compat_stat file_stat{};
             if (!compat_stat(local_filename, &file_stat))
@@ -1966,7 +1978,12 @@ namespace sogen
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 
-            windows_path filepath(filename);
+            const windows_path filepath(filename);
+            if (!has_valid_filename_characters(filepath.u16string()))
+            {
+                return STATUS_OBJECT_NAME_INVALID;
+            }
+
             if (filepath.is_relative())
             {
                 return STATUS_OBJECT_NAME_NOT_FOUND;

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -1088,7 +1088,7 @@ namespace sogen
 
         std::optional<uint64_t> get_lock_range_end(const LARGE_INTEGER& byte_offset, const LARGE_INTEGER& length)
         {
-            if (byte_offset.QuadPart < 0 || length.QuadPart <= 0)
+            if (byte_offset.QuadPart < 0 || length.QuadPart == 0)
             {
                 return std::nullopt;
             }

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -286,7 +286,7 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            if (info_class == MemoryRegionInformation)
+            if (info_class == MemoryRegionInformation || info_class == MemoryRegionInformationEx)
             {
                 if (return_length)
                 {
@@ -311,9 +311,18 @@ namespace sogen
 
                     image_info.AllocationBase = region_info.allocation_base;
                     image_info.AllocationProtect = map_emulator_to_nt_protection(region_info.initial_permissions);
-                    // image_info.PartitionId = 0;
+                    image_info.RegionType = memory_region_policy::to_memory_region_information_type(region_info.kind);
                     image_info.RegionSize = static_cast<int64_t>(region_info.allocation_length);
-                    image_info.Reserved = 0x10;
+
+                    const auto& reserved_regions = c.win_emu.memory.get_reserved_regions();
+                    const auto allocation = reserved_regions.find(region_info.allocation_base);
+                    if (allocation != reserved_regions.end())
+                    {
+                        for (const auto& committed : allocation->second.committed_regions | std::views::values)
+                        {
+                            image_info.CommitSize += static_cast<int64_t>(committed.length);
+                        }
+                    }
                 });
 
                 return STATUS_SUCCESS;


### PR DESCRIPTION
This PR does the following improvements to Sogen:

* Improves `NtQueryVirtualMemory` handling for `MemoryRegionInformation` and `MemoryRegionInformationEx`.
* Reports region types more accurately, and fills commit size from committed subregions. 
* Correctly rejects invalid filenames in file attribute queries.
* Resolves `\SystemRoot` paths during file opens.
* Allows negative `LockFile` lengths.
  * _This fixes the `GetPrivateProfileString` API._
* Rejects relative paths in `NtQueryFullAttributesFile`.
* Hardens some writes to `IO_STATUS_BLOCK` so invalid guest pointers do not cause unsafe writes.