### PR TITLE
io_device: device registry + fuzzer corpus retention

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -85,11 +85,11 @@ jobs:
       - name: Build fuzzer
         run: cmake --build build/fuzz --target windows-emulator-fuzz
 
-      # Accumulate coverage across nightly runs. actions/cache restores the newest matching key and
-      # saves under the run-specific key at job end, so the corpus grows over time.
+      # Accumulate coverage across nightly runs: restore the newest existing corpus, and save the grown
+      # one under a run-specific key at the end. Restore/save are split (not the combined cache action) so
+      # the save still runs when the fuzzer finds a crash and fails the job (see "Save corpus" below).
       - name: Restore corpus
-        id: corpus
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: corpus
           key: fuzz-corpus-${{ github.run_id }}
@@ -112,6 +112,14 @@ jobs:
           echo "fuzz_status=${status}" >> "$GITHUB_ENV"
           # A nonzero exit means libFuzzer saved a crash reproducer in artifacts/.
           exit 0
+
+      # Persist the grown corpus even when the fuzzer found a crash (the job fails below).
+      - name: Save corpus
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ github.run_id }}
 
       - name: Upload crash artifacts
         if: ${{ env.fuzz_status != '0' }}

--- a/src/windows-emulator-fuzz/device_fuzz.cpp
+++ b/src/windows-emulator-fuzz/device_fuzz.cpp
@@ -55,18 +55,27 @@ namespace sogen::fuzz
             return windows_emulator{mock::make_mock_emulator(), settings, {}, std::move(interfaces)};
         }
 
-        // One persistent instance of every registered io_device, drawn from the shared device registry
-        // so newly added devices are fuzzed automatically. Constructing a device that reaches out to host
-        // resources (e.g. gpu_bridge's vulkan_host) may fail on a headless box, so guard each.
+        // One persistent instance of every registered io_device type, drawn from the shared device
+        // registry so newly added devices are fuzzed automatically. The registry maps names to factories
+        // and several names share a factory (e.g. the transport stub), so dedupe by factory pointer.
+        // Constructing a device that reaches out to host resources (e.g. gpu_bridge's vulkan_host) may
+        // fail on a headless box, so guard each.
         std::vector<std::unique_ptr<io_device>> make_devices()
         {
             std::vector<std::unique_ptr<io_device>> devices;
             const device_creation_context context{.is_32_bit = false};
-            for (const auto& registration : get_device_registrations())
+            std::vector<device_factory> seen;
+            for (const auto& [name, factory] : get_device_registry())
             {
+                if (std::ranges::find(seen, factory) != seen.end())
+                {
+                    continue;
+                }
+                seen.push_back(factory);
+
                 try
                 {
-                    if (auto d = registration.create(context))
+                    if (auto d = factory(context))
                     {
                         devices.push_back(std::move(d));
                     }

--- a/src/windows-emulator-fuzz/device_fuzz.cpp
+++ b/src/windows-emulator-fuzz/device_fuzz.cpp
@@ -11,6 +11,7 @@
 #include <exception>
 #include <filesystem>
 #include <memory>
+#include <unordered_set>
 
 #include <windows_emulator.hpp>
 #include <network/static_socket_factory.hpp>
@@ -64,14 +65,13 @@ namespace sogen::fuzz
         {
             std::vector<std::unique_ptr<io_device>> devices;
             const device_creation_context context{.is_32_bit = false};
-            std::vector<device_factory> seen;
+            std::unordered_set<device_factory> seen;
             for (const auto& [name, factory] : get_device_registry())
             {
-                if (std::ranges::find(seen, factory) != seen.end())
+                if (!seen.insert(factory).second)
                 {
                     continue;
                 }
-                seen.push_back(factory);
 
                 try
                 {

--- a/src/windows-emulator-fuzz/device_fuzz.cpp
+++ b/src/windows-emulator-fuzz/device_fuzz.cpp
@@ -61,11 +61,12 @@ namespace sogen::fuzz
         std::vector<std::unique_ptr<io_device>> make_devices()
         {
             std::vector<std::unique_ptr<io_device>> devices;
+            const device_creation_context context{.is_32_bit = false};
             for (const auto& registration : get_device_registrations())
             {
                 try
                 {
-                    if (auto d = registration.create(false))
+                    if (auto d = registration.create(context))
                     {
                         devices.push_back(std::move(d));
                     }

--- a/src/windows-emulator-fuzz/device_fuzz.cpp
+++ b/src/windows-emulator-fuzz/device_fuzz.cpp
@@ -16,12 +16,6 @@
 #include <network/static_socket_factory.hpp>
 
 #include <io_device.hpp>
-#include <devices/afd_endpoint.hpp>
-#include <devices/console.hpp>
-#include <devices/gpu_bridge.hpp>
-#include <devices/mount_point_manager.hpp>
-#include <devices/network_store_interface.hpp>
-#include <devices/security_support_provider.hpp>
 
 #include <vector>
 
@@ -61,31 +55,25 @@ namespace sogen::fuzz
             return windows_emulator{mock::make_mock_emulator(), settings, {}, std::move(interfaces)};
         }
 
-        // One persistent instance of every fuzzable io_device. Constructing a device that reaches out
-        // to host resources (e.g. gpu_bridge's vulkan_host) may fail on a headless box, so guard each.
+        // One persistent instance of every registered io_device, drawn from the shared device registry
+        // so newly added devices are fuzzed automatically. Constructing a device that reaches out to host
+        // resources (e.g. gpu_bridge's vulkan_host) may fail on a headless box, so guard each.
         std::vector<std::unique_ptr<io_device>> make_devices()
         {
             std::vector<std::unique_ptr<io_device>> devices;
-            const auto add = [&](auto factory) {
+            for (const auto& registration : get_device_registrations())
+            {
                 try
                 {
-                    if (auto d = factory())
+                    if (auto d = registration.create(false))
                     {
                         devices.push_back(std::move(d));
                     }
                 }
-                catch (...)
+                catch (const std::exception&)
                 {
                 }
-            };
-
-            add([] { return create_security_support_provider(); });
-            add([] { return create_console_device(); });
-            add([] { return create_mount_point_manager(); });
-            add([] { return create_network_store_interface(); });
-            add([] { return create_afd_endpoint(false); });
-            add([] { return create_afd_async_connect_hlp(false); });
-            add([] { return create_gpu_bridge(); });
+            }
             return devices;
         }
 

--- a/src/windows-emulator/devices/afd_endpoint.cpp
+++ b/src/windows-emulator/devices/afd_endpoint.cpp
@@ -1340,9 +1340,9 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_afd_endpoint(const bool is_32_bit)
+    std::unique_ptr<io_device> create_afd_endpoint(const device_creation_context& context)
     {
-        if (is_32_bit)
+        if (context.is_32_bit)
         {
             return std::make_unique<afd_endpoint<EmulatorTraits<Emu32>>>();
         }
@@ -1350,9 +1350,9 @@ namespace sogen
         return std::make_unique<afd_endpoint<EmulatorTraits<Emu64>>>();
     }
 
-    std::unique_ptr<io_device> create_afd_async_connect_hlp(const bool is_32_bit)
+    std::unique_ptr<io_device> create_afd_async_connect_hlp(const device_creation_context& context)
     {
-        if (is_32_bit)
+        if (context.is_32_bit)
         {
             return std::make_unique<afd_async_connect_hlp<EmulatorTraits<Emu32>>>();
         }

--- a/src/windows-emulator/devices/afd_endpoint.hpp
+++ b/src/windows-emulator/devices/afd_endpoint.hpp
@@ -4,7 +4,7 @@
 namespace sogen
 {
 
-    std::unique_ptr<io_device> create_afd_endpoint(bool is_32_bit);
-    std::unique_ptr<io_device> create_afd_async_connect_hlp(bool is_32_bit);
+    std::unique_ptr<io_device> create_afd_endpoint(const device_creation_context& context);
+    std::unique_ptr<io_device> create_afd_async_connect_hlp(const device_creation_context& context);
 
 } // namespace sogen

--- a/src/windows-emulator/devices/console.cpp
+++ b/src/windows-emulator/devices/console.cpp
@@ -206,7 +206,7 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_console_device()
+    std::unique_ptr<io_device> create_console_device(const device_creation_context&)
     {
         return std::make_unique<console_device>();
     }

--- a/src/windows-emulator/devices/console.hpp
+++ b/src/windows-emulator/devices/console.hpp
@@ -5,6 +5,6 @@
 namespace sogen
 {
 
-    std::unique_ptr<io_device> create_console_device();
+    std::unique_ptr<io_device> create_console_device(const device_creation_context& context);
 
 } // namespace sogen

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -3055,7 +3055,7 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_gpu_bridge()
+    std::unique_ptr<io_device> create_gpu_bridge(const device_creation_context&)
     {
         return std::make_unique<gpu_bridge_device>();
     }

--- a/src/windows-emulator/devices/gpu_bridge.hpp
+++ b/src/windows-emulator/devices/gpu_bridge.hpp
@@ -4,5 +4,5 @@
 
 namespace sogen
 {
-    std::unique_ptr<io_device> create_gpu_bridge();
+    std::unique_ptr<io_device> create_gpu_bridge(const device_creation_context& context);
 }

--- a/src/windows-emulator/devices/mount_point_manager.cpp
+++ b/src/windows-emulator/devices/mount_point_manager.cpp
@@ -230,7 +230,7 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_mount_point_manager()
+    std::unique_ptr<io_device> create_mount_point_manager(const device_creation_context&)
     {
         return std::make_unique<mount_point_manager>();
     }

--- a/src/windows-emulator/devices/mount_point_manager.hpp
+++ b/src/windows-emulator/devices/mount_point_manager.hpp
@@ -4,6 +4,6 @@
 namespace sogen
 {
 
-    std::unique_ptr<io_device> create_mount_point_manager();
+    std::unique_ptr<io_device> create_mount_point_manager(const device_creation_context& context);
 
 } // namespace sogen

--- a/src/windows-emulator/devices/network_store_interface.cpp
+++ b/src/windows-emulator/devices/network_store_interface.cpp
@@ -243,7 +243,7 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_network_store_interface()
+    std::unique_ptr<io_device> create_network_store_interface(const device_creation_context&)
     {
         return std::make_unique<network_store_interface_device>();
     }

--- a/src/windows-emulator/devices/network_store_interface.hpp
+++ b/src/windows-emulator/devices/network_store_interface.hpp
@@ -4,5 +4,5 @@
 
 namespace sogen
 {
-    std::unique_ptr<io_device> create_network_store_interface();
+    std::unique_ptr<io_device> create_network_store_interface(const device_creation_context& context);
 }

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -111,7 +111,7 @@ namespace sogen
         };
     }
 
-    std::unique_ptr<io_device> create_security_support_provider()
+    std::unique_ptr<io_device> create_security_support_provider(const device_creation_context&)
     {
         return std::make_unique<security_support_provider>();
     }

--- a/src/windows-emulator/devices/security_support_provider.hpp
+++ b/src/windows-emulator/devices/security_support_provider.hpp
@@ -4,6 +4,6 @@
 namespace sogen
 {
 
-    std::unique_ptr<io_device> create_security_support_provider();
+    std::unique_ptr<io_device> create_security_support_provider(const device_creation_context& context);
 
 } // namespace sogen

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -44,47 +44,19 @@ namespace sogen
             }
         };
 
-        // Uniform factory signature (bool is_32_bit) so every device fits one table entry; nullary
-        // factories just ignore the flag.
-        std::unique_ptr<io_device> make_dummy(bool)
+        // Factories for the devices defined locally in this file, matching the shared create_*
+        // (device_creation_context) signature so they slot straight into the registry.
+        std::unique_ptr<io_device> create_dummy_device(const device_creation_context&)
         {
             return std::make_unique<dummy_device>();
         }
-        std::unique_ptr<io_device> make_transport_stub(bool)
+        std::unique_ptr<io_device> create_transport_stub_device(const device_creation_context&)
         {
             return std::make_unique<transport_stub_device>();
         }
-        std::unique_ptr<io_device> make_named_pipe(bool)
+        std::unique_ptr<io_device> create_named_pipe_device(const device_creation_context&)
         {
             return std::make_unique<named_pipe>();
-        }
-        std::unique_ptr<io_device> make_console(bool)
-        {
-            return create_console_device();
-        }
-        std::unique_ptr<io_device> make_nsi(bool)
-        {
-            return create_network_store_interface();
-        }
-        std::unique_ptr<io_device> make_afd_endpoint(bool is_32_bit)
-        {
-            return create_afd_endpoint(is_32_bit);
-        }
-        std::unique_ptr<io_device> make_afd_async_connect_hlp(bool is_32_bit)
-        {
-            return create_afd_async_connect_hlp(is_32_bit);
-        }
-        std::unique_ptr<io_device> make_mount_point_manager(bool)
-        {
-            return create_mount_point_manager();
-        }
-        std::unique_ptr<io_device> make_ksecdd(bool)
-        {
-            return create_security_support_provider();
-        }
-        std::unique_ptr<io_device> make_gpu(bool)
-        {
-            return create_gpu_bridge();
         }
 
         using namespace std::string_view_literals;
@@ -102,16 +74,16 @@ namespace sogen
         constexpr std::u16string_view transport_names[] = {u"Tcp"sv, u"Tcp6"sv, u"Udp"sv, u"RawIp"sv};
 
         constexpr device_registration registrations[] = {
-            {dummy_names, make_dummy},
-            {console_names, make_console},
-            {nsi_names, make_nsi},
-            {afd_endpoint_names, make_afd_endpoint},
-            {afd_hlp_names, make_afd_async_connect_hlp},
-            {mount_names, make_mount_point_manager},
-            {ksecdd_names, make_ksecdd},
-            {named_pipe_names, make_named_pipe},
-            {gpu_names, make_gpu},
-            {transport_names, make_transport_stub},
+            {dummy_names, create_dummy_device},
+            {console_names, create_console_device},
+            {nsi_names, create_network_store_interface},
+            {afd_endpoint_names, create_afd_endpoint},
+            {afd_hlp_names, create_afd_async_connect_hlp},
+            {mount_names, create_mount_point_manager},
+            {ksecdd_names, create_security_support_provider},
+            {named_pipe_names, create_named_pipe_device},
+            {gpu_names, create_gpu_bridge},
+            {transport_names, create_transport_stub_device},
         };
     }
 
@@ -125,7 +97,7 @@ namespace sogen
         return win_emu.process.is_wow64_process;
     }
 
-    std::unique_ptr<io_device> create_device(const std::u16string_view device, const bool is_32_bit)
+    std::unique_ptr<io_device> create_device(const std::u16string_view device, const device_creation_context& context)
     {
         for (const auto& registration : registrations)
         {
@@ -133,7 +105,7 @@ namespace sogen
             {
                 if (name == device)
                 {
-                    return registration.create(is_32_bit);
+                    return registration.create(context);
                 }
             }
         }

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -61,11 +61,11 @@ namespace sogen
 
     }
 
-    const std::unordered_map<std::u16string_view, device_factory>& get_device_registry()
+    const std::map<std::u16string_view, device_factory>& get_device_registry()
     {
         using namespace std::string_view_literals;
 
-        static const std::unordered_map<std::u16string_view, device_factory> registry = {
+        static const std::map<std::u16string_view, device_factory> registry = {
             // Dummy
             {u"CNG"sv, create_dummy_device},
             {u"RasAcd"sv, create_dummy_device},
@@ -76,12 +76,13 @@ namespace sogen
             // Generic
             {u"Console"sv, create_console_device},
             {u"Nsi"sv, create_network_store_interface},
-            {u"Afd\\Endpoint"sv, create_afd_endpoint},
-            {u"Afd\\AsyncConnectHlp"sv, create_afd_async_connect_hlp},
             {u"MountPointManager"sv, create_mount_point_manager},
             {u"KsecDD"sv, create_security_support_provider},
             {u"NamedPipe"sv, create_named_pipe_device},
             {u"SogenGpu"sv, create_gpu_bridge},
+            // AFD
+            {u"Afd\\Endpoint"sv, create_afd_endpoint},
+            {u"Afd\\AsyncConnectHlp"sv, create_afd_async_connect_hlp},
             // Transport
             {u"Tcp"sv, create_transport_stub_device},
             {u"Tcp6"sv, create_transport_stub_device},

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -59,37 +59,33 @@ namespace sogen
             return std::make_unique<named_pipe>();
         }
 
-        using namespace std::string_view_literals;
-
-        constexpr std::u16string_view dummy_names[] = {
-            u"CNG"sv, u"RasAcd"sv, u"PcwDrv"sv, u"DeviceApi\\CMApi"sv, u"DeviceApi\\CMNotify"sv, u"ConDrv\\Server"sv};
-        constexpr std::u16string_view console_names[] = {u"Console"sv};
-        constexpr std::u16string_view nsi_names[] = {u"Nsi"sv};
-        constexpr std::u16string_view afd_endpoint_names[] = {u"Afd\\Endpoint"sv};
-        constexpr std::u16string_view afd_hlp_names[] = {u"Afd\\AsyncConnectHlp"sv};
-        constexpr std::u16string_view mount_names[] = {u"MountPointManager"sv};
-        constexpr std::u16string_view ksecdd_names[] = {u"KsecDD"sv};
-        constexpr std::u16string_view named_pipe_names[] = {u"NamedPipe"sv};
-        constexpr std::u16string_view gpu_names[] = {u"SogenGpu"sv};
-        constexpr std::u16string_view transport_names[] = {u"Tcp"sv, u"Tcp6"sv, u"Udp"sv, u"RawIp"sv};
-
-        constexpr device_registration registrations[] = {
-            {dummy_names, create_dummy_device},
-            {console_names, create_console_device},
-            {nsi_names, create_network_store_interface},
-            {afd_endpoint_names, create_afd_endpoint},
-            {afd_hlp_names, create_afd_async_connect_hlp},
-            {mount_names, create_mount_point_manager},
-            {ksecdd_names, create_security_support_provider},
-            {named_pipe_names, create_named_pipe_device},
-            {gpu_names, create_gpu_bridge},
-            {transport_names, create_transport_stub_device},
-        };
     }
 
-    std::span<const device_registration> get_device_registrations()
+    const std::unordered_map<std::u16string_view, device_factory>& get_device_registry()
     {
-        return registrations;
+        using namespace std::string_view_literals;
+
+        static const std::unordered_map<std::u16string_view, device_factory> registry = {
+            {u"CNG"sv, create_dummy_device},
+            {u"RasAcd"sv, create_dummy_device},
+            {u"PcwDrv"sv, create_dummy_device},
+            {u"DeviceApi\\CMApi"sv, create_dummy_device},
+            {u"DeviceApi\\CMNotify"sv, create_dummy_device},
+            {u"ConDrv\\Server"sv, create_dummy_device},
+            {u"Console"sv, create_console_device},
+            {u"Nsi"sv, create_network_store_interface},
+            {u"Afd\\Endpoint"sv, create_afd_endpoint},
+            {u"Afd\\AsyncConnectHlp"sv, create_afd_async_connect_hlp},
+            {u"MountPointManager"sv, create_mount_point_manager},
+            {u"KsecDD"sv, create_security_support_provider},
+            {u"NamedPipe"sv, create_named_pipe_device},
+            {u"SogenGpu"sv, create_gpu_bridge},
+            {u"Tcp"sv, create_transport_stub_device},
+            {u"Tcp6"sv, create_transport_stub_device},
+            {u"Udp"sv, create_transport_stub_device},
+            {u"RawIp"sv, create_transport_stub_device},
+        };
+        return registry;
     }
 
     bool needs_32_bit_devices(const windows_emulator& win_emu)
@@ -99,18 +95,14 @@ namespace sogen
 
     std::unique_ptr<io_device> create_device(const std::u16string_view device, const device_creation_context& context)
     {
-        for (const auto& registration : registrations)
+        const auto& registry = get_device_registry();
+        const auto it = registry.find(device);
+        if (it == registry.end())
         {
-            for (const auto name : registration.names)
-            {
-                if (name == device)
-                {
-                    return registration.create(context);
-                }
-            }
+            throw std::runtime_error("Unsupported device: " + u16_to_u8(device));
         }
 
-        throw std::runtime_error("Unsupported device: " + u16_to_u8(device));
+        return it->second(context);
     }
 
     emulator_thread& io_device_context::thread() const

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -43,6 +43,81 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
         };
+
+        // Uniform factory signature (bool is_32_bit) so every device fits one table entry; nullary
+        // factories just ignore the flag.
+        std::unique_ptr<io_device> make_dummy(bool)
+        {
+            return std::make_unique<dummy_device>();
+        }
+        std::unique_ptr<io_device> make_transport_stub(bool)
+        {
+            return std::make_unique<transport_stub_device>();
+        }
+        std::unique_ptr<io_device> make_named_pipe(bool)
+        {
+            return std::make_unique<named_pipe>();
+        }
+        std::unique_ptr<io_device> make_console(bool)
+        {
+            return create_console_device();
+        }
+        std::unique_ptr<io_device> make_nsi(bool)
+        {
+            return create_network_store_interface();
+        }
+        std::unique_ptr<io_device> make_afd_endpoint(bool is_32_bit)
+        {
+            return create_afd_endpoint(is_32_bit);
+        }
+        std::unique_ptr<io_device> make_afd_async_connect_hlp(bool is_32_bit)
+        {
+            return create_afd_async_connect_hlp(is_32_bit);
+        }
+        std::unique_ptr<io_device> make_mount_point_manager(bool)
+        {
+            return create_mount_point_manager();
+        }
+        std::unique_ptr<io_device> make_ksecdd(bool)
+        {
+            return create_security_support_provider();
+        }
+        std::unique_ptr<io_device> make_gpu(bool)
+        {
+            return create_gpu_bridge();
+        }
+
+        using namespace std::string_view_literals;
+
+        constexpr std::u16string_view dummy_names[] = {
+            u"CNG"sv, u"RasAcd"sv, u"PcwDrv"sv, u"DeviceApi\\CMApi"sv, u"DeviceApi\\CMNotify"sv, u"ConDrv\\Server"sv};
+        constexpr std::u16string_view console_names[] = {u"Console"sv};
+        constexpr std::u16string_view nsi_names[] = {u"Nsi"sv};
+        constexpr std::u16string_view afd_endpoint_names[] = {u"Afd\\Endpoint"sv};
+        constexpr std::u16string_view afd_hlp_names[] = {u"Afd\\AsyncConnectHlp"sv};
+        constexpr std::u16string_view mount_names[] = {u"MountPointManager"sv};
+        constexpr std::u16string_view ksecdd_names[] = {u"KsecDD"sv};
+        constexpr std::u16string_view named_pipe_names[] = {u"NamedPipe"sv};
+        constexpr std::u16string_view gpu_names[] = {u"SogenGpu"sv};
+        constexpr std::u16string_view transport_names[] = {u"Tcp"sv, u"Tcp6"sv, u"Udp"sv, u"RawIp"sv};
+
+        constexpr device_registration registrations[] = {
+            {dummy_names, make_dummy},
+            {console_names, make_console},
+            {nsi_names, make_nsi},
+            {afd_endpoint_names, make_afd_endpoint},
+            {afd_hlp_names, make_afd_async_connect_hlp},
+            {mount_names, make_mount_point_manager},
+            {ksecdd_names, make_ksecdd},
+            {named_pipe_names, make_named_pipe},
+            {gpu_names, make_gpu},
+            {transport_names, make_transport_stub},
+        };
+    }
+
+    std::span<const device_registration> get_device_registrations()
+    {
+        return registrations;
     }
 
     bool needs_32_bit_devices(const windows_emulator& win_emu)
@@ -52,59 +127,15 @@ namespace sogen
 
     std::unique_ptr<io_device> create_device(const std::u16string_view device, const bool is_32_bit)
     {
-        if (device == u"CNG"                    //
-            || device == u"RasAcd"              //
-            || device == u"PcwDrv"              //
-            || device == u"DeviceApi\\CMApi"    //
-            || device == u"DeviceApi\\CMNotify" //
-            || device == u"ConDrv\\Server")
+        for (const auto& registration : registrations)
         {
-            return std::make_unique<dummy_device>();
-        }
-
-        if (device == u"Console")
-        {
-            return create_console_device();
-        }
-
-        if (device == u"Nsi")
-        {
-            return create_network_store_interface();
-        }
-
-        if (device == u"Afd\\Endpoint")
-        {
-            return create_afd_endpoint(is_32_bit);
-        }
-
-        if (device == u"Afd\\AsyncConnectHlp")
-        {
-            return create_afd_async_connect_hlp(is_32_bit);
-        }
-
-        if (device == u"MountPointManager")
-        {
-            return create_mount_point_manager();
-        }
-
-        if (device == u"KsecDD")
-        {
-            return create_security_support_provider();
-        }
-
-        if (device == u"NamedPipe")
-        {
-            return std::make_unique<named_pipe>();
-        }
-
-        if (device == u"SogenGpu")
-        {
-            return create_gpu_bridge();
-        }
-
-        if (device == u"Tcp" || device == u"Tcp6" || device == u"Udp" || device == u"RawIp")
-        {
-            return std::make_unique<transport_stub_device>();
+            for (const auto name : registration.names)
+            {
+                if (name == device)
+                {
+                    return registration.create(is_32_bit);
+                }
+            }
         }
 
         throw std::runtime_error("Unsupported device: " + u16_to_u8(device));

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -66,12 +66,14 @@ namespace sogen
         using namespace std::string_view_literals;
 
         static const std::unordered_map<std::u16string_view, device_factory> registry = {
+            // Dummy
             {u"CNG"sv, create_dummy_device},
             {u"RasAcd"sv, create_dummy_device},
             {u"PcwDrv"sv, create_dummy_device},
             {u"DeviceApi\\CMApi"sv, create_dummy_device},
             {u"DeviceApi\\CMNotify"sv, create_dummy_device},
             {u"ConDrv\\Server"sv, create_dummy_device},
+            // Generic
             {u"Console"sv, create_console_device},
             {u"Nsi"sv, create_network_store_interface},
             {u"Afd\\Endpoint"sv, create_afd_endpoint},
@@ -80,6 +82,7 @@ namespace sogen
             {u"KsecDD"sv, create_security_support_provider},
             {u"NamedPipe"sv, create_named_pipe_device},
             {u"SogenGpu"sv, create_gpu_bridge},
+            // Transport
             {u"Tcp"sv, create_transport_stub_device},
             {u"Tcp6"sv, create_transport_stub_device},
             {u"Udp"sv, create_transport_stub_device},

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string_view>
-#include <unordered_map>
 #include <arch_emulator.hpp>
 #include <serialization.hpp>
 
@@ -153,7 +153,8 @@ namespace sogen
     // map to the same factory (e.g. the transport stub serves Tcp/Tcp6/Udp/RawIp). create_device() looks a
     // name up here, and consumers that need every device type (e.g. the handler fuzzer) enumerate it and
     // dedupe by factory, so a newly added device is visible everywhere without a second list to update.
-    const std::unordered_map<std::u16string_view, device_factory>& get_device_registry();
+    // Ordered so the fuzzer's enumeration is deterministic across runs.
+    const std::map<std::u16string_view, device_factory>& get_device_registry();
 
     class io_device_container : public io_device
     {
@@ -202,7 +203,8 @@ namespace sogen
 
         void setup()
         {
-            this->device_ = create_device(this->device_name_, device_creation_context{.is_32_bit = this->is_32_bit_});
+            const device_creation_context context{.is_32_bit = this->is_32_bit_};
+            this->device_ = create_device(this->device_name_, context);
         }
 
         void assert_validity() const

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <span>
 #include <string_view>
+#include <unordered_map>
 #include <arch_emulator.hpp>
 #include <serialization.hpp>
 
@@ -145,19 +145,15 @@ namespace sogen
         bool is_32_bit{};
     };
 
+    using device_factory = std::unique_ptr<io_device> (*)(const device_creation_context& context);
+
     std::unique_ptr<io_device> create_device(std::u16string_view device, const device_creation_context& context);
 
-    // Single source of truth for the emulator's IO devices: which NT device names each handler serves
-    // and how to construct it. create_device() resolves a name through this table, and consumers that
-    // need every device (e.g. the handler fuzzer) can enumerate it, so a newly added device is visible
-    // everywhere without a second list to update.
-    struct device_registration
-    {
-        std::span<const std::u16string_view> names;
-        std::unique_ptr<io_device> (*create)(const device_creation_context& context);
-    };
-
-    std::span<const device_registration> get_device_registrations();
+    // Single source of truth for the emulator's IO devices: NT device name -> factory. Several names may
+    // map to the same factory (e.g. the transport stub serves Tcp/Tcp6/Udp/RawIp). create_device() looks a
+    // name up here, and consumers that need every device type (e.g. the handler fuzzer) enumerate it and
+    // dedupe by factory, so a newly added device is visible everywhere without a second list to update.
+    const std::unordered_map<std::u16string_view, device_factory>& get_device_registry();
 
     class io_device_container : public io_device
     {

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -137,7 +137,15 @@ namespace sogen
     };
 
     bool needs_32_bit_devices(const windows_emulator& win_emu);
-    std::unique_ptr<io_device> create_device(std::u16string_view device, bool is_32_bit);
+
+    // Everything a device factory needs to construct its device. Only the WoW64 flag for now; grows as
+    // more construction-time context is required, without touching every factory signature again.
+    struct device_creation_context
+    {
+        bool is_32_bit{};
+    };
+
+    std::unique_ptr<io_device> create_device(std::u16string_view device, const device_creation_context& context);
 
     // Single source of truth for the emulator's IO devices: which NT device names each handler serves
     // and how to construct it. create_device() resolves a name through this table, and consumers that
@@ -146,7 +154,7 @@ namespace sogen
     struct device_registration
     {
         std::span<const std::u16string_view> names;
-        std::unique_ptr<io_device> (*create)(bool is_32_bit);
+        std::unique_ptr<io_device> (*create)(const device_creation_context& context);
     };
 
     std::span<const device_registration> get_device_registrations();
@@ -198,7 +206,7 @@ namespace sogen
 
         void setup()
         {
-            this->device_ = create_device(this->device_name_, this->is_32_bit_);
+            this->device_ = create_device(this->device_name_, device_creation_context{.is_32_bit = this->is_32_bit_});
         }
 
         void assert_validity() const

--- a/src/windows-emulator/io_device.hpp
+++ b/src/windows-emulator/io_device.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <span>
+#include <string_view>
 #include <arch_emulator.hpp>
 #include <serialization.hpp>
 
@@ -136,6 +138,18 @@ namespace sogen
 
     bool needs_32_bit_devices(const windows_emulator& win_emu);
     std::unique_ptr<io_device> create_device(std::u16string_view device, bool is_32_bit);
+
+    // Single source of truth for the emulator's IO devices: which NT device names each handler serves
+    // and how to construct it. create_device() resolves a name through this table, and consumers that
+    // need every device (e.g. the handler fuzzer) can enumerate it, so a newly added device is visible
+    // everywhere without a second list to update.
+    struct device_registration
+    {
+        std::span<const std::u16string_view> names;
+        std::unique_ptr<io_device> (*create)(bool is_32_bit);
+    };
+
+    std::span<const device_registration> get_device_registrations();
 
     class io_device_container : public io_device
     {


### PR DESCRIPTION
Two fuzzing follow-ups from #1190.

## 1. Device registry (prototype)
Addresses the review note that the fuzzer keeping its own device list means new devices get forgotten. Replaces the hand-written `create_device()` name→factory if-chain with a single table:

```cpp
struct device_registration {
    std::span<const std::u16string_view> names;   // NT device names this handler serves
    std::unique_ptr<io_device> (*create)(bool is_32_bit);
};
std::span<const device_registration> get_device_registrations();
```

- `create_device(name, is_32_bit)` resolves a name through the table (same behavior, incl. the multi-name dummy/transport stubs).
- The handler **fuzzer** now iterates `get_device_registrations()` instead of a hardcoded list — a newly added device is fuzzed automatically.

Design choices to confirm (prototype):
- Uniform factory signature `(bool is_32_bit)`; nullary factories ignore the flag.
- Names live centrally in the table rather than each device declaring its own — open to moving them to the devices if preferred.
- The fuzzer enumerates **all** registered devices including stubs (dummy/transport/named_pipe). Harmless and matches "nothing forgotten", but could be filtered to real handlers.

## 2. Corpus retention (`fuzz.yml`)
The combined `actions/cache@v4` only saves on job **success**, but the fuzz job fails when it finds a crash — so the grown corpus from the most valuable runs was lost. Split into `cache/restore` + `cache/save` with `if: always()`, so the corpus persists across nightly runs regardless of a crash.

## Verification
- `windows-emulator` builds clean (full build, not just syntax) with the constexpr registry table.
- clang-format + YAML validated.