### PR TITLE
windows-emulator: bound dynamic-state allocation in create_graphics_pipeline

### DIFF
--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2004,12 +2004,12 @@ namespace sogen
                     attribute = {.location = a.location, .binding = a.binding, .format = a.format, .offset = a.offset};
                 }
 
-                std::vector<uint32_t> dynamic_states(request.dynamic_state_count);
                 const size_t dynamic_bytes = static_cast<size_t>(request.dynamic_state_count) * sizeof(uint32_t);
                 if (dynamic_bytes > trailer.size() - bindings_bytes - attributes_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
+                std::vector<uint32_t> dynamic_states(request.dynamic_state_count);
                 if (request.dynamic_state_count > 0)
                 {
                     std::memcpy(dynamic_states.data(), trailer.data() + bindings_bytes + attributes_bytes, dynamic_bytes);


### PR DESCRIPTION
Found by the IO-device handler fuzzer (the harness in #1190, on its first real run).

`handle_create_graphics_pipeline` sized the `dynamic_states` vector from the guest-controlled `request.dynamic_state_count` **before** bounding that count against the remaining trailer size:

```cpp
std::vector<uint32_t> dynamic_states(request.dynamic_state_count);   // allocates first
const size_t dynamic_bytes = static_cast<size_t>(request.dynamic_state_count) * sizeof(uint32_t);
if (dynamic_bytes > trailer.size() - bindings_bytes - attributes_bytes) {   // check comes after
    return STATUS_INVALID_PARAMETER;
}
```

A guest sending `dynamic_state_count ≈ 0xFFFFFFFF` triggers a ~16 GB allocation (`4294967286 × 4 = 17179869144` — the exact size ASAN/libFuzzer reported) before the check can reject it → OOM.

This is the unbounded-guest-allocation class already hardened elsewhere (#1187). The `bindings` and `attributes` vectors immediately above are correctly constructed only *after* their bounds check; only `dynamic_states` had the order wrong. Fix: move the size check ahead of the allocation. After the check, `dynamic_state_count * 4 ≤` the remaining trailer bytes, so the vector is bounded by the (guest-memory-backed) input buffer.

Severity: DoS / unbounded allocation (not memory corruption).