### PR TITLE
windows-emulator: security hardening for GPU bridge and file system

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -396,6 +396,16 @@ namespace sogen
 
                 const auto request = emulator_object<gpu_bridge::destroy_instance_request>{win_emu.emu(), context.input_buffer}.read();
 
+                // destroy_instance internally tears down all devices for this instance via erase_device,
+                // which frees Vulkan memory without consulting direct_mappings_. Release all guest VA
+                // aliases first to prevent stale mappings to freed host pages.
+                for (auto it = this->direct_mappings_.begin(); it != this->direct_mappings_.end();)
+                {
+                    win_emu.memory.release_memory(it->second.guest_address, static_cast<size_t>(it->second.size));
+                    this->vulkan_.unmap_memory(it->second.device, it->first);
+                    it = this->direct_mappings_.erase(it);
+                }
+
                 this->vulkan_.destroy_instance(request.instance);
                 return STATUS_SUCCESS;
             }
@@ -727,6 +737,19 @@ namespace sogen
                 }
 
                 const auto request = emulator_object<gpu_bridge::destroy_device_request>{win_emu.emu(), context.input_buffer}.read();
+
+                for (auto it = this->direct_mappings_.begin(); it != this->direct_mappings_.end();)
+                {
+                    if (it->second.device != request.device)
+                    {
+                        ++it;
+                        continue;
+                    }
+
+                    win_emu.memory.release_memory(it->second.guest_address, static_cast<size_t>(it->second.size));
+                    this->vulkan_.unmap_memory(it->second.device, it->first);
+                    it = this->direct_mappings_.erase(it);
+                }
 
                 this->vulkan_.destroy_device(request.device);
                 return STATUS_SUCCESS;

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1847,6 +1847,13 @@ namespace sogen
 
                 const auto avail = static_cast<uint32_t>(context.output_buffer_length - sizeof(response_t));
                 const auto data_size = std::min<uint32_t>(request.data_size, avail);
+
+                if (request.query_count > 0 && request.stride > 0 &&
+                    static_cast<uint64_t>(request.stride) * request.query_count > data_size)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
                 std::vector<std::byte> data(data_size);
                 size_t written = 0;
                 const int32_t result =

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2759,8 +2759,8 @@ namespace sogen
                     {
                         return vk_error_initialization_failed;
                     }
-                    const uint32_t total = req.color_attachment_count + (req.has_depth ? 1u : 0u) + (req.has_stencil ? 1u : 0u);
-                    if (static_cast<size_t>(total) * sizeof(gpu_bridge::rendering_attachment) > size - sizeof(req))
+                    const size_t total = static_cast<size_t>(req.color_attachment_count) + (req.has_depth ? 1u : 0u) + (req.has_stencil ? 1u : 0u);
+                    if (total * sizeof(gpu_bridge::rendering_attachment) > size - sizeof(req))
                     {
                         return vk_error_initialization_failed;
                     }

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1976,7 +1976,7 @@ namespace sogen
 
                 const size_t bindings_bytes = static_cast<size_t>(request.binding_count) * sizeof(gpu_bridge::vertex_input_binding);
                 const size_t attributes_bytes = static_cast<size_t>(request.attribute_count) * sizeof(gpu_bridge::vertex_input_attribute);
-                if (bindings_bytes + attributes_bytes > trailer.size())
+                if (bindings_bytes > trailer.size() || attributes_bytes > trailer.size() - bindings_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
@@ -2003,7 +2003,11 @@ namespace sogen
 
                 std::vector<uint32_t> dynamic_states(request.dynamic_state_count);
                 const size_t dynamic_bytes = static_cast<size_t>(request.dynamic_state_count) * sizeof(uint32_t);
-                if (bindings_bytes + attributes_bytes + dynamic_bytes <= trailer.size() && request.dynamic_state_count > 0)
+                if (dynamic_bytes > trailer.size() - bindings_bytes - attributes_bytes)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                if (request.dynamic_state_count > 0)
                 {
                     std::memcpy(dynamic_states.data(), trailer.data() + bindings_bytes + attributes_bytes, dynamic_bytes);
                 }
@@ -2016,11 +2020,11 @@ namespace sogen
                 std::vector<uint8_t> vs_data;
                 std::vector<uint8_t> fs_data;
                 const auto parse_spec = [&](uint32_t entry_count, uint32_t data_size, std::vector<vulkan_host::spec_entry>& entries,
-                                            std::vector<uint8_t>& data) {
+                                            std::vector<uint8_t>& data) -> bool {
                     const size_t entries_bytes = static_cast<size_t>(entry_count) * sizeof(gpu_bridge::specialization_map_entry);
-                    if (spec_cursor + entries_bytes + data_size > trailer.size())
+                    if (entries_bytes > trailer.size() - spec_cursor || data_size > trailer.size() - spec_cursor - entries_bytes)
                     {
-                        return;
+                        return false;
                     }
                     entries.resize(entry_count);
                     for (auto& entry : entries)
@@ -2028,6 +2032,11 @@ namespace sogen
                         gpu_bridge::specialization_map_entry e{};
                         std::memcpy(&e, trailer.data() + spec_cursor, sizeof(e));
                         spec_cursor += sizeof(e);
+
+                        if (e.offset > data_size || e.size > data_size - e.offset)
+                        {
+                            return false;
+                        }
                         entry = {.constant_id = e.constant_id, .offset = e.offset, .size = e.size};
                     }
                     data.resize(data_size);
@@ -2036,9 +2045,13 @@ namespace sogen
                         std::memcpy(data.data(), trailer.data() + spec_cursor, data_size);
                         spec_cursor += data_size;
                     }
+                    return true;
                 };
-                parse_spec(request.vs_spec_entry_count, request.vs_spec_data_size, vs_entries, vs_data);
-                parse_spec(request.fs_spec_entry_count, request.fs_spec_data_size, fs_entries, fs_data);
+                if (!parse_spec(request.vs_spec_entry_count, request.vs_spec_data_size, vs_entries, vs_data) ||
+                    !parse_spec(request.fs_spec_entry_count, request.fs_spec_data_size, fs_entries, fs_data))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
 
                 const vulkan_host::depth_state depth{.test_enable = request.depth_test_enable,
                                                      .write_enable = request.depth_write_enable,

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2759,7 +2759,8 @@ namespace sogen
                     {
                         return vk_error_initialization_failed;
                     }
-                    const size_t total = static_cast<size_t>(req.color_attachment_count) + (req.has_depth ? 1u : 0u) + (req.has_stencil ? 1u : 0u);
+                    const size_t total =
+                        static_cast<size_t>(req.color_attachment_count) + (req.has_depth ? 1u : 0u) + (req.has_stencil ? 1u : 0u);
                     if (total * sizeof(gpu_bridge::rendering_attachment) > size - sizeof(req))
                     {
                         return vk_error_initialization_failed;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -4677,6 +4677,23 @@ namespace sogen
         // the two info structs must outlive the vkCreateGraphicsPipelines call below.
         std::array<std::vector<VkSpecializationMapEntry>, 2> spec_map_entries;
         std::array<VkSpecializationInfo, 2> spec_infos{};
+
+        const auto valid_spec = [](const specialization& spec) {
+            for (const auto& e : spec.entries)
+            {
+                if (e.offset > spec.data.size() || e.size > spec.data.size() - e.offset)
+                {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        if (!valid_spec(vs_spec) || !valid_spec(fs_spec))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
         const auto build_spec = [&](const specialization& spec, size_t idx) -> const VkSpecializationInfo* {
             if (spec.entries.empty() || spec.data.empty())
             {

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -93,7 +93,7 @@ namespace sogen
                 c.win_emu.log.warn("--> File rename requested: %s --> %s\n", u16_to_u8(f->name).c_str(), u16_to_u8(new_name).c_str());
 
                 std::error_code ec{};
-                bool file_exists = std::filesystem::exists(new_name, ec);
+                bool file_exists = std::filesystem::exists(c.win_emu.file_sys.translate(new_name), ec);
 
                 if (ec)
                 {


### PR DESCRIPTION
fixes several sandbox boundary issues found during a security audit of the windows-emulator, focused on the GPU bridge IOCTL handlers and syscall layer. this was done with my local LLM experimenting for auditing, letting Claude Opus confirm and write the fixes for sending here.

- **destroy_device/destroy_instance UAF**: direct_mappings_ entries survived
    device teardown, leaving guest VA aliases to freed Vulkan memory. this is the best solution for security purposes, but it can clean all mappings and is **not** instance specific.
- **query pool stride overflow**: guest-controlled stride in
    get_query_pool_results could overflow the host heap buffer
- **specialization map entry OOB**: invalid offset+size forwarded to host
    vkCreateGraphicsPipelines, reading past the specialization data buffer
- **file rename info leak**: exists-check used untranslated guest path,
    letting guest probe host filesystem
- **cmd_begin_rendering DoS**: uint32_t wrap in color_attachment_count
    bypassed the bounds check