### PR TITLE
Fix AFD connect address offset for 32-bit (WoW64) guests

### DIFF
--- a/src/windows-emulator/devices/afd_endpoint.cpp
+++ b/src/windows-emulator/devices/afd_endpoint.cpp
@@ -635,7 +635,8 @@ namespace sogen
 
                 auto data = win_emu.emu().read_memory(c.input_buffer, c.input_buffer_length);
 
-                constexpr auto address_offset = 24;
+                // AFD_CONNECT_INFO::RemoteAddress follows BOOLEAN + two ULONG_PTR (pointer-aligned): 24 on x64, 12 on WoW64.
+                constexpr auto address_offset = 3 * sizeof(typename Traits::ULONG_PTR);
 
                 if (data.size() < address_offset)
                 {


### PR DESCRIPTION
`ioctl_connect` hardcoded the `RemoteAddress` offset within `AFD_CONNECT_INFO` to **24** — the 64-bit layout (`BOOLEAN UseSAN` + two `ULONG_PTR` fields, each pointer-aligned).

On a **32-bit WoW64 guest** the pointers are 4 bytes, so the sockaddr sits at offset **12**. Reading at 24 ran past it and threw `"Bad address size"`, breaking every `connect()` from a 32-bit guest.

The fix derives the offset from the guest pointer width (`3 * sizeof(typename Traits::ULONG_PTR)`) so both 64-bit (24) and 32-bit (12) guests work. `ioctl_bind`'s offset of 4 was already bitness-independent (a `ULONG` share-type field), so only connect was affected.

Found while bringing up a 32-bit game that was hitting this on its first `connect()`.