### PR TITLE
windows-emulator-fuzz: fuzz output length + enable value profile

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -105,6 +105,7 @@ jobs:
           ./build/fuzz/artifacts/windows-emulator-fuzz \
             corpus \
             -max_total_time=${DURATION} \
+            -use_value_profile=1 \
             -print_final_stats=1 \
             -artifact_prefix=artifacts/ \
             2>&1 | tee fuzz.log

--- a/src/windows-emulator-fuzz/device_fuzz.cpp
+++ b/src/windows-emulator-fuzz/device_fuzz.cpp
@@ -90,7 +90,9 @@ namespace sogen::fuzz
         // Persistent across iterations: building the emulator is expensive, so do it once.
         struct fuzz_state
         {
-            static constexpr size_t scratch_size = 0x2000;
+            static constexpr size_t input_capacity = 0x1000;
+            static constexpr size_t output_capacity = 0x1000;
+            static constexpr size_t scratch_size = input_capacity + output_capacity;
 
             windows_emulator emu = make_bare_emulator();
             // Fuzzed garbage makes the handlers log constantly; fully mute the terminal (errors included).
@@ -108,8 +110,9 @@ namespace sogen::fuzz
 
     void run(std::span<const uint8_t> data)
     {
-        // Header: [u32 device selector][u32 ioctl code], then the request/input buffer.
-        if (data.size() < 2 * sizeof(uint32_t))
+        // Header: [u32 device selector][u32 ioctl code][u32 output_buffer_length], then the input payload.
+        constexpr size_t header_size = 3 * sizeof(uint32_t);
+        if (data.size() < header_size)
         {
             return;
         }
@@ -122,16 +125,17 @@ namespace sogen::fuzz
 
         uint32_t selector = 0;
         uint32_t code = 0;
-        std::memcpy(&selector, data.data(), sizeof(selector));
-        std::memcpy(&code, data.data() + sizeof(selector), sizeof(code));
+        uint32_t output_len = 0;
+        std::memcpy(&selector, data.data() + 0, sizeof(selector));
+        std::memcpy(&code, data.data() + 4, sizeof(code));
+        std::memcpy(&output_len, data.data() + 8, sizeof(output_len));
 
         io_device& device = *s.devices[selector % s.devices.size()];
-        const auto payload = data.subspan(2 * sizeof(uint32_t));
+        const auto payload = data.subspan(header_size);
 
-        constexpr size_t half = fuzz_state::scratch_size / 2;
         const uint64_t in_buf = s.scratch;
-        const uint64_t out_buf = s.scratch + half;
-        const size_t in_len = std::min(payload.size(), half);
+        const uint64_t out_buf = s.scratch + fuzz_state::input_capacity;
+        const size_t in_len = std::min(payload.size(), fuzz_state::input_capacity);
 
         if (in_len > 0)
         {
@@ -143,7 +147,10 @@ namespace sogen::fuzz
         ctx.input_buffer = in_buf;
         ctx.input_buffer_length = static_cast<ULONG>(in_len);
         ctx.output_buffer = out_buf;
-        ctx.output_buffer_length = static_cast<ULONG>(half);
+        // Guest-controlled output length from the fuzz input. The backing buffer is only output_capacity
+        // bytes, so a handler that honors an oversized length faults in the (contained) guest domain, while
+        // one that sizes a host allocation/arithmetic from it can be caught by the sanitizer.
+        ctx.output_buffer_length = output_len;
 
         try
         {


### PR DESCRIPTION
Two changes to make the handler fuzzer reach more, following up on #1190/#1194.

## Fuzz the output buffer length
`output_buffer_length` was hardcoded to a fixed page; now it's derived from the fuzz input. New wire layout:

```
[u32 device selector][u32 ioctl code][u32 output_buffer_length][payload...]
```

The declared length is fed straight into `io_device_context::output_buffer_length` (guest-controlled), while the backing output buffer stays a fixed page. So a handler that:
- honors an oversized length → faults in the **contained guest domain** (swallowed), but
- sizes a **host** allocation or does arithmetic (`output_buffer_length - X` underflows, `min(..., avail)`) from it → can be caught by ASAN/OOM.

This opens the length-driven host-bug paths the previous harness couldn't reach.

## Enable value profile
Pass `-use_value_profile=1`. Our handlers gate on magic values (`io_control_code != 0x390400`, `algorithm_name == u"SHA256"`, …); value profile feeds those comparison operands back into the mutator, so libFuzzer discovers valid ioctl codes and string checks from the compare instrumentation instead of brute-forcing the 2^32 code space. No committed dictionary needed.

## Heads-up
Fuzzing the output length will likely surface the transport stub's `std::vector<std::byte>(output_buffer_length)` (io_device.cpp) as an unbounded host allocation almost immediately — that's a **real** guest-reachable DoS (via `\Device\Tcp` etc.), not just a harness artifact. Expect it as the first finding; it wants the same bound as the other allocation fixes.

## Verified
- Harness syntax-checks (MSVC); `fuzz.yml` YAML valid.