### PR TITLE
Improve desktop, file-system, and system-information syscalls

### DIFF
--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -464,6 +464,14 @@ namespace sogen
         UINT32 Reason;
     };
 
+    struct EMU_D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS
+    {
+        BOOLEAN HdcpSupported;
+        ULONG DefaultControlPort;
+        BOOLEAN UsesIhvSolution;
+    };
+    static_assert(sizeof(EMU_D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS) == 0xC);
+
     struct EMU_D3DKMT_DESTROYALLOCATION
     {
         UINT32 hDevice;

--- a/src/emulator-platform/platform/kernel_mapped.hpp
+++ b/src/emulator-platform/platform/kernel_mapped.hpp
@@ -943,14 +943,6 @@ namespace sogen
     static_assert(sizeof(GDI_TEB_BATCH32) == 1248, "sizeof(GDI_TEB_BATCH32) is incorrect");
 
 #ifndef OS_WINDOWS
-    typedef struct _GUID
-    {
-        uint32_t Data1;
-        uint16_t Data2;
-        uint16_t Data3;
-        uint8_t Data4[8];
-    } GUID;
-
     typedef struct _PROCESSOR_NUMBER
     {
         WORD Group;

--- a/src/emulator-platform/platform/primitives.hpp
+++ b/src/emulator-platform/platform/primitives.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include "compiler.hpp"
 
-// NOLINTBEGIN(modernize-use-using,cppcoreguidelines-use-enum-class)
+// NOLINTBEGIN(modernize-use-using,cppcoreguidelines-use-enum-class,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
 #ifdef OS_WINDOWS
 
@@ -67,6 +67,14 @@ namespace sogen
         LONG right;
         LONG bottom;
     } RECT;
+
+    typedef struct _GUID
+    {
+        uint32_t Data1;
+        uint16_t Data2;
+        uint16_t Data3;
+        uint8_t Data4[8];
+    } GUID;
 #endif
 
 using WORD = std::uint16_t;
@@ -90,7 +98,7 @@ static_assert(sizeof(ULONG) == 4);
 static_assert(sizeof(int) == 4);
 static_assert(sizeof(BOOLEAN) == 1);
 
-// NOLINTEND(modernize-use-using,cppcoreguidelines-use-enum-class)
+// NOLINTEND(modernize-use-using,cppcoreguidelines-use-enum-class,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #ifndef OS_WINDOWS
 } // namespace sogen
 #endif

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -764,6 +764,13 @@ namespace sogen
         ULONG CodeIntegrityOptions;
     } SYSTEM_CODEINTEGRITY_INFORMATION, *PSYSTEM_CODEINTEGRITY_INFORMATION;
 
+    typedef struct _SYSTEM_BOOT_ENVIRONMENT_INFORMATION
+    {
+        GUID BootIdentifier;
+        ULONG FirmwareType;
+        ULONGLONG BootFlags;
+    } SYSTEM_BOOT_ENVIRONMENT_INFORMATION, *PSYSTEM_BOOT_ENVIRONMENT_INFORMATION;
+
     typedef struct _SYSTEM_DEVICE_INFORMATION
     {
         ULONG NumberOfDisks;

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -256,8 +256,12 @@ namespace sogen
 
     struct USER_CLASS
     {
-        uint8_t unknown[0xFF];
+        uint8_t pad_000[0x30];
+        uint64_t lpszAnsiClassName;
+        uint8_t pad_038[0xC8];
     };
+    static_assert(offsetof(USER_CLASS, lpszAnsiClassName) == 0x30);
+    static_assert(sizeof(USER_CLASS) == 0x100);
 
     struct USER_WINDOW
     {

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -538,7 +538,7 @@ namespace sogen
         // Initialize 32-bit TEB
         this->teb32->access([&](TEB32& teb32_obj) {
             // Set NT_TIB32 fields
-            teb32_obj.DeallocationStack = static_cast<uint32_t>(nttib32_stack_base);
+            teb32_obj.DeallocationStack = static_cast<uint32_t>(nttib32_stack_limit);
             // TODO: Proper GuaranteedStack implementation.
             teb32_obj.GuaranteedStackBytes = static_cast<ULONG>(this->wow64_stack_size.value());
             teb32_obj.NtTib.Self = static_cast<uint32_t>(teb32_addr);                // Self pointer to 32-bit TEB

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -406,6 +406,8 @@ namespace sogen
                 teb_obj.ClientId.UniqueProcess = process_context::process_id;
                 teb_obj.ClientId.UniqueThread = static_cast<uint64_t>(this->id);
                 teb_obj.DeallocationStack = this->stack_base;
+                // TODO: Proper GuaranteedStack implementation.
+                teb_obj.GuaranteedStackBytes = static_cast<ULONG>(this->stack_size);
                 teb_obj.NtTib.StackLimit = this->stack_base;
                 teb_obj.NtTib.StackBase = this->stack_base + this->stack_size;
                 teb_obj.NtTib.Self = this->teb64->value();
@@ -480,6 +482,8 @@ namespace sogen
 
             // Native 64-bit stack
             teb_obj.DeallocationStack = this->stack_base;
+            // TODO: Proper GuaranteedStack implementation.
+            teb_obj.GuaranteedStackBytes = static_cast<ULONG>(this->stack_size);
             teb_obj.NtTib.StackLimit = this->stack_base;
             teb_obj.NtTib.StackBase = wow64_cpureserved_base;
             teb_obj.NtTib.Self = this->teb64->value();
@@ -534,6 +538,9 @@ namespace sogen
         // Initialize 32-bit TEB
         this->teb32->access([&](TEB32& teb32_obj) {
             // Set NT_TIB32 fields
+            teb32_obj.DeallocationStack = static_cast<uint32_t>(nttib32_stack_base);
+            // TODO: Proper GuaranteedStack implementation.
+            teb32_obj.GuaranteedStackBytes = static_cast<ULONG>(this->wow64_stack_size.value());
             teb32_obj.NtTib.Self = static_cast<uint32_t>(teb32_addr);                // Self pointer to 32-bit TEB
             teb32_obj.NtTib.StackBase = static_cast<uint32_t>(nttib32_stack_base);   // Top of 32-bit stack (High address)
             teb32_obj.NtTib.StackLimit = static_cast<uint32_t>(nttib32_stack_limit); // Bottom of 32-bit stack (Low address)

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -560,6 +560,38 @@ namespace sogen
             window.processId = process_context::process_id;
         });
 
+        const auto create_shell_window = [&](const std::u16string_view class_name, const std::u16string_view title, const int32_t x,
+                                             const int32_t y, const int32_t width, const int32_t height) {
+            auto [handle, shell_win] = this->windows.create(win_emu.memory);
+            shell_win.handle = handle.bits;
+            shell_win.parent_handle = this->default_desktop_window_handle.bits;
+            shell_win.class_name = class_name;
+            shell_win.name = title;
+            shell_win.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+            shell_win.x = x;
+            shell_win.y = y;
+            shell_win.width = width;
+            shell_win.height = height;
+            shell_win.host_surface_window = false;
+            const auto shell_class = allocate_user_class(win_emu.memory, class_name);
+            shell_win.guest.access([&](USER_WINDOW& window) {
+                window.hWnd = handle.bits;
+                window.ptrBase = shell_win.guest.value();
+                window.pcls = shell_class;
+                window.spwndParent = desktop_win.guest.value();
+                window.dwStyle = shell_win.style;
+                window.rcWindow = {.left = x, .top = y, .right = x + width, .bottom = y + height};
+                window.rcClient = window.rcWindow;
+                window.windowBand = 1; // ZBID_DESKTOP
+                window.dpiContext = USER_DEFAULT_DPI_CONTEXT;
+                window.processId = process_context::process_id;
+            });
+            return handle;
+        };
+
+        create_shell_window(u"Progman", u"Program Manager", 0, 0, desktop_win.width, desktop_win.height);
+        create_shell_window(u"Shell_TrayWnd", u"", 0, desktop_win.height - 40, desktop_win.width, 40);
+
         const auto user_display_info = this->user_handles.get_display_info();
         user_display_info.access([&](USER_DISPINFO& display_info) {
             display_info.dwMonitorCount = 1;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -542,12 +542,15 @@ namespace sogen
         auto [wh, desktop_win] = this->windows.create(win_emu.memory);
         this->default_desktop_window_handle = wh;
         desktop_win.handle = wh.bits;
+        desktop_win.class_name = u"#32769";
         desktop_win.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
         desktop_win.width = 1920;
         desktop_win.height = 1080;
+        const auto desktop_class = allocate_user_class(win_emu.memory, desktop_win.class_name);
         desktop_win.guest.access([&](USER_WINDOW& window) {
             window.hWnd = wh.bits;
             window.ptrBase = desktop_win.guest.value();
+            window.pcls = desktop_class;
             window.dwStyle = desktop_win.style;
             window.rcWindow = {.left = 0, .top = 0, .right = desktop_win.width, .bottom = desktop_win.height};
             window.rcClient = window.rcWindow;
@@ -563,6 +566,21 @@ namespace sogen
             display_info.pPrimaryMonitor = monitor_obj.value();
             display_info.rcScreen = {.left = 0, .top = 0, .right = 1920, .bottom = 1080};
         });
+    }
+
+    emulator_pointer process_context::allocate_user_class(memory_manager& memory, const std::u16string_view class_name)
+    {
+        const auto ansi_class_name = u16_to_cp1252(class_name);
+        const auto cls_size = static_cast<size_t>(page_align_up(sizeof(USER_CLASS) + ansi_class_name.size() + 1));
+        const auto cls_ptr = memory.allocate_memory(cls_size, memory_permission::read);
+        const auto ansi_class_name_ptr = cls_ptr + sizeof(USER_CLASS);
+
+        memory.write_memory(ansi_class_name_ptr, ansi_class_name.c_str(), ansi_class_name.size() + 1);
+
+        const emulator_object<USER_CLASS> cls{memory, cls_ptr};
+        cls.access([&](USER_CLASS& value) { value.lpszAnsiClassName = ansi_class_name_ptr; });
+
+        return cls_ptr;
     }
 
     void process_context::serialize(utils::buffer_serializer& buffer, const emulator_thread* active_thread) const

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -333,6 +333,8 @@ namespace sogen
         void setup(windows_emulator& win_emu, const application_settings& app_settings, const mapped_module& executable,
                    const mapped_module& ntdll, const apiset::container& apiset_container, const mapped_module* ntdll32 = nullptr);
 
+        static emulator_pointer allocate_user_class(memory_manager& memory, std::u16string_view class_name);
+
         handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size, uint32_t create_flags,
                              bool initial_thread = false);
         void terminate_thread(emulator_thread& thread, NTSTATUS thread_exit_status);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -689,6 +689,8 @@ namespace sogen
         BOOL handle_NtUserSetWinEventHook();
         BOOL handle_NtUserUnhookWinEvent();
         BOOL handle_NtUserDisableThreadIme();
+        BOOL handle_NtUserGetPointerDevices();
+        BOOL handle_NtUserHwndQueryRedirectionInfo();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -813,6 +815,8 @@ namespace sogen
         NTSTATUS handle_NtGdiDdDDIMarkDeviceAsError(const syscall_context& c, emulator_object<EMU_D3DKMT_MARKDEVICEASERROR> mark_error);
         NTSTATUS handle_NtGdiDdDDIGetCachedHybridQueryValue(const syscall_context& c, emulator_object<uint32_t> value);
         NTSTATUS handle_NtGdiDdDDICacheHybridQueryValue();
+        NTSTATUS handle_NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport(
+            const syscall_context& c, emulator_object<EMU_D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS> display_caps);
         NTSTATUS handle_NtGdiDdDDIDestroyAllocation2(const syscall_context& c,
                                                      emulator_object<EMU_D3DKMT_DESTROYALLOCATION2> destroy_allocation);
         NTSTATUS handle_NtGdiDdDDIDestroyAllocation(const syscall_context& c,
@@ -1151,6 +1155,7 @@ namespace sogen
         {
             return STATUS_SUCCESS;
         }
+
     }
 
     // NOLINTNEXTLINE(readability-function-size,hicpp-function-size)
@@ -1560,6 +1565,7 @@ namespace sogen
         add_handler(NtGdiDdDDIMarkDeviceAsError);
         add_handler(NtGdiDdDDIGetCachedHybridQueryValue);
         add_handler(NtGdiDdDDICacheHybridQueryValue);
+        add_handler(NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport);
         add_handler(NtGdiDdDDIUnlock);
         add_handler(NtGdiDdDDIDestroyAllocation2);
         add_handler(NtGdiDdDDIDestroyAllocation);
@@ -1648,6 +1654,8 @@ namespace sogen
         add_handler(NtUserSetWinEventHook);
         add_handler(NtUserUnhookWinEvent);
         add_handler(NtUserDisableThreadIme);
+        add_handler(NtUserGetPointerDevices);
+        add_handler(NtUserHwndQueryRedirectionInfo);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -316,11 +316,26 @@ namespace sogen
             std::vector<file_entry> files{};
 
             const auto dir = file_sys.translate(win_path);
+            const auto make_file_entry = [](const std::filesystem::path& file_path, const std::filesystem::path& host_path,
+                                            const bool is_directory) {
+                file_entry entry{.file_path = file_path, .is_directory = is_directory};
+
+                struct compat_stat file_stat{};
+                if (compat_stat(host_path, &file_stat))
+                {
+                    entry.file_size = is_directory ? 0 : static_cast<uint64_t>(file_stat.st_size);
+                    entry.creation_time = convert_timespec_to_filetime(file_stat.st_ctimespec);
+                    entry.last_access_time = convert_timespec_to_filetime(file_stat.st_atimespec);
+                    entry.last_write_time = convert_timespec_to_filetime(file_stat.st_mtimespec);
+                }
+
+                return entry;
+            };
 
             if (file_mask.empty() || file_mask == u"*")
             {
-                files.emplace_back(file_entry{.file_path = ".", .is_directory = true});
-                files.emplace_back(file_entry{.file_path = "..", .is_directory = true});
+                files.emplace_back(make_file_entry(".", dir, true));
+                files.emplace_back(make_file_entry("..", dir.parent_path(), true));
             }
 
             std::error_code ec{};
@@ -331,11 +346,7 @@ namespace sogen
                     continue;
                 }
 
-                files.emplace_back(file_entry{
-                    .file_path = file.path().filename(),
-                    .file_size = file.is_directory() ? 0 : file.file_size(),
-                    .is_directory = file.is_directory(),
-                });
+                files.emplace_back(make_file_entry(file.path().filename(), file.path(), file.is_directory()));
             }
 
             file_sys.access_mapped_entries(win_path, [&](const std::pair<windows_path, std::filesystem::path>& entry) {
@@ -352,11 +363,7 @@ namespace sogen
                     return;
                 }
 
-                files.emplace_back(file_entry{
-                    .file_path = filename,
-                    .file_size = dir_entry.is_directory() ? 0 : dir_entry.file_size(),
-                    .is_directory = dir_entry.is_directory(),
-                });
+                files.emplace_back(make_file_entry(filename, entry.second, dir_entry.is_directory()));
             });
 
             return files;
@@ -371,7 +378,7 @@ namespace sogen
             if (!f->enumeration_state || query_flags & SL_RESTART_SCAN)
             {
                 const auto mask = file_mask ? read_unicode_string(c.emu, file_mask) : u"";
-                c.win_emu.callbacks.on_generic_access("Enumerating directory", f->name);
+                c.win_emu.callbacks.on_generic_access("Enumerating directory", f->name + mask);
 
                 f->enumeration_state.emplace(file_enumeration_state{});
                 f->enumeration_state->files = scan_directory(c.win_emu.file_sys, f->name, mask);
@@ -427,6 +434,12 @@ namespace sogen
                 T info{};
                 info.NextEntryOffset = 0;
                 info.FileIndex = static_cast<ULONG>(current_index);
+
+                info.CreationTime = current_file.creation_time;
+                info.LastAccessTime = current_file.last_access_time;
+                info.LastWriteTime = current_file.last_write_time;
+                info.ChangeTime = info.LastWriteTime;
+
                 info.FileAttributes = current_file.is_directory ? FILE_ATTRIBUTE_DIRECTORY : FILE_ATTRIBUTE_NORMAL;
                 info.FileNameLength = static_cast<ULONG>(file_name.size() * 2);
                 info.EndOfFile.QuadPart = current_file.file_size;

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -4649,6 +4649,18 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport(
+            const syscall_context&, const emulator_object<EMU_D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS> display_caps)
+        {
+            if (!display_caps)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            display_caps.write({});
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtGdiDdDDIUnlock()
         {
             return STATUS_SUCCESS;

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -394,6 +394,7 @@ namespace sogen
                 return handle_system_process_information(c, system_information, system_information_length, return_length);
 
             case 250: // Build 27744
+            case 252:
             case SystemFlushInformation:
             case SystemCodeIntegrityPolicyInformation:
             case SystemHypervisorSharedPageInformation:
@@ -401,6 +402,7 @@ namespace sogen
             case SystemSupportedProcessorArchitectures2:
             case SystemFeatureConfigurationSectionInformation:
             case SystemFirmwareTableInformation:
+            case SystemPolicyInformation:
                 return STATUS_NOT_SUPPORTED;
 
             case SystemControlFlowTransition:

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -92,6 +92,13 @@ namespace sogen
                 constexpr auto group_size = group_root_size + sizeof(EMU_GROUP_RELATIONSHIP64);
                 constexpr auto numa_root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, NumaNode);
                 constexpr auto numa_size = numa_root_size + sizeof(EMU_NUMA_NODE_RELATIONSHIP64);
+                constexpr auto core_root_size = offsetof(EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64, Processor);
+                constexpr auto core_size = core_root_size + sizeof(EMU_PROCESSOR_RELATIONSHIP64);
+
+                const auto active_processor_count =
+                    std::min<uint32_t>(c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; }), 64);
+                const auto active_processor_mask =
+                    active_processor_count == 64 ? ~uint64_t{0} : (uint64_t{1} << active_processor_count) - 1;
 
                 const auto write_group = [&](const uint64_t output_buffer) {
                     EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
@@ -105,9 +112,8 @@ namespace sogen
                     group.MaximumGroupCount = 1;
 
                     auto& group_info = group.GroupInfo[0];
-                    group_info.ActiveProcessorCount =
-                        static_cast<uint8_t>(c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; }));
-                    group_info.ActiveProcessorMask = (1ULL << group_info.ActiveProcessorCount) - 1;
+                    group_info.ActiveProcessorCount = static_cast<uint8_t>(active_processor_count);
+                    group_info.ActiveProcessorMask = active_processor_mask;
                     group_info.MaximumProcessorCount = group_info.ActiveProcessorCount;
 
                     c.emu.write_memory(output_buffer + group_root_size, group);
@@ -126,6 +132,23 @@ namespace sogen
                     c.emu.write_memory(output_buffer + numa_root_size, numa_node);
                 };
 
+                const auto write_cores = [&](const uint64_t output_buffer) {
+                    for (uint32_t processor = 0; processor < active_processor_count; ++processor)
+                    {
+                        const auto entry_buffer = output_buffer + processor * core_size;
+
+                        EMU_SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX64 proc_info{};
+                        proc_info.Size = core_size;
+                        proc_info.Relationship = RelationProcessorCore;
+                        c.emu.write_memory(entry_buffer, &proc_info, core_root_size);
+
+                        EMU_PROCESSOR_RELATIONSHIP64 core{};
+                        core.GroupCount = 1;
+                        core.GroupMask[0].Mask = uint64_t{1} << processor;
+                        c.emu.write_memory(entry_buffer + core_root_size, core);
+                    }
+                };
+
                 if (input_buffer_length != sizeof(LOGICAL_PROCESSOR_RELATIONSHIP))
                 {
                     return STATUS_INVALID_PARAMETER;
@@ -135,7 +158,8 @@ namespace sogen
 
                 if (request == RelationAll)
                 {
-                    constexpr auto required_size = group_size + numa_size;
+                    const auto core_total_size = static_cast<uint32_t>(core_size * active_processor_count);
+                    const auto required_size = static_cast<uint32_t>(core_total_size + group_size + numa_size);
 
                     if (return_length)
                     {
@@ -147,8 +171,27 @@ namespace sogen
                         return STATUS_INFO_LENGTH_MISMATCH;
                     }
 
-                    write_group(system_information);
-                    write_numa(system_information + group_size);
+                    write_cores(system_information);
+                    write_numa(system_information + core_total_size);
+                    write_group(system_information + core_total_size + numa_size);
+                    return STATUS_SUCCESS;
+                }
+
+                if (request == RelationProcessorCore)
+                {
+                    const auto required_size = static_cast<uint32_t>(core_size * active_processor_count);
+
+                    if (return_length)
+                    {
+                        return_length.write(required_size);
+                    }
+
+                    if (system_information_length < required_size)
+                    {
+                        return STATUS_INFO_LENGTH_MISMATCH;
+                    }
+
+                    write_cores(system_information);
                     return STATUS_SUCCESS;
                 }
 
@@ -184,7 +227,7 @@ namespace sogen
                     return STATUS_SUCCESS;
                 }
 
-                c.win_emu.log.error("Unsupported processor relationship: %X\n", request);
+                c.win_emu.log.error("Unsupported processor relationship: 0x%X\n", request);
                 c.emu.stop();
                 return STATUS_NOT_SUPPORTED;
             }

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -717,6 +717,17 @@ namespace sogen
                                                                       });
             }
 
+            case SystemBootEnvironmentInformation:
+                return handle_query<SYSTEM_BOOT_ENVIRONMENT_INFORMATION>(
+                    c.emu, system_information, system_information_length, return_length, [&](SYSTEM_BOOT_ENVIRONMENT_INFORMATION& info) {
+                        info.BootIdentifier = {.Data1 = 0x7B5E10A1,
+                                               .Data2 = 0xF859,
+                                               .Data3 = 0x4BD4,
+                                               .Data4 = {0xA6, 0x35, 0x15, 0xC2, 0xA4, 0x4D, 0xD1, 0xE3}};
+                        info.FirmwareType = 2; // FirmwareTypeUefi
+                        info.BootFlags = 0;
+                    });
+
             default:
                 c.win_emu.log.error("Unsupported system info class: 0x%X\n", info_class);
                 c.emu.stop();

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -257,8 +257,7 @@ namespace sogen
                 return nullptr;
             }
 
-            constexpr auto cls_size = static_cast<size_t>(page_align_up(sizeof(USER_CLASS)));
-            const auto cls_ptr = c.win_emu.memory.allocate_memory(cls_size, memory_permission::read);
+            const auto cls_ptr = process_context::allocate_user_class(c.win_emu.memory, normalized_name);
 
             EMU_WNDCLASSEX wnd_class{};
             wnd_class.cbSize = sizeof(wnd_class);
@@ -2450,8 +2449,7 @@ namespace sogen
             const auto class_name_str = read_unicode_string(c.emu, class_name);
             const auto index = c.proc.add_or_find_atom(class_name_str);
 
-            constexpr auto cls_size = static_cast<size_t>(page_align_up(sizeof(USER_CLASS)));
-            const auto cls_ptr = c.win_emu.memory.allocate_memory(cls_size, memory_permission::read);
+            const auto cls_ptr = process_context::allocate_user_class(c.win_emu.memory, class_name_str);
 
             const auto wnd_class = wnd_class_ex.read();
             const auto entry = process_context::class_entry{cls_ptr, wnd_class, class_menu_name.read()};

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5783,6 +5783,16 @@ namespace sogen
         {
             return TRUE;
         }
+
+        BOOL handle_NtUserGetPointerDevices()
+        {
+            return FALSE;
+        }
+
+        BOOL handle_NtUserHwndQueryRedirectionInfo()
+        {
+            return FALSE;
+        }
     }
 
 } // namespace sogen

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -575,12 +575,18 @@ namespace sogen
         std::filesystem::path file_path{};
         uint64_t file_size{};
         bool is_directory{};
+        LARGE_INTEGER creation_time{};
+        LARGE_INTEGER last_access_time{};
+        LARGE_INTEGER last_write_time{};
 
         void serialize(utils::buffer_serializer& buffer) const
         {
             buffer.write(this->file_path);
             buffer.write(this->file_size);
             buffer.write(this->is_directory);
+            buffer.write(this->creation_time);
+            buffer.write(this->last_access_time);
+            buffer.write(this->last_write_time);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
@@ -588,6 +594,9 @@ namespace sogen
             buffer.read(this->file_path);
             buffer.read(this->file_size);
             buffer.read(this->is_directory);
+            buffer.read(this->creation_time);
+            buffer.read(this->last_access_time);
+            buffer.read(this->last_write_time);
         }
     };
 


### PR DESCRIPTION
This PR does the following improvements to Sogen:

- [Populates more stack metadata in the TEB](https://github.com/momo5502/sogen/commit/06fd859399ddb49cb31278ce5257a7d56f24e7a5). This is actually just a temporary approximation because stack guard pages are not yet supported. See [SetThreadStackGuarantee](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadstackguarantee) for more info.
- [Improves directory enumeration metadata reporting](https://github.com/momo5502/sogen/commit/d24d3d454d545d66b9a5d0d1bd0e80a704fa09a1), so directory entries report the host file timestamps.
- [Adds support for ANSI window-class names](https://github.com/momo5502/sogen/commit/4e4aa32d3050707d3ead99d962cdcd607a9449df), so `GetClassNameA` works in the emulator.
- [Creates default desktop shell windows](https://github.com/momo5502/sogen/commit/6bb1eb55d814538923947cdecf74d4470ed71c76), so anti-debug checks do not fail merely because the emulator reports no windows.
- [Reports processor-core topology through `NtQuerySystemInformation`](https://github.com/momo5502/sogen/commit/538eb79c56096e57b0b33b0a5e99368f5268c855).
- [Reports boot-environment information through `NtQuerySystemInformation`](https://github.com/momo5502/sogen/commit/29bd1d5503cb5d4cb14e22ac4738ca360d5e7778).
- [Handles additional unsupported `NtQuerySystemInformation` classes](https://github.com/momo5502/sogen/commit/8ce006c0e97533582afb0904a8e23b1d730cfa9f).
- [Adds more syscall stubs](https://github.com/momo5502/sogen/commit/831921bc93e295ebbbf5b9d6568e9c18749731f3): `NtUserGetPointerDevices`, `NtUserHwndQueryRedirectionInfo`, and `NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport`.