### PR TITLE
docs: fix stale solution filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ git clone --recurse-submodules https://github.com/momo5502/sogen.git
 cmake --preset=vs2022
 ```
 
-3\. Build the solution that was generated at `build/vs2022/emulator.sln`
+3\. Build the solution that was generated at `build/vs2022/sogen.sln`
 
 4\. Create a registry dump by running the [grab-registry.bat](https://github.com/momo5502/sogen/blob/main/src/tools/grab-registry.bat) as administrator and place it in the artifacts folder next to the `analyzer.exe`
 


### PR DESCRIPTION
The CMake project was renamed from emulator to sogen in https://github.com/momo5502/sogen/commit/fc9a240d9ff691a8ae443ae94d52d3b5b11ead13, so `cmake --preset=vs2022` now generates `build/vs2022/sogen.sln`. Fix the readme reference for first time setups.