### PR TITLE
Fix virtual screen dimensions and some syscall fixes

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -71,8 +71,11 @@ namespace sogen
     {
         DWORD dwMonitorCount;
         EMULATOR_CAST(uint64_t, USER_MONITOR*) pPrimaryMonitor;
+        uint8_t pad_10[0x8];
+        RECT rcScreen;
         uint8_t unknown[0xFF];
     };
+    static_assert(offsetof(USER_DISPINFO, rcScreen) == 0x18);
 
     struct USER_HANDLEENTRY
     {

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -559,6 +559,7 @@ namespace sogen
         user_display_info.access([&](USER_DISPINFO& display_info) {
             display_info.dwMonitorCount = 1;
             display_info.pPrimaryMonitor = monitor_obj.value();
+            display_info.rcScreen = {.left = 0, .top = 0, .right = 1920, .bottom = 1080};
         });
     }
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -575,6 +575,8 @@ namespace sogen
                                             DWORD thread_id, UINT hwnd_max, emulator_pointer hwnd_list, emulator_object<UINT> hwnd_needed);
         BOOL handle_NtUserEnumDisplayMonitors(const syscall_context& c, hdc hdc_in, uint64_t clip_rect_ptr, uint64_t callback,
                                               uint64_t param);
+        BOOL handle_NtUserGetDpiForMonitor(const syscall_context& c, handle monitor, uint32_t dpi_type, emulator_object<uint32_t> dpi_x,
+                                           emulator_object<uint32_t> dpi_y);
         BOOL completion_NtUserEnumDisplayMonitors(const syscall_context& c, hdc hdc_in, uint64_t clip_rect_ptr, uint64_t callback,
                                                   uint64_t param);
         BOOL handle_NtUserInheritWindowMonitor(const syscall_context& c, hwnd hwnd_tgt, hwnd hwnd_inherit);
@@ -1458,6 +1460,7 @@ namespace sogen
         add_handler(NtUserChangeDisplaySettings);
         add_handler(NtUserBuildHwndList);
         add_handler(NtUserEnumDisplayMonitors);
+        add_handler(NtUserGetDpiForMonitor);
         add_handler(NtUserInheritWindowMonitor);
         add_handler(NtUserSetProp);
         add_handler(NtUserSetProp2);

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -342,10 +342,7 @@ namespace sogen
 
                 const emulator_object<THREAD_BASIC_INFORMATION64> info{c.emu, thread_information};
                 info.access([&](THREAD_BASIC_INFORMATION64& i) {
-                    if (thread->exit_status)
-                    {
-                        i.ExitStatus = *thread->exit_status;
-                    }
+                    i.ExitStatus = thread->exit_status.value_or(STATUS_PENDING);
                     i.TebBaseAddress = thread->teb64->value();
                     i.ClientId = thread->teb64->read().ClientId;
                 });

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3771,6 +3771,19 @@ namespace sogen
             return {};
         }
 
+        BOOL handle_NtUserGetDpiForMonitor(const syscall_context& c, const handle monitor, const uint32_t dpi_type,
+                                           const emulator_object<uint32_t> dpi_x, const emulator_object<uint32_t> dpi_y)
+        {
+            if (monitor != c.proc.default_monitor_handle || dpi_type > 2 || !dpi_x || !dpi_y)
+            {
+                return FALSE;
+            }
+
+            dpi_x.write(96);
+            dpi_y.write(96);
+            return TRUE;
+        }
+
         BOOL completion_NtUserEnumDisplayMonitors(const syscall_context& c, const hdc /*hdc_in*/, const uint64_t /*clip_rect_ptr*/,
                                                   const uint64_t /*callback*/, const uint64_t /*param*/)
         {

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -39,21 +39,21 @@ namespace sogen
                 srv.defaultFontHeightScale = -11;
                 srv.defaultFontWidthScale = 0;
                 srv.systemDpi = 96;
-                srv.systemMetrics[0] = 1920; // SM_CXSCREEN
-                srv.systemMetrics[1] = 1080; // SM_CYSCREEN
-                srv.systemMetrics[2] = 17;   // SM_CXVSCROLL
-                srv.systemMetrics[3] = 17;   // SM_CYHSCROLL
-                srv.systemMetrics[10] = 17;  // SM_CXHTHUMB
-                srv.systemMetrics[11] = 32;  // SM_CXICON
-                srv.systemMetrics[12] = 32;  // SM_CYICON
-                srv.systemMetrics[19] = 1;   // SM_MOUSEPRESENT
-                srv.systemMetrics[20] = 17;  // SM_CYVSCROLL
-                srv.systemMetrics[21] = 17;  // SM_CXHSCROLL
-                srv.systemMetrics[43] = 3;   // SM_CMOUSEBUTTONS
-                srv.systemMetrics[75] = 1;   // SM_MOUSEWHEELPRESENT
+                srv.systemMetrics[0] = 1920;  // SM_CXSCREEN
+                srv.systemMetrics[1] = 1080;  // SM_CYSCREEN
+                srv.systemMetrics[2] = 17;    // SM_CXVSCROLL
+                srv.systemMetrics[3] = 17;    // SM_CYHSCROLL
+                srv.systemMetrics[10] = 17;   // SM_CXHTHUMB
+                srv.systemMetrics[11] = 32;   // SM_CXICON
+                srv.systemMetrics[12] = 32;   // SM_CYICON
+                srv.systemMetrics[19] = 1;    // SM_MOUSEPRESENT
+                srv.systemMetrics[20] = 17;   // SM_CYVSCROLL
+                srv.systemMetrics[21] = 17;   // SM_CXHSCROLL
+                srv.systemMetrics[43] = 3;    // SM_CMOUSEBUTTONS
+                srv.systemMetrics[75] = 1;    // SM_MOUSEWHEELPRESENT
                 srv.systemMetrics[78] = 1920; // SM_CXVIRTUALSCREEN
                 srv.systemMetrics[79] = 1080; // SM_CYVIRTUALSCREEN
-                srv.systemMetrics[91] = 1;   // SM_MOUSEHORIZONTALWHEELPRESENT
+                srv.systemMetrics[91] = 1;    // SM_MOUSEHORIZONTALWHEELPRESENT
             });
 
             const auto handle_table_size = static_cast<size_t>(page_align_up(sizeof(USER_HANDLEENTRY) * MAX_HANDLES));

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -51,6 +51,8 @@ namespace sogen
                 srv.systemMetrics[21] = 17;  // SM_CXHSCROLL
                 srv.systemMetrics[43] = 3;   // SM_CMOUSEBUTTONS
                 srv.systemMetrics[75] = 1;   // SM_MOUSEWHEELPRESENT
+                srv.systemMetrics[78] = 1920; // SM_CXVIRTUALSCREEN
+                srv.systemMetrics[79] = 1080; // SM_CYVIRTUALSCREEN
                 srv.systemMetrics[91] = 1;   // SM_MOUSEHORIZONTALWHEELPRESENT
             });
 


### PR DESCRIPTION
This PR includes the following fixes:

* [Fixes the virtual screen size](https://github.com/momo5502/sogen/commit/5026e2f2151e7f891dea06589465c167495d46f2), which represents the area spanning all monitors on a computer and was previously reported as 0x0.
* [Implements NtUserGetDpiForMonitor](https://github.com/momo5502/sogen/commit/ee14b5f3c396a051518253744e0601a62a7f3621).
* [Fixes ExitStatus for running threads](https://github.com/momo5502/sogen/commit/2d140b772651fe4b59b221c54382afaa3071b180) so it matches the [documented behavior](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodethread).

These changes seem to be all that was needed to get a Unity game running on Sogen.
