### PR TITLE
windows-emulator: harden GPU host against cross-device ids and out-of-range direct-map offsets

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1390,7 +1390,10 @@ namespace sogen
                 if (const auto existing = this->direct_mappings_.find(request.memory); existing != this->direct_mappings_.end())
                 {
                     response.vk_result = 0; // VK_SUCCESS
-                    response.guest_address = existing->second.guest_address + request.offset;
+                    // Only hand back an aliased address for offsets inside the mapping; an out-of-range
+                    // offset returns guest_address = 0 so the shim falls back to the bounded staging path.
+                    response.guest_address =
+                        (request.offset < existing->second.size) ? (existing->second.guest_address + request.offset) : 0;
                     return write_output(win_emu, context, response);
                 }
 
@@ -1420,7 +1423,7 @@ namespace sogen
 
                 this->direct_mappings_[request.memory] =
                     direct_mapping{.guest_address = va, .size = mapped_size, .device = request.device, .host_ptr = host_ptr};
-                response.guest_address = va + request.offset;
+                response.guest_address = (request.offset < mapped_size) ? (va + request.offset) : 0;
                 return write_output(win_emu, context, response);
             }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -2570,7 +2570,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->memories.find(memory);
-        if (it == this->impl_->memories.end())
+        // Only the owning device may free the memory; ignore a cross-device free request.
+        if (it == this->impl_->memories.end() || it->second.device_id != device)
         {
             return;
         }
@@ -2658,7 +2659,7 @@ namespace sogen
         const auto buf = this->impl_->buffers.find(buffer);
         const auto mem = this->impl_->memories.find(memory);
         if (dev == this->impl_->devices.end() || buf == this->impl_->buffers.end() || mem == this->impl_->memories.end() ||
-            !dev->second.bind_buffer_memory)
+            buf->second.device_id != device || mem->second.device_id != device || !dev->second.bind_buffer_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2691,7 +2692,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.map_memory || !dev->second.unmap_memory)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.map_memory || !dev->second.unmap_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2719,7 +2721,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.map_memory || !dev->second.unmap_memory)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.map_memory || !dev->second.unmap_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2747,7 +2750,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.flush_mapped_memory_ranges)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.flush_mapped_memory_ranges)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2769,7 +2773,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.invalidate_mapped_memory_ranges)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.invalidate_mapped_memory_ranges)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2793,7 +2798,8 @@ namespace sogen
         out_size = 0;
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.map_memory)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.map_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2824,7 +2830,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto mem = this->impl_->memories.find(memory);
-        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || !dev->second.unmap_memory)
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device ||
+            !dev->second.unmap_memory)
         {
             return;
         }
@@ -2952,7 +2959,7 @@ namespace sogen
         const auto img = this->impl_->images.find(image);
         const auto mem = this->impl_->memories.find(memory);
         if (dev == this->impl_->devices.end() || img == this->impl_->images.end() || mem == this->impl_->memories.end() ||
-            !dev->second.bind_image_memory)
+            img->second.device_id != device || mem->second.device_id != device || !dev->second.bind_image_memory)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -1839,7 +1839,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->command_pools.find(pool);
-        if (it == this->impl_->command_pools.end())
+        if (it == this->impl_->command_pools.end() || it->second.device_id != device)
         {
             return;
         }
@@ -1889,7 +1889,7 @@ namespace sogen
         const auto dev = this->impl_->devices.find(device);
         const auto pool_it = this->impl_->command_pools.find(pool);
         const auto cb = this->impl_->command_buffers.find(command_buffer);
-        if (cb == this->impl_->command_buffers.end())
+        if (cb == this->impl_->command_buffers.end() || cb->second.device_id != device)
         {
             return;
         }
@@ -2009,7 +2009,7 @@ namespace sogen
         }
 
         const auto it = this->impl_->command_pools.find(pool);
-        if (it == this->impl_->command_pools.end())
+        if (it == this->impl_->command_pools.end() || it->second.device_id != device)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2093,7 +2093,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->fences.find(fence);
-        if (it == this->impl_->fences.end())
+        if (it == this->impl_->fences.end() || it->second.device_id != device)
         {
             return;
         }
@@ -2221,7 +2221,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->semaphores.find(semaphore);
-        if (it == this->impl_->semaphores.end())
+        if (it == this->impl_->semaphores.end() || it->second.device_id != device)
         {
             return;
         }
@@ -2238,7 +2238,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->fences.find(fence);
-        if (dev == this->impl_->devices.end() || it == this->impl_->fences.end() || !dev->second.reset_fences)
+        if (dev == this->impl_->devices.end() || it == this->impl_->fences.end() || it->second.device_id != device ||
+            !dev->second.reset_fences)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2294,7 +2295,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->events.find(event);
-        if (it == this->impl_->events.end())
+        if (it == this->impl_->events.end() || it->second.device_id != device)
         {
             return;
         }
@@ -2326,7 +2327,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->events.find(event);
-        if (dev == this->impl_->devices.end() || it == this->impl_->events.end() || !dev->second.set_event)
+        if (dev == this->impl_->devices.end() || it == this->impl_->events.end() || it->second.device_id != device ||
+            !dev->second.set_event)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2338,7 +2340,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->events.find(event);
-        if (dev == this->impl_->devices.end() || it == this->impl_->events.end() || !dev->second.reset_event)
+        if (dev == this->impl_->devices.end() || it == this->impl_->events.end() || it->second.device_id != device ||
+            !dev->second.reset_event)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -2617,7 +2620,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->buffers.find(buffer);
-        if (it == this->impl_->buffers.end())
+        if (it == this->impl_->buffers.end() || it->second.device_id != device)
         {
             return;
         }
@@ -2884,7 +2887,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->images.find(image);
-        if (it == this->impl_->images.end())
+        if (it == this->impl_->images.end() || it->second.device_id != device)
         {
             return;
         }
@@ -3349,7 +3352,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->samplers.find(sampler);
-        if (it == this->impl_->samplers.end())
+        if (it == this->impl_->samplers.end() || it->second.device_id != device)
         {
             return;
         }
@@ -3849,7 +3852,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->shader_modules.find(shader_module);
-        if (it == this->impl_->shader_modules.end())
+        if (it == this->impl_->shader_modules.end() || it->second.device_id != device)
         {
             return;
         }
@@ -3905,7 +3908,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->image_views.find(image_view);
-        if (it == this->impl_->image_views.end())
+        if (it == this->impl_->image_views.end() || it->second.device_id != device)
         {
             return;
         }
@@ -3951,7 +3954,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->buffer_views.find(buffer_view);
-        if (it == this->impl_->buffer_views.end())
+        if (it == this->impl_->buffer_views.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4024,7 +4027,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->query_pools.find(query_pool);
-        if (it == this->impl_->query_pools.end())
+        if (it == this->impl_->query_pools.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4039,7 +4042,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto qp = this->impl_->query_pools.find(query_pool);
-        if (dev == this->impl_->devices.end() || qp == this->impl_->query_pools.end() || !dev->second.reset_query_pool)
+        if (dev == this->impl_->devices.end() || qp == this->impl_->query_pools.end() || qp->second.device_id != device ||
+            !dev->second.reset_query_pool)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -4220,7 +4224,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->render_passes.find(render_pass);
-        if (it == this->impl_->render_passes.end())
+        if (it == this->impl_->render_passes.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4283,7 +4287,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->framebuffers.find(framebuffer);
-        if (it == this->impl_->framebuffers.end())
+        if (it == this->impl_->framebuffers.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4348,7 +4352,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->pipeline_layouts.find(pipeline_layout);
-        if (it == this->impl_->pipeline_layouts.end())
+        if (it == this->impl_->pipeline_layouts.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4402,7 +4406,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->descriptor_set_layouts.find(layout);
-        if (it == this->impl_->descriptor_set_layouts.end())
+        if (it == this->impl_->descriptor_set_layouts.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4454,7 +4458,8 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->descriptor_pools.find(pool);
-        if (dev == this->impl_->devices.end() || it == this->impl_->descriptor_pools.end() || !dev->second.reset_descriptor_pool)
+        if (dev == this->impl_->devices.end() || it == this->impl_->descriptor_pools.end() || it->second.device_id != device ||
+            !dev->second.reset_descriptor_pool)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -4473,7 +4478,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->descriptor_pools.find(pool);
-        if (it == this->impl_->descriptor_pools.end())
+        if (it == this->impl_->descriptor_pools.end() || it->second.device_id != device)
         {
             return;
         }
@@ -4924,7 +4929,7 @@ namespace sogen
     {
         const auto dev = this->impl_->devices.find(device);
         const auto it = this->impl_->pipelines.find(pipeline);
-        if (it == this->impl_->pipelines.end())
+        if (it == this->impl_->pipelines.end() || it->second.device_id != device)
         {
             return;
         }


### PR DESCRIPTION
Defense-in-depth hardening for the GPU host, following up on the two host-OOB fixes in #1188. Neither item here is host memory corruption on its own (both are DoS/contained), but both feed attacker-controlled guest input to the driver or to pointer arithmetic without a check.

## 1. Cross-device object ownership

The memory handlers (`free_memory`, `map_memory`, `unmap_memory`, `upload_memory`, `download_memory`, `flush_mapped_memory_range`, `invalidate_mapped_memory_range`) and `bind_buffer_memory` / `bind_image_memory` looked up the guest-supplied object id **globally** and never verified it belongs to the passed `device`. `memory_data`/`buffer_data`/`image_data` all record their owning `device_id`, and the destroy paths already filter on it, but the per-call handlers did not.

**Trigger:** a guest that creates more than one `VkDevice` can name memory allocated on device A while passing device B, making the host call e.g. `vkMapMemory(deviceB, memoryFromA)` — Vulkan undefined behaviour (driver crash / UB). Bounds bookkeeping stayed correct (`allocation_size` is device-independent), so this is host-driver UB, not host-heap corruption.

**Fix:** reject when `object.device_id != device` in each handler (and `free_memory` ignores a cross-device free).

## 2. Out-of-range direct-map offset

`handle_map_memory_direct` returned `guest_address = base + request.offset` (both the already-aliased fast path and the fresh-map path) with `request.offset` never bounded against the mapping size, and the addition could wrap.

**Impact:** contained — the returned VA beyond the alias is unmapped guest memory (faults) or another guest allocation; the guest can't reach host bytes outside the aliased region. Robustness only.

**Fix:** return `guest_address = 0` for offsets outside the mapping, so the shim falls back to the bounded staging path (the existing can't-alias signal).

## Verification
- MSVC syntax-check (`/Zs`) of both translation units passes.
- `clang-format --dry-run --Werror` clean.
- Single-device usage (the normal case, e.g. DXVK) always passes the `device_id` check, so no functional change there.