### PR TITLE
windows-emulator: fix section-map host OOB read + validate KsecDD ioctl buffers

### DIFF
--- a/src/common/utils/string.hpp
+++ b/src/common/utils/string.hpp
@@ -48,6 +48,15 @@ namespace sogen
             array[size] = {};
         }
 
+        // View a fixed-size, possibly non-NUL-terminated character buffer as a string, truncated at the
+        // first NUL terminator (or the whole span when none is present) so the scan never leaves the span.
+        template <typename T>
+        std::basic_string_view<T> to_string_view(const std::span<const T> data)
+        {
+            const std::basic_string_view<T> view(data.data(), data.size());
+            return view.substr(0, view.find(T{}));
+        }
+
         inline char char_to_lower(const char val)
         {
             return static_cast<char>(std::tolower(static_cast<unsigned char>(val)));

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -3,11 +3,27 @@
 
 #include "../windows_emulator.hpp"
 
+#include <utils/string.hpp>
+
 namespace sogen
 {
 
     namespace
     {
+        // Partial layout of the KsecDD ioctl 0x390400 request, covering the two fields the handler
+        // consumes: the operation selector and the requested algorithm name.
+        struct ksec_algorithm_request
+        {
+            std::array<uint8_t, 6> reserved0;
+            uint16_t operation;
+            std::array<uint8_t, 0x28> reserved1;
+            std::array<char16_t, 8> algorithm_name;
+        };
+
+        static_assert(offsetof(ksec_algorithm_request, operation) == 6);
+        static_assert(offsetof(ksec_algorithm_request, algorithm_name) == 0x30);
+        static_assert(sizeof(ksec_algorithm_request) == 0x40);
+
         struct security_support_provider : stateless_device
         {
             // RNG Microsoft Primitive Provider
@@ -48,24 +64,20 @@ namespace sogen
                     return STATUS_NOT_SUPPORTED;
                 }
 
-                // The input/output buffers and their lengths are guest-controlled. Validate the input
-                // covers the fields read below (USHORT at +6, 16 bytes at +0x30) before touching it.
-                if (!c.input_buffer || c.input_buffer_length < 0x40)
+                // The input buffer and its length are guest-controlled; require the full request layout
+                // before reading any field out of it.
+                if (!c.input_buffer || c.input_buffer_length < sizeof(ksec_algorithm_request))
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto operation = win_emu.emu().read_memory<USHORT>(c.input_buffer + 6);
+                const auto request = win_emu.emu().read_memory<ksec_algorithm_request>(c.input_buffer);
 
-                if (operation == 2)
+                if (request.operation == 2)
                 {
-                    std::array<char16_t, 8> alg_name_buffer{};
-                    win_emu.emu().read_memory(c.input_buffer + 0x30, alg_name_buffer.data(), sizeof(alg_name_buffer));
-
-                    // alg_name_buffer is guest-controlled and may not be NUL-terminated; bound the view to
-                    // the fixed array so we never scan past it looking for a terminator.
-                    const std::u16string_view raw_name(alg_name_buffer.data(), alg_name_buffer.size());
-                    const auto algorithm_name = raw_name.substr(0, raw_name.find(u'\0'));
+                    // algorithm_name is guest-controlled and may not be NUL-terminated; the util bounds the
+                    // view to the fixed array so we never scan past it looking for a terminator.
+                    const auto algorithm_name = utils::string::to_string_view<char16_t>(request.algorithm_name);
 
                     // The response is a fixed-size record; never write past the guest-declared output buffer.
                     const auto write_response = [&](const auto& output_data) -> NTSTATUS {

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -48,6 +48,13 @@ namespace sogen
                     return STATUS_NOT_SUPPORTED;
                 }
 
+                // The input/output buffers and their lengths are guest-controlled. Validate the input
+                // covers the fields read below (USHORT at +6, 16 bytes at +0x30) before touching it.
+                if (!c.input_buffer || c.input_buffer_length < 0x40)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
                 const auto operation = win_emu.emu().read_memory<USHORT>(c.input_buffer + 6);
 
                 if (operation == 2)
@@ -57,28 +64,31 @@ namespace sogen
 
                     const std::u16string algorithm_name(alg_name_buffer.data());
 
+                    // The response is a fixed-size record; never write past the guest-declared output buffer.
+                    const auto write_response = [&](const auto& output_data) -> NTSTATUS {
+                        if (!c.output_buffer || c.output_buffer_length < sizeof(output_data))
+                        {
+                            return STATUS_BUFFER_TOO_SMALL;
+                        }
+
+                        win_emu.emu().write_memory(c.output_buffer, output_data);
+
+                        if (c.io_status_block)
+                        {
+                            IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
+                            block.Information = sizeof(output_data);
+                            c.io_status_block.write(block);
+                        }
+
+                        return STATUS_SUCCESS;
+                    };
+
                     if (algorithm_name == u"SHA256")
                     {
-                        win_emu.emu().write_memory(c.output_buffer, sha256_output_data);
-
-                        if (c.io_status_block)
-                        {
-                            IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
-                            block.Information = sizeof(sha256_output_data);
-                            c.io_status_block.write(block);
-                        }
+                        return write_response(sha256_output_data);
                     }
-                    else
-                    {
-                        win_emu.emu().write_memory(c.output_buffer, rng_output_data);
 
-                        if (c.io_status_block)
-                        {
-                            IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
-                            block.Information = sizeof(rng_output_data);
-                            c.io_status_block.write(block);
-                        }
-                    }
+                    return write_response(rng_output_data);
                 }
 
                 return STATUS_SUCCESS;

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -62,7 +62,10 @@ namespace sogen
                     std::array<char16_t, 8> alg_name_buffer{};
                     win_emu.emu().read_memory(c.input_buffer + 0x30, alg_name_buffer.data(), sizeof(alg_name_buffer));
 
-                    const std::u16string algorithm_name(alg_name_buffer.data());
+                    // alg_name_buffer is guest-controlled and may not be NUL-terminated; bound the view to
+                    // the fixed array so we never scan past it looking for a terminator.
+                    const std::u16string_view raw_name(alg_name_buffer.data(), alg_name_buffer.size());
+                    const auto algorithm_name = raw_name.substr(0, raw_name.find(u'\0'));
 
                     // The response is a fixed-size record; never write past the guest-declared output buffer.
                     const auto write_response = [&](const auto& output_data) -> NTSTATUS {

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -425,6 +425,13 @@ namespace sogen
                 return STATUS_INVALID_PARAMETER;
             }
 
+            // The guest fully controls the mapping offset. Reject anything past the file so the
+            // subtraction below cannot underflow into a huge copy that reads past file_data.
+            if (static_cast<uint64_t>(offset) > file_data.size())
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
             const auto size = static_cast<size_t>(file_data.size() - offset);
             const auto aligned_size = static_cast<size_t>(page_align_up(size));
             const auto reserve_only = section_entry->allocation_attributes == SEC_RESERVE;


### PR DESCRIPTION
Two sandbox-boundary hardening fixes, following #1181.

## 1. Host OOB read in `NtMapViewOfSection` (file-backed sections)

On the **file-backed** mapping path, the guest-controlled `SectionOffset` is only clamped to `>= 0` and never checked against the file size. When the offset exceeds the file length, the unsigned subtraction

```cpp
const auto size = static_cast<size_t>(file_data.size() - offset);
```

underflows to a near-`2^64` value, and

```cpp
c.emu.write_memory(address, file_data.data() + offset, size);
```

copies from `file_data.data() + offset` — a host pointer past the end of the `std::vector` — into the guest view. The copy **source** is host-side and not MMU-checked, so this reads out-of-bounds host heap memory into guest-readable memory (host info disclosure, or a crash).

The sibling **pagefile-backed** path already rejects this (`aligned_offset >= backing_size`); this adds the equivalent bound on the file-backed path before the copy size is computed.

**Trigger:** `NtCreateFile` on a small file → `NtCreateSection` file-backed data section (no `SEC_IMAGE`) → `NtMapViewOfSection` with `SectionOffset` larger than the file.

## 2. Unvalidated buffers in `\Device\KsecDD` ioctl 0x390400

The handler read a `USHORT` at `input+6` and 16 bytes at `input+0x30`, and wrote a fixed 224/216-byte response to `output_buffer`, without checking any guest-controlled buffer pointer or length. A guest could point `output_buffer` at a small mapped buffer and have the handler overwrite bytes past it. Now validates `input_buffer_length` covers the read fields and rejects an undersized output buffer, mirroring the guards the GPU bridge applies to every fixed-size response.