### PR TITLE
Refactor emulator stack allocation leak tracking

### DIFF
--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -4,8 +4,13 @@
 #include "memory_interface.hpp"
 #include "serialization.hpp"
 
+#include <algorithm>
+#include <array>
 #include <limits>
+#include <source_location>
+#include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 
 namespace sogen
@@ -14,6 +19,13 @@ namespace sogen
     class emulator_stack_leak_collector
     {
       public:
+        struct leak_record
+        {
+            uint64_t address{};
+            uint64_t previous_stack_pointer{};
+            std::source_location origin{};
+        };
+
         emulator_stack_leak_collector()
             : previous_(std::exchange(active_, this))
         {
@@ -29,27 +41,83 @@ namespace sogen
         emulator_stack_leak_collector(emulator_stack_leak_collector&&) = delete;
         emulator_stack_leak_collector& operator=(emulator_stack_leak_collector&&) = delete;
 
-        static void report_leak() noexcept
+        static void report_leak(const leak_record& leak) noexcept
         {
             if (active_)
             {
-                active_->leaked_ = true;
+                if (active_->leak_count_ < active_->leaks_.size())
+                {
+                    active_->leaks_[active_->leak_count_] = leak;
+                }
+                ++active_->leak_count_;
             }
         }
 
         void throw_if_leaked() const
         {
-            if (leaked_)
+            if (leak_count_ != 0)
             {
-                throw std::runtime_error("Emulator stack allocation was not released");
+                std::ostringstream message{};
+                message << leak_count_ << " emulator stack allocation(s) were not released";
+
+                const auto recorded_count = std::min(leak_count_, leaks_.size());
+                for (size_t i = 0; i < recorded_count; ++i)
+                {
+                    const auto& leak = leaks_[i];
+                    message << "\n  guest stack 0x" << std::hex << leak.address << "..0x" << leak.previous_stack_pointer << std::dec;
+                    if (leak.origin.line() != 0)
+                    {
+                        message << " allocated at " << leak.origin.file_name() << ':' << leak.origin.line() << " in "
+                                << get_short_function_name(leak.origin);
+                    }
+                    else
+                    {
+                        message << " restored from serialized state";
+                    }
+                }
+
+                if (leak_count_ > recorded_count)
+                {
+                    message << "\n  ... and " << (leak_count_ - recorded_count) << " more";
+                }
+
+                throw std::runtime_error(message.str());
             }
         }
 
       private:
+        static std::string_view get_short_function_name(const std::source_location& origin)
+        {
+            std::string_view name{origin.function_name()};
+            if (const auto parameters = name.find('('); parameters != std::string_view::npos)
+            {
+                name = name.substr(0, parameters);
+            }
+
+            const auto end = name.find_last_not_of(' ');
+            if (end == std::string_view::npos)
+            {
+                return {};
+            }
+            name = name.substr(0, end + 1);
+
+            if (const auto scope = name.rfind("::"); scope != std::string_view::npos)
+            {
+                return name.substr(scope + 2);
+            }
+            if (const auto space = name.find_last_of(' '); space != std::string_view::npos)
+            {
+                return name.substr(space + 1);
+            }
+            return name;
+        }
+
         inline static thread_local emulator_stack_leak_collector* active_{};
+        static constexpr size_t max_recorded_leaks = 16;
 
         emulator_stack_leak_collector* previous_{};
-        bool leaked_{};
+        std::array<leak_record, max_recorded_leaks> leaks_{};
+        size_t leak_count_{};
     };
 
     struct emulator_stack_allocation
@@ -60,7 +128,7 @@ namespace sogen
         {
             if (*this)
             {
-                emulator_stack_leak_collector::report_leak();
+                emulator_stack_leak_collector::report_leak({address_, previous_stack_pointer_, origin_});
             }
         }
 
@@ -69,7 +137,8 @@ namespace sogen
 
         emulator_stack_allocation(emulator_stack_allocation&& other) noexcept
             : address_(std::exchange(other.address_, 0)),
-              previous_stack_pointer_(std::exchange(other.previous_stack_pointer_, 0))
+              previous_stack_pointer_(std::exchange(other.previous_stack_pointer_, 0)),
+              origin_(std::exchange(other.origin_, std::source_location{}))
         {
         }
 
@@ -84,6 +153,7 @@ namespace sogen
 
                 address_ = std::exchange(other.address_, 0);
                 previous_stack_pointer_ = std::exchange(other.previous_stack_pointer_, 0);
+                origin_ = std::exchange(other.origin_, std::source_location{});
             }
             return *this;
         }
@@ -125,6 +195,7 @@ namespace sogen
 
             address_ = address;
             previous_stack_pointer_ = previous_stack_pointer;
+            origin_ = {};
         }
 
       private:
@@ -133,9 +204,10 @@ namespace sogen
 
         static constexpr uint64_t stack_alignment = 16;
 
-        emulator_stack_allocation(const uint64_t address, const uint64_t previous_stack_pointer)
+        emulator_stack_allocation(const uint64_t address, const uint64_t previous_stack_pointer, const std::source_location origin)
             : address_(address),
-              previous_stack_pointer_(previous_stack_pointer)
+              previous_stack_pointer_(previous_stack_pointer),
+              origin_(origin)
         {
         }
 
@@ -143,10 +215,12 @@ namespace sogen
         {
             address_ = 0;
             previous_stack_pointer_ = 0;
+            origin_ = {};
         }
 
         uint64_t address_{};
         uint64_t previous_stack_pointer_{};
+        std::source_location origin_{};
     };
 
     // A single virtual CPU's view of the machine: typed register and stack access
@@ -312,7 +386,8 @@ namespace sogen
 
         template <typename T>
             requires std::is_trivially_copyable_v<T>
-        [[nodiscard]] emulator_stack_allocation push_stack(const T& data)
+        [[nodiscard]] emulator_stack_allocation push_stack(const T& data,
+                                                           const std::source_location origin = std::source_location::current())
         {
             const auto old_rsp = read_stack_pointer();
             if (sizeof(T) > static_cast<uint64_t>(old_rsp))
@@ -324,7 +399,7 @@ namespace sogen
             write_memory(new_rsp, &data, sizeof(T));
             reg(stack_pointer, new_rsp);
 
-            return emulator_stack_allocation{new_rsp, old_rsp};
+            return emulator_stack_allocation{new_rsp, old_rsp, origin};
         }
 
         void pop_stack(emulator_stack_allocation&& allocation)

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -128,7 +128,8 @@ namespace sogen
         {
             if (*this)
             {
-                emulator_stack_leak_collector::report_leak({address_, previous_stack_pointer_, origin_});
+                emulator_stack_leak_collector::report_leak(
+                    {.address = address_, .previous_stack_pointer = previous_stack_pointer_, .origin = origin_});
             }
         }
 
@@ -142,6 +143,8 @@ namespace sogen
         {
         }
 
+        // This operation deliberately rejects overwriting a live allocation instead of terminating.
+        // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations,hicpp-noexcept-move,performance-noexcept-move-constructor)
         emulator_stack_allocation& operator=(emulator_stack_allocation&& other)
         {
             if (this != &other)
@@ -402,7 +405,7 @@ namespace sogen
             return emulator_stack_allocation{new_rsp, old_rsp, origin};
         }
 
-        void pop_stack(emulator_stack_allocation&& allocation)
+        void pop_stack(emulator_stack_allocation& allocation)
         {
             if (!allocation)
             {

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -4,54 +4,149 @@
 #include "memory_interface.hpp"
 #include "serialization.hpp"
 
-#include <cassert>
+#include <limits>
+#include <stdexcept>
 #include <utility>
 
 namespace sogen
 {
 
+    class emulator_stack_leak_collector
+    {
+      public:
+        emulator_stack_leak_collector()
+            : previous_(std::exchange(active_, this))
+        {
+        }
+
+        ~emulator_stack_leak_collector()
+        {
+            active_ = previous_;
+        }
+
+        emulator_stack_leak_collector(const emulator_stack_leak_collector&) = delete;
+        emulator_stack_leak_collector& operator=(const emulator_stack_leak_collector&) = delete;
+        emulator_stack_leak_collector(emulator_stack_leak_collector&&) = delete;
+        emulator_stack_leak_collector& operator=(emulator_stack_leak_collector&&) = delete;
+
+        static void report_leak() noexcept
+        {
+            if (active_)
+            {
+                active_->leaked_ = true;
+            }
+        }
+
+        void throw_if_leaked() const
+        {
+            if (leaked_)
+            {
+                throw std::runtime_error("Emulator stack allocation was not released");
+            }
+        }
+
+      private:
+        inline static thread_local emulator_stack_leak_collector* active_{};
+
+        emulator_stack_leak_collector* previous_{};
+        bool leaked_{};
+    };
+
     struct emulator_stack_allocation
     {
-        uint64_t address{};
-        size_t size{};
-
         emulator_stack_allocation() = default;
 
         ~emulator_stack_allocation()
         {
-            assert(address == 0 && "Emulator stack leak: allocation was not freed before destruction");
+            if (*this)
+            {
+                emulator_stack_leak_collector::report_leak();
+            }
         }
 
         emulator_stack_allocation(const emulator_stack_allocation&) = delete;
         emulator_stack_allocation& operator=(const emulator_stack_allocation&) = delete;
 
         emulator_stack_allocation(emulator_stack_allocation&& other) noexcept
-            : address(std::exchange(other.address, 0)),
-              size(std::exchange(other.size, 0))
+            : address_(std::exchange(other.address_, 0)),
+              previous_stack_pointer_(std::exchange(other.previous_stack_pointer_, 0))
         {
         }
 
-        emulator_stack_allocation& operator=(emulator_stack_allocation&& other) noexcept
+        emulator_stack_allocation& operator=(emulator_stack_allocation&& other)
         {
             if (this != &other)
             {
-                address = std::exchange(other.address, 0);
-                size = std::exchange(other.size, 0);
+                if (*this)
+                {
+                    throw std::logic_error("Attempted to overwrite an active emulator stack allocation");
+                }
+
+                address_ = std::exchange(other.address_, 0);
+                previous_stack_pointer_ = std::exchange(other.previous_stack_pointer_, 0);
             }
             return *this;
         }
 
+        explicit operator bool() const
+        {
+            return previous_stack_pointer_ != 0;
+        }
+
+        uint64_t address() const
+        {
+            return address_;
+        }
+
         void serialize(utils::buffer_serializer& buffer) const
         {
-            buffer.write(address);
-            buffer.write(size);
+            buffer.write(address_);
+            buffer.write(previous_stack_pointer_);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
         {
+            if (*this)
+            {
+                throw std::logic_error("Attempted to deserialize over an active emulator stack allocation");
+            }
+
+            uint64_t address{};
+            uint64_t previous_stack_pointer{};
             buffer.read(address);
-            buffer.read(size);
+            buffer.read(previous_stack_pointer);
+
+            const bool is_active = previous_stack_pointer != 0;
+            if ((!is_active && address != 0) ||
+                (is_active && (previous_stack_pointer <= address || (address & (stack_alignment - 1)) != 0)))
+            {
+                throw std::runtime_error("Invalid serialized emulator stack allocation");
+            }
+
+            address_ = address;
+            previous_stack_pointer_ = previous_stack_pointer;
         }
+
+      private:
+        template <typename>
+        friend class typed_cpu;
+
+        static constexpr uint64_t stack_alignment = 16;
+
+        emulator_stack_allocation(const uint64_t address, const uint64_t previous_stack_pointer)
+            : address_(address),
+              previous_stack_pointer_(previous_stack_pointer)
+        {
+        }
+
+        void release()
+        {
+            address_ = 0;
+            previous_stack_pointer_ = 0;
+        }
+
+        uint64_t address_{};
+        uint64_t previous_stack_pointer_{};
     };
 
     // A single virtual CPU's view of the machine: typed register and stack access
@@ -217,28 +312,37 @@ namespace sogen
 
         template <typename T>
             requires std::is_trivially_copyable_v<T>
-        emulator_stack_allocation push_stack(const T& data)
+        [[nodiscard]] emulator_stack_allocation push_stack(const T& data)
         {
-            uint64_t old_rsp = read_stack_pointer();
-            uint64_t new_rsp = (old_rsp - sizeof(T)) & ~0xF;
+            const auto old_rsp = read_stack_pointer();
+            if (sizeof(T) > static_cast<uint64_t>(old_rsp))
+            {
+                throw std::underflow_error("Emulator stack allocation underflow");
+            }
 
-            reg(stack_pointer, new_rsp);
+            const auto new_rsp = static_cast<pointer_type>((old_rsp - sizeof(T)) & ~(emulator_stack_allocation::stack_alignment - 1));
             write_memory(new_rsp, &data, sizeof(T));
+            reg(stack_pointer, new_rsp);
 
-            emulator_stack_allocation alloc{};
-            alloc.address = new_rsp;
-            alloc.size = static_cast<size_t>(old_rsp - new_rsp);
-
-            return alloc;
+            return emulator_stack_allocation{new_rsp, old_rsp};
         }
 
-        void pop_stack(emulator_stack_allocation allocation)
+        void pop_stack(emulator_stack_allocation&& allocation)
         {
-            uint64_t current_rsp = read_stack_pointer();
-            assert(current_rsp == allocation.address && "Invalid stack deallocation");
+            if (!allocation)
+            {
+                throw std::logic_error("Attempted to release an inactive emulator stack allocation");
+            }
 
-            reg(stack_pointer, current_rsp + allocation.size);
-            allocation = {};
+            const auto current_rsp = read_stack_pointer();
+            if (current_rsp != allocation.address_ || allocation.previous_stack_pointer_ <= allocation.address_ ||
+                allocation.previous_stack_pointer_ > std::numeric_limits<pointer_type>::max())
+            {
+                throw std::runtime_error("Invalid emulator stack deallocation order");
+            }
+
+            reg(stack_pointer, allocation.previous_stack_pointer_);
+            allocation.release();
         }
 
       private:

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -191,7 +191,7 @@ namespace sogen
 
             const bool is_active = previous_stack_pointer != 0;
             if ((!is_active && address != 0) ||
-                (is_active && (previous_stack_pointer <= address || (address & (stack_alignment - 1)) != 0)))
+                (is_active && (address == 0 || previous_stack_pointer <= address || (address & (stack_alignment - 1)) != 0)))
             {
                 throw std::runtime_error("Invalid serialized emulator stack allocation");
             }

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -1001,13 +1001,20 @@ namespace sogen
                 }
             }
 
-            const auto frame = std::move(t.callback_stack.back());
+            auto frame = std::move(t.callback_stack.back());
             t.callback_stack.pop_back();
 
             frame.restore_registers(c.emu);
 
             auto dispatch_result =
                 c.win_emu.dispatcher.dispatch_completion(c.win_emu, c.vcpu, frame.handler_id, frame.state.get(), callback_result);
+
+            if (dispatch_result == dispatch_result::completed)
+            {
+                emulator_stack_leak_collector leak_collector{};
+                frame.state.reset();
+                leak_collector.throw_if_leaked();
+            }
 
             if (dispatch_result != dispatch_result::new_callback)
             {

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2947,12 +2947,12 @@ namespace sogen
 
             if (s.window_pos_alloc)
             {
-                c.emu.pop_stack(std::move(s.window_pos_alloc));
+                c.emu.pop_stack(s.window_pos_alloc);
             }
 
-            c.emu.pop_stack(std::move(s.min_max_info_alloc));
-            c.emu.pop_stack(std::move(s.window_rect_alloc));
-            c.emu.pop_stack(std::move(s.create_struct_alloc));
+            c.emu.pop_stack(s.min_max_info_alloc);
+            c.emu.pop_stack(s.window_rect_alloc);
+            c.emu.pop_stack(s.create_struct_alloc);
 
             return s.handle;
         }
@@ -3177,7 +3177,7 @@ namespace sogen
                 return {};
             }
 
-            c.emu.pop_stack(std::move(s.window_pos_alloc));
+            c.emu.pop_stack(s.window_pos_alloc);
 
             return s.was_visible ? TRUE : FALSE;
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2881,10 +2881,10 @@ namespace sogen
             state.min_max_info_alloc = c.emu.push_stack(mmi);
 
             state.message_queue = {
-                {.message = WM_CREATE, .wParam = 0, .lParam = state.create_struct_alloc.address},
-                {.message = WM_NCCALCSIZE, .wParam = 0, .lParam = state.window_rect_alloc.address},
-                {.message = WM_NCCREATE, .wParam = 0, .lParam = state.create_struct_alloc.address},
-                {.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address},
+                {.message = WM_CREATE, .wParam = 0, .lParam = state.create_struct_alloc.address()},
+                {.message = WM_NCCALCSIZE, .wParam = 0, .lParam = state.window_rect_alloc.address()},
+                {.message = WM_NCCREATE, .wParam = 0, .lParam = state.create_struct_alloc.address()},
+                {.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address()},
             };
 
             if ((style & WS_VISIBLE) != 0)
@@ -2907,12 +2907,12 @@ namespace sogen
                 const std::initializer_list<qmsg> sw_messages = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                     {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
                     {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
                     {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
+                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = 1, .lParam = 0},
                 };
                 state.message_queue.insert(state.message_queue.begin(), sw_messages);
@@ -2945,7 +2945,7 @@ namespace sogen
                 return {};
             }
 
-            if (s.window_pos_alloc.address != 0)
+            if (s.window_pos_alloc)
             {
                 c.emu.pop_stack(std::move(s.window_pos_alloc));
             }
@@ -3126,12 +3126,12 @@ namespace sogen
                 state.message_queue = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                     {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
                     {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
                     {.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
+                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0},
                 };
 
@@ -3143,8 +3143,8 @@ namespace sogen
                     {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
                     {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                     {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = FALSE, .lParam = 0},
                 };
 

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -187,7 +187,7 @@ namespace sogen
     {
         if (frame.window_pos_alloc)
         {
-            this->emu_.pop_stack(std::move(frame.window_pos_alloc));
+            this->emu_.pop_stack(frame.window_pos_alloc);
         }
     }
 

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -161,8 +161,8 @@ namespace sogen
                 {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
                 {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                 {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.window_pos_alloc.address},
-                {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = frame.window_pos_alloc.address},
+                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.window_pos_alloc.address()},
+                {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = frame.window_pos_alloc.address()},
                 {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
             };
         }
@@ -185,7 +185,7 @@ namespace sogen
 
     void window_destroy_orchestrator::pop_frame_allocation(window_destroy_frame& frame) const
     {
-        if (frame.window_pos_alloc.address != 0)
+        if (frame.window_pos_alloc)
         {
             this->emu_.pop_stack(std::move(frame.window_pos_alloc));
         }


### PR DESCRIPTION
This PR replaces the assertion-based stack-allocation checks with runtime errors and adds allocation-site diagnostics for leaks during callback completion.

Example:
<img width="1640" height="115" alt="image" src="https://github.com/user-attachments/assets/93c1aef4-8c89-410b-82b6-97f9f97a2b13" />