### PR TITLE
Improve keyboard layout syscalls and other fixes

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -278,7 +278,8 @@ namespace sogen
         RECT rcClient;
         uint64_t lpfnWndProc;
         uint64_t pcls;
-        uint8_t pad_088[16];
+        uint64_t hrgnUpdate;
+        uint8_t pad_090[8];
         uint64_t spmenu;
         uint8_t pad_0A0[24];
         uint32_t dwTextLengthBytes;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -360,6 +360,7 @@ namespace sogen
             p.NumberOfProcessors = fake_env.number_of_processors;
             p.ImageSubsystemMajorVersion = 6;
 
+            // TODO: p.SessionId = 1;
             p.OSPlatformId = 2;
             p.OSMajorVersion = version.get_major_version();
             p.OSMinorVersion = version.get_minor_version();
@@ -452,6 +453,7 @@ namespace sogen
                 p32.NumberOfProcessors = fake_env.number_of_processors;
                 p32.ImageSubsystemMajorVersion = 6;
 
+                // TODO: p32.SessionId = 1;
                 p32.OSPlatformId = 2;
                 p32.OSMajorVersion = version.get_major_version();
                 p32.OSMinorVersion = version.get_minor_version();

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -547,7 +547,8 @@ namespace sogen
         uint64_t handle_NtUserGetProp(const syscall_context& c, hwnd window, uint16_t atom);
         uint64_t handle_NtUserGetProp2(const syscall_context& c, hwnd window, emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> str);
         uint64_t handle_NtUserRemoveProp(const syscall_context& c, hwnd window, uint16_t atom);
-        uint64_t handle_NtUserChangeWindowMessageFilterEx();
+        BOOL handle_NtUserChangeWindowMessageFilterEx();
+        BOOL handle_NtUserChangeWindowMessageFilter();
         BOOL handle_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
         BOOL completion_NtUserShowWindow(const syscall_context& c, hwnd hwnd, LONG cmd_show);
         uint64_t handle_NtUserMessageCall(const syscall_context& c, hwnd hwnd, UINT msg, uint64_t w_param, uint64_t l_param,
@@ -683,6 +684,9 @@ namespace sogen
         uint64_t handle_NtUserAttachThreadInput();
         BOOL handle_NtUserRegisterTouchHitTestingWindow();
         BOOL handle_NtUserGetGUIThreadInfo(const syscall_context& c, uint32_t thread_id, emulator_pointer info);
+        BOOL handle_NtUserSetWinEventHook();
+        BOOL handle_NtUserUnhookWinEvent();
+        BOOL handle_NtUserDisableThreadIme();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -737,6 +741,9 @@ namespace sogen
                                    emulator_pointer face_name, ULONG charset, emulator_pointer count, emulator_pointer buffer);
         uint32_t handle_NtGdiGetTextCharsetInfo(const syscall_context& c, hdc dc, emulator_pointer sig, uint32_t flags);
         uint32_t handle_NtGdiQueryFontAssocInfo(const syscall_context& c, hdc dc);
+        uint32_t handle_NtGdiGetPublicFontTableChangeCookie();
+        int32_t handle_NtGdiAddFontResourceW(const syscall_context& c, emulator_pointer files, uint32_t character_count,
+                                             uint32_t file_count, uint32_t flags, uint32_t thread_id, emulator_pointer design_vector);
         uint32_t handle_NtGdiGetTextMetricsW(const syscall_context& c, hdc dc, emulator_pointer ptm, uint32_t cj);
         int32_t handle_NtGdiGetTextFaceW(const syscall_context& c, hdc dc, int32_t count, emulator_pointer face_name, BOOL alias_name);
         uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, hdc dc, UINT character, UINT format, emulator_pointer glyph_metrics,
@@ -1272,6 +1279,8 @@ namespace sogen
         add_handler(NtGdiEnumFonts);
         add_handler(NtGdiGetTextCharsetInfo);
         add_handler(NtGdiQueryFontAssocInfo);
+        add_handler(NtGdiGetPublicFontTableChangeCookie);
+        add_handler(NtGdiAddFontResourceW);
         add_handler(NtGdiGetTextMetricsW);
         add_handler(NtGdiGetTextFaceW);
         add_handler(NtGdiGetTextExtent);
@@ -1632,6 +1641,10 @@ namespace sogen
         add_handler(NtUserActivateKeyboardLayout);
         add_handler(NtUserGetGUIThreadInfo);
         add_handler(NtNotifyChangeDirectoryFile);
+        add_handler(NtUserChangeWindowMessageFilter);
+        add_handler(NtUserSetWinEventHook);
+        add_handler(NtUserUnhookWinEvent);
+        add_handler(NtUserDisableThreadIme);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -682,6 +682,7 @@ namespace sogen
         uint64_t handle_NtUserSetKeyboardState();
         uint64_t handle_NtUserAttachThreadInput();
         BOOL handle_NtUserRegisterTouchHitTestingWindow();
+        BOOL handle_NtUserGetGUIThreadInfo(const syscall_context& c, uint32_t thread_id, emulator_pointer info);
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -1629,6 +1630,7 @@ namespace sogen
         add_handler(NtUserAttachThreadInput);
         add_handler(NtUserRegisterTouchHitTestingWindow);
         add_handler(NtUserActivateKeyboardLayout);
+        add_handler(NtUserGetGUIThreadInfo);
         add_handler(NtNotifyChangeDirectoryFile);
 
 #undef add_handler

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -432,6 +432,10 @@ namespace sogen
                                                        emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> attributes,
                                                        ULONG number_of_attributes, uint64_t buffer, ULONG buffer_length,
                                                        emulator_object<ULONG> return_length);
+        NTSTATUS handle_NtAccessCheck(const syscall_context& c, uint64_t security_descriptor, handle client_token,
+                                      ACCESS_MASK desired_access, emulator_object<EMU_GENERIC_MAPPING> generic_mapping,
+                                      uint64_t privilege_set, emulator_object<ULONG> privilege_set_length,
+                                      emulator_object<ACCESS_MASK> granted_access, emulator_object<NTSTATUS> access_status);
         NTSTATUS handle_NtAdjustPrivilegesToken();
         NTSTATUS handle_NtQuerySecurityPolicy();
         NTSTATUS handle_NtFlushInstructionCache(const syscall_context& c, handle process_handle, emulator_object<uint64_t> base_address,
@@ -964,11 +968,6 @@ namespace sogen
         }
 
         NTSTATUS handle_NtQueryInformationJobObject()
-        {
-            return STATUS_NOT_SUPPORTED;
-        }
-
-        NTSTATUS handle_NtAccessCheck()
         {
             return STATUS_NOT_SUPPORTED;
         }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -556,6 +556,7 @@ namespace sogen
         BOOL handle_NtUserWaitMessage(const syscall_context& c);
         BOOL handle_NtUserInvalidateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect, BOOL erase);
         BOOL handle_NtUserValidateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect);
+        BOOL handle_NtUserGetUpdateRect(const syscall_context& c, hwnd hwnd, emulator_object<RECT> rect, BOOL erase);
         BOOL handle_NtUserUpdateWindow(const syscall_context& c, hwnd hwnd);
         BOOL completion_NtUserUpdateWindow(const syscall_context& c, hwnd hwnd);
         int32_t handle_NtUserGetKeyNameText(const syscall_context& c, int32_t l_param, emulator_pointer buffer, int32_t character_count);
@@ -1445,6 +1446,7 @@ namespace sogen
         add_handler(NtUserWaitMessage);
         add_handler(NtUserInvalidateRect);
         add_handler(NtUserValidateRect);
+        add_handler(NtUserGetUpdateRect);
         add_handler(NtUserUpdateWindow);
         add_handler(NtUserGetCursorInfo);
         add_handler(NtUserMapVirtualKeyEx);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -133,7 +133,10 @@ namespace sogen
                                            emulator_object<ULONG> section_size);
         NTSTATUS handle_NtGetMUIRegistryInfo();
         NTSTATUS handle_NtIsUILanguageComitted();
-        NTSTATUS handle_NtUserGetKeyboardLayout();
+        uint64_t handle_NtUserActivateKeyboardLayout(const syscall_context& c, uint64_t keyboard_layout, uint32_t flags);
+        uint64_t handle_NtUserGetKeyboardLayout(const syscall_context& c, uint32_t thread_id);
+        uint32_t handle_NtUserGetKeyboardLayoutList(const syscall_context& c, uint32_t buffer_count, emulator_pointer keyboard_layouts);
+        BOOL handle_NtUserGetKeyboardLayoutName(const syscall_context& c, emulator_pointer name);
         NTSTATUS handle_NtQueryDefaultUILanguage(const syscall_context&, emulator_object<LANGID> language_id);
         NTSTATUS handle_NtQueryInstallUILanguage(const syscall_context&, emulator_object<LANGID> language_id);
 
@@ -675,7 +678,6 @@ namespace sogen
         uint64_t handle_NtUserSetKeyboardState();
         uint64_t handle_NtUserAttachThreadInput();
         BOOL handle_NtUserRegisterTouchHitTestingWindow();
-        uint64_t handle_NtUserActivateKeyboardLayout();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -1355,6 +1357,8 @@ namespace sogen
         add_handler(NtQueryTimerResolution);
         add_handler(NtSetInformationKey);
         add_handler(NtUserGetKeyboardLayout);
+        add_handler(NtUserGetKeyboardLayoutList);
+        add_handler(NtUserGetKeyboardLayoutName);
         add_handler(NtQueryDirectoryFileEx);
         add_handler(NtQueryDirectoryFile);
         add_handler(NtUserSystemParametersInfo);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1944,6 +1944,18 @@ namespace sogen
             return handle_value;
         }
 
+        int32_t handle_NtGdiAddFontResourceW(const syscall_context&, const emulator_pointer files, const uint32_t character_count,
+                                             const uint32_t file_count, const uint32_t /*flags*/, const uint32_t /*thread_id*/,
+                                             const emulator_pointer /*design_vector*/)
+        {
+            if (files == 0 || character_count == 0 || file_count == 0)
+            {
+                return 0;
+            }
+
+            return static_cast<int32_t>(file_count);
+        }
+
         BOOL handle_NtGdiRemoveFontMemResourceEx(const syscall_context& /*c*/, const uint64_t font_handle)
         {
             return font_handle != 0 ? TRUE : FALSE;
@@ -4896,6 +4908,11 @@ namespace sogen
             }
 
             return bgra_to_colorref(*pixel);
+        }
+
+        uint32_t handle_NtGdiGetPublicFontTableChangeCookie()
+        {
+            return 1;
         }
     }
 

--- a/src/windows-emulator/syscalls/locale.cpp
+++ b/src/windows-emulator/syscalls/locale.cpp
@@ -73,9 +73,54 @@ namespace sogen
             return STATUS_NOT_SUPPORTED;
         }
 
-        NTSTATUS handle_NtUserGetKeyboardLayout()
+        uint64_t handle_NtUserActivateKeyboardLayout(const syscall_context&, const uint64_t /*keyboard_layout*/, const uint32_t /*flags*/)
         {
-            return STATUS_NOT_SUPPORTED;
+            return 0x04070407;
+        }
+
+        uint64_t handle_NtUserGetKeyboardLayout(const syscall_context&, const uint32_t /*thread_id*/)
+        {
+            return 0x04070407;
+        }
+
+        uint32_t handle_NtUserGetKeyboardLayoutList(const syscall_context& c, const uint32_t buffer_count,
+                                                    const emulator_pointer keyboard_layouts)
+        {
+            constexpr uint64_t keyboard_layout = 0x04070407;
+
+            if (buffer_count == 0)
+            {
+                return 1;
+            }
+
+            if (keyboard_layouts == 0)
+            {
+                return 0;
+            }
+
+            if (c.proc.is_wow64_process)
+            {
+                c.emu.write_memory(keyboard_layouts, static_cast<uint32_t>(keyboard_layout));
+            }
+            else
+            {
+                c.emu.write_memory(keyboard_layouts, keyboard_layout);
+            }
+
+            return 1;
+        }
+
+        BOOL handle_NtUserGetKeyboardLayoutName(const syscall_context& c, const emulator_pointer name)
+        {
+            static constexpr char16_t keyboard_layout_name[] = u"00000407";
+
+            if (name == 0)
+            {
+                return FALSE;
+            }
+
+            c.emu.write_memory(name, keyboard_layout_name, sizeof(keyboard_layout_name));
+            return TRUE;
         }
 
         NTSTATUS handle_NtQueryDefaultUILanguage(const syscall_context&, const emulator_object<LANGID> language_id)

--- a/src/windows-emulator/syscalls/locale.cpp
+++ b/src/windows-emulator/syscalls/locale.cpp
@@ -112,14 +112,14 @@ namespace sogen
 
         BOOL handle_NtUserGetKeyboardLayoutName(const syscall_context& c, const emulator_pointer name)
         {
-            static constexpr char16_t keyboard_layout_name[] = u"00000407";
+            static const std::u16string keyboard_layout_name = u"00000407";
 
             if (name == 0)
             {
                 return FALSE;
             }
 
-            c.emu.write_memory(name, keyboard_layout_name, sizeof(keyboard_layout_name));
+            c.emu.write_memory(name, keyboard_layout_name.data(), keyboard_layout_name.size() * sizeof(char16_t));
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/memory.cpp
+++ b/src/windows-emulator/syscalls/memory.cpp
@@ -372,8 +372,11 @@ namespace sogen
                 return STATUS_INVALID_ADDRESS;
             }
 
-            const auto current_protection = map_emulator_to_nt_protection(old_protection_value);
-            old_protection.write(current_protection);
+            if (old_protection)
+            {
+                const auto current_protection = map_emulator_to_nt_protection(old_protection_value);
+                old_protection.write(current_protection);
+            }
 
             return STATUS_SUCCESS;
         }

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -236,6 +236,31 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            case ProcessImageFileName: {
+                const auto image_path = c.win_emu.mod_manager.executable->module_path.to_device_path();
+                const auto string_length = image_path.size() * sizeof(char16_t);
+                const auto required_length = sizeof(UNICODE_STRING<EmulatorTraits<Emu64>>) + string_length + sizeof(char16_t);
+
+                if (return_length)
+                {
+                    return_length.write(static_cast<uint32_t>(required_length));
+                }
+
+                if (process_information_length < required_length)
+                {
+                    return STATUS_INFO_LENGTH_MISMATCH;
+                }
+
+                const auto buffer = process_information + sizeof(UNICODE_STRING<EmulatorTraits<Emu64>>);
+                c.emu.write_memory(buffer, image_path.c_str(), string_length + sizeof(char16_t));
+                emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>>{c.emu, process_information}.write({
+                    .Length = static_cast<USHORT>(string_length),
+                    .MaximumLength = static_cast<USHORT>(string_length + sizeof(char16_t)),
+                    .Buffer = buffer,
+                });
+                return STATUS_SUCCESS;
+            }
+
             case ProcessImageFileNameWin32: {
                 const auto peb = c.proc.peb64.read();
                 emulator_object<RTL_USER_PROCESS_PARAMETERS64> proc_params{c.emu, peb.ProcessParameters};
@@ -266,7 +291,7 @@ namespace sogen
             }
 
             default:
-                c.win_emu.log.error("Unsupported process info class: %X\n", info_class);
+                c.win_emu.log.error("Unsupported process info class: 0x%X\n", info_class);
                 c.emu.stop();
 
                 return STATUS_NOT_SUPPORTED;

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -232,7 +232,7 @@ namespace sogen
 
             if (!is_knowndll && attributes.RootDirectory != BASE_NAMED_OBJECTS_DIRECTORY)
             {
-                c.win_emu.log.error("Unsupported section\n");
+                c.win_emu.log.error("Unsupported section: %s\n", u16_to_u8(filename_sv).c_str());
                 c.emu.stop();
                 return STATUS_NOT_SUPPORTED;
             }

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -7,6 +7,54 @@ namespace sogen
 
     namespace syscalls
     {
+        namespace
+        {
+            constexpr std::array<uint8_t, 12> interactive_sid = {
+                0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x00, 0x00,
+            };
+
+            bool sid_matches(const memory_manager& memory, const uint64_t address, const std::span<const uint8_t> expected)
+            {
+                std::array<uint8_t, 8> header{};
+                memory.read_memory(address, header.data(), header.size());
+                const auto size = 8 + static_cast<size_t>(header[1]) * sizeof(uint32_t);
+                if (size != expected.size())
+                {
+                    return false;
+                }
+
+                std::vector<uint8_t> sid(size);
+                memory.read_memory(address, sid.data(), sid.size());
+                return std::ranges::equal(sid, expected);
+            }
+
+            ACCESS_MASK map_generic_access(ACCESS_MASK access, const EMU_GENERIC_MAPPING& mapping)
+            {
+                constexpr ACCESS_MASK generic_read = 0x80000000;
+                constexpr ACCESS_MASK generic_write = 0x40000000;
+                constexpr ACCESS_MASK generic_execute = 0x20000000;
+                constexpr ACCESS_MASK generic_all = 0x10000000;
+
+                if (access & generic_read)
+                {
+                    access = (access & ~generic_read) | mapping.GenericRead;
+                }
+                if (access & generic_write)
+                {
+                    access = (access & ~generic_write) | mapping.GenericWrite;
+                }
+                if (access & generic_execute)
+                {
+                    access = (access & ~generic_execute) | mapping.GenericExecute;
+                }
+                if (access & generic_all)
+                {
+                    access = (access & ~generic_all) | mapping.GenericAll;
+                }
+                return access;
+            }
+        }
+
         TOKEN_TYPE get_token_type(const handle token_handle)
         {
             return token_handle == DUMMY_IMPERSONATION_TOKEN //
@@ -74,7 +122,8 @@ namespace sogen
 
             if (token_information_class == TokenGroups)
             {
-                const auto required_size = sizeof(TOKEN_GROUPS64) + sid.size();
+                constexpr auto group_entry_size = sizeof(SID_AND_ATTRIBUTES64);
+                const auto required_size = sizeof(TOKEN_GROUPS64) + group_entry_size + sid.size() + interactive_sid.size();
                 return_length.write(static_cast<ULONG>(required_size));
 
                 if (required_size > token_information_length)
@@ -83,12 +132,18 @@ namespace sogen
                 }
 
                 TOKEN_GROUPS64 groups{};
-                groups.GroupCount = 1;
+                groups.GroupCount = 2;
                 groups.Groups[0].Attributes = 0;
-                groups.Groups[0].Sid = token_information + sizeof(TOKEN_GROUPS64);
+                groups.Groups[0].Sid = token_information + sizeof(TOKEN_GROUPS64) + group_entry_size;
+
+                SID_AND_ATTRIBUTES64 interactive_group{};
+                interactive_group.Attributes = 0x7; // SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_ENABLED
+                interactive_group.Sid = groups.Groups[0].Sid + sid.size();
 
                 emulator_object<TOKEN_GROUPS64>{c.emu, token_information}.write(groups);
-                c.emu.write_memory(token_information + sizeof(TOKEN_GROUPS64), sid.data(), sid.size());
+                c.emu.write_memory(token_information + sizeof(TOKEN_GROUPS64), interactive_group);
+                c.emu.write_memory(groups.Groups[0].Sid, sid.data(), sid.size());
+                c.emu.write_memory(interactive_group.Sid, interactive_sid);
                 return STATUS_SUCCESS;
             }
 
@@ -312,7 +367,7 @@ namespace sogen
                 TOKEN_STATISTICS stats{};
                 stats.TokenType = get_token_type(token_handle);
                 stats.ImpersonationLevel = stats.TokenType == TokenImpersonation ? SecurityImpersonation : SecurityAnonymous;
-                stats.GroupCount = 1;
+                stats.GroupCount = 2;
                 stats.PrivilegeCount = 0;
 
                 c.emu.write_memory(token_information, stats);
@@ -402,6 +457,77 @@ namespace sogen
             c.win_emu.log.error("Unsupported token info class: %X\n", token_information_class);
             c.emu.stop();
             return STATUS_NOT_SUPPORTED;
+        }
+
+        NTSTATUS handle_NtAccessCheck(const syscall_context& c, const uint64_t security_descriptor, const handle client_token,
+                                      const ACCESS_MASK desired_access, const emulator_object<EMU_GENERIC_MAPPING> generic_mapping,
+                                      const uint64_t /*privilege_set*/, const emulator_object<ULONG> privilege_set_length,
+                                      const emulator_object<ACCESS_MASK> granted_access, const emulator_object<NTSTATUS> access_status)
+        {
+            if (client_token != CURRENT_PROCESS_TOKEN && client_token != CURRENT_THREAD_TOKEN &&
+                client_token != CURRENT_THREAD_EFFECTIVE_TOKEN && client_token != DUMMY_IMPERSONATION_TOKEN)
+            {
+                return STATUS_INVALID_HANDLE;
+            }
+
+            const auto control = emulator_object<SECURITY_DESCRIPTOR_CONTROL>{c.emu, security_descriptor + 2}.read();
+            uint64_t dacl_address = 0;
+            if (control & SE_SELF_RELATIVE)
+            {
+                const auto descriptor = emulator_object<SECURITY_DESCRIPTOR_RELATIVE>{c.emu, security_descriptor}.read();
+                dacl_address = descriptor.Dacl == 0 ? 0 : security_descriptor + descriptor.Dacl;
+            }
+            else
+            {
+                dacl_address = emulator_object<uint64_t>{c.emu, security_descriptor + 32}.read();
+            }
+
+            const auto mapping = generic_mapping.read();
+            const auto requested = map_generic_access(desired_access, mapping);
+            ACCESS_MASK remaining = requested;
+            ACCESS_MASK granted = 0;
+            bool denied = false;
+
+            if (!(control & SE_DACL_PRESENT) || dacl_address == 0)
+            {
+                granted = requested;
+                remaining = 0;
+            }
+            else
+            {
+                const auto acl = emulator_object<ACL>{c.emu, dacl_address}.read();
+                auto ace_address = dacl_address + sizeof(ACL);
+                for (USHORT i = 0; i < acl.AceCount; ++i)
+                {
+                    const auto ace = emulator_object<ACCESS_ALLOWED_ACE>{c.emu, ace_address}.read();
+                    if (ace.Header.AceSize < sizeof(ACCESS_ALLOWED_ACE))
+                    {
+                        return STATUS_INVALID_PARAMETER;
+                    }
+
+                    const auto ace_mask = map_generic_access(ace.Mask, mapping);
+                    const auto ace_sid = ace_address + offsetof(ACCESS_ALLOWED_ACE, SidStart);
+                    const bool applies =
+                        sid_matches(c.emu.memory(), ace_sid, c.proc.sid) || sid_matches(c.emu.memory(), ace_sid, interactive_sid);
+                    if (applies && ace.Header.AceType == 1 && (ace_mask & remaining) != 0)
+                    {
+                        denied = true;
+                        break;
+                    }
+                    if (applies && ace.Header.AceType == 0)
+                    {
+                        const auto allowed = ace_mask & remaining;
+                        granted |= allowed;
+                        remaining &= ~allowed;
+                    }
+                    ace_address += ace.Header.AceSize;
+                }
+            }
+
+            privilege_set_length.write(0);
+            granted_access.write(granted);
+            access_status.write(!denied && remaining == 0 ? STATUS_SUCCESS : STATUS_ACCESS_DENIED);
+            return STATUS_SUCCESS;
         }
 
         NTSTATUS handle_NtQuerySecurityAttributesToken(const syscall_context& c, const handle token_handle,

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3070,9 +3070,14 @@ namespace sogen
             return data;
         }
 
-        uint64_t handle_NtUserChangeWindowMessageFilterEx()
+        BOOL handle_NtUserChangeWindowMessageFilterEx()
         {
-            return 0;
+            return TRUE;
+        }
+
+        BOOL handle_NtUserChangeWindowMessageFilter()
+        {
+            return TRUE;
         }
 
         BOOL handle_NtUserShowWindow(const syscall_context& c, const hwnd hwnd, const LONG cmd_show)
@@ -5750,6 +5755,21 @@ namespace sogen
             info = {.cbSize = sizeof(info), .hwndActive = active, .hwndFocus = active, .hwndCapture = capture};
             c.emu.write_memory(info_address, info);
 
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetWinEventHook()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserUnhookWinEvent()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserDisableThreadIme()
+        {
             return TRUE;
         }
     }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5736,15 +5736,15 @@ namespace sogen
 
             struct gui_thread_info
             {
-                DWORD cbSize;
-                DWORD flags;
-                hwnd hwndActive;
-                hwnd hwndFocus;
-                hwnd hwndCapture;
-                hwnd hwndMenuOwner;
-                hwnd hwndMoveSize;
-                hwnd hwndCaret;
-                RECT rcCaret;
+                DWORD cbSize{};
+                DWORD flags{};
+                hwnd hwndActive{};
+                hwnd hwndFocus{};
+                hwnd hwndCapture{};
+                hwnd hwndMenuOwner{};
+                hwnd hwndMoveSize{};
+                hwnd hwndCaret{};
+                RECT rcCaret{};
             };
 
             auto info = emulator_object<gui_thread_info>{c.emu, info_address}.read();

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2736,6 +2736,7 @@ namespace sogen
                 guest_win.spwndOwner = parent_win && has_owner ? parent_win->guest.value() : 0;
                 guest_win.lpfnWndProc = win.wnd_proc;
                 guest_win.pcls = class_obj_addr;
+                guest_win.hrgnUpdate = !is_message_only ? 0x12345678 : 0;
                 guest_win.cbWndExtra = wnd_class->cbWndExtra;
                 // Control id offset is build-specific: Win11 reads wID (WND+0x140), Server 2022 reads
                 // spmenu (WND+0x98). Populate both so builtin wndprocs emit the right WM_COMMAND id.
@@ -3460,6 +3461,22 @@ namespace sogen
 
             validate_window(*win);
             return TRUE;
+        }
+
+        BOOL handle_NtUserGetUpdateRect(const syscall_context& c, const hwnd hwnd, const emulator_object<RECT> rect, const BOOL /*erase*/)
+        {
+            const auto* win = c.proc.windows.get(hwnd);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            if (rect)
+            {
+                rect.write(win->update_pending ? win->update_rect : RECT{});
+            }
+
+            return win->update_pending ? TRUE : FALSE;
         }
 
         void collect_pending_paint_tree(const syscall_context& c, window& win, std::vector<uint64_t>& order)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5710,6 +5710,48 @@ namespace sogen
         {
             return TRUE;
         }
+
+        BOOL handle_NtUserGetGUIThreadInfo(const syscall_context& c, const uint32_t thread_id, const emulator_pointer info_address)
+        {
+            if (info_address == 0)
+            {
+                return FALSE;
+            }
+
+            const auto target_thread_id = thread_id == 0 ? c.vcpu.active_thread->id : thread_id;
+            if (c.proc.find_thread_by_id(target_thread_id) == nullptr)
+            {
+                return FALSE;
+            }
+
+            const auto* foreground = c.proc.windows.get(c.proc.foreground_window);
+            const auto active = foreground && foreground->thread_id == target_thread_id ? c.proc.foreground_window : 0;
+            const auto* captured = c.proc.windows.get(c.proc.mouse_capture_window);
+            const auto capture = captured && captured->thread_id == target_thread_id ? c.proc.mouse_capture_window : 0;
+
+            struct gui_thread_info
+            {
+                DWORD cbSize;
+                DWORD flags;
+                hwnd hwndActive;
+                hwnd hwndFocus;
+                hwnd hwndCapture;
+                hwnd hwndMenuOwner;
+                hwnd hwndMoveSize;
+                hwnd hwndCaret;
+                RECT rcCaret;
+            };
+
+            auto info = emulator_object<gui_thread_info>{c.emu, info_address}.read();
+            if (info.cbSize != sizeof(info))
+            {
+                return FALSE;
+            }
+            info = {.cbSize = sizeof(info), .hwndActive = active, .hwndFocus = active, .hwndCapture = capture};
+            c.emu.write_memory(info_address, info);
+
+            return TRUE;
+        }
     }
 
 } // namespace sogen

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5710,11 +5710,6 @@ namespace sogen
         {
             return TRUE;
         }
-
-        uint64_t handle_NtUserActivateKeyboardLayout()
-        {
-            return 0x1337;
-        }
     }
 
 } // namespace sogen


### PR DESCRIPTION
This PR includes the following improvements:

* [Fixes `UpdateWindow` calls](https://github.com/momo5502/sogen/commit/ece4c0e568bbac4eabbdb8e27567560c2ab48137). Previously, calling `UpdateWindow` was treated as a no-op if the window had no children, which broke applications that call it during rendering.
* [Improves keyboard layout syscalls](https://github.com/momo5502/sogen/commit/33632c5cee77a10c86348047b83d25f3d3b5a373) so they behave consistently.
* [Fixes `IsInteractiveUserLogon`](https://github.com/momo5502/sogen/commit/9ec57d8d6bee69bc1136392c8c4907c9f19cab3c). The issue was that the process/thread token was not previously reported as interactive.
* [Implements `ProcessImageFileName` in `NtQueryInformationProcess`](https://github.com/momo5502/sogen/commit/05064bbed43e53971c50c769717e62a9ae84b80a).
* [Implements `NtUserGetGUIThreadInfo`](https://github.com/momo5502/sogen/commit/a4a30e430f485ff9433137caf781b3ba7fa10168).
* [Adds more syscall stubs](https://github.com/momo5502/sogen/commit/6a879ae4cdb0c75e0d4a9dbe395c5684febeca68), namely: `NtGdiGetPublicFontTableChangeCookie`, `NtGdiAddFontResourceW`, `NtUserChangeWindowMessageFilter`, `NtUserSetWinEventHook`, `NtUserUnhookWinEvent`, and `NtUserDisableThreadIme`.
