### PR TITLE
windows-emulator: bound guest-controlled allocations in device handlers

### DIFF
--- a/src/windows-emulator/devices/afd_endpoint.cpp
+++ b/src/windows-emulator/devices/afd_endpoint.cpp
@@ -1168,6 +1168,14 @@ namespace sogen
                 const auto send_info = emu.read_memory<AFD_SEND_DATAGRAM_INFO<Traits>>(c.input_buffer);
                 const auto buffer = emu.read_memory<EMU_WSABUF<Traits>>(send_info.BufferArray);
 
+                // RemoteAddressLength is a signed LONG; a negative or oversized value would turn into a
+                // huge read below. A sockaddr is at most sizeof(win_sockaddr_in6).
+                if (send_info.TdiConnInfo.RemoteAddressLength < 0 ||
+                    static_cast<size_t>(send_info.TdiConnInfo.RemoteAddressLength) > sizeof(win_sockaddr_in6))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
                 auto address_buffer =
                     emu.read_memory(send_info.TdiConnInfo.RemoteAddress, static_cast<size_t>(send_info.TdiConnInfo.RemoteAddressLength));
 

--- a/src/windows-emulator/devices/mount_point_manager.cpp
+++ b/src/windows-emulator/devices/mount_point_manager.cpp
@@ -142,7 +142,7 @@ namespace sogen
                 // cap the buffer we read to avoid a huge host allocation.
                 if (c.input_buffer_length > 0x1000)
                 {
-                    return STATUS_INVALID_PARAMETER;
+                    return STATUS_NOT_SUPPORTED;
                 }
 
                 const auto data = win_emu.emu().read_memory(c.input_buffer, c.input_buffer_length);

--- a/src/windows-emulator/devices/mount_point_manager.cpp
+++ b/src/windows-emulator/devices/mount_point_manager.cpp
@@ -138,6 +138,13 @@ namespace sogen
                     return STATUS_NOT_SUPPORTED;
                 }
 
+                // input_buffer_length is guest-controlled (up to 4 GiB). A device name is tiny, so
+                // cap the buffer we read to avoid a huge host allocation.
+                if (c.input_buffer_length > 0x1000)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
                 const auto data = win_emu.emu().read_memory(c.input_buffer, c.input_buffer_length);
                 mountdev_target_name_header target_name{};
                 std::memcpy(&target_name, data.data(), sizeof(target_name));

--- a/src/windows-emulator/devices/network_store_interface.cpp
+++ b/src/windows-emulator/devices/network_store_interface.cpp
@@ -99,8 +99,15 @@ namespace sogen
                 return;
             }
 
-            std::vector<uint8_t> zeroes(static_cast<size_t>(buffer.size), 0);
-            win_emu.emu().write_memory(buffer.address, zeroes.data(), zeroes.size());
+            // buffer.size is a guest-controlled 64-bit value; zero the region in bounded chunks
+            // instead of materializing the whole span as one host allocation.
+            constexpr uint64_t chunk_size = 0x1000;
+            const std::vector<uint8_t> zeroes(static_cast<size_t>(std::min(buffer.size, chunk_size)), 0);
+            for (uint64_t written = 0; written < buffer.size; written += zeroes.size())
+            {
+                const auto count = static_cast<size_t>(std::min<uint64_t>(zeroes.size(), buffer.size - written));
+                win_emu.emu().write_memory(buffer.address + written, zeroes.data(), count);
+            }
         }
 
         void write_adapter_key(windows_emulator& win_emu, const nsi_buffer buffer)

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -1523,10 +1523,17 @@ namespace sogen
         std::vector<std::vector<float>> priorities_store;
         queue_infos.reserve(entry_count);
         priorities_store.reserve(entry_count);
+        // A real queue family exposes only a handful of queues; reject an absurd guest-supplied
+        // queue_count before it sizes the priorities allocation below.
+        constexpr uint32_t max_queues_per_family = 64;
         for (size_t i = 0; i < entry_count; ++i)
         {
             const uint32_t family = entries ? entries[i].queue_family_index : 0;
             const uint32_t requested = entries ? entries[i].queue_count : 1;
+            if (requested > max_queues_per_family)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
             const uint32_t queues = (requested == 0) ? 1 : requested;
 
             auto& priorities = priorities_store.emplace_back(queues, 1.0f);


### PR DESCRIPTION
Robustness hardening for the device IOCTL layer (companion to the memory-safety fixes in #1186).

Several handlers sized a host allocation directly from a guest-controlled count/length with no upper bound, so a malformed request could force a multi-gigabyte allocation and an uncaught `bad_alloc`. **None of these are memory-safety issues** — a guest can already terminate its own emulated process — but the emulator should reject bad input rather than crash, and the codebase already caps such allocations elsewhere (e.g. the 256 MB descriptor-update limit).

- **vulkan_host `create_device`**: reject `queue_count` above a sane per-family max before it sizes the priorities vector. A single queue-create entry with `queue_count = 0xFFFFFFFF` otherwise requests a ~16 GB `std::vector<float>`.
- **network_store_interface `write_zeroes`**: zero the guest region in bounded chunks instead of materializing the full 64-bit guest `size` as one host allocation.
- **mount_point_manager `get_drive_letter`**: cap the guest `input_buffer_length` (a device name is tiny) before reading it into a host buffer.
- **afd `send_datagram`**: reject a negative/oversized `RemoteAddressLength` (a signed `LONG`) before it is cast to `size_t` and used as a read length.