### PR TITLE
Map image sections from existing loaded modules

### DIFF
--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -188,9 +188,10 @@ namespace sogen
     }
 
     // PE32 Mapping Strategy Implementation
-    mapped_module pe32_mapping_strategy::map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path)
+    mapped_module pe32_mapping_strategy::map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                                       const uint64_t relocation_base)
     {
-        return map_module_from_file<std::uint32_t>(memory, std::move(file), std::move(module_path));
+        return map_module_from_file<std::uint32_t>(memory, std::move(file), std::move(module_path), relocation_base);
     }
 
     mapped_module pe32_mapping_strategy::map_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size,
@@ -200,9 +201,10 @@ namespace sogen
     }
 
     // PE64 Mapping Strategy Implementation
-    mapped_module pe64_mapping_strategy::map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path)
+    mapped_module pe64_mapping_strategy::map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                                       const uint64_t relocation_base)
     {
-        return map_module_from_file<std::uint64_t>(memory, std::move(file), std::move(module_path));
+        return map_module_from_file<std::uint64_t>(memory, std::move(file), std::move(module_path), relocation_base);
     }
 
     mapped_module pe64_mapping_strategy::map_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size,
@@ -249,34 +251,25 @@ namespace sogen
         try
         {
             [[maybe_unused]] auto& strategy = strategy_factory_.get_strategy(detection_result.architecture);
-            return this->register_mapped_module(mapper(), is_static);
+            mapped_module mod = mapper();
+            mod.is_static = is_static;
+
+            if (!mod.path.empty())
+            {
+                this->modules_load_count[mod.path]++;
+            }
+
+            const auto image_base = mod.image_base;
+            const auto entry = this->modules_.try_emplace(image_base, std::move(mod));
+            this->last_module_cache_ = this->modules_.end();
+            this->callbacks_->on_module_load(entry.first->second);
+            return &entry.first->second;
         }
         catch (const std::exception& e)
         {
             logger.error("Failed to map module: %s\n", e.what());
             return nullptr;
         }
-    }
-
-    mapped_module* module_manager::register_mapped_module(mapped_module module, const bool is_static)
-    {
-        module.is_static = is_static;
-
-        const auto image_base = module.image_base;
-        const auto entry = this->modules_.try_emplace(image_base, std::move(module));
-        if (!entry.second)
-        {
-            throw std::runtime_error("Module already mapped at base 0x" + std::to_string(image_base));
-        }
-
-        if (!entry.first->second.path.empty())
-        {
-            this->modules_load_count[entry.first->second.path]++;
-        }
-
-        this->last_module_cache_ = this->modules_.end();
-        this->callbacks_->on_module_load(entry.first->second);
-        return &entry.first->second;
     }
 
     execution_mode module_manager::detect_execution_mode(const windows_path& executable_path, const logger& logger)
@@ -496,16 +489,17 @@ namespace sogen
         return {};
     }
 
-    mapped_module* module_manager::map_module(windows_path file, const logger& logger, const bool is_static, bool allow_duplicate)
+    mapped_module* module_manager::map_module(windows_path file, const logger& logger, const bool is_static, bool allow_duplicate,
+                                              const uint64_t relocation_base)
     {
         auto local_file = this->file_sys_->translate(file);
 
         if (local_file.filename() == "win32u.dll")
         {
-            return this->map_local_module(local_file, std::move(file), logger, is_static, false);
+            return this->map_local_module(local_file, std::move(file), logger, is_static, false, relocation_base);
         }
 
-        return this->map_local_module(local_file, std::move(file), logger, is_static, allow_duplicate);
+        return this->map_local_module(local_file, std::move(file), logger, is_static, allow_duplicate, relocation_base);
     }
 
     mapped_module* module_manager::map_module_or_throw(const windows_path& file, const logger& logger, const bool is_static,
@@ -521,7 +515,7 @@ namespace sogen
     }
 
     mapped_module* module_manager::map_local_module(const std::filesystem::path& file, windows_path module_path, const logger& logger,
-                                                    const bool is_static, bool allow_duplicate)
+                                                    const bool is_static, bool allow_duplicate, const uint64_t relocation_base)
     {
         auto local_file = weakly_canonical(absolute(file));
 
@@ -542,7 +536,7 @@ namespace sogen
             detection_result,
             [&]() {
                 auto& strategy = strategy_factory_.get_strategy(detection_result.architecture);
-                return strategy.map_from_file(*this->memory_, std::move(local_file), std::move(module_path));
+                return strategy.map_from_file(*this->memory_, std::move(local_file), std::move(module_path), relocation_base);
             },
             logger, is_static);
     }

--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -249,30 +249,34 @@ namespace sogen
         try
         {
             [[maybe_unused]] auto& strategy = strategy_factory_.get_strategy(detection_result.architecture);
-            mapped_module mod = mapper();
-            mod.is_static = is_static;
-
-            if (!mod.path.empty())
-            {
-                this->modules_load_count[mod.path]++;
-            }
-
-            const auto image_base = mod.image_base;
-            const auto entry = this->modules_.try_emplace(image_base, std::move(mod));
-            if (!entry.second)
-            {
-                throw std::runtime_error("Module already mapped at base 0x" + std::to_string(image_base));
-            }
-
-            this->last_module_cache_ = this->modules_.end();
-            this->callbacks_->on_module_load(entry.first->second);
-            return &entry.first->second;
+            return this->register_mapped_module(mapper(), is_static);
         }
         catch (const std::exception& e)
         {
             logger.error("Failed to map module: %s\n", e.what());
             return nullptr;
         }
+    }
+
+    mapped_module* module_manager::register_mapped_module(mapped_module module, const bool is_static)
+    {
+        module.is_static = is_static;
+
+        const auto image_base = module.image_base;
+        const auto entry = this->modules_.try_emplace(image_base, std::move(module));
+        if (!entry.second)
+        {
+            throw std::runtime_error("Module already mapped at base 0x" + std::to_string(image_base));
+        }
+
+        if (!entry.first->second.path.empty())
+        {
+            this->modules_load_count[entry.first->second.path]++;
+        }
+
+        this->last_module_cache_ = this->modules_.end();
+        this->callbacks_->on_module_load(entry.first->second);
+        return &entry.first->second;
     }
 
     execution_mode module_manager::detect_execution_mode(const windows_path& executable_path, const logger& logger)

--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -259,6 +259,11 @@ namespace sogen
 
             const auto image_base = mod.image_base;
             const auto entry = this->modules_.try_emplace(image_base, std::move(mod));
+            if (!entry.second)
+            {
+                throw std::runtime_error("Module already mapped at base 0x" + std::to_string(image_base));
+            }
+
             this->last_module_cache_ = this->modules_.end();
             this->callbacks_->on_module_load(entry.first->second);
             return &entry.first->second;

--- a/src/windows-emulator/module/module_manager.hpp
+++ b/src/windows-emulator/module/module_manager.hpp
@@ -39,7 +39,8 @@ namespace sogen
     {
       public:
         virtual ~module_mapping_strategy() = default;
-        virtual mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path) = 0;
+        virtual mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                            uint64_t relocation_base) = 0;
         virtual mapped_module map_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size,
                                               windows_path module_path) = 0;
     };
@@ -47,7 +48,8 @@ namespace sogen
     class pe32_mapping_strategy : public module_mapping_strategy
     {
       public:
-        mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path) override;
+        mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                    uint64_t relocation_base) override;
         mapped_module map_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size,
                                       windows_path module_path) override;
     };
@@ -55,7 +57,8 @@ namespace sogen
     class pe64_mapping_strategy : public module_mapping_strategy
     {
       public:
-        mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path) override;
+        mapped_module map_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                    uint64_t relocation_base) override;
         mapped_module map_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size,
                                       windows_path module_path) override;
     };
@@ -96,15 +99,14 @@ namespace sogen
                               const logger& logger);
 
         std::optional<uint64_t> get_module_load_count_by_path(const windows_path& path);
-        mapped_module* map_module(windows_path file, const logger& logger, bool is_static = false, bool allow_duplicate = false);
+        mapped_module* map_module(windows_path file, const logger& logger, bool is_static = false, bool allow_duplicate = false,
+                                  uint64_t relocation_base = 0);
         mapped_module* map_module_or_throw(const windows_path& file, const logger& logger, bool is_static = false,
                                            bool allow_duplicate = false);
         mapped_module* map_local_module(const std::filesystem::path& file, windows_path module_path, const logger& logger,
-                                        bool is_static = false, bool allow_duplicate = false);
+                                        bool is_static = false, bool allow_duplicate = false, uint64_t relocation_base = 0);
         mapped_module* map_memory_module(uint64_t base_address, uint64_t image_size, windows_path module_path, const logger& logger,
                                          bool is_static = false, bool allow_duplicate = false);
-        mapped_module* register_mapped_module(mapped_module module, bool is_static = false);
-
         mapped_module* find_by_address(const uint64_t address)
         {
             const auto entry = this->get_module(address);

--- a/src/windows-emulator/module/module_manager.hpp
+++ b/src/windows-emulator/module/module_manager.hpp
@@ -103,6 +103,7 @@ namespace sogen
                                         bool is_static = false, bool allow_duplicate = false);
         mapped_module* map_memory_module(uint64_t base_address, uint64_t image_size, windows_path module_path, const logger& logger,
                                          bool is_static = false, bool allow_duplicate = false);
+        mapped_module* register_mapped_module(mapped_module module, bool is_static = false);
 
         mapped_module* find_by_address(const uint64_t address)
         {

--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -356,9 +356,10 @@ namespace sogen
         }
 
         template <typename T>
-        void apply_relocations(const mapped_module& binary, memory_manager& memory, const PEOptionalHeader_t<T>& optional_header)
+        void apply_relocations(const mapped_module& binary, memory_manager& memory, const PEOptionalHeader_t<T>& optional_header,
+                               const uint64_t relocation_base)
         {
-            const auto delta = binary.image_base - optional_header.ImageBase;
+            const auto delta = relocation_base - optional_header.ImageBase;
             if (delta == 0)
             {
                 return;
@@ -502,7 +503,8 @@ namespace sogen
         template <typename T>
         bool try_map_module_at_current_base(memory_manager& memory, mapped_module& binary,
                                             const utils::safe_buffer_accessor<const std::byte> buffer, const PENTHeaders_t<T>& nt_headers,
-                                            const uint64_t nt_headers_offset, const PEOptionalHeader_t<T>& optional_header)
+                                            const uint64_t nt_headers_offset, const PEOptionalHeader_t<T>& optional_header,
+                                            const uint64_t relocation_base)
         {
             binary.sections.clear();
             binary.exports.clear();
@@ -535,12 +537,12 @@ namespace sogen
                     return false;
                 }
 
-                const auto image_base = static_cast<T>(binary.image_base);
+                const auto image_base = static_cast<T>(relocation_base);
                 const auto image_base_address = binary.image_base + nt_headers_offset + offsetof(PENTHeaders_t<T>, OptionalHeader) +
                                                 offsetof(PEOptionalHeader_t<T>, ImageBase);
                 memory.write_memory(image_base_address, &image_base, sizeof(image_base));
 
-                apply_relocations(binary, memory, optional_header);
+                apply_relocations(binary, memory, optional_header, relocation_base);
                 collect_exports(binary, memory, optional_header);
                 collect_imports(binary, memory, optional_header);
 
@@ -567,8 +569,8 @@ namespace sogen
     }
 
     template <typename T>
-    mapped_module map_module_from_data(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
-                                       windows_path module_path)
+    mapped_module map_module_from_data_impl(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
+                                            windows_path module_path, const std::optional<uint64_t> relocation_base)
     {
         mapped_module binary{};
         binary.path = std::move(file);
@@ -613,9 +615,10 @@ namespace sogen
         const auto has_dynamic_base = optional_header.DllCharacteristics & IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE;
         const auto is_relocatable = is_dll || has_dynamic_base;
 
-        if (!try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header))
+        if (!binary.image_base || !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
+                                                                  relocation_base.value_or(binary.image_base)))
         {
-            if (!is_relocatable)
+            if (!is_relocatable && !relocation_base)
             {
                 throw std::runtime_error("Memory range not allocatable");
             }
@@ -638,8 +641,8 @@ namespace sogen
                     memory.find_free_allocation_base(static_cast<size_t>(binary.size_of_image), DEFAULT_ALLOCATION_ADDRESS_64BIT);
             }
 
-            if (!binary.image_base ||
-                !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header))
+            if (!binary.image_base || !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset,
+                                                                      optional_header, relocation_base.value_or(binary.image_base)))
             {
                 throw std::runtime_error("Memory range not allocatable");
             }
@@ -648,6 +651,13 @@ namespace sogen
         binary.entry_point = binary.image_base + optional_header.AddressOfEntryPoint;
 
         return binary;
+    }
+
+    template <typename T>
+    mapped_module map_module_from_data(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
+                                       windows_path module_path)
+    {
+        return map_module_from_data_impl<T>(memory, data, std::move(file), std::move(module_path), std::nullopt);
     }
 
     template <typename T>
@@ -660,6 +670,19 @@ namespace sogen
         }
 
         return map_module_from_data<T>(memory, data, std::move(file), std::move(module_path));
+    }
+
+    template <typename T>
+    mapped_module map_image_view_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                           const uint64_t relocation_base)
+    {
+        const auto data = utils::io::read_file(file);
+        if (data.empty())
+        {
+            throw std::runtime_error("Bad file data: " + file.string());
+        }
+
+        return map_module_from_data_impl<T>(memory, data, std::move(file), std::move(module_path), relocation_base);
     }
 
     template <typename T>
@@ -770,6 +793,10 @@ namespace sogen
                                                                windows_path module_path);
     template mapped_module map_module_from_file<std::uint64_t>(memory_manager& memory, std::filesystem::path file,
                                                                windows_path module_path);
+    template mapped_module map_image_view_from_file<std::uint32_t>(memory_manager& memory, std::filesystem::path file,
+                                                                   windows_path module_path, uint64_t relocation_base);
+    template mapped_module map_image_view_from_file<std::uint64_t>(memory_manager& memory, std::filesystem::path file,
+                                                                   windows_path module_path, uint64_t relocation_base);
 
     template mapped_module map_module_from_memory<std::uint32_t>(memory_manager& memory, uint64_t base_address, uint64_t image_size,
                                                                  windows_path module_path);

--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -569,8 +569,8 @@ namespace sogen
     }
 
     template <typename T>
-    mapped_module map_module_from_data_impl(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
-                                            windows_path module_path, const std::optional<uint64_t> relocation_base)
+    mapped_module map_module_from_data(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
+                                       windows_path module_path, const uint64_t relocation_base)
     {
         mapped_module binary{};
         binary.path = std::move(file);
@@ -616,9 +616,9 @@ namespace sogen
         const auto is_relocatable = is_dll || has_dynamic_base;
 
         if (!binary.image_base || !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
-                                                                  relocation_base.value_or(binary.image_base)))
+                                                                  relocation_base ? relocation_base : binary.image_base))
         {
-            if (!is_relocatable && !relocation_base)
+            if (!is_relocatable && relocation_base == 0)
             {
                 throw std::runtime_error("Memory range not allocatable");
             }
@@ -641,8 +641,9 @@ namespace sogen
                     memory.find_free_allocation_base(static_cast<size_t>(binary.size_of_image), DEFAULT_ALLOCATION_ADDRESS_64BIT);
             }
 
-            if (!binary.image_base || !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset,
-                                                                      optional_header, relocation_base.value_or(binary.image_base)))
+            if (!binary.image_base ||
+                !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
+                                                relocation_base ? relocation_base : binary.image_base))
             {
                 throw std::runtime_error("Memory range not allocatable");
             }
@@ -654,14 +655,8 @@ namespace sogen
     }
 
     template <typename T>
-    mapped_module map_module_from_data(memory_manager& memory, const std::span<const std::byte> data, std::filesystem::path file,
-                                       windows_path module_path)
-    {
-        return map_module_from_data_impl<T>(memory, data, std::move(file), std::move(module_path), std::nullopt);
-    }
-
-    template <typename T>
-    mapped_module map_module_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path)
+    mapped_module map_module_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                       const uint64_t relocation_base)
     {
         const auto data = utils::io::read_file(file);
         if (data.empty())
@@ -669,20 +664,7 @@ namespace sogen
             throw std::runtime_error("Bad file data: " + file.string());
         }
 
-        return map_module_from_data<T>(memory, data, std::move(file), std::move(module_path));
-    }
-
-    template <typename T>
-    mapped_module map_image_view_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
-                                           const uint64_t relocation_base)
-    {
-        const auto data = utils::io::read_file(file);
-        if (data.empty())
-        {
-            throw std::runtime_error("Bad file data: " + file.string());
-        }
-
-        return map_module_from_data_impl<T>(memory, data, std::move(file), std::move(module_path), relocation_base);
+        return map_module_from_data<T>(memory, data, std::move(file), std::move(module_path), relocation_base);
     }
 
     template <typename T>
@@ -786,17 +768,15 @@ namespace sogen
     }
 
     template mapped_module map_module_from_data<std::uint32_t>(memory_manager& memory, const std::span<const std::byte> data,
-                                                               std::filesystem::path file, windows_path module_path);
+                                                               std::filesystem::path file, windows_path module_path,
+                                                               uint64_t relocation_base);
     template mapped_module map_module_from_data<std::uint64_t>(memory_manager& memory, const std::span<const std::byte> data,
-                                                               std::filesystem::path file, windows_path module_path);
-    template mapped_module map_module_from_file<std::uint32_t>(memory_manager& memory, std::filesystem::path file,
-                                                               windows_path module_path);
-    template mapped_module map_module_from_file<std::uint64_t>(memory_manager& memory, std::filesystem::path file,
-                                                               windows_path module_path);
-    template mapped_module map_image_view_from_file<std::uint32_t>(memory_manager& memory, std::filesystem::path file,
-                                                                   windows_path module_path, uint64_t relocation_base);
-    template mapped_module map_image_view_from_file<std::uint64_t>(memory_manager& memory, std::filesystem::path file,
-                                                                   windows_path module_path, uint64_t relocation_base);
+                                                               std::filesystem::path file, windows_path module_path,
+                                                               uint64_t relocation_base);
+    template mapped_module map_module_from_file<std::uint32_t>(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                                               uint64_t relocation_base);
+    template mapped_module map_module_from_file<std::uint64_t>(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                                               uint64_t relocation_base);
 
     template mapped_module map_module_from_memory<std::uint32_t>(memory_manager& memory, uint64_t base_address, uint64_t image_size,
                                                                  windows_path module_path);

--- a/src/windows-emulator/module/module_mapping.hpp
+++ b/src/windows-emulator/module/module_mapping.hpp
@@ -8,13 +8,11 @@ namespace sogen
 
     template <typename T>
     mapped_module map_module_from_data(memory_manager& memory, std::span<const std::byte> data, std::filesystem::path file,
-                                       windows_path module_path);
+                                       windows_path module_path, uint64_t relocation_base = 0);
 
     template <typename T>
-    mapped_module map_module_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path);
-    template <typename T>
-    mapped_module map_image_view_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
-                                           uint64_t relocation_base);
+    mapped_module map_module_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                       uint64_t relocation_base = 0);
     template <typename T>
     mapped_module map_module_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size, windows_path module_path);
 

--- a/src/windows-emulator/module/module_mapping.hpp
+++ b/src/windows-emulator/module/module_mapping.hpp
@@ -13,6 +13,9 @@ namespace sogen
     template <typename T>
     mapped_module map_module_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path);
     template <typename T>
+    mapped_module map_image_view_from_file(memory_manager& memory, std::filesystem::path file, windows_path module_path,
+                                           uint64_t relocation_base);
+    template <typename T>
     mapped_module map_module_from_memory(memory_manager& memory, uint64_t base_address, uint64_t image_size, windows_path module_path);
 
     bool unmap_module(memory_manager& memory, const mapped_module& mod);

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -2,6 +2,7 @@
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../memory_manager.hpp"
+#include "../module/module_mapping.hpp"
 
 #include <utils/io.hpp>
 
@@ -34,6 +35,81 @@ namespace sogen
             };
 
             static_assert(sizeof(ini_file_mapping64) == 0x20);
+
+            struct ldr_data_table_entry_prefix32
+            {
+                LIST_ENTRY32 in_load_order_links;
+                LIST_ENTRY32 in_memory_order_links;
+                LIST_ENTRY32 in_initialization_order_links;
+                uint32_t dll_base;
+            };
+
+            struct ldr_data_table_entry_prefix64
+            {
+                LIST_ENTRY64 in_load_order_links;
+                LIST_ENTRY64 in_memory_order_links;
+                LIST_ENTRY64 in_initialization_order_links;
+                uint64_t dll_base;
+            };
+
+            static_assert(offsetof(ldr_data_table_entry_prefix32, dll_base) == 0x18);
+            static_assert(offsetof(ldr_data_table_entry_prefix64, dll_base) == 0x30);
+
+            template <typename Pointer, typename Entry>
+            bool loader_list_contains_image(const syscall_context& c, const uint64_t ldr_address, const uint64_t image_base)
+            {
+                if (!ldr_address)
+                {
+                    return false;
+                }
+
+                using ldr_data = std::conditional_t<sizeof(Pointer) == sizeof(uint32_t), PEB_LDR_DATA32, PEB_LDR_DATA64>;
+                const auto list_head = ldr_address + offsetof(ldr_data, InLoadOrderModuleList);
+                Pointer current{};
+                if (!c.win_emu.memory.try_read_memory(list_head, &current, sizeof(current)))
+                {
+                    return false;
+                }
+
+                for (size_t i = 0; i < 1024 && current != list_head; ++i)
+                {
+                    if (!current)
+                    {
+                        return false;
+                    }
+
+                    Pointer dll_base{};
+                    if (!c.win_emu.memory.try_read_memory(static_cast<uint64_t>(current) + offsetof(Entry, dll_base), &dll_base,
+                                                          sizeof(dll_base)))
+                    {
+                        return false;
+                    }
+
+                    if (dll_base == image_base)
+                    {
+                        return true;
+                    }
+
+                    if (!c.win_emu.memory.try_read_memory(current, &current, sizeof(current)))
+                    {
+                        return false;
+                    }
+                }
+
+                return false;
+            }
+
+            bool loader_list_contains_image(const syscall_context& c, const mapped_module& module)
+            {
+                if (module.machine == IMAGE_FILE_MACHINE_I386 && c.proc.peb32)
+                {
+                    const auto ldr = c.proc.peb32->read().Ldr;
+                    return loader_list_contains_image<uint32_t, ldr_data_table_entry_prefix32>(c, ldr, module.image_base);
+                }
+
+                const auto ldr = c.proc.peb64.read().Ldr;
+                return loader_list_contains_image<uint64_t, ldr_data_table_entry_prefix64>(c, ldr, module.image_base);
+            }
 
             NTSTATUS initialize_shared_section_base_static_server_data_mapping(const syscall_context& c,
                                                                                const uint64_t shared_section_address,
@@ -125,73 +201,37 @@ namespace sogen
             bool map_existing_image_view(const syscall_context& c, const mapped_module& source, const section& section_entry,
                                          uint64_t& mapped_address)
             {
-                const auto image_size = static_cast<size_t>(source.size_of_image);
-                const auto start_address =
-                    source.machine == IMAGE_FILE_MACHINE_I386 ? DEFAULT_DYNAMIC_MODULE_ADDRESS_32BIT : DEFAULT_ALLOCATION_ADDRESS_64BIT;
-                const auto address = c.win_emu.memory.allocate_memory(image_size, memory_permission::all, true, start_address,
-                                                                      memory_region_kind::section_image);
-                if (!address)
-                {
-                    return false;
-                }
-
-                const auto header_end = source.sections.empty() ? image_size : source.sections.front().region.start - source.image_base;
-                if (header_end &&
-                    !c.win_emu.memory.commit_image_memory(address, static_cast<size_t>(header_end), memory_permission::read_write))
-                {
-                    c.win_emu.memory.release_memory(address, 0);
-                    return false;
-                }
-
                 try
                 {
-                    const auto copy_memory = [&](const uint64_t source_address, const uint64_t target_address, const size_t size) {
-                        constexpr size_t page_size = 0x1000;
-                        std::vector<std::byte> data(std::min(size, page_size));
-                        for (size_t offset = 0; offset < size;)
-                        {
-                            const auto remaining_page_size = page_size - ((source_address + offset) & (page_size - 1));
-                            const auto chunk_size = std::min({data.size(), size - offset, static_cast<size_t>(remaining_page_size)});
-                            if (!c.win_emu.memory.try_read_memory(source_address + offset, data.data(), chunk_size))
-                            {
-                                std::fill_n(data.begin(), chunk_size, std::byte{});
-                            }
-                            c.emu.write_memory(target_address + offset, data.data(), chunk_size);
-                            offset += chunk_size;
-                        }
-                    };
-
-                    if (header_end)
+                    const auto is_loader_module = loader_list_contains_image(c, source);
+                    mapped_module view{};
+                    if (source.machine == IMAGE_FILE_MACHINE_I386)
                     {
-                        copy_memory(source.image_base, address, static_cast<size_t>(header_end));
+                        view = is_loader_module ? map_image_view_from_file<uint32_t>(c.win_emu.memory, source.path, source.module_path,
+                                                                                     source.image_base)
+                                                : map_module_from_file<uint32_t>(c.win_emu.memory, source.path, source.module_path);
+                    }
+                    else if (source.machine == IMAGE_FILE_MACHINE_AMD64)
+                    {
+                        view = is_loader_module ? map_image_view_from_file<uint64_t>(c.win_emu.memory, source.path, source.module_path,
+                                                                                     source.image_base)
+                                                : map_module_from_file<uint64_t>(c.win_emu.memory, source.path, source.module_path);
+                    }
+                    else
+                    {
+                        return false;
                     }
 
-                    for (const auto& image_section : source.sections)
-                    {
-                        const auto section_size = image_section.region.length;
-                        const auto section_offset = image_section.region.start - source.image_base;
-                        if (!c.win_emu.memory.commit_image_memory(address + section_offset, section_size, memory_permission::read_write))
-                        {
-                            throw std::runtime_error("Failed to commit image section view");
-                        }
-
-                        copy_memory(image_section.region.start, address + section_offset, section_size);
-
-                        if (!c.win_emu.memory.protect_memory(address + section_offset, section_size, image_section.region.permissions))
-                        {
-                            throw std::runtime_error("Failed to protect image section view");
-                        }
-                    }
+                    mapped_address = view.image_base;
+                    c.win_emu.memory.set_region_mapped_filename(mapped_address, section_entry.file_name);
+                    c.win_emu.mod_manager.register_mapped_module(std::move(view));
+                    return true;
                 }
-                catch (...)
+                catch (const std::exception& e)
                 {
-                    c.win_emu.memory.release_memory(address, 0);
+                    c.win_emu.log.error("Failed to map existing image view: %s\n", e.what());
                     return false;
                 }
-
-                c.win_emu.memory.set_region_mapped_filename(address, section_entry.file_name);
-                mapped_address = address;
-                return true;
             }
         }
 
@@ -437,7 +477,7 @@ namespace sogen
                     }
 
                     base_address.write(mapped_address);
-                    return STATUS_SUCCESS;
+                    return STATUS_IMAGE_NOT_AT_BASE;
                 }
 
                 const auto* binary = c.win_emu.mod_manager.map_module(section_entry->file_name, c.win_emu.log, false, true);

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -2,7 +2,6 @@
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../memory_manager.hpp"
-#include "../module/module_mapping.hpp"
 
 #include <utils/io.hpp>
 
@@ -36,26 +35,7 @@ namespace sogen
 
             static_assert(sizeof(ini_file_mapping64) == 0x20);
 
-            struct ldr_data_table_entry_prefix32
-            {
-                LIST_ENTRY32 in_load_order_links;
-                LIST_ENTRY32 in_memory_order_links;
-                LIST_ENTRY32 in_initialization_order_links;
-                uint32_t dll_base;
-            };
-
-            struct ldr_data_table_entry_prefix64
-            {
-                LIST_ENTRY64 in_load_order_links;
-                LIST_ENTRY64 in_memory_order_links;
-                LIST_ENTRY64 in_initialization_order_links;
-                uint64_t dll_base;
-            };
-
-            static_assert(offsetof(ldr_data_table_entry_prefix32, dll_base) == 0x18);
-            static_assert(offsetof(ldr_data_table_entry_prefix64, dll_base) == 0x30);
-
-            template <typename Pointer, typename Entry>
+            template <typename Pointer>
             bool loader_list_contains_image(const syscall_context& c, const uint64_t ldr_address, const uint64_t image_base)
             {
                 if (!ldr_address)
@@ -64,6 +44,7 @@ namespace sogen
                 }
 
                 using ldr_data = std::conditional_t<sizeof(Pointer) == sizeof(uint32_t), PEB_LDR_DATA32, PEB_LDR_DATA64>;
+                constexpr auto dll_base_offset = sizeof(Pointer) == sizeof(uint32_t) ? 0x18 : 0x30;
                 const auto list_head = ldr_address + offsetof(ldr_data, InLoadOrderModuleList);
                 Pointer current{};
                 if (!c.win_emu.memory.try_read_memory(list_head, &current, sizeof(current)))
@@ -79,8 +60,7 @@ namespace sogen
                     }
 
                     Pointer dll_base{};
-                    if (!c.win_emu.memory.try_read_memory(static_cast<uint64_t>(current) + offsetof(Entry, dll_base), &dll_base,
-                                                          sizeof(dll_base)))
+                    if (!c.win_emu.memory.try_read_memory(static_cast<uint64_t>(current) + dll_base_offset, &dll_base, sizeof(dll_base)))
                     {
                         return false;
                     }
@@ -104,11 +84,16 @@ namespace sogen
                 if (module.machine == IMAGE_FILE_MACHINE_I386 && c.proc.peb32)
                 {
                     const auto ldr = c.proc.peb32->read().Ldr;
-                    return loader_list_contains_image<uint32_t, ldr_data_table_entry_prefix32>(c, ldr, module.image_base);
+                    return loader_list_contains_image<uint32_t>(c, ldr, module.image_base);
+                }
+
+                if (module.machine != IMAGE_FILE_MACHINE_AMD64)
+                {
+                    return false;
                 }
 
                 const auto ldr = c.proc.peb64.read().Ldr;
-                return loader_list_contains_image<uint64_t, ldr_data_table_entry_prefix64>(c, ldr, module.image_base);
+                return loader_list_contains_image<uint64_t>(c, ldr, module.image_base);
             }
 
             NTSTATUS initialize_shared_section_base_static_server_data_mapping(const syscall_context& c,
@@ -196,42 +181,6 @@ namespace sogen
                     c.proc.base_allocator.make_unicode_string(ucs, u"\\Sessions\\1\\BaseNamedObjects");
                     ucs.Buffer = ucs.Buffer - obj_address;
                 });
-            }
-
-            bool map_existing_image_view(const syscall_context& c, const mapped_module& source, const section& section_entry,
-                                         uint64_t& mapped_address)
-            {
-                try
-                {
-                    const auto is_loader_module = loader_list_contains_image(c, source);
-                    mapped_module view{};
-                    if (source.machine == IMAGE_FILE_MACHINE_I386)
-                    {
-                        view = is_loader_module ? map_image_view_from_file<uint32_t>(c.win_emu.memory, source.path, source.module_path,
-                                                                                     source.image_base)
-                                                : map_module_from_file<uint32_t>(c.win_emu.memory, source.path, source.module_path);
-                    }
-                    else if (source.machine == IMAGE_FILE_MACHINE_AMD64)
-                    {
-                        view = is_loader_module ? map_image_view_from_file<uint64_t>(c.win_emu.memory, source.path, source.module_path,
-                                                                                     source.image_base)
-                                                : map_module_from_file<uint64_t>(c.win_emu.memory, source.path, source.module_path);
-                    }
-                    else
-                    {
-                        return false;
-                    }
-
-                    mapped_address = view.image_base;
-                    c.win_emu.memory.set_region_mapped_filename(mapped_address, section_entry.file_name);
-                    c.win_emu.mod_manager.register_mapped_module(std::move(view));
-                    return true;
-                }
-                catch (const std::exception& e)
-                {
-                    c.win_emu.log.error("Failed to map existing image view: %s\n", e.what());
-                    return false;
-                }
             }
         }
 
@@ -455,32 +404,18 @@ namespace sogen
             {
                 const auto file_path =
                     std::filesystem::weakly_canonical(std::filesystem::absolute(c.win_emu.file_sys.translate(section_entry->file_name)));
+                uint64_t relocation_base{};
                 for (const auto& loaded_module : c.win_emu.mod_manager.modules() | std::views::values)
                 {
-                    if (loaded_module.path != file_path)
+                    if (loaded_module.path == file_path && loader_list_contains_image(c, loaded_module))
                     {
-                        continue;
+                        relocation_base = loaded_module.image_base;
+                        break;
                     }
-
-                    uint64_t mapped_address{};
-                    if (!map_existing_image_view(c, loaded_module, *section_entry, mapped_address))
-                    {
-                        return STATUS_NO_MEMORY;
-                    }
-
-                    std::u16string wide_name(loaded_module.name.begin(), loaded_module.name.end());
-                    section_entry->name = utils::string::to_lower_consume(wide_name);
-
-                    if (view_size.value())
-                    {
-                        view_size.write(loaded_module.size_of_image);
-                    }
-
-                    base_address.write(mapped_address);
-                    return STATUS_IMAGE_NOT_AT_BASE;
                 }
 
-                const auto* binary = c.win_emu.mod_manager.map_module(section_entry->file_name, c.win_emu.log, false, true);
+                const auto* binary =
+                    c.win_emu.mod_manager.map_module(section_entry->file_name, c.win_emu.log, false, true, relocation_base);
                 if (!binary)
                 {
                     return STATUS_FILE_INVALID;

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -121,6 +121,78 @@ namespace sogen
                     ucs.Buffer = ucs.Buffer - obj_address;
                 });
             }
+
+            bool map_existing_image_view(const syscall_context& c, const mapped_module& source, const section& section_entry,
+                                         uint64_t& mapped_address)
+            {
+                const auto image_size = static_cast<size_t>(source.size_of_image);
+                const auto start_address =
+                    source.machine == IMAGE_FILE_MACHINE_I386 ? DEFAULT_DYNAMIC_MODULE_ADDRESS_32BIT : DEFAULT_ALLOCATION_ADDRESS_64BIT;
+                const auto address = c.win_emu.memory.allocate_memory(image_size, memory_permission::all, true, start_address,
+                                                                      memory_region_kind::section_image);
+                if (!address)
+                {
+                    return false;
+                }
+
+                const auto header_end = source.sections.empty() ? image_size : source.sections.front().region.start - source.image_base;
+                if (header_end &&
+                    !c.win_emu.memory.commit_image_memory(address, static_cast<size_t>(header_end), memory_permission::read_write))
+                {
+                    c.win_emu.memory.release_memory(address, 0);
+                    return false;
+                }
+
+                try
+                {
+                    const auto copy_memory = [&](const uint64_t source_address, const uint64_t target_address, const size_t size) {
+                        constexpr size_t page_size = 0x1000;
+                        std::vector<std::byte> data(std::min(size, page_size));
+                        for (size_t offset = 0; offset < size;)
+                        {
+                            const auto remaining_page_size = page_size - ((source_address + offset) & (page_size - 1));
+                            const auto chunk_size = std::min({data.size(), size - offset, static_cast<size_t>(remaining_page_size)});
+                            if (!c.win_emu.memory.try_read_memory(source_address + offset, data.data(), chunk_size))
+                            {
+                                std::fill_n(data.begin(), chunk_size, std::byte{});
+                            }
+                            c.emu.write_memory(target_address + offset, data.data(), chunk_size);
+                            offset += chunk_size;
+                        }
+                    };
+
+                    if (header_end)
+                    {
+                        copy_memory(source.image_base, address, static_cast<size_t>(header_end));
+                    }
+
+                    for (const auto& image_section : source.sections)
+                    {
+                        const auto section_size = image_section.region.length;
+                        const auto section_offset = image_section.region.start - source.image_base;
+                        if (!c.win_emu.memory.commit_image_memory(address + section_offset, section_size, memory_permission::read_write))
+                        {
+                            throw std::runtime_error("Failed to commit image section view");
+                        }
+
+                        copy_memory(image_section.region.start, address + section_offset, section_size);
+
+                        if (!c.win_emu.memory.protect_memory(address + section_offset, section_size, image_section.region.permissions))
+                        {
+                            throw std::runtime_error("Failed to protect image section view");
+                        }
+                    }
+                }
+                catch (...)
+                {
+                    c.win_emu.memory.release_memory(address, 0);
+                    return false;
+                }
+
+                c.win_emu.memory.set_region_mapped_filename(address, section_entry.file_name);
+                mapped_address = address;
+                return true;
+            }
         }
 
         NTSTATUS handle_NtCreateSection(const syscall_context& c, const emulator_object<handle> section_handle,
@@ -341,6 +413,33 @@ namespace sogen
 
             if (section_entry->is_image())
             {
+                const auto file_path =
+                    std::filesystem::weakly_canonical(std::filesystem::absolute(c.win_emu.file_sys.translate(section_entry->file_name)));
+                for (const auto& loaded_module : c.win_emu.mod_manager.modules() | std::views::values)
+                {
+                    if (loaded_module.path != file_path)
+                    {
+                        continue;
+                    }
+
+                    uint64_t mapped_address{};
+                    if (!map_existing_image_view(c, loaded_module, *section_entry, mapped_address))
+                    {
+                        return STATUS_NO_MEMORY;
+                    }
+
+                    std::u16string wide_name(loaded_module.name.begin(), loaded_module.name.end());
+                    section_entry->name = utils::string::to_lower_consume(wide_name);
+
+                    if (view_size.value())
+                    {
+                        view_size.write(loaded_module.size_of_image);
+                    }
+
+                    base_address.write(mapped_address);
+                    return STATUS_SUCCESS;
+                }
+
                 const auto* binary = c.win_emu.mod_manager.map_module(section_entry->file_name, c.win_emu.log, false, true);
                 if (!binary)
                 {


### PR DESCRIPTION
This PR fixes secondary image mappings for modules that are already loaded.

When `NtMapViewOfSection` maps another view of an existing loader-managed image, the new view must preserve the relocation base of the original image. Previously, the emulator treated it as an independent module load and relocated it against the new view address, producing incorrect image contents.

I've used the following code to test this change: [test_manualmap.cpp](https://pastebin.com/0cBwL2M8)