### PR TITLE
Handle console screen buffer IOCTLs on CONSOLE_HANDLE

### DIFF
--- a/src/windows-emulator/devices/console.cpp
+++ b/src/windows-emulator/devices/console.cpp
@@ -1,0 +1,214 @@
+#include "../std_include.hpp"
+#include "console.hpp"
+
+#include "../windows_emulator.hpp"
+
+namespace sogen
+{
+
+    namespace
+    {
+        constexpr ULONG console_ioctl = 0x500016;
+
+        enum class console_api : uint32_t
+        {
+            fill_console_output = 0x02000000,
+            set_console_cursor_position = 0x0200000A,
+            set_console_text_attribute = 0x0200000D,
+            get_console_screen_buffer_info = 0x02000007,
+        };
+
+        enum class fill_console_output_type : uint32_t
+        {
+            ansi_character = 1,
+            unicode_character = 2,
+            attribute = 3,
+        };
+
+        struct console_coordinate
+        {
+            int16_t x;
+            int16_t y;
+        };
+
+        static_assert(sizeof(console_coordinate) == 4);
+
+        struct fill_console_output_request
+        {
+            console_coordinate coordinate;
+            fill_console_output_type type;
+            uint16_t value;
+            uint16_t padding;
+            uint32_t count;
+        };
+
+        static_assert(sizeof(fill_console_output_request) == 16);
+
+        struct console_screen_buffer_info_response
+        {
+            int16_t size_x;
+            int16_t size_y;
+            int16_t cursor_x;
+            int16_t cursor_y;
+            int16_t window_left;
+            int16_t window_top;
+            uint16_t attributes;
+            int16_t window_width;
+            int16_t window_height;
+            int16_t maximum_window_width;
+            int16_t maximum_window_height;
+            uint16_t popup_attributes;
+            uint8_t fullscreen_supported;
+            std::array<uint32_t, 16> color_table;
+        };
+
+        static_assert(sizeof(console_screen_buffer_info_response) == 92);
+
+        struct console_ioctl_header
+        {
+            uint64_t target_handle;
+            uint32_t input_count;
+            uint32_t output_count;
+            uint32_t message_buffer_size;
+            uint32_t padding;
+            uint64_t message;
+            uint64_t data_size;
+            uint64_t data;
+        };
+
+        static_assert(sizeof(console_ioctl_header) == 48);
+
+        struct console_message_header
+        {
+            uint32_t api_number;
+            uint32_t data_size;
+        };
+
+    }
+
+    namespace
+    {
+        struct console_device final : io_device
+        {
+            void serialize_object(utils::buffer_serializer& buffer) const override
+            {
+                buffer.write(text_attributes_);
+                buffer.write(cursor_position_);
+            }
+
+            void deserialize_object(utils::buffer_deserializer& buffer) override
+            {
+                buffer.read(text_attributes_);
+                buffer.read(cursor_position_);
+            }
+
+            NTSTATUS io_control(windows_emulator& win_emu, const io_device_context& context) override
+            {
+                if (context.io_control_code != console_ioctl)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                if (!context.input_buffer || context.input_buffer_length < sizeof(console_ioctl_header))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                console_ioctl_header header{};
+                win_emu.emu().read_memory(context.input_buffer, &header, sizeof(header));
+                if (header.target_handle != STDOUT_HANDLE.h || header.input_count != 1 || header.output_count != 1 ||
+                    header.message_buffer_size != sizeof(console_message_header) + header.data_size ||
+                    header.data != header.message + sizeof(console_message_header) || !header.message || !header.data)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                console_message_header message{};
+                win_emu.emu().read_memory(header.message, &message, sizeof(message));
+                if (message.data_size != header.data_size)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                switch (static_cast<console_api>(message.api_number))
+                {
+                case console_api::fill_console_output: {
+                    if (message.data_size != sizeof(fill_console_output_request))
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    fill_console_output_request request{};
+                    win_emu.emu().read_memory(header.data, &request, sizeof(request));
+                    switch (request.type)
+                    {
+                    case fill_console_output_type::ansi_character:
+                    case fill_console_output_type::unicode_character:
+                    case fill_console_output_type::attribute:
+                        // TODO
+                        win_emu.emu().write_memory(header.data, &request, sizeof(request));
+                        return STATUS_SUCCESS;
+                    }
+
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                case console_api::set_console_cursor_position:
+                    if (message.data_size != sizeof(cursor_position_))
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    win_emu.emu().read_memory(header.data, &cursor_position_, sizeof(cursor_position_));
+                    return STATUS_SUCCESS;
+
+                case console_api::set_console_text_attribute: {
+                    if (message.data_size != sizeof(text_attributes_))
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    win_emu.emu().read_memory(header.data, &text_attributes_, sizeof(text_attributes_));
+                    return STATUS_SUCCESS;
+                }
+
+                case console_api::get_console_screen_buffer_info: {
+                    if (message.data_size != sizeof(console_screen_buffer_info_response))
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    console_screen_buffer_info_response response{};
+                    response.size_x = 80;
+                    response.size_y = 25;
+                    response.cursor_x = cursor_position_.x;
+                    response.cursor_y = cursor_position_.y;
+                    response.window_width = response.size_x;
+                    response.window_height = response.size_y;
+                    response.maximum_window_width = response.size_x;
+                    response.maximum_window_height = response.size_y;
+                    response.attributes = text_attributes_;
+                    response.popup_attributes = 0xF5;
+                    response.color_table = {0x00000000, 0x00800000, 0x00008000, 0x00808000, 0x00000080, 0x00800080, 0x00008080, 0x00C0C0C0,
+                                            0x00808080, 0x00FF0000, 0x0000FF00, 0x00FFFF00, 0x000000FF, 0x00FF00FF, 0x0000FFFF, 0x00FFFFFF};
+                    win_emu.emu().write_memory(header.data, &response, sizeof(response));
+
+                    return STATUS_SUCCESS;
+                }
+                }
+
+                return STATUS_INVALID_PARAMETER;
+            }
+
+          private:
+            uint16_t text_attributes_{7};
+            console_coordinate cursor_position_{};
+        };
+    }
+
+    std::unique_ptr<io_device> create_console_device()
+    {
+        return std::make_unique<console_device>();
+    }
+
+} // namespace sogen

--- a/src/windows-emulator/devices/console.hpp
+++ b/src/windows-emulator/devices/console.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "../io_device.hpp"
+
+namespace sogen
+{
+
+    std::unique_ptr<io_device> create_console_device();
+
+} // namespace sogen

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -7,6 +7,7 @@
 #include "devices/named_pipe.hpp"
 #include "devices/network_store_interface.hpp"
 #include "devices/gpu_bridge.hpp"
+#include "devices/console.hpp"
 #include <iostream>
 
 namespace sogen
@@ -59,6 +60,11 @@ namespace sogen
             || device == u"ConDrv\\Server")
         {
             return std::make_unique<dummy_device>();
+        }
+
+        if (device == u"Console")
+        {
+            return create_console_device();
         }
 
         if (device == u"Nsi")

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -249,18 +249,23 @@ namespace sogen
         }
     }
 
-    void process_context::setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
-                                windows_version_manager& version, const fake_environment_config& fake_env,
-                                const application_settings& app_settings, const mapped_module& executable, const mapped_module& ntdll,
-                                const apiset::container& apiset_container, const mapped_module* ntdll32)
+    void process_context::setup(windows_emulator& win_emu, const application_settings& app_settings, const mapped_module& executable,
+                                const mapped_module& ntdll, const apiset::container& apiset_container, const mapped_module* ntdll32)
     {
-        this->sid = get_sid(registry);
+        auto& emu = win_emu.emu();
+        const auto& version = win_emu.version;
+        const auto& fake_env = win_emu.fake_env;
 
-        setup_gdt(emu, memory);
+        io_device_container console{u"Console", win_emu, {}};
+        this->console_handle = this->devices.store(std::move(console));
+
+        this->sid = get_sid(win_emu.registry);
+
+        setup_gdt(emu, win_emu.memory);
 
         this->kusd.setup(version, fake_env);
 
-        this->base_allocator = create_allocator(memory, PEB_SEGMENT_SIZE, this->is_wow64_process);
+        this->base_allocator = create_allocator(win_emu.memory, PEB_SEGMENT_SIZE, this->is_wow64_process);
         auto& allocator = this->base_allocator;
 
         this->peb64 = allocator.reserve_page_aligned<PEB64>();
@@ -299,7 +304,7 @@ namespace sogen
 
             proc_params.Environment = allocator.copy_string(u"=::=::\\");
 
-            const auto env_map = get_environment_variables(registry, version, app_settings);
+            const auto env_map = get_environment_variables(win_emu.registry, version, app_settings);
             for (const auto& [name, value] : env_map)
             {
                 std::u16string entry;
@@ -467,8 +472,8 @@ namespace sogen
 
         this->apiset = apiset::get_namespace_table(reinterpret_cast<const API_SET_NAMESPACE*>(apiset_container.data.data()));
         const auto& system_root = version.get_system_root();
-        this->build_knowndlls_section_table<uint64_t>(registry, file_system, apiset, system_root, false);
-        this->build_knowndlls_section_table<uint32_t>(registry, file_system, apiset, system_root, true);
+        this->build_knowndlls_section_table<uint64_t>(win_emu.registry, win_emu.file_sys, apiset, system_root, false);
+        this->build_knowndlls_section_table<uint32_t>(win_emu.registry, win_emu.file_sys, apiset, system_root, true);
 
         this->ntdll_image_base = ntdll.image_base;
         this->ldr_initialize_thunk = ntdll.find_export("LdrInitializeThunk");
@@ -532,7 +537,7 @@ namespace sogen
             }
         });
 
-        auto [wh, desktop_win] = this->windows.create(memory);
+        auto [wh, desktop_win] = this->windows.create(win_emu.memory);
         this->default_desktop_window_handle = wh;
         desktop_win.handle = wh.bits;
         desktop_win.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
@@ -613,6 +618,7 @@ namespace sogen
         buffer.write_map(this->file_locks);
         buffer.write(this->sections);
         buffer.write(this->devices);
+        buffer.write(this->console_handle);
         buffer.write(this->semaphores);
         buffer.write(this->io_completions);
         buffer.write(this->wait_completion_packets);
@@ -702,6 +708,7 @@ namespace sogen
         buffer.read_map(this->file_locks);
         buffer.read(this->sections);
         buffer.read(this->devices);
+        buffer.read(this->console_handle);
         buffer.read(this->semaphores);
         buffer.read(this->io_completions);
         buffer.read(this->wait_completion_packets);
@@ -857,6 +864,11 @@ namespace sogen
         if (handle == CURRENT_THREAD)
         {
             return this->threads.find_handle(active_thread);
+        }
+
+        if (handle == CONSOLE_HANDLE)
+        {
+            return this->console_handle;
         }
 
         return handle;

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -330,10 +330,8 @@ namespace sogen
         {
         }
 
-        void setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
-                   windows_version_manager& version, const fake_environment_config& fake_env, const application_settings& app_settings,
-                   const mapped_module& executable, const mapped_module& ntdll, const apiset::container& apiset_container,
-                   const mapped_module* ntdll32 = nullptr);
+        void setup(windows_emulator& win_emu, const application_settings& app_settings, const mapped_module& executable,
+                   const mapped_module& ntdll, const apiset::container& apiset_container, const mapped_module* ntdll32 = nullptr);
 
         handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size, uint32_t create_flags,
                              bool initial_thread = false);
@@ -459,6 +457,7 @@ namespace sogen
         utils::insensitive_u16string_map<file_lock_ranges> file_locks{};
         handle_store<handle_types::section, section> sections{};
         handle_store<handle_types::device, io_device_container> devices{};
+        handle console_handle{};
         handle_store<handle_types::semaphore, semaphore> semaphores{};
         handle_store<handle_types::io_completion, io_completion> io_completions{};
         handle_store<handle_types::wait_completion_packet, wait_completion_packet> wait_completion_packets{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -3,6 +3,7 @@
 #include "cpu_context.hpp"
 #include "emulator_utils.hpp"
 #include "syscall_utils.hpp"
+#include "devices/console.hpp"
 
 #include <numeric>
 #include <cwctype>
@@ -903,7 +904,8 @@ namespace sogen
                                               const ULONG input_buffer_length, const emulator_pointer output_buffer,
                                               const ULONG output_buffer_length)
         {
-            auto* device = c.proc.devices.get(file_handle);
+            const auto resolved_file_handle = c.proc.resolve_object_pseudo_handle(file_handle, c.vcpu.active_thread);
+            auto* device = c.proc.devices.get(resolved_file_handle);
             if (!device)
             {
                 return STATUS_INVALID_HANDLE;

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -689,8 +689,7 @@ namespace sogen
 
         const auto apiset_data = apiset::obtain(this->emulation_root);
 
-        this->process.setup(this->emu(), this->memory, this->registry, this->file_sys, this->version, this->fake_env,
-                            this->application_settings_, *executable, *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32);
+        this->process.setup(*this, this->application_settings_, *executable, *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32);
 
         const auto ntdll_data = emu.read_memory(ntdll->image_base, static_cast<size_t>(ntdll->size_of_image));
         const auto win32u_data = emu.read_memory(win32u->image_base, static_cast<size_t>(win32u->size_of_image));


### PR DESCRIPTION
This PR implements handling for console screen-buffer IOCTLs on `CONSOLE_HANDLE`, returning synthetic screen-buffer information for callers that query basic console state.