### PR TITLE
fuzz: run parallel workers (-jobs/-workers) instead of -fork

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -99,22 +99,24 @@ jobs:
         run: |
           mkdir -p corpus artifacts
           set +e
-          # -fork=$(nproc): parallel fuzzing across all cores, sharing the corpus dir.
-          # -ignore_ooms/timeouts=0: fork mode ignores OOMs and timeouts by default; treat them as
-          # findings so they fail the job (a huge guest-driven allocation is a real bug here).
+          # -jobs/-workers=$(nproc): one long-lived fuzzer per core, all sharing the corpus dir. Unlike
+          # -fork (which respawns a short-lived child per micro-job and re-pays our expensive emulator
+          # construction + a full corpus replay every time), each worker builds the emulator once and then
+          # fuzzes continuously, so throughput stays high as the retained corpus grows. An OOM/timeout/crash
+          # in a worker aborts that worker and writes a reproducer to artifacts/ (detected below).
           ./build/fuzz/artifacts/windows-emulator-fuzz \
             corpus \
-            -fork=$(nproc) \
-            -ignore_ooms=0 \
-            -ignore_timeouts=0 \
-            -ignore_crashes=0 \
+            -jobs=$(nproc) \
+            -workers=$(nproc) \
             -max_total_time=${DURATION} \
             -use_value_profile=1 \
             -print_final_stats=1 \
             -artifact_prefix=artifacts/ \
             2>&1 | tee fuzz.log
-          # In fork mode the process exit code is unreliable, so detect a finding by the reproducer files
-          # libFuzzer writes to artifacts/ (crash-*/oom-*/timeout-*/leak-*). Any match is a failure.
+          # In -jobs mode each worker logs to fuzz-<n>.log; fold them into fuzz.log for the artifact.
+          cat fuzz-*.log >> fuzz.log 2>/dev/null || true
+          # The launcher's exit code is unreliable, so detect a finding by the reproducer files libFuzzer
+          # writes to artifacts/ (crash-*/oom-*/timeout-*/leak-*). Any match is a failure.
           if find artifacts -type f \( -name 'crash-*' -o -name 'oom-*' -o -name 'timeout-*' -o -name 'leak-*' \) | grep -q .; then
             echo "fuzz_status=1" >> "$GITHUB_ENV"
           else
@@ -138,6 +140,7 @@ jobs:
           path: |
             artifacts/
             fuzz.log
+            fuzz-*.log
           retention-days: 30
 
       - name: Fail on crash


### PR DESCRIPTION
## Why

`-fork` respawns a short-lived child per micro-job, so it re-pays the harness's expensive `windows_emulator` construction **and a full corpus replay on every respawn**. As the retained corpus grew into the thousands, that per-job overhead came to dominate and exec/s collapsed (observed dropping to a few hundred/s on the nightly runs).

## What

Switch the Fuzz step from `-fork=$(nproc)` to `-jobs=$(nproc) -workers=$(nproc)`:

- **One long-lived fuzzer per core**, each building the emulator **once** and fuzzing continuously, all sharing the `corpus` dir. Init and corpus load are amortized over the whole run instead of repeated per micro-job.
- Dropped the fork-only `-ignore_ooms/-ignore_timeouts/-ignore_crashes` flags. In `-jobs` mode an OOM/timeout/crash aborts that worker and writes a reproducer to `artifacts/` natively — the existing `find`-based reproducer detection already catches all of those, so the gate is unchanged.
- `-jobs` workers log to `fuzz-<n>.log` rather than stdout, so those are folded into `fuzz.log` and added to the crash-artifact upload.

## Trade-off

We originally chose `-fork` for its central OOM/timeout supervision, which mattered while the device handlers still OOM'd freely. Now that those allocations are capped (#1196), that safety net is much less important. The one thing given up: fork's clean reaping of a true infinite-loop hang — in `-jobs` mode `-timeout` still fires and writes a `timeout-*` file, which the gate catches.

Corpus retention (cache save/restore) is untouched; workers still write new finds to the shared `corpus` dir.