### PR TITLE
windows-emulator: bound output_buffer_length-driven host allocations

### DIFF
--- a/src/emulator/arch_emulator.hpp
+++ b/src/emulator/arch_emulator.hpp
@@ -62,6 +62,7 @@ namespace sogen
         using arch_emulator<Traits>::write_memory;
         using arch_emulator<Traits>::try_write_memory;
         using arch_emulator<Traits>::move_memory;
+        using arch_emulator<Traits>::set_memory;
 
         virtual size_t vcpu_count() const
         {

--- a/src/emulator/memory_interface.hpp
+++ b/src/emulator/memory_interface.hpp
@@ -1,4 +1,8 @@
 #pragma once
+#include <array>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 #include <functional>
 #include <stdexcept>
@@ -114,6 +118,22 @@ namespace sogen
                 this->write_memory(p_dst, elem);
                 p_src += increment;
                 p_dst += increment;
+            }
+        }
+
+        // Fill a guest range with a byte value (memset). Writes in bounded chunks so a large size never
+        // materializes a matching host allocation.
+        void set_memory(uint64_t address, uint8_t value, uint64_t size)
+        {
+            std::array<std::byte, 0x1000> buffer{};
+            buffer.fill(static_cast<std::byte>(value));
+
+            while (size > 0)
+            {
+                const auto count = static_cast<size_t>(std::min<uint64_t>(buffer.size(), size));
+                this->write_memory(address, buffer.data(), count);
+                address += count;
+                size -= count;
             }
         }
     };

--- a/src/emulator/typed_cpu.hpp
+++ b/src/emulator/typed_cpu.hpp
@@ -310,6 +310,11 @@ namespace sogen
             return this->memory().try_write_memory(address, data, size);
         }
 
+        void set_memory(const uint64_t address, const uint8_t value, const uint64_t size)
+        {
+            this->memory().set_memory(address, value, size);
+        }
+
         template <typename T>
         T read_memory(const uint64_t address) const
         {

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -478,7 +478,7 @@ namespace sogen
                 }
 
                 win_emu.emu().write_memory(context.output_buffer, properties.data(), properties.size());
-                set_information(context, context.output_buffer_length);
+                set_information(context, static_cast<ULONG>(properties.size()));
                 return STATUS_SUCCESS;
             }
 
@@ -1191,7 +1191,7 @@ namespace sogen
                 }
 
                 win_emu.emu().write_memory(context.output_buffer, properties.data(), properties.size());
-                set_information(context, context.output_buffer_length);
+                set_information(context, static_cast<ULONG>(properties.size()));
                 return STATUS_SUCCESS;
             }
 
@@ -3068,7 +3068,7 @@ namespace sogen
                 }
 
                 win_emu.emu().write_memory(context.output_buffer, caps.data(), caps.size());
-                set_information(context, context.output_buffer_length);
+                set_information(context, static_cast<ULONG>(caps.size()));
                 return STATUS_SUCCESS;
             }
         };

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -427,8 +427,9 @@ namespace sogen
 
                 const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
 
-                const auto array_capacity =
-                    static_cast<uint32_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id));
+                const auto array_capacity = static_cast<uint32_t>(
+                    std::min<uint64_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id),
+                                       max_array_readback_bytes / sizeof(gpu_bridge::object_id)));
                 const auto max_count = std::min(request.max_count, array_capacity);
 
                 std::vector<uint64_t> ids(max_count);
@@ -497,7 +498,7 @@ namespace sogen
                 }
 
                 const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
-                const auto array_bytes = context.output_buffer_length - static_cast<uint32_t>(sizeof(response_t));
+                const auto array_bytes = std::min<size_t>(context.output_buffer_length - sizeof(response_t), max_array_readback_bytes);
 
                 std::vector<std::byte> properties(array_bytes);
                 uint32_t count = 0;
@@ -536,7 +537,7 @@ namespace sogen
                 }
 
                 const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
-                const auto array_bytes = context.output_buffer_length - static_cast<uint32_t>(sizeof(response_t));
+                const auto array_bytes = std::min<size_t>(context.output_buffer_length - sizeof(response_t), max_array_readback_bytes);
 
                 std::vector<std::byte> properties(array_bytes);
                 uint32_t count = 0;
@@ -1317,7 +1318,7 @@ namespace sogen
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                const auto copy_bytes = std::min<uint64_t>(request.size, context.output_buffer_length);
+                const auto copy_bytes = std::min<uint64_t>({request.size, context.output_buffer_length, max_memory_transfer_bytes});
 
                 std::vector<std::byte> bytes(static_cast<size_t>(copy_bytes));
                 const auto direct = this->direct_mappings_.find(request.memory);
@@ -1662,8 +1663,9 @@ namespace sogen
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                const auto array_capacity =
-                    static_cast<uint32_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id));
+                const auto array_capacity = static_cast<uint32_t>(
+                    std::min<uint64_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id),
+                                       max_array_readback_bytes / sizeof(gpu_bridge::object_id)));
                 const auto max_count = std::min(request.max_count, array_capacity);
 
                 std::vector<uint64_t> ids(max_count);
@@ -1849,7 +1851,8 @@ namespace sogen
                 }
 
                 const auto avail = static_cast<uint32_t>(context.output_buffer_length - sizeof(response_t));
-                const auto data_size = std::min<uint32_t>(request.data_size, avail);
+                const auto data_size =
+                    std::min<uint32_t>(request.data_size, std::min<uint32_t>(avail, static_cast<uint32_t>(max_array_readback_bytes)));
 
                 if (request.query_count > 0 && request.stride > 0 &&
                     static_cast<uint64_t>(request.stride) * request.query_count > data_size)
@@ -2225,8 +2228,9 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto array_capacity =
-                    static_cast<uint32_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id));
+                const auto array_capacity = static_cast<uint32_t>(
+                    std::min<uint64_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id),
+                                       max_array_readback_bytes / sizeof(gpu_bridge::object_id)));
                 std::vector<uint64_t> ids(std::min(request.set_count, array_capacity));
                 uint32_t count = 0;
                 const int32_t result =
@@ -2250,6 +2254,17 @@ namespace sogen
             // Cap for property/capability readbacks staged from output_buffer_length: these responses are
             // small fixed-size structs, so a bogus output length can't force a huge allocation.
             static constexpr size_t max_readback_bytes = 64 * 1024;
+
+            // Cap for variable-length array readbacks staged from output_buffer_length (object-id lists,
+            // queue-family/extension property arrays). Larger than a single struct but still bounded, so a
+            // bogus output length can't force a huge allocation while never truncating a realistic result.
+            static constexpr size_t max_array_readback_bytes = size_t{16} * 1024 * 1024;
+
+            // Cap for bulk memory transfers (download_memory). A real transfer is bounded by the memory
+            // object, but we don't track its size for the general path, so bound the host staging buffer so a
+            // bogus request.size/output length can't force a huge allocation. Sized to fit realistic
+            // single-resource readbacks (4K/8K textures, large buffers).
+            static constexpr size_t max_memory_transfer_bytes = size_t{256} * 1024 * 1024;
 
             // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
             // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -470,7 +470,7 @@ namespace sogen
 
                 // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
                 // bound the staging allocation instead of trusting the declared length.
-                std::vector<std::byte> properties(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
+                std::vector<std::byte> properties(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_physical_device_properties(request.physical_device, properties.data(),
                                                                                     properties.size(), win_emu.process.is_wow64_process);
                 if (result != 0)
@@ -1185,7 +1185,7 @@ namespace sogen
 
                 // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
                 // bound the staging allocation instead of trusting the declared length.
-                std::vector<std::byte> properties(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
+                std::vector<std::byte> properties(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result =
                     this->vulkan_.get_physical_device_memory_properties(request.physical_device, properties.data(), properties.size());
                 if (result != 0)
@@ -3050,7 +3050,7 @@ namespace sogen
 
                 // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
                 // bound the staging allocation instead of trusting the declared length.
-                std::vector<std::byte> caps(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
+                std::vector<std::byte> caps(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_surface_capabilities(request.physical_device, request.surface, window_width,
                                                                               window_height, caps.data(), caps.size());
                 if (result != 0)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -468,7 +468,9 @@ namespace sogen
 
                 const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
 
-                std::vector<std::byte> properties(context.output_buffer_length);
+                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
+                // bound the staging allocation instead of trusting the declared length.
+                std::vector<std::byte> properties(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_physical_device_properties(request.physical_device, properties.data(),
                                                                                     properties.size(), win_emu.process.is_wow64_process);
                 if (result != 0)
@@ -1181,7 +1183,9 @@ namespace sogen
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                std::vector<std::byte> properties(context.output_buffer_length);
+                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
+                // bound the staging allocation instead of trusting the declared length.
+                std::vector<std::byte> properties(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result =
                     this->vulkan_.get_physical_device_memory_properties(request.physical_device, properties.data(), properties.size());
                 if (result != 0)
@@ -2247,6 +2251,10 @@ namespace sogen
             // Cap guest-declared descriptor-update payloads so a bogus IOCTL length can't force a huge allocation.
             static constexpr size_t max_descriptor_update_input_bytes = size_t{256} * 1024 * 1024;
 
+            // Cap for property/capability readbacks staged from output_buffer_length: these responses are
+            // small fixed-size structs, so a bogus output length can't force a huge allocation.
+            static constexpr size_t max_readback_bytes = 64 * 1024;
+
             // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
             // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.
             int32_t apply_update_descriptor_sets(const std::byte* data, size_t size, size_t& offset)
@@ -3040,7 +3048,9 @@ namespace sogen
                     }
                 }
 
-                std::vector<std::byte> caps(context.output_buffer_length);
+                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
+                // bound the staging allocation instead of trusting the declared length.
+                std::vector<std::byte> caps(std::min<uint64_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_surface_capabilities(request.physical_device, request.surface, window_width,
                                                                               window_height, caps.data(), caps.size());
                 if (result != 0)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -468,8 +468,6 @@ namespace sogen
 
                 const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
 
-                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
-                // bound the staging allocation instead of trusting the declared length.
                 std::vector<std::byte> properties(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_physical_device_properties(request.physical_device, properties.data(),
                                                                                     properties.size(), win_emu.process.is_wow64_process);
@@ -1183,8 +1181,6 @@ namespace sogen
                     return STATUS_BUFFER_TOO_SMALL;
                 }
 
-                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
-                // bound the staging allocation instead of trusting the declared length.
                 std::vector<std::byte> properties(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result =
                     this->vulkan_.get_physical_device_memory_properties(request.physical_device, properties.data(), properties.size());
@@ -3048,8 +3044,6 @@ namespace sogen
                     }
                 }
 
-                // output_buffer_length is guest-controlled; the response is a small fixed-size struct, so
-                // bound the staging allocation instead of trusting the declared length.
                 std::vector<std::byte> caps(std::min<size_t>(context.output_buffer_length, max_readback_bytes));
                 const int32_t result = this->vulkan_.get_surface_capabilities(request.physical_device, request.surface, window_width,
                                                                               window_height, caps.data(), caps.size());

--- a/src/windows-emulator/devices/network_store_interface.cpp
+++ b/src/windows-emulator/devices/network_store_interface.cpp
@@ -99,15 +99,7 @@ namespace sogen
                 return;
             }
 
-            // buffer.size is a guest-controlled 64-bit value; zero the region in bounded chunks
-            // instead of materializing the whole span as one host allocation.
-            constexpr uint64_t chunk_size = 0x1000;
-            const std::vector<uint8_t> zeroes(static_cast<size_t>(std::min(buffer.size, chunk_size)), 0);
-            for (uint64_t written = 0; written < buffer.size; written += zeroes.size())
-            {
-                const auto count = static_cast<size_t>(std::min<uint64_t>(zeroes.size(), buffer.size - written));
-                win_emu.emu().write_memory(buffer.address + written, zeroes.data(), count);
-            }
+            win_emu.emu().set_memory(buffer.address, 0, buffer.size);
         }
 
         void write_adapter_key(windows_emulator& win_emu, const nsi_buffer buffer)

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -29,15 +29,7 @@ namespace sogen
             {
                 if (context.output_buffer && context.output_buffer_length)
                 {
-                    // output_buffer_length is guest-controlled; zero the region in bounded chunks instead
-                    // of materializing the whole (possibly multi-GB) span as one host allocation.
-                    constexpr size_t chunk_size = 0x1000;
-                    const std::vector<std::byte> zeros(std::min<size_t>(context.output_buffer_length, chunk_size), std::byte{0});
-                    for (ULONG offset = 0; offset < context.output_buffer_length; offset += static_cast<ULONG>(zeros.size()))
-                    {
-                        const auto count = std::min<size_t>(zeros.size(), context.output_buffer_length - offset);
-                        win_emu.emu().write_memory(context.output_buffer + offset, zeros.data(), count);
-                    }
+                    win_emu.emu().set_memory(context.output_buffer, 0, context.output_buffer_length);
                 }
 
                 if (context.io_status_block)

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -29,8 +29,15 @@ namespace sogen
             {
                 if (context.output_buffer && context.output_buffer_length)
                 {
-                    std::vector<std::byte> output(context.output_buffer_length, std::byte{0});
-                    win_emu.emu().write_memory(context.output_buffer, output.data(), output.size());
+                    // output_buffer_length is guest-controlled; zero the region in bounded chunks instead
+                    // of materializing the whole (possibly multi-GB) span as one host allocation.
+                    constexpr size_t chunk_size = 0x1000;
+                    const std::vector<std::byte> zeros(std::min<size_t>(context.output_buffer_length, chunk_size), std::byte{0});
+                    for (ULONG offset = 0; offset < context.output_buffer_length; offset += static_cast<ULONG>(zeros.size()))
+                    {
+                        const auto count = std::min<size_t>(zeros.size(), context.output_buffer_length - offset);
+                        win_emu.emu().write_memory(context.output_buffer + offset, zeros.data(), count);
+                    }
                 }
 
                 if (context.io_status_block)

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -618,8 +618,7 @@ namespace sogen
                 // of rejecting an unexpected size.
                 if (system_information)
                 {
-                    const std::vector<std::byte> zeros(system_information_length, std::byte{});
-                    c.emu.write_memory(system_information, zeros.data(), zeros.size());
+                    c.emu.set_memory(system_information, 0, system_information_length);
                 }
                 if (return_length)
                 {
@@ -737,8 +736,7 @@ namespace sogen
             // "power/idle status" queries without modeling the full power subsystem.
             if (output_buffer && output_buffer_length > 0)
             {
-                const std::vector<std::byte> zeros(output_buffer_length, std::byte{});
-                c.emu.write_memory(output_buffer, zeros.data(), zeros.size());
+                c.emu.set_memory(output_buffer, 0, output_buffer_length);
             }
 
             return STATUS_SUCCESS;


### PR DESCRIPTION
Found by the IO-device handler fuzzer once it started fuzzing the guest-declared `output_buffer_length` (the harness change on main). Several handlers size a **host** allocation directly from that guest-controlled length, so a bogus output length forces a multi-GB allocation → OOM.

## Fixes
- **transport stub** (`io_device.cpp`) — did `std::vector<std::byte>(output_buffer_length)` to zero-fill the output. Now zeros the guest region in bounded 4 KB chunks. Reachable via `\Device\Tcp`/`Tcp6`/`Udp`/`RawIp` (the fuzzer hit this one first: any ioctl code triggers it).
- **gpu_bridge** `get_physical_device_properties` (471), `get_physical_device_memory_properties` (1184), `get_surface_capabilities` (3043) — each staged a **small fixed-size struct** (< 1 KB) into an `output_buffer_length`-sized vector. Cap the staging allocation at `max_readback_bytes` (64 KiB). No behavior change for legit callers (their buffers are struct-sized); it only bounds the allocation.

Same DoS / unbounded-allocation class as #1187 and #1193.

## Verification
- Reproduced the OOM locally (`malloc(2795939533)` from the transport stub), applied the fixes, and re-ran the fuzzer 90 s unclamped — no OOM, stable (`DONE cov: 1641`, exit 0).
- Not touched here (let the fuzzer surface them next if reachable): the `output_buffer_length - sizeof(response_t)` underflow candidates and the `input_buffer_length`-sized allocations (the harness caps input at 4 KB, so those aren't reachable yet).