### PR TITLE
Increase WOW64_NATIVE_STACK_SIZE

### DIFF
--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -41,7 +41,7 @@ namespace sogen
     }
 
 // TODO: Get rid of that
-#define WOW64_NATIVE_STACK_SIZE 0x8000
+#define WOW64_NATIVE_STACK_SIZE 0x40000ULL
 #define WOW64_32BIT_STACK_SIZE  (1 << 20)
 
     struct emulator_settings;


### PR DESCRIPTION
While trying to run a specific x86 app in sogen, I encountered a peculiar issue where it would fail unexpectedly while creating it's Windows. After some debugging, I found that this was caused by the WoW64 stack being too small. This PR increases it so that it at least matches the lower bound of the x64 stack.
