### PR TITLE
gpu_bridge: shrink download_memory staging cap in fuzz builds

### DIFF
--- a/cmake/compiler-env.cmake
+++ b/cmake/compiler-env.cmake
@@ -40,6 +40,16 @@ endif()
 
 ##########################################
 
+# Let handler code shrink fuzz-only tunables (e.g. gpu_bridge's bulk-transfer staging cap) so the
+# fuzzer doesn't burn most of its time on large allocations that are already proven bounded.
+if(SOGEN_ENABLE_FUZZING)
+    add_compile_definitions(SOGEN_ENABLE_FUZZING=1)
+else()
+    add_compile_definitions(SOGEN_ENABLE_FUZZING=0)
+endif()
+
+##########################################
+
 set(SOGEN_ENABLE_RUST OFF)
 if(SOGEN_ENABLE_RUST_CODE AND NOT MINGW AND NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
   find_program(CARGO cargo)

--- a/cmake/compiler-env.cmake
+++ b/cmake/compiler-env.cmake
@@ -40,12 +40,8 @@ endif()
 
 ##########################################
 
-# Let handler code shrink fuzz-only tunables (e.g. gpu_bridge's bulk-transfer staging cap) so the
-# fuzzer doesn't burn most of its time on large allocations that are already proven bounded.
 if(SOGEN_ENABLE_FUZZING)
-    add_compile_definitions(SOGEN_ENABLE_FUZZING=1)
-else()
-    add_compile_definitions(SOGEN_ENABLE_FUZZING=0)
+    add_compile_definitions(SOGEN_ENABLE_FUZZING)
 endif()
 
 ##########################################

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2264,10 +2264,8 @@ namespace sogen
             // object, but we don't track its size for the general path, so bound the host staging buffer so a
             // bogus request.size/output length can't force a huge allocation. Sized to fit realistic
             // single-resource readbacks (4K/8K textures, large buffers).
-#if SOGEN_ENABLE_FUZZING
-            // Fuzz builds shrink it: the fuzzer drives download_memory with bogus requests and no real GPU
-            // memory behind them, so the full 256 MiB staging buffer is pure zero-fill overhead (~121 ms per
-            // execution) that dominates throughput. 1 MiB still exercises the path; the shipped cap is 256 MiB.
+#ifdef SOGEN_ENABLE_FUZZING
+            // Shrunk for fuzzing: bogus download requests would otherwise zero-fill 256 MiB every execution.
             static constexpr size_t max_memory_transfer_bytes = size_t{1} * 1024 * 1024;
 #else
             static constexpr size_t max_memory_transfer_bytes = size_t{256} * 1024 * 1024;

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2264,7 +2264,14 @@ namespace sogen
             // object, but we don't track its size for the general path, so bound the host staging buffer so a
             // bogus request.size/output length can't force a huge allocation. Sized to fit realistic
             // single-resource readbacks (4K/8K textures, large buffers).
+#if SOGEN_ENABLE_FUZZING
+            // Fuzz builds shrink it: the fuzzer drives download_memory with bogus requests and no real GPU
+            // memory behind them, so the full 256 MiB staging buffer is pure zero-fill overhead (~121 ms per
+            // execution) that dominates throughput. 1 MiB still exercises the path; the shipped cap is 256 MiB.
+            static constexpr size_t max_memory_transfer_bytes = size_t{1} * 1024 * 1024;
+#else
             static constexpr size_t max_memory_transfer_bytes = size_t{256} * 1024 * 1024;
+#endif
 
             // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
             // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.


### PR DESCRIPTION
## Why

The host-side fuzzer drives `download_memory` with bogus requests — there's no real GPU memory behind them — but the handler still allocates and **zero-fills** its staging buffer up to `max_memory_transfer_bytes` (256 MiB). Measured at **~121 ms per execution**. Coverage-guided fuzzing keeps those inputs (they hit new edges) and replays them across every worker, which measurably dominated throughput: dropping just this cap 256 MiB → 1 MiB recovered **~4×** exec/s in a CI A/B (per-worker ~700 → ~2,750).

## What

Emit `SOGEN_ENABLE_FUZZING=1/0` as a compile definition from CMake (in `compiler-env.cmake`, following the existing `SOGEN_BUILD_STATIC` / `SOGEN_ENABLE_RUST_CODE` pattern), and use it in `gpu_bridge.cpp` to cap the `download_memory` staging buffer at **1 MiB in fuzz builds only**:

```cpp
#if SOGEN_ENABLE_FUZZING
    static constexpr size_t max_memory_transfer_bytes = size_t{1} * 1024 * 1024;
#else
    static constexpr size_t max_memory_transfer_bytes = size_t{256} * 1024 * 1024;
#endif
```

The **shipped (non-fuzz) build keeps the 256 MiB cap unchanged** — this only affects `SOGEN_ENABLE_FUZZING=ON` builds. The code path is still fully exercised by the fuzzer; only the buffer size shrinks, so no coverage is lost.

## Verified

- Production build (`SOGEN_ENABLE_FUZZING=0`): compiles, uses 256 MiB.
- Fuzz build (`SOGEN_ENABLE_FUZZING=1`): replaying the `download_memory` OOM reproducer drops from **~121 ms/exec → ~0 ms/exec**.

Note: adding a new global compile definition triggers a one-time full rebuild when it lands (same as any change to `SOGEN_BUILD_STATIC` et al.).