### PR TITLE
dns_resolver: support 32-bit (WoW64) callers

### DIFF
--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -85,9 +85,9 @@ namespace sogen
             // The hostname length/name follow a run of pointer-sized fields, so a 32-bit (WoW64) caller packs
             // them at half the 64-bit offsets; parse relative to the caller's pointer width.
             const size_t ptr = win_emu.process.is_wow64_process ? sizeof(uint32_t) : sizeof(uint64_t);
-            const ULONG length_offset = static_cast<ULONG>(1 * ptr);   // name character count (incl. NUL)
-            const ULONG actual_length_offset = static_cast<ULONG>(3 * ptr);
-            const ULONG hostname_offset = static_cast<ULONG>(4 * ptr); // UTF-16 hostname
+            const auto length_offset = static_cast<ULONG>(1 * ptr);   // name character count (incl. NUL)
+            const auto actual_length_offset = static_cast<ULONG>(3 * ptr);
+            const auto hostname_offset = static_cast<ULONG>(4 * ptr); // UTF-16 hostname
             constexpr ULONG fixed_trailer_size = 8;
             auto& emu = win_emu.emu();
 

--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -4,8 +4,6 @@
 #include "binary_writer.hpp"
 #include "../windows_emulator.hpp"
 
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
 
 #define DNS_TYPE_A     0x01
@@ -56,11 +54,9 @@ namespace sogen
                 if (record)
                 {
                     writer.write_ndr_pointer(false);
-                    // The 32-bit (WoW64) DnsResolver reply carries one extra null pointer field before the
-                    // name pointer that the 64-bit layout does not. Without it the record is shifted and the
-                    // 32-bit dnsapi stub rejects the whole reply with ERROR_INVALID_PARAMETER (confirmed by
-                    // diffing a real dnscache reply). Match the real wire layout per caller width.
-                    if (writer.pointer_size() == 4)
+                    // A real 32-bit dnscache reply carries one extra null pointer here that the 64-bit layout
+                    // lacks; without it the record is shifted and the 32-bit dnsapi stub rejects the reply.
+                    if (writer.pointer_size() == utils::aligned_binary_writer::pointer_size_32)
                     {
                         writer.write_ndr_pointer(false);
                     }
@@ -86,10 +82,8 @@ namespace sogen
 
         bool parse_dns_query_request(windows_emulator& win_emu, const lpc_request_context& c, dns_query_request& request)
         {
-            // The DnsQuery request is a run of pointer-sized fields followed by the UTF-16 hostname: a header
-            // word, the name character count, a word, the name max count, then the name. Its offsets are
-            // therefore pointer-sized -- a 32-bit (WoW64) caller packs them at half the 64-bit offsets, so
-            // parse relative to the caller's pointer width (matches the reply writer in handle_rpc_call).
+            // The hostname length/name follow a run of pointer-sized fields, so a 32-bit (WoW64) caller packs
+            // them at half the 64-bit offsets; parse relative to the caller's pointer width.
             const size_t ptr = win_emu.process.is_wow64_process ? sizeof(uint32_t) : sizeof(uint64_t);
             const ULONG length_offset = static_cast<ULONG>(1 * ptr);   // name character count (incl. NUL)
             const ULONG actual_length_offset = static_cast<ULONG>(3 * ptr);
@@ -138,13 +132,6 @@ namespace sogen
         {
             const auto family = dns_type == DNS_TYPE_A ? AF_INET : AF_INET6;
             const auto results = win_emu.dns_lookup().resolve_host(u16_to_u8(host), family);
-
-            if (std::getenv("SOGEN_AFD_TRACE"))
-            {
-                std::fprintf(stderr, "[dns] resolve %s (type=%u) -> %zu result(s)\n", u16_to_u8(host).c_str(),
-                             static_cast<unsigned>(dns_type), results.size());
-                std::fflush(stderr);
-            }
 
             std::vector<resolved_dns_record> records;
             for (const auto& current : results)

--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -4,6 +4,8 @@
 #include "binary_writer.hpp"
 #include "../windows_emulator.hpp"
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 #define DNS_TYPE_A     0x01
@@ -54,6 +56,14 @@ namespace sogen
                 if (record)
                 {
                     writer.write_ndr_pointer(false);
+                    // The 32-bit (WoW64) DnsResolver reply carries one extra null pointer field before the
+                    // name pointer that the 64-bit layout does not. Without it the record is shifted and the
+                    // 32-bit dnsapi stub rejects the whole reply with ERROR_INVALID_PARAMETER (confirmed by
+                    // diffing a real dnscache reply). Match the real wire layout per caller width.
+                    if (writer.pointer_size() == 4)
+                    {
+                        writer.write_ndr_pointer(false);
+                    }
                     writer.write_ndr_pointer(true);
                     writer.write(record->type);
                     writer.write(record->data_length);
@@ -76,8 +86,14 @@ namespace sogen
 
         bool parse_dns_query_request(windows_emulator& win_emu, const lpc_request_context& c, dns_query_request& request)
         {
-            constexpr ULONG hostname_header_offset = 0x08;
-            constexpr ULONG hostname_offset = 0x20;
+            // The DnsQuery request is a run of pointer-sized fields followed by the UTF-16 hostname: a header
+            // word, the name character count, a word, the name max count, then the name. Its offsets are
+            // therefore pointer-sized -- a 32-bit (WoW64) caller packs them at half the 64-bit offsets, so
+            // parse relative to the caller's pointer width (matches the reply writer in handle_rpc_call).
+            const size_t ptr = win_emu.process.is_wow64_process ? sizeof(uint32_t) : sizeof(uint64_t);
+            const ULONG length_offset = static_cast<ULONG>(1 * ptr);   // name character count (incl. NUL)
+            const ULONG actual_length_offset = static_cast<ULONG>(3 * ptr);
+            const ULONG hostname_offset = static_cast<ULONG>(4 * ptr); // UTF-16 hostname
             constexpr ULONG fixed_trailer_size = 8;
             auto& emu = win_emu.emu();
 
@@ -86,8 +102,12 @@ namespace sogen
                 return false;
             }
 
-            const auto hostname_length = static_cast<size_t>(emu.read_memory<uint64_t>(c.send_buffer + hostname_header_offset));
-            const auto hostname_actual_length = static_cast<size_t>(emu.read_memory<uint64_t>(c.send_buffer + 0x18));
+            const auto read_count = [&](const emulator_pointer at) -> size_t {
+                return win_emu.process.is_wow64_process ? static_cast<size_t>(emu.read_memory<uint32_t>(at))
+                                                        : static_cast<size_t>(emu.read_memory<uint64_t>(at));
+            };
+            const auto hostname_length = read_count(c.send_buffer + length_offset);
+            const auto hostname_actual_length = read_count(c.send_buffer + actual_length_offset);
             if (hostname_length == 0 || hostname_actual_length != hostname_length)
             {
                 return false;
@@ -118,6 +138,13 @@ namespace sogen
         {
             const auto family = dns_type == DNS_TYPE_A ? AF_INET : AF_INET6;
             const auto results = win_emu.dns_lookup().resolve_host(u16_to_u8(host), family);
+
+            if (std::getenv("SOGEN_AFD_TRACE"))
+            {
+                std::fprintf(stderr, "[dns] resolve %s (type=%u) -> %zu result(s)\n", u16_to_u8(host).c_str(),
+                             static_cast<unsigned>(dns_type), results.size());
+                std::fflush(stderr);
+            }
 
             std::vector<resolved_dns_record> records;
             for (const auto& current : results)

--- a/src/windows-emulator/ports/dns_resolver.cpp
+++ b/src/windows-emulator/ports/dns_resolver.cpp
@@ -85,7 +85,7 @@ namespace sogen
             // The hostname length/name follow a run of pointer-sized fields, so a 32-bit (WoW64) caller packs
             // them at half the 64-bit offsets; parse relative to the caller's pointer width.
             const size_t ptr = win_emu.process.is_wow64_process ? sizeof(uint32_t) : sizeof(uint64_t);
-            const auto length_offset = static_cast<ULONG>(1 * ptr);   // name character count (incl. NUL)
+            const auto length_offset = static_cast<ULONG>(1 * ptr); // name character count (incl. NUL)
             const auto actual_length_offset = static_cast<ULONG>(3 * ptr);
             const auto hostname_offset = static_cast<ULONG>(4 * ptr); // UTF-16 hostname
             constexpr ULONG fixed_trailer_size = 8;


### PR DESCRIPTION
The emulated `DNSResolver` ALPC port marshalled both the request and the reply with a fixed 64-bit layout, so DNS resolution failed for every 32-bit (WoW64) guest process — `gethostbyname`, `getaddrinfo` and `DnsQuery` all returned failure.

## Fixes

- **Request parse** (`parse_dns_query_request`): the hostname length and name were read at hard-coded 64-bit offsets. They are now derived from the caller's pointer width (`win_emu.process.is_wow64_process`), since a 32-bit caller packs the pointer-sized fields at half the offsets.

- **Response marshal** (`dns_query_response::write`): the record was emitted with the 64-bit layout. A real 32-bit `dnscache` reply carries one extra null pointer before the name pointer; without it the `DNS_RECORD` is shifted and the 32-bit `dnsapi` stub rejects the whole reply with `ERROR_INVALID_PARAMETER`. The extra field is now emitted for 32-bit callers.

## Verification

The emulator's reply was diffed against a real `dnscache` reply captured with an `NtAlpcSendWaitReceivePort` hook. With a small test program under the emulator:

- 32-bit: `gethostbyname` / `getaddrinfo` / `DnsQuery_A` now resolve.
- 64-bit: unchanged (the derived offsets match the previous hard-coded constants).
- Smoke tests pass.
