### PR TITLE
clang-format: enforce braces and blank lines between definitions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,6 +15,8 @@ AlignEscapedNewlines: Left
 PackConstructorInitializers: Never
 IndentPPDirectives: None
 InsertNewlineAtEOF: true
+InsertBraces: true
+SeparateDefinitionBlocks: Always
 ColumnLimit: 140
 AlignConsecutiveMacros:
   Enabled: true

--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -243,6 +243,7 @@ namespace sogen::kvm
         {
           public:
             file_descriptor() = default;
+
             explicit file_descriptor(const int fd)
                 : fd_(fd)
             {
@@ -414,6 +415,7 @@ namespace sogen::kvm
                 this->initialize_syscall_intercept_page();
                 this->initialize_exception_handling();
             }
+
             ~kvm_x86_64_emulator() override
             {
                 utils::reset_object_with_delayed_destruction(this->memory_write_hooks_);
@@ -444,6 +446,7 @@ namespace sogen::kvm
                 table.limit = value.limit;
                 return true;
             }
+
             void start(size_t count) override
             {
                 if (count > 1)
@@ -575,6 +578,7 @@ namespace sogen::kvm
                     }
                 }
             }
+
             void stop() override
             {
                 this->stop_requested_ = true;
@@ -593,6 +597,7 @@ namespace sogen::kvm
                     pthread_kill(this->vcpu_thread_.load(std::memory_order_acquire), this->kick_signal_);
                 }
             }
+
             size_t read_raw_register(int reg, void* value, size_t size) override
             {
                 const auto xreg = static_cast<x86_register>(reg);
@@ -732,6 +737,7 @@ namespace sogen::kvm
 
                 return size;
             }
+
             size_t write_raw_register(int reg, const void* value, size_t size) override
             {
                 const auto xreg = static_cast<x86_register>(reg);
@@ -896,6 +902,7 @@ namespace sogen::kvm
 
                 return size;
             }
+
             std::vector<std::byte> save_registers() const override
             {
                 register_snapshot snapshot{};
@@ -910,6 +917,7 @@ namespace sogen::kvm
                 std::memcpy(bytes.data(), &snapshot, sizeof(snapshot));
                 return bytes;
             }
+
             void restore_registers(const std::vector<std::byte>& register_data) override
             {
                 if (register_data.size() != sizeof(register_snapshot))
@@ -926,10 +934,12 @@ namespace sogen::kvm
                 this->set_msr(MSR_LSTAR, snapshot.lstar);
                 this->set_msr(MSR_SYSCALL_MASK, snapshot.sfmask);
             }
+
             bool has_violation() const override
             {
                 return false;
             }
+
             bool supports_instruction_counting() const override
             {
                 return false;
@@ -951,6 +961,7 @@ namespace sogen::kvm
             {
                 return "Linux KVM";
             }
+
             void set_segment_base(x86_register base, pointer_type value) override
             {
                 auto sregs = this->get_sregs();
@@ -958,11 +969,13 @@ namespace sogen::kvm
                 segment.base = value;
                 this->set_sregs(sregs);
             }
+
             pointer_type get_segment_base(x86_register base) override
             {
                 const auto sregs = this->get_sregs();
                 return get_segment_register(sregs, map_register(base).name).base;
             }
+
             void load_gdt(pointer_type address, uint32_t limit) override
             {
                 auto sregs = this->get_sregs();
@@ -979,10 +992,12 @@ namespace sogen::kvm
                     throw std::runtime_error("Failed to read KVM guest memory");
                 }
             }
+
             bool try_read_memory(uint64_t address, void* data, size_t size) const override
             {
                 return detail::access_memory(this->mapped_pages_, address, data, size, false);
             }
+
             void write_memory(uint64_t address, const void* data, size_t size) override
             {
                 if (!this->try_write_memory(address, data, size))
@@ -990,6 +1005,7 @@ namespace sogen::kvm
                     throw std::runtime_error("Failed to write KVM guest memory");
                 }
             }
+
             bool try_write_memory(uint64_t address, const void* data, size_t size) override
             {
                 return detail::access_memory(this->mapped_pages_, address, const_cast<void*>(data), size, true);
@@ -1006,12 +1022,14 @@ namespace sogen::kvm
                     execution_hook_entry{.address = std::nullopt, .size = 0, .callback = std::move(callback)};
                 return hook;
             }
+
             emulator_hook* hook_memory_execution(uint64_t address, memory_execution_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
                 this->memory_execution_hooks_[hook] = execution_hook_entry{.address = address, .size = 1, .callback = std::move(callback)};
                 return hook;
             }
+
             emulator_hook* hook_memory_range_execution(uint64_t address, uint64_t size, memory_execution_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
@@ -1019,6 +1037,7 @@ namespace sogen::kvm
                     execution_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
                 return hook;
             }
+
             emulator_hook* hook_memory_read(uint64_t address, uint64_t size, memory_access_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
@@ -1026,6 +1045,7 @@ namespace sogen::kvm
                     memory_access_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
                 return hook;
             }
+
             emulator_hook* hook_memory_write(uint64_t address, uint64_t size, memory_access_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
@@ -1033,6 +1053,7 @@ namespace sogen::kvm
                     memory_access_hook_entry{.address = address, .size = size, .callback = std::move(callback)};
                 return hook;
             }
+
             emulator_hook* hook_instruction(int instruction_type, instruction_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
@@ -1045,24 +1066,28 @@ namespace sogen::kvm
                 }
                 return hook;
             }
+
             emulator_hook* hook_interrupt(interrupt_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
                 this->interrupt_hooks_[hook] = std::move(callback);
                 return hook;
             }
+
             emulator_hook* hook_memory_violation(memory_violation_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
                 this->memory_violation_hooks_[hook] = std::move(callback);
                 return hook;
             }
+
             emulator_hook* hook_basic_block(basic_block_hook_callback callback) override
             {
                 auto* hook = this->make_hook();
                 this->basic_block_hooks_[hook] = std::move(callback);
                 return hook;
             }
+
             void delete_hook(emulator_hook* hook) override
             {
                 const auto instruction_it = this->instruction_hooks_.find(hook);
@@ -1084,6 +1109,7 @@ namespace sogen::kvm
             {
                 buffer.write_vector(this->save_registers());
             }
+
             void deserialize_state(utils::buffer_deserializer& buffer, bool) override
             {
                 this->restore_registers(buffer.read_vector<std::byte>());
@@ -1146,6 +1172,7 @@ namespace sogen::kvm
                 this->rebuild_mappings();
                 this->mmio_regions_[address] = std::move(region);
             }
+
             void map_memory(uint64_t address, size_t size, memory_permission permissions) override
             {
                 if (!is_page_aligned(address) || !is_page_aligned(size))
@@ -1210,6 +1237,7 @@ namespace sogen::kvm
 
                 this->rebuild_mappings();
             }
+
             void map_host_memory(uint64_t address, size_t size, void* host_pointer, memory_permission permissions) override
             {
                 if (!is_page_aligned(address) || !is_page_aligned(size))
@@ -1242,6 +1270,7 @@ namespace sogen::kvm
 
                 this->rebuild_mappings();
             }
+
             bool host_memory_aliasing_is_coherent() const override
             {
                 // KVM aliases the host pages into the guest as write-back cacheable, but a device sharing the
@@ -1249,10 +1278,12 @@ namespace sogen::kvm
                 // guest's cached writes are therefore not guaranteed visible without an explicit flush.
                 return false;
             }
+
             void flush_host_memory_cache(const void* host_pointer, size_t size) override
             {
                 flush_cache_line_range(host_pointer, size);
             }
+
             void unmap_memory(uint64_t address, size_t size) override
             {
                 if (!is_page_aligned(address) || !is_page_aligned(size))
@@ -1291,6 +1322,7 @@ namespace sogen::kvm
 
                 this->rebuild_mappings();
             }
+
             void apply_memory_protection(uint64_t address, size_t size, memory_permission permissions) override
             {
                 if (!is_page_aligned(address) || !is_page_aligned(size))
@@ -1373,12 +1405,14 @@ namespace sogen::kvm
                     throw std::runtime_error("KVM vCPU mmap size is invalid");
                 }
             }
+
             void configure_partition()
             {
                 this->vm_fd_.reset(::ioctl(this->kvm_fd_.get(), KVM_CREATE_VM, 0));
                 check_ioctl_result(this->vm_fd_.get(), "KVM_CREATE_VM");
                 (void)::ioctl(this->vm_fd_.get(), KVM_SET_TSS_ADDR, 0xfffbd000);
             }
+
             void configure_virtual_processor()
             {
                 this->vcpu_fd_.reset(::ioctl(this->vm_fd_.get(), KVM_CREATE_VCPU, vp_index));
@@ -1394,6 +1428,7 @@ namespace sogen::kvm
 
                 this->initialize_cpuid();
             }
+
             void initialize_cpuid()
             {
                 constexpr uint32_t cpuid_entries = 256;
@@ -1403,6 +1438,7 @@ namespace sogen::kvm
                 check_ioctl_result(::ioctl(this->kvm_fd_.get(), KVM_GET_SUPPORTED_CPUID, cpuid), "KVM_GET_SUPPORTED_CPUID");
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_SET_CPUID2, cpuid), "KVM_SET_CPUID2");
             }
+
             void initialize_virtual_processor_state()
             {
                 auto sregs = this->get_sregs();
@@ -1432,6 +1468,7 @@ namespace sogen::kvm
                 this->set_msr(MSR_STAR, (0x23ull << 48) | (0x08ull << 32));
                 this->set_msr(MSR_SYSCALL_MASK, 0);
             }
+
             void initialize_syscall_intercept_page()
             {
                 this->syscall_hook_page_ = this->allocate_internal_page(true);
@@ -1439,6 +1476,7 @@ namespace sogen::kvm
                 code[0] = 0xF4;
                 this->set_msr(MSR_LSTAR, this->syscall_hook_page_);
             }
+
             void initialize_exception_handling()
             {
                 this->exception_stub_page_ = this->allocate_internal_page(true);
@@ -1505,6 +1543,7 @@ namespace sogen::kvm
                 sregs.tr.unusable = 0;
                 this->set_sregs(sregs);
             }
+
             void install_exception_gdt_entries()
             {
                 if (this->exception_tss_page_ == 0)
@@ -1540,10 +1579,12 @@ namespace sogen::kvm
                     throw std::runtime_error("Failed to install KVM exception TSS descriptor");
                 }
             }
+
             void initialize_long_mode_page_tables()
             {
                 this->pml4_gpa_ = this->allocate_internal_page(false, false);
             }
+
             uint64_t allocate_internal_page(bool executable = false, bool map_into_guest = true)
             {
                 auto backing = allocate_backing_memory(page_size);
@@ -1588,6 +1629,7 @@ namespace sogen::kvm
                 this->rebuild_mappings();
                 return result;
             }
+
             uint64_t allocate_guest_physical_page()
             {
                 const auto page_gpa = this->next_guest_physical_page_;
@@ -1599,6 +1641,7 @@ namespace sogen::kvm
                 this->next_guest_physical_page_ += page_size;
                 return page_gpa;
             }
+
             uint64_t ensure_guest_physical_page(mapped_page& page)
             {
                 if (!page.physical_page)
@@ -1612,6 +1655,7 @@ namespace sogen::kvm
 
                 return *page.physical_page;
             }
+
             void ensure_virtual_mapping(uint64_t guest_address, uint64_t physical_page, bool user_accessible = true)
             {
                 detail::ensure_virtual_mapping(
@@ -1621,6 +1665,7 @@ namespace sogen::kvm
                     },
                     guest_address, physical_page, user_accessible);
             }
+
             // Defer the (O(total mappings)) memslot reconciliation. A single high-level memory operation can
             // allocate several page-table pages, each of which would otherwise trigger its own full rebuild,
             // making memory mapping quadratic. Mark the layout dirty here and flush it once before the next
@@ -1630,6 +1675,7 @@ namespace sogen::kvm
             {
                 this->mappings_dirty_ = true;
             }
+
             void flush_dirty_mappings()
             {
                 if (!this->mappings_dirty_)
@@ -1640,6 +1686,7 @@ namespace sogen::kvm
                 this->mappings_dirty_ = false;
                 this->synchronize_memslots();
             }
+
             void synchronize_memslots()
             {
                 // Project mapped_pages_ onto the desired memslot layout (physically contiguous,
@@ -1714,6 +1761,7 @@ namespace sogen::kvm
                     this->current_slots_[run_gpa] = installed_memslot{.id = slot, .size = run.size, .host = run.host, .flags = run.flags};
                 }
             }
+
             int allocate_slot_id()
             {
                 if (!this->free_slot_ids_.empty())
@@ -1730,6 +1778,7 @@ namespace sogen::kvm
 
                 return this->next_slot_id_++;
             }
+
             void set_memslot(int slot, uint64_t guest_address, size_t size, void* host_base, uint32_t flags)
             {
                 kvm_userspace_memory_region region{};
@@ -1747,6 +1796,7 @@ namespace sogen::kvm
                     throw std::runtime_error(stream.str());
                 }
             }
+
             void delete_memslot(int slot)
             {
                 kvm_userspace_memory_region region{};
@@ -1755,6 +1805,7 @@ namespace sogen::kvm
                 check_ioctl_result(::ioctl(this->vm_fd_.get(), KVM_SET_USER_MEMORY_REGION, &region), "KVM_SET_USER_MEMORY_REGION");
                 this->free_slot_ids_.push_back(slot);
             }
+
             uint32_t to_kvm_map_flags(memory_permission permissions) const
             {
                 if (permissions == memory_permission::none)
@@ -1770,6 +1821,7 @@ namespace sogen::kvm
 
                 return flags;
             }
+
             void refresh_mmio_pages()
             {
                 for (auto& [base, region] : this->mmio_regions_)
@@ -1822,6 +1874,7 @@ namespace sogen::kvm
 
                 return false;
             }
+
             bool handle_breakpoint_instruction()
             {
                 const auto rip = this->read_instruction_pointer();
@@ -1841,6 +1894,7 @@ namespace sogen::kvm
 
                 return handled;
             }
+
             bool handle_instruction_hook(x86_hookable_instructions type, uint64_t instruction_size)
             {
                 // Capture RIP before the callbacks so the post-callback comparison can tell whether a
@@ -1875,6 +1929,7 @@ namespace sogen::kvm
 
                 return false;
             }
+
             bool handle_invalid_instruction_hook()
             {
                 bool consumed = false;
@@ -1899,6 +1954,7 @@ namespace sogen::kvm
 
                 return consumed;
             }
+
             std::optional<std::pair<mmio_region*, uint64_t>> find_mmio_region_for_physical_address(uint64_t physical_address)
             {
                 for (auto& [base, region] : this->mmio_regions_)
@@ -1921,6 +1977,7 @@ namespace sogen::kvm
 
                 return std::nullopt;
             }
+
             std::optional<uint64_t> translate_guest_physical_address(uint64_t physical_address)
             {
                 for (auto& [guest_page, page] : this->mapped_pages_)
@@ -1939,6 +1996,7 @@ namespace sogen::kvm
 
                 return std::nullopt;
             }
+
             bool handle_mmio_exit()
             {
                 const auto& mmio = this->run_->mmio;
@@ -1973,6 +2031,7 @@ namespace sogen::kvm
 
                 return false;
             }
+
             bool handle_exception(uint32_t exception, uint64_t error_code)
             {
                 if (exception == invalid_opcode_interrupt && this->handle_invalid_instruction_hook())
@@ -2004,6 +2063,7 @@ namespace sogen::kvm
 
                 return handled;
             }
+
             bool handle_exception_trap(uint64_t stub_rip)
             {
                 const auto vector = static_cast<uint32_t>((stub_rip - 1 - this->exception_stub_page_) / exception_stub_stride);
@@ -2027,6 +2087,7 @@ namespace sogen::kvm
                     uint64_t rsp;
                     uint64_t ss;
                 } frame{};
+
                 this->read_memory(frame_address, &frame, sizeof(frame));
 
                 // A 32-bit compatibility-mode (WOW64) fault must be resumed through a real IRETQ: KVM_SET_SREGS
@@ -2103,6 +2164,7 @@ namespace sogen::kvm
 
                 return true;
             }
+
             void clear_pending_exception_state()
             {
                 // After the synthetic IDT has delivered an exception and we have rewound the vCPU to the
@@ -2129,6 +2191,7 @@ namespace sogen::kvm
 
                 (void)::ioctl(this->vcpu_fd_.get(), KVM_SET_VCPU_EVENTS, &events);
             }
+
             bool handle_debug_exit()
             {
                 const auto rip = this->read_instruction_pointer();
@@ -2153,6 +2216,7 @@ namespace sogen::kvm
 
                 return handled;
             }
+
             std::optional<uint64_t> handle_syscall_halt()
             {
                 if (!this->syscall_hook_)
@@ -2198,6 +2262,7 @@ namespace sogen::kvm
                 this->set_sregs(sregs);
                 return pre_syscall_rip;
             }
+
             void advance_rip(uint64_t amount)
             {
                 auto regs = this->get_regs();
@@ -2226,6 +2291,7 @@ namespace sogen::kvm
 
                 return entry->data;
             }
+
             void set_msr(uint32_t msr, uint64_t value)
             {
                 alignas(kvm_msrs) std::array<std::byte, sizeof(kvm_msrs) + sizeof(kvm_msr_entry)> storage{};
@@ -2241,6 +2307,7 @@ namespace sogen::kvm
                     throw std::runtime_error("KVM_SET_MSRS failed");
                 }
             }
+
             // The general and segment registers are accessed many times per exit (syscall arguments,
             // results, the run loop's RIP checks, ...). KVM_GET_REGS/KVM_SET_REGS fetch and store the
             // whole register file, so doing one ioctl per single-register access is the dominant cost.
@@ -2256,12 +2323,14 @@ namespace sogen::kvm
                 }
                 return this->regs_cache_;
             }
+
             void set_regs(const kvm_regs& regs)
             {
                 this->regs_cache_ = regs;
                 this->regs_cache_valid_ = true;
                 this->regs_cache_dirty_ = true;
             }
+
             kvm_sregs get_sregs() const
             {
                 if (!this->sregs_cache_valid_)
@@ -2271,12 +2340,14 @@ namespace sogen::kvm
                 }
                 return this->sregs_cache_;
             }
+
             void set_sregs(const kvm_sregs& sregs)
             {
                 this->sregs_cache_ = sregs;
                 this->sregs_cache_valid_ = true;
                 this->sregs_cache_dirty_ = true;
             }
+
             void flush_register_cache()
             {
                 if (this->regs_cache_dirty_)
@@ -2290,22 +2361,26 @@ namespace sogen::kvm
                     this->sregs_cache_dirty_ = false;
                 }
             }
+
             void invalidate_register_cache()
             {
                 this->regs_cache_valid_ = false;
                 this->sregs_cache_valid_ = false;
             }
+
             kvm_fpu get_fpu() const
             {
                 kvm_fpu fpu{};
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_GET_FPU, &fpu), "KVM_GET_FPU");
                 return fpu;
             }
+
             void set_fpu(const kvm_fpu& fpu)
             {
                 auto mutable_fpu = fpu;
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_SET_FPU, &mutable_fpu), "KVM_SET_FPU");
             }
+
             xsave_area get_xsave() const
             {
                 // Captures the full extended state (x87, SSE, and the AVX YMM upper halves), unlike
@@ -2315,17 +2390,20 @@ namespace sogen::kvm
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_GET_XSAVE, xsave.data()), "KVM_GET_XSAVE");
                 return xsave;
             }
+
             void set_xsave(const xsave_area& xsave)
             {
                 auto mutable_xsave = xsave;
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_SET_XSAVE, mutable_xsave.data()), "KVM_SET_XSAVE");
             }
+
             kvm_debugregs get_debugregs() const
             {
                 kvm_debugregs debugregs{};
                 check_ioctl_result(::ioctl(this->vcpu_fd_.get(), KVM_GET_DEBUGREGS, &debugregs), "KVM_GET_DEBUGREGS");
                 return debugregs;
             }
+
             void set_debugregs(const kvm_debugregs& debugregs)
             {
                 auto mutable_debugregs = debugregs;
@@ -2376,10 +2454,12 @@ namespace sogen::kvm
                     throw std::runtime_error("Unsupported KVM GP register");
                 }
             }
+
             static const __u64* get_gp_register_pointer(const kvm_regs& regs, register_name name)
             {
                 return get_gp_register_pointer(const_cast<kvm_regs&>(regs), name);
             }
+
             static kvm_segment& get_segment_register(kvm_sregs& sregs, register_name name)
             {
                 switch (name)
@@ -2400,10 +2480,12 @@ namespace sogen::kvm
                     throw std::runtime_error("Unsupported KVM segment register");
                 }
             }
+
             static const kvm_segment& get_segment_register(const kvm_sregs& sregs, register_name name)
             {
                 return get_segment_register(const_cast<kvm_sregs&>(sregs), name);
             }
+
             static kvm_dtable& get_table_register(kvm_sregs& sregs, register_name name)
             {
                 switch (name)
@@ -2416,10 +2498,12 @@ namespace sogen::kvm
                     throw std::runtime_error("Unsupported KVM table register");
                 }
             }
+
             static const kvm_dtable& get_table_register(const kvm_sregs& sregs, register_name name)
             {
                 return get_table_register(const_cast<kvm_sregs&>(sregs), name);
             }
+
             static uint8_t* get_fp_register_pointer(kvm_fpu& fpu, register_name name)
             {
                 const auto index = static_cast<int>(name) - static_cast<int>(register_name::fp0);
@@ -2430,10 +2514,12 @@ namespace sogen::kvm
 
                 return fpu.fpr[index];
             }
+
             static const uint8_t* get_fp_register_pointer(const kvm_fpu& fpu, register_name name)
             {
                 return get_fp_register_pointer(const_cast<kvm_fpu&>(fpu), name);
             }
+
             static uint8_t* get_xmm_register_pointer(kvm_fpu& fpu, register_name name)
             {
                 const auto index = static_cast<int>(name) - static_cast<int>(register_name::xmm0);
@@ -2444,6 +2530,7 @@ namespace sogen::kvm
 
                 return fpu.xmm[index];
             }
+
             static const uint8_t* get_xmm_register_pointer(const kvm_fpu& fpu, register_name name)
             {
                 return get_xmm_register_pointer(const_cast<kvm_fpu&>(fpu), name);

--- a/src/common/utils/concurrency.hpp
+++ b/src/common/utils/concurrency.hpp
@@ -43,6 +43,7 @@ namespace sogen
             {
                 return object_;
             }
+
             const T& get_raw() const
             {
                 return object_;

--- a/src/common/utils/path_key.hpp
+++ b/src/common/utils/path_key.hpp
@@ -12,6 +12,7 @@ namespace sogen
         {
           public:
             path_key() = default;
+
             path_key(const std::filesystem::path& p)
                 : path_(canonicalize_path(p))
             {

--- a/src/disassembler/disassembler.hpp
+++ b/src/disassembler/disassembler.hpp
@@ -17,6 +17,7 @@ namespace sogen
     {
       public:
         instructions() = default;
+
         ~instructions()
         {
             this->release();
@@ -77,6 +78,7 @@ namespace sogen
         {
             return this->instructions_.begin();
         }
+
         auto end() const
         {
             return this->instructions_.end();

--- a/src/emulator-platform/platform/elf.hpp
+++ b/src/emulator-platform/platform/elf.hpp
@@ -170,6 +170,7 @@ namespace sogen
         {
             return static_cast<uint8_t>((bind << 4) + (type & 0x0F));
         }
+
         // NOLINTEND(readability-redundant-inline-specifier)
 
         // ---- x86-64 Relocation types -------------------------------------------
@@ -206,6 +207,7 @@ namespace sogen
         {
             return (static_cast<uint64_t>(sym) << 32) | type;
         }
+
         // NOLINTEND(readability-redundant-inline-specifier)
 
         // ---- Auxiliary vector types (for initial stack) -------------------------
@@ -323,6 +325,7 @@ namespace sogen
         struct Elf64_Dyn
         {
             int64_t d_tag;
+
             union
             {
                 uint64_t d_val;

--- a/src/emulator-platform/platform/file_management.hpp
+++ b/src/emulator-platform/platform/file_management.hpp
@@ -618,6 +618,7 @@ namespace sogen
 
 #ifndef OS_WINDOWS
     typedef BOOLEAN SECURITY_CONTEXT_TRACKING_MODE, *PSECURITY_CONTEXT_TRACKING_MODE;
+
     typedef struct _SECURITY_QUALITY_OF_SERVICE
     {
         DWORD Length;

--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -60,6 +60,7 @@ namespace sogen
         BYTE lfPitchAndFamily;
         char16_t lfFaceName[32];
     };
+
     static_assert(sizeof(EMU_LOGFONTW) == 0x5C);
 
     struct EMU_ENUMLOGFONTEXW
@@ -69,6 +70,7 @@ namespace sogen
         char16_t elfStyle[32];
         char16_t elfScript[32];
     };
+
     static_assert(sizeof(EMU_ENUMLOGFONTEXW) == 0x15C);
 
     struct EMU_NEWTEXTMETRICW
@@ -98,6 +100,7 @@ namespace sogen
         UINT ntmCellHeight;
         UINT ntmAvgWidth;
     };
+
     static_assert(sizeof(EMU_NEWTEXTMETRICW) == 0x4C);
 
     struct EMU_NEWTEXTMETRICEXW
@@ -106,6 +109,7 @@ namespace sogen
         DWORD fsUsb[4];
         DWORD fsCsb[2];
     };
+
     static_assert(sizeof(EMU_NEWTEXTMETRICEXW) == 0x64);
 
     struct FIXED
@@ -113,6 +117,7 @@ namespace sogen
         uint16_t fract;
         int16_t value;
     };
+
     static_assert(sizeof(FIXED) == 0x04);
 
     struct POINTFX
@@ -120,6 +125,7 @@ namespace sogen
         FIXED x;
         FIXED y;
     };
+
     static_assert(sizeof(POINTFX) == 0x08);
 
     struct EMU_TTPOLYGONHEADER
@@ -128,6 +134,7 @@ namespace sogen
         uint32_t dwType{};
         POINTFX pfxStart{};
     };
+
     static_assert(sizeof(EMU_TTPOLYGONHEADER) == 0x10);
 
     struct EMU_TTPOLYCURVE_HEADER
@@ -135,6 +142,7 @@ namespace sogen
         uint16_t wType{};
         uint16_t cpfx{};
     };
+
     static_assert(sizeof(EMU_TTPOLYCURVE_HEADER) == 0x04);
 
     struct EMU_BITMAPINFOHEADER
@@ -151,6 +159,7 @@ namespace sogen
         DWORD biClrUsed;
         DWORD biClrImportant;
     };
+
     static_assert(sizeof(EMU_BITMAPINFOHEADER) == 0x28);
 
     struct GDI_HANDLE_ENTRY64
@@ -188,6 +197,7 @@ namespace sogen
         UCHAR Flags;
         uint32_t UserPointer;
     };
+
     static_assert(sizeof(GDI_HANDLE_ENTRY32) == 0x10);
 
 #define GDI_MAX_HANDLE_COUNT 0xFFFF // 0x4000
@@ -199,6 +209,7 @@ namespace sogen
         uint64_t Objects[0x20];
         uint64_t Data[0x200]; // ?
     };
+
     static_assert(offsetof(GDI_SHARED_MEMORY64, Objects) == 0x1800B0);
 
     struct EMU_D3DKMT_ADAPTERINFO
@@ -227,6 +238,7 @@ namespace sogen
         UINT32 Padding;
         UINT64 pAdapters;
     };
+
     static_assert(sizeof(EMU_D3DKMT_ENUMADAPTERS3) == 0x18);
 
     struct EMU_D3DKMT_GET_PROPERTIES
@@ -416,6 +428,7 @@ namespace sogen
         UINT64 GpuVirtualAddress;
         UINT64 Reserved[6];
     };
+
     static_assert(sizeof(EMU_D3DDDI_OPENALLOCATIONINFO2) == 80);
 
     struct EMU_D3DKMT_OPENRESOURCE
@@ -449,6 +462,7 @@ namespace sogen
     {
         UINT32 hDevice;
         UINT32 StateType;
+
         union
         {
             UINT32 State;
@@ -470,6 +484,7 @@ namespace sogen
         ULONG DefaultControlPort;
         BOOLEAN UsesIhvSolution;
     };
+
     static_assert(sizeof(EMU_D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS) == 0xC);
 
     struct EMU_D3DKMT_DESTROYALLOCATION
@@ -491,6 +506,7 @@ namespace sogen
                 UINT32 Reserved : 29;
                 UINT32 SystemUseOnly : 1;
             };
+
             UINT32 Value;
         };
     };

--- a/src/emulator-platform/platform/kernel_mapped.hpp
+++ b/src/emulator-platform/platform/kernel_mapped.hpp
@@ -684,9 +684,11 @@ namespace sogen
         BOOLEAN InheritedAddressSpace;
         BOOLEAN ReadImageFileExecOptions;
         BOOLEAN BeingDebugged;
+
         union
         {
             BOOLEAN BitField;
+
             struct
             {
                 BOOLEAN ImageUsesLargePages : 1;
@@ -714,6 +716,7 @@ namespace sogen
         union
         {
             ULONG CrossProcessFlags;
+
             struct
             {
                 ULONG ProcessInJob : 1;
@@ -727,11 +730,13 @@ namespace sogen
                 ULONG ReservedBits0 : 24;
             };
         };
+
         union
         {
             EMULATOR_CAST(std::uint32_t, PVOID32) KernelCallbackTable;
             EMULATOR_CAST(std::uint32_t, PVOID32) UserSharedInfoPtr;
         };
+
         ULONG SystemReserved;
         ULONG AtlThunkSListPtr32;
         EMULATOR_CAST(std::uint32_t, struct _API_SET_NAMESPACE*) ApiSetMap;
@@ -820,9 +825,11 @@ namespace sogen
         };
 
         EMULATOR_CAST(std::uint32_t, PVOID32) pImageHeaderHash;
+
         union
         {
             ULONG TracingFlags;
+
             struct
             {
                 ULONG HeapTracingEnabled : 1;
@@ -831,6 +838,7 @@ namespace sogen
                 ULONG SpareTracingBits : 29;
             };
         };
+
         ULONGLONG CsrServerReadOnlySharedMemoryBase;
         EMULATOR_CAST(std::uint32_t, struct _RTL_CRITICAL_SECTION32*) TppWorkerpListLock;
         LIST_ENTRY32 TppWorkerpList;
@@ -841,15 +849,18 @@ namespace sogen
         CHAR PlaceholderCompatibilityMode;
         ARRAY_CONTAINER<CHAR, 7> PlaceholderCompatibilityModeReserved;
         EMULATOR_CAST(std::uint32_t, struct _LEAP_SECOND_DATA*) LeapSecondData; // REDSTONE5
+
         union
         {
             ULONG LeapSecondFlags;
+
             struct
             {
                 ULONG SixtySecondEnabled : 1;
                 ULONG Reserved : 31;
             };
         };
+
         ULONG NtGlobalFlag2;
         ULONGLONG ExtendedFeatureDisableMask; // since WIN11
 
@@ -1229,6 +1240,7 @@ namespace sogen
         {
             EMULATOR_CAST(std::uint32_t, PROCESSOR_NUMBER) CurrentIdealProcessor;
             ULONG IdealProcessorValue;
+
             struct
             {
                 UCHAR ReservedPad0;
@@ -1265,9 +1277,11 @@ namespace sogen
             USHORT CrossTebFlags;
             USHORT SpareCrossTebBits : 16;
         };
+
         union
         {
             USHORT SameTebFlags;
+
             struct
             {
                 USHORT SafeThunkCall : 1;
@@ -1306,12 +1320,14 @@ namespace sogen
     static_assert(sizeof(TEB32) == 4120, "sizeof(TEB32) is incorrect");
 
 #pragma pack(push, 4)
+
     typedef struct _KSYSTEM_TIME
     {
         ULONG LowPart;
         LONG High1Time;
         LONG High2Time;
     } KSYSTEM_TIME, *PKSYSTEM_TIME;
+
 #pragma pack(pop)
 
     typedef enum _NT_PRODUCT_TYPE
@@ -1411,9 +1427,11 @@ namespace sogen
         std::uint64_t EnabledFeatures;
         std::uint64_t EnabledVolatileFeatures;
         ULONG Size;
+
         union
         {
             ULONG ControlFlags;
+
             struct
             {
                 ULONG OptimizedSave : 1;
@@ -1421,6 +1439,7 @@ namespace sogen
                 ULONG Reserved1 : 30;
             };
         };
+
         XSTATE_FEATURE Features[MAXIMUM_XSTATE_FEATURES];
         std::uint64_t EnabledSupervisorFeatures;
         std::uint64_t AlignedFeatures;
@@ -1653,9 +1672,11 @@ namespace sogen
     {
         EMULATOR_CAST(std::uint64_t, SIZE_T) Size; // Ignored as input, written with structure size on output
         PROCESS_BASIC_INFORMATION64 BasicInfo;
+
         union
         {
             ULONG Flags;
+
             struct
             {
                 ULONG IsProtectedProcess : 1;
@@ -1888,15 +1909,18 @@ namespace sogen
         ULONG64 SystemDllNativeRelocation;
         ULONG Wow64SharedInformation[16]; // use WOW64_SHARED_INFORMATION as index
         ULONG RngData;
+
         union
         {
             ULONG Flags;
+
             struct
             {
                 ULONG CfgOverride : 1; // since REDSTONE
                 ULONG Reserved : 31;
             };
         };
+
         ULONG64 MitigationOptions;
         ULONG64 CfgBitMap; // since WINBLUE
         ULONG64 CfgBitMapSize;
@@ -1912,15 +1936,18 @@ namespace sogen
         ULONG64 SystemDllNativeRelocation;
         ULONG64 Wow64SharedInformation[16]; // use WOW64_SHARED_INFORMATION as index
         ULONG RngData;
+
         union
         {
             ULONG Flags;
+
             struct
             {
                 ULONG CfgOverride : 1;
                 ULONG Reserved : 31;
             };
         };
+
         PS_MITIGATION_OPTIONS_MAP_V2 MitigationOptionsMap;
         ULONG64 CfgBitMap;
         ULONG64 CfgBitMapSize;
@@ -1937,15 +1964,18 @@ namespace sogen
         ULONG64 SystemDllNativeRelocation;
         ULONG64 Wow64SharedInformation[16]; // use WOW64_SHARED_INFORMATION_V5 as index
         ULONG RngData;
+
         union
         {
             ULONG Flags;
+
             struct
             {
                 ULONG CfgOverride : 1; // effectively since REDSTONE
                 ULONG Reserved : 31;
             };
         };
+
         PS_MITIGATION_OPTIONS_MAP_V3 MitigationOptionsMap;
         ULONG64 CfgBitMap; // effectively since WINBLUE
         ULONG64 CfgBitMapSize;

--- a/src/emulator-platform/platform/namespace.hpp
+++ b/src/emulator-platform/platform/namespace.hpp
@@ -37,15 +37,18 @@ namespace sogen
         ULONG Version;
         ULONG Items;
         ULONG TotalSize;
+
         union
         {
             ULONG Flags;
+
             struct
             {
                 ULONG AddAppContainerSid : 1;
                 ULONG Reserved : 31;
             };
         };
+
         // OBJECT_BOUNDARY_ENTRY Entries[1];
     };
 

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -947,6 +947,7 @@ namespace sogen
         TokenPrimary = 1,
         TokenImpersonation
     } TOKEN_TYPE;
+
     typedef TOKEN_TYPE* PTOKEN_TYPE;
 
     typedef struct _TOKEN_ELEVATION
@@ -1096,6 +1097,7 @@ namespace sogen
         DWORD NodeNumber;
         BYTE Reserved[18];
         WORD GroupCount;
+
         union
         {
             EMU_GROUP_AFFINITY64 GroupMask;
@@ -1112,6 +1114,7 @@ namespace sogen
         PROCESSOR_CACHE_TYPE Type;
         BYTE Reserved[18];
         WORD GroupCount;
+
         union
         {
             EMU_GROUP_AFFINITY64 GroupMask;
@@ -1148,6 +1151,7 @@ namespace sogen
     {
         LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
         DWORD Size;
+
         union
         {
             EMU_PROCESSOR_RELATIONSHIP64 Processor;
@@ -1171,16 +1175,19 @@ namespace sogen
     {
         Traits::ULONG_PTR ProcessorMask;
         LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
+
         union
         {
             struct
             {
                 BYTE Flags;
             } ProcessorCore;
+
             struct
             {
                 DWORD NodeNumber;
             } NumaNode;
+
             EMU_CACHE_DESCRIPTOR Cache;
             ULONGLONG Reserved[2];
         } DUMMYUNIONNAME;
@@ -1307,5 +1314,6 @@ namespace sogen
         ULONG Reserved;
         uint64_t Callback;
     };
+
     // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)
 } // namespace sogen

--- a/src/emulator-platform/platform/ui_backend.hpp
+++ b/src/emulator-platform/platform/ui_backend.hpp
@@ -68,6 +68,7 @@ namespace sogen
 
         virtual void set_event_sink(event_sink sink) = 0;
         virtual void pump_events() = 0;
+
         virtual void reset()
         {
         }
@@ -75,33 +76,42 @@ namespace sogen
         virtual void create_window(const ui_window_desc& /*desc*/)
         {
         }
+
         virtual void destroy_window(const hwnd /*window*/)
         {
         }
+
         virtual void set_window_rect(const hwnd /*window*/, const RECT& /*rect*/)
         {
         }
+
         virtual void set_window_visible(const hwnd /*window*/, const bool /*visible*/)
         {
         }
+
         virtual void set_window_enabled(const hwnd /*window*/, const bool /*enabled*/)
         {
         }
+
         virtual void set_window_title(const hwnd /*window*/, std::u16string_view /*title*/)
         {
         }
+
         virtual void invalidate(const hwnd /*window*/, const std::optional<RECT>& /*rect*/)
         {
         }
+
         virtual void present_surface(const hwnd /*window*/, const ui_surface_desc& /*surface*/)
         {
         }
+
         // Warp the host cursor so it tracks a guest SetCursorPos. Without this, the next host mouse-motion
         // event reports the (unchanged) host position and overwrites the recentered guest cursor, making
         // relative-mouse deltas (in-game look) jump. screen_x/y are emulated-desktop screen coordinates.
         virtual void set_cursor_position(const hwnd /*window*/, const int32_t /*screen_x*/, const int32_t /*screen_y*/)
         {
         }
+
         // Show or hide the host cursor. Games that capture the mouse hide it (ShowCursor(FALSE) /
         // SetCursor(NULL)) and recenter every frame; without honoring this the host cursor stays visible
         // and flickers as the guest warps it back to the center.
@@ -116,9 +126,11 @@ namespace sogen
         void set_event_sink(event_sink /*sink*/) override
         {
         }
+
         void pump_events() override
         {
         }
+
         void reset() override
         {
         }

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -58,6 +58,7 @@ namespace sogen
         uint8_t pad_1b58[0x286];
         uint64_t foregroundWindow;
     };
+
     static_assert(offsetof(USER_SERVERINFO, apfnClientA) == 0x188);
     static_assert(offsetof(USER_SERVERINFO, systemMetrics) == 0x768);
     static_assert(offsetof(USER_SERVERINFO, ahbrSystem) == 0x1258);
@@ -75,6 +76,7 @@ namespace sogen
         RECT rcScreen;
         uint8_t unknown[0xFF];
     };
+
     static_assert(offsetof(USER_DISPINFO, rcScreen) == 0x18);
 
     struct USER_HANDLEENTRY
@@ -86,6 +88,7 @@ namespace sogen
         uint8_t bFlags;
         uint16_t wUniq;
     };
+
     static_assert(offsetof(USER_HANDLEENTRY, unknown) == 0x10);
     static_assert(offsetof(USER_HANDLEENTRY, bType) == 0x18);
     static_assert(sizeof(USER_HANDLEENTRY) == 0x20);
@@ -95,6 +98,7 @@ namespace sogen
         DWORD maxMsgs;
         uint64_t abMsgs;
     };
+
     static_assert(offsetof(USER_WNDMSG, abMsgs) == 0x8);
     static_assert(sizeof(USER_WNDMSG) == 0x10);
 
@@ -110,6 +114,7 @@ namespace sogen
         USER_WNDMSG DefWindowMsgs;
         USER_WNDMSG DefWindowSpecMsgs;
     };
+
     static_assert(offsetof(USER_SHAREDINFO, pDispInfo) == 0x18);
     static_assert(offsetof(USER_SHAREDINFO, awmControl) == 0x98);
     static_assert(offsetof(USER_SHAREDINFO, DefWindowMsgs) == 0x218);
@@ -141,6 +146,7 @@ namespace sogen
         uint32_t ime_msg_bits;
         uint8_t reserved9[0x114];
     };
+
     static_assert(offsetof(WIN32K_USERCONNECT32, ahe_list) == 0x8);
     static_assert(offsetof(WIN32K_USERCONNECT32, he_entry_size) == 0x10);
     static_assert(offsetof(WIN32K_USERCONNECT32, disp_info_low) == 0x18);
@@ -157,6 +163,7 @@ namespace sogen
         uint32_t dwFlags;
         uint32_t hwndTarget;
     };
+
     static_assert(sizeof(RAWINPUTDEVICE32) == 0x0C);
 
     struct RAWINPUTHEADER32
@@ -166,6 +173,7 @@ namespace sogen
         uint32_t hDevice;
         uint32_t wParam;
     };
+
     static_assert(sizeof(RAWINPUTHEADER32) == 0x10);
 
     // The mouse body has no pointer fields, so its layout is identical for 32- and 64-bit guests.
@@ -179,6 +187,7 @@ namespace sogen
         int32_t lLastY;
         uint32_t ulExtraInformation;
     };
+
     static_assert(sizeof(RAWMOUSE32) == 0x18);
 
     struct RAWKEYBOARD32
@@ -190,6 +199,7 @@ namespace sogen
         uint32_t Message;
         uint32_t ExtraInformation;
     };
+
     static_assert(sizeof(RAWKEYBOARD32) == 0x10);
 
     enum USER_HANDLETYPE : uint8_t
@@ -226,6 +236,7 @@ namespace sogen
         uint8_t unknown1[0x14];
         RECT rcMonitor;
         RECT rcWork;
+
         union
         {
             struct
@@ -233,6 +244,7 @@ namespace sogen
                 uint16_t monitorDpi;
                 uint16_t nativeDpi;
             } b26;
+
             struct
             {
                 uint32_t unknown1;
@@ -243,6 +255,7 @@ namespace sogen
                 RECT rcMonitorDpiAware;
             } b20;
         };
+
         uint8_t unknown4[0xFF];
     };
 
@@ -260,6 +273,7 @@ namespace sogen
         uint64_t lpszAnsiClassName;
         uint8_t pad_038[0xC8];
     };
+
     static_assert(offsetof(USER_CLASS, lpszAnsiClassName) == 0x30);
     static_assert(sizeof(USER_CLASS) == 0x100);
 
@@ -309,6 +323,7 @@ namespace sogen
         uint32_t threadId;
         uint32_t processId;
     };
+
     static_assert(offsetof(USER_WINDOW, dpiContext) == 0x120);
     static_assert(offsetof(USER_WINDOW, threadId) == 0x148);
     static_assert(offsetof(USER_WINDOW, processId) == 0x14C);
@@ -323,6 +338,7 @@ namespace sogen
         uint32_t flags;
         uint32_t cItems;
     };
+
     static_assert(offsetof(USER_MENU, hMenu) == 0x0);
     static_assert(offsetof(USER_MENU, ptrBase) == 0x8);
     static_assert(offsetof(USER_MENU, rgItems) == 0x20);
@@ -351,6 +367,7 @@ namespace sogen
         uint64_t hbmpItem;
         uint8_t pad_68[8]{};
     };
+
     static_assert(offsetof(USER_MENU_ITEM, state) == 0x4);
     static_assert(offsetof(USER_MENU_ITEM, id) == 0x8);
     static_assert(offsetof(USER_MENU_ITEM, submenu) == 0x10);

--- a/src/emulator-platform/platform/win_pefile.hpp
+++ b/src/emulator-platform/platform/win_pefile.hpp
@@ -293,11 +293,13 @@ namespace sogen
     typedef struct _IMAGE_SECTION_HEADER
     {
         std::uint8_t Name[IMAGE_SIZEOF_SHORT_NAME];
+
         union
         {
             std::uint32_t PhysicalAddress;
             std::uint32_t VirtualSize;
         } Misc;
+
         std::uint32_t VirtualAddress;
         std::uint32_t SizeOfRawData;
         std::uint32_t PointerToRawData;
@@ -398,6 +400,7 @@ namespace sogen
         {
             return IMAGE_ORDINAL32(ordinal);
         }
+
         static constexpr bool snap_by_ordinal(DWORD ordinal)
         {
             return IMAGE_SNAP_BY_ORDINAL32(ordinal);
@@ -414,6 +417,7 @@ namespace sogen
         {
             return IMAGE_ORDINAL64(ordinal);
         }
+
         static constexpr bool snap_by_ordinal(ULONGLONG ordinal)
         {
             return IMAGE_SNAP_BY_ORDINAL64(ordinal);

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -484,6 +484,7 @@ namespace sogen
         WORD dmSize;
         WORD dmDriverExtra;
         DWORD dmFields;
+
         union
         {
             struct
@@ -497,7 +498,9 @@ namespace sogen
                 int16_t dmDefaultSource;
                 int16_t dmPrintQuality;
             } s;
+
             POINT dmPosition;
+
             struct
             {
                 POINT dmPosition;
@@ -505,6 +508,7 @@ namespace sogen
                 DWORD dmDisplayFixedOutput;
             } s2;
         } u;
+
         int16_t dmColor;
         int16_t dmDuplex;
         int16_t dmYResolution;
@@ -515,11 +519,13 @@ namespace sogen
         DWORD dmBitsPerPel;
         DWORD dmPelsWidth;
         DWORD dmPelsHeight;
+
         union
         {
             DWORD dmDisplayFlags;
             DWORD dmNup;
         } u2;
+
         DWORD dmDisplayFrequency;
         DWORD dmICMMethod;
         DWORD dmICMIntent;
@@ -550,15 +556,18 @@ namespace sogen
     {
         LUID adapterId;
         UINT32 id;
+
         union
         {
             UINT32 modeInfoIdx;
+
             struct
             {
                 UINT32 cloneGroupId : 16;
                 UINT32 sourceModeInfoIdx : 16;
             } s;
         } u;
+
         UINT32 statusFlags;
     };
 
@@ -586,15 +595,18 @@ namespace sogen
     {
         LUID adapterId;
         UINT32 id;
+
         union
         {
             UINT32 modeInfoIdx;
+
             struct
             {
                 UINT32 desktopModeInfoIdx : 16;
                 UINT32 targetModeInfoIdx : 16;
             } s;
         } u;
+
         EMULATOR_CAST(uint32_t, DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY) outputTechnology;
         EMULATOR_CAST(uint32_t, DISPLAYCONFIG_ROTATION) rotation;
         EMULATOR_CAST(uint32_t, DISPLAYCONFIG_SCALING) scaling;
@@ -618,6 +630,7 @@ namespace sogen
         DISPLAYCONFIG_RATIONAL vSyncFreq;
         DISPLAYCONFIG_2DREGION activeSize;
         DISPLAYCONFIG_2DREGION totalSize;
+
         union
         {
             struct
@@ -626,8 +639,10 @@ namespace sogen
                 UINT32 vSyncFreqDivider : 6;
                 UINT32 reserved : 10;
             } AdditionalSignalInfo;
+
             UINT32 videoStandard;
         } u;
+
         uint32_t scanLineOrdering;
     };
 
@@ -649,6 +664,7 @@ namespace sogen
         uint32_t infoType;
         UINT32 id;
         LUID adapterId;
+
         union
         {
             EMU_DISPLAYCONFIG_TARGET_MODE targetMode;
@@ -717,6 +733,7 @@ namespace sogen
     struct EMU_DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO
     {
         EMU_DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+
         union
         {
             struct
@@ -727,8 +744,10 @@ namespace sogen
                 UINT32 advancedColorForceDisabled : 1; // Advanced color is force disabled due to system/OS policy
                 UINT32 reserved : 28;
             } s;
+
             UINT32 value;
         } u;
+
         EMULATOR_CAST(uint32_t, DISPLAYCONFIG_COLOR_ENCODING) colorEncoding;
         UINT32 bitsPerColorChannel;
     };

--- a/src/emulator-platform/segment_utils.hpp
+++ b/src/emulator-platform/segment_utils.hpp
@@ -16,6 +16,7 @@ namespace sogen::segment_utils
     };
 
 #pragma pack(push, 1)
+
     struct raw_segment_descriptor
     {
         uint16_t limit_low;
@@ -25,6 +26,7 @@ namespace sogen::segment_utils
         uint8_t limit_high_flags;
         uint8_t base_high;
     };
+
 #pragma pack(pop)
 
     struct descriptor

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -1121,6 +1121,7 @@ namespace sogen::gpu_bridge
         uint32_t depth;
         uint32_t reserved;
     };
+
     static_assert(sizeof(cmd_copy_image_request) == 104, "wire layout drift");
 
     struct cmd_blit_image_request
@@ -1153,6 +1154,7 @@ namespace sogen::gpu_bridge
         uint32_t filter; // VkFilter
         uint32_t reserved;
     };
+
     static_assert(sizeof(cmd_blit_image_request) == 120, "wire layout drift");
 
     // Updates a buffer region inline from data that trails this header in the wire stream (vkCmdUpdateBuffer).

--- a/src/linux-emulator/linux_emulator.cpp
+++ b/src/linux-emulator/linux_emulator.cpp
@@ -21,6 +21,7 @@ namespace sogen
         constexpr uint16_t GDT_DATA64_SEL = 0x2B; // 64-bit data segment (ring 3)
 
 #pragma pack(push, 1)
+
         struct gdt_entry
         {
             uint16_t limit_low;
@@ -30,6 +31,7 @@ namespace sogen
             uint8_t granularity;
             uint8_t base_high;
         };
+
 #pragma pack(pop)
 
         static_assert(sizeof(gdt_entry) == GDT_ENTRY_SIZE);

--- a/src/linux-emulator/linux_fd_table.hpp
+++ b/src/linux-emulator/linux_fd_table.hpp
@@ -33,6 +33,7 @@ namespace sogen
         std::string content{};
         size_t offset{};
     };
+
     struct linux_socket_state
     {
         int domain{};
@@ -53,6 +54,7 @@ namespace sogen
         uint32_t peer_addr{};
 
         linux_socket_state() = default;
+
         ~linux_socket_state()
         {
 #if !defined(_WIN32)

--- a/src/linux-emulator/linux_memory_manager.hpp
+++ b/src/linux-emulator/linux_memory_manager.hpp
@@ -112,6 +112,7 @@ namespace sogen
         uint64_t add_memory_protect_callback(memory_protect_callback callback);
         uint64_t add_memory_release_callback(memory_release_callback callback);
         void remove_memory_callback(uint64_t id);
+
         uint64_t get_mmap_base() const
         {
             return this->mmap_base_;

--- a/src/linux-emulator/linux_stat.hpp
+++ b/src/linux-emulator/linux_stat.hpp
@@ -6,6 +6,7 @@
 // Matches the kernel's struct stat for x86-64
 // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
+
 namespace sogen
 {
 
@@ -30,6 +31,7 @@ namespace sogen
         uint64_t st_ctime_nsecs;
         int64_t reserved_[3];
     };
+
 #pragma pack(pop)
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 

--- a/src/linux-emulator/procfs.cpp
+++ b/src/linux-emulator/procfs.cpp
@@ -390,6 +390,7 @@ namespace sogen
     {
         return "5.15.0-sogen\n";
     }
+
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
 } // namespace sogen

--- a/src/linux-emulator/signal_dispatch.hpp
+++ b/src/linux-emulator/signal_dispatch.hpp
@@ -87,6 +87,7 @@ namespace sogen
 // Linux x86-64 sigcontext (from arch/x86/include/uapi/asm/sigcontext.h)
 // This matches the kernel struct sigcontext layout exactly
 #pragma pack(push, 1)
+
     struct linux_sigcontext
     {
         uint64_t r8;
@@ -118,12 +119,14 @@ namespace sogen
         uint64_t fpstate_ptr; // pointer to fpstate (or 0)
         uint64_t reserved1[8];
     };
+
 #pragma pack(pop)
 
     static_assert(sizeof(linux_sigcontext) == 256);
 
 // Linux x86-64 siginfo_t (128 bytes)
 #pragma pack(push, 1)
+
     struct linux_siginfo_t
     {
         int32_t si_signo;
@@ -134,12 +137,14 @@ namespace sogen
         uint64_t fault_address; // _sigfault.si_addr
         uint8_t _pad[128 - 24]; // pad to 128 bytes total
     };
+
 #pragma pack(pop)
 
     static_assert(sizeof(linux_siginfo_t) == 128);
 
 // Linux x86-64 stack_t
 #pragma pack(push, 1)
+
     struct linux_stack_t
     {
         uint64_t ss_sp;
@@ -147,12 +152,14 @@ namespace sogen
         int32_t _pad;
         uint64_t ss_size;
     };
+
 #pragma pack(pop)
 
     static_assert(sizeof(linux_stack_t) == 24);
 
 // Linux x86-64 ucontext_t
 #pragma pack(push, 1)
+
     struct linux_ucontext_t
     {
         uint64_t uc_flags;
@@ -162,17 +169,21 @@ namespace sogen
         uint64_t uc_sigmask;           // signal mask (64-bit)
         uint8_t _pad_sigmask[128 - 8]; // __unused[] in kernel -- sigset_t is 128 bytes
     };
+
 #pragma pack(pop)
 
 // rt_sigframe -- what the kernel pushes on the user stack before entering a signal handler
 #pragma pack(push, 1)
+
     struct linux_rt_sigframe
     {
         uint64_t pretcode;    // return address: points to sigreturn trampoline
         linux_siginfo_t info; // 128 bytes
         linux_ucontext_t uc;  // ucontext
     };
+
 #pragma pack(pop)
+
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
     // Signal dispatch engine

--- a/src/linux-emulator/syscalls/file.cpp
+++ b/src/linux-emulator/syscalls/file.cpp
@@ -514,6 +514,7 @@ namespace sogen
         }
 
 #pragma pack(push, 1)
+
         struct linux_dirent64_header
         {
             uint64_t d_ino;
@@ -521,6 +522,7 @@ namespace sogen
             uint16_t d_reclen;
             uint8_t d_type;
         };
+
 #pragma pack(pop)
 
         const char* translate_open_mode(const int flags, const bool file_existed)
@@ -2791,6 +2793,7 @@ namespace sogen
         // Linux struct statfs (120 bytes on x86-64)
         // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
+
         struct linux_statfs
         {
             int64_t f_type;
@@ -2806,6 +2809,7 @@ namespace sogen
             int64_t f_flags;
             int64_t f_spare[4];
         };
+
 #pragma pack(pop)
         // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
@@ -2837,6 +2841,7 @@ namespace sogen
 
         // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
+
         struct linux_statfs
         {
             int64_t f_type;
@@ -2852,6 +2857,7 @@ namespace sogen
             int64_t f_flags;
             int64_t f_spare[4];
         };
+
 #pragma pack(pop)
         // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
@@ -2905,6 +2911,7 @@ namespace sogen
         case TIOCGWINSZ: {
             const auto arg_addr = get_linux_syscall_argument(c.emu, 2);
 #pragma pack(push, 1)
+
             struct winsize
             {
                 uint16_t ws_row;
@@ -2912,6 +2919,7 @@ namespace sogen
                 uint16_t ws_xpixel;
                 uint16_t ws_ypixel;
             };
+
 #pragma pack(pop)
             winsize ws{};
             ws.ws_row = 25;

--- a/src/linux-emulator/syscalls/io.cpp
+++ b/src/linux-emulator/syscalls/io.cpp
@@ -384,11 +384,13 @@ namespace sogen
     {
 
 #pragma pack(push, 1)
+
         struct linux_epoll_event
         {
             uint32_t events;
             uint64_t data;
         };
+
 #pragma pack(pop)
 
         static_assert(sizeof(linux_epoll_event) == 12);
@@ -526,12 +528,14 @@ namespace sogen
         (void)timeout;
 
 #pragma pack(push, 1)
+
         struct linux_pollfd
         {
             int32_t fd;
             int16_t events;
             int16_t revents;
         };
+
 #pragma pack(pop)
 
         static_assert(sizeof(linux_pollfd) == 8);
@@ -692,6 +696,7 @@ namespace sogen
         // We ignore the signal mask and delegate to select logic
         sys_select(c);
     }
+
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
 } // namespace sogen

--- a/src/linux-emulator/syscalls/process.cpp
+++ b/src/linux-emulator/syscalls/process.cpp
@@ -28,6 +28,7 @@ namespace sogen
             char machine[65];
             char domainname[65];
         };
+
         // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
         static_assert(sizeof(linux_utsname) == 390);
@@ -635,6 +636,7 @@ namespace sogen
         // Linux struct sysinfo
 // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
+
         struct linux_sysinfo
         {
             int64_t uptime;
@@ -653,6 +655,7 @@ namespace sogen
             uint32_t mem_unit;
             char padding[4]; // padding to 112 bytes
         };
+
 #pragma pack(pop)
         // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 

--- a/src/linux-emulator/syscalls/socket.cpp
+++ b/src/linux-emulator/syscalls/socket.cpp
@@ -61,6 +61,7 @@ namespace sogen
         // Linux sockaddr_in (16 bytes)
         // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 #pragma pack(push, 1)
+
         struct linux_sockaddr_in
         {
             uint16_t sin_family;
@@ -68,6 +69,7 @@ namespace sogen
             uint32_t sin_addr;
             uint8_t sin_zero[8];
         };
+
 #pragma pack(pop)
         // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 

--- a/src/python-bindings/sogen_internal.hpp
+++ b/src/python-bindings/sogen_internal.hpp
@@ -38,6 +38,7 @@ namespace sogen::py
             hook_state& operator=(const hook_state&) = delete;
 
             void remove();
+
             bool active() const
             {
                 return this->hook != nullptr || static_cast<bool>(this->remover);
@@ -55,6 +56,7 @@ namespace sogen::py
         {
             return this->shared_state && this->shared_state->active();
         }
+
         void remove() const;
     };
 

--- a/src/samples/steam-shim/steam_shim.cpp
+++ b/src/samples/steam-shim/steam_shim.cpp
@@ -195,6 +195,7 @@ namespace
         uint32_t end = 0;                   // valid extent
         std::vector<unsigned char> current; // keeps the payload alive until the next BGetCallback
     };
+
     thread_local callback_queue g_cbq;
 
     bool drain_batch(int32_t pipe)

--- a/src/samples/steam-shim/steam_shim_reverse.cpp
+++ b/src/samples/steam-shim/steam_shim_reverse.cpp
@@ -16,6 +16,7 @@ namespace
         void* obj;
         int32_t type;
     };
+
     std::mutex g_resp_mutex;
     std::unordered_map<uint64_t, response_entry> g_responses;
     std::unordered_map<void*, uint64_t> g_obj_tokens; // dedup by object pointer -> one token per object
@@ -26,6 +27,7 @@ namespace
     {
         const unsigned char* p;
         const unsigned char* end;
+
         template <typename T>
         T get()
         {
@@ -37,6 +39,7 @@ namespace
             }
             return v;
         }
+
         void bytes(void* dst, size_t n)
         {
             if (p + n <= end)
@@ -49,6 +52,7 @@ namespace
                 std::memset(dst, 0, n);
             }
         }
+
         const char* cstr()
         {
             const char* s = reinterpret_cast<const char*>(p);

--- a/src/samples/steam-shim/steam_shim_runtime.hpp
+++ b/src/samples/steam-shim/steam_shim_runtime.hpp
@@ -39,10 +39,12 @@ namespace sogen::steam_shim
     struct is_complete : std::false_type
     {
     };
+
     template <typename T>
     struct is_complete<T, std::void_t<decltype(sizeof(T))>> : std::true_type
     {
     };
+
     template <typename T>
     inline constexpr bool is_complete_v = is_complete<T>::value;
 
@@ -61,6 +63,7 @@ namespace sogen::steam_shim
             const auto* b = static_cast<const unsigned char*>(p);
             in_.insert(in_.end(), b, b + n);
         }
+
         // Every by-value scalar takes a fixed 8-byte slot, so the wire format is arch-agnostic (a 32-bit
         // guest and the 64-bit host agree); each side copies only its native width to/from the low bytes.
         void put_scalar(const void* p, size_t n)
@@ -70,6 +73,7 @@ namespace sogen::steam_shim
             std::memcpy(slot.data(), p, n);
             put(slot.data(), slot.size());
         }
+
         void put_cstr(const char* s)
         {
             if (!s)
@@ -78,6 +82,7 @@ namespace sogen::steam_shim
             }
             put(s, std::strlen(s) + 1);
         }
+
         // Opaque token + interface-type id for a game response object; the host substitutes a proxy that
         // routes calls back (reverse-callback channel).
         void put_callback_token(uint64_t token, int32_t type)
@@ -85,10 +90,12 @@ namespace sogen::steam_shim
             put(&token, sizeof(token));
             put(&type, sizeof(type));
         }
+
         void put_in_ref(const void* p, size_t n)
         {
             put(p, n);
         }
+
         // A pointer arg carries a presence byte first; a reference is always present.
         void put_in_ptr(const void* p, size_t n)
         {
@@ -131,10 +138,12 @@ namespace sogen::steam_shim
         {
             return ret_;
         }
+
         void ret_bytes(void* dst, size_t n)
         {
             std::memcpy(dst, &ret_, n <= sizeof(ret_) ? n : sizeof(ret_));
         }
+
         template <typename T>
         T ret_floating()
         {
@@ -150,6 +159,7 @@ namespace sogen::steam_shim
             }
             return v;
         }
+
         // A string return follows any out-params in the out-blob, NUL-terminated.
         const char* ret_cstr()
         {

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -199,6 +199,7 @@ namespace
         uint64_t offset{};
         uint64_t size{};
     };
+
     std::unordered_map<gb::object_id, mapped_range> g_mapped_ranges;
 
     // Memory objects the bridge aliased straight into the guest address space (no staging copy). These are
@@ -2794,6 +2795,7 @@ extern "C"
             uint8_t* body;
             uint32_t body_size;
         };
+
         std::vector<dest> dests;
         std::vector<gb::feature_chain_record> records;
 
@@ -2877,6 +2879,7 @@ extern "C"
             uint8_t* body;
             uint32_t body_size;
         };
+
         std::vector<dest> dests;
         std::vector<gb::feature_chain_record> records;
         for (auto* next = static_cast<VkBaseOutStructure*>(pProperties->pNext); next; next = next->pNext)

--- a/src/steam-host-backend/steam_host_backend.cpp
+++ b/src/steam-host-backend/steam_host_backend.cpp
@@ -57,11 +57,13 @@ namespace
         std::string version;
         void* iface;
     };
+
     std::unordered_map<uint64_t, entry> g_handles;
     uint64_t g_next_handle = 1;
 
 #ifdef _WIN32
     using lib_handle = HMODULE;
+
     lib_handle load_client(const std::string& path)
     {
         if (const auto slash = path.find_last_of("\\/"); slash != std::string::npos)
@@ -71,33 +73,40 @@ namespace
         constexpr uint32_t load_with_altered_search_path = 0x00000008;
         return LoadLibraryExA(path.c_str(), nullptr, load_with_altered_search_path);
     }
+
     void* client_symbol(lib_handle module, const char* name)
     {
         return reinterpret_cast<void*>(GetProcAddress(module, name));
     }
+
     void set_env(const char* name, const char* value)
     {
         const std::string kv = std::string(name) + "=" + value;
         _putenv(kv.c_str()); // _putenv copies the string into the environment
     }
+
     std::string default_client_path()
     {
         return R"(C:\Program Files (x86)\Steam\steamclient64.dll)";
     }
 #else
     using lib_handle = void*;
+
     lib_handle load_client(const std::string& path)
     {
         return dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL); // GLOBAL so steamclient's sibling libs resolve
     }
+
     void* client_symbol(lib_handle module, const char* name)
     {
         return dlsym(module, name);
     }
+
     void set_env(const char* name, const char* value)
     {
         ::setenv(name, value, 1);
     }
+
     std::string default_client_path()
     {
         const char* home = std::getenv("HOME");

--- a/src/steam-host-backend/steam_host_runtime.hpp
+++ b/src/steam-host-backend/steam_host_runtime.hpp
@@ -54,6 +54,7 @@ namespace sogen::steam_host
                 p = end;
             }
         }
+
         // Reads a by-value scalar from its fixed 8-byte wire slot into the host's native width (see the
         // guest's put_scalar). Arch-agnostic: only the low `n` bytes are taken.
         void get_scalar(void* dst, size_t n)
@@ -63,6 +64,7 @@ namespace sogen::steam_host
             n = (std::min)(n, slot.size());
             std::memcpy(dst, slot.data(), n);
         }
+
         const char* get_cstr()
         {
             const char* s = reinterpret_cast<const char*>(p);
@@ -81,6 +83,7 @@ namespace sogen::steam_host
             }
             return s;
         }
+
         std::vector<unsigned char> get_var()
         {
             uint32_t len = 0;
@@ -111,6 +114,7 @@ namespace sogen::steam_host
             const auto* b = static_cast<const unsigned char*>(q);
             out.insert(out.end(), b, b + n);
         }
+
         void put_cstr(const char* s)
         {
             if (!s)
@@ -123,15 +127,18 @@ namespace sogen::steam_host
             out.push_back(nul);
             ret = (n != 0) ? 1 : 0;
         }
+
         void put_ret(const void* q, size_t n)
         {
             ret = 0;
             std::memcpy(&ret, q, n <= sizeof(ret) ? n : sizeof(ret));
         }
+
         void put_ret_value(uint64_t v)
         {
             ret = v;
         }
+
         template <typename T>
         void put_ret_floating(T v)
         {
@@ -154,6 +161,7 @@ namespace sogen::steam_host
     {
         return n > max_payload ? max_payload : n;
     }
+
     template <typename T>
     size_t cap_count(size_t n)
     {
@@ -166,10 +174,12 @@ namespace sogen::steam_host
     struct is_complete : std::false_type
     {
     };
+
     template <typename T>
     struct is_complete<T, std::void_t<decltype(sizeof(T))>> : std::true_type
     {
     };
+
     template <typename T>
     inline constexpr bool is_complete_v = is_complete<T>::value;
 

--- a/src/steam-host-backend/steam_reverse.cpp
+++ b/src/steam-host-backend/steam_reverse.cpp
@@ -30,23 +30,28 @@ namespace sogen::steam_host
         struct args
         {
             std::vector<unsigned char> b;
+
             void put(const void* p, size_t n)
             {
                 const auto* c = static_cast<const unsigned char*>(p);
                 b.insert(b.end(), c, c + n);
             }
+
             void u64(uint64_t v)
             {
                 put(&v, 8);
             }
+
             void i32(int32_t v)
             {
                 put(&v, 4);
             }
+
             void f32(float v)
             {
                 put(&v, 4);
             }
+
             void cstr(const char* s)
             {
                 if (!s)
@@ -98,6 +103,7 @@ namespace sogen::steam_host
         struct ServerListProxy : ISteamMatchmakingServerListResponse
         {
             uint64_t token;
+
             void ServerResponded(HServerListRequest hReq, int iServer) override
             {
                 args a;
@@ -105,6 +111,7 @@ namespace sogen::steam_host
                 a.i32(iServer);
                 enqueue(token, 0, a);
             }
+
             void ServerFailedToRespond(HServerListRequest hReq, int iServer) override
             {
                 args a;
@@ -112,6 +119,7 @@ namespace sogen::steam_host
                 a.i32(iServer);
                 enqueue(token, 1, a);
             }
+
             void RefreshComplete(HServerListRequest hReq, EMatchMakingServerResponse response) override
             {
                 args a;
@@ -128,6 +136,7 @@ namespace sogen::steam_host
         struct PingProxy : ISteamMatchmakingPingResponse
         {
             uint64_t token;
+
             void ServerResponded(gameserveritem_t& server) override
             {
                 args a;
@@ -138,6 +147,7 @@ namespace sogen::steam_host
                     delete this;
                 }
             }
+
             void ServerFailedToRespond() override
             {
                 args a;
@@ -152,6 +162,7 @@ namespace sogen::steam_host
         struct PlayersProxy : ISteamMatchmakingPlayersResponse
         {
             uint64_t token;
+
             void AddPlayerToList(const char* pchName, int nScore, float flTimePlayed) override
             {
                 args a;
@@ -160,6 +171,7 @@ namespace sogen::steam_host
                 a.f32(flTimePlayed);
                 enqueue(token, 0, a);
             }
+
             void PlayersFailedToRespond() override
             {
                 args a;
@@ -169,6 +181,7 @@ namespace sogen::steam_host
                     delete this;
                 }
             }
+
             void PlayersRefreshComplete() override
             {
                 args a;
@@ -183,6 +196,7 @@ namespace sogen::steam_host
         struct RulesProxy : ISteamMatchmakingRulesResponse
         {
             uint64_t token;
+
             void RulesResponded(const char* pchRule, const char* pchValue) override
             {
                 args a;
@@ -190,6 +204,7 @@ namespace sogen::steam_host
                 a.cstr(pchValue);
                 enqueue(token, 0, a);
             }
+
             void RulesFailedToRespond() override
             {
                 args a;
@@ -199,6 +214,7 @@ namespace sogen::steam_host
                     delete this;
                 }
             }
+
             void RulesRefreshComplete() override
             {
                 args a;

--- a/src/windows-analyzer/analysis_reporter.hpp
+++ b/src/windows-analyzer/analysis_reporter.hpp
@@ -22,6 +22,7 @@ namespace sogen
       public:
         virtual ~analysis_reporter() = default;
         virtual void report(const analysis_event& event) = 0;
+
         virtual void flush()
         {
         }

--- a/src/windows-analyzer/reflect_extension.hpp
+++ b/src/windows-analyzer/reflect_extension.hpp
@@ -8,6 +8,7 @@ namespace
         template <class T>
         using type = std::remove_reference_t<T>&&;
     };
+
     template <>
     struct REFLECT_FWD_LIKE2<true>
     {
@@ -48,6 +49,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63), REFLECT_FWD_LIKE(T, _64),
                                    REFLECT_FWD_LIKE(T, _65));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 66>) noexcept
         {
@@ -72,6 +74,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63), REFLECT_FWD_LIKE(T, _64),
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 67>) noexcept
         {
@@ -96,6 +99,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63), REFLECT_FWD_LIKE(T, _64),
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 68>) noexcept
         {
@@ -120,6 +124,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63), REFLECT_FWD_LIKE(T, _64),
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67), REFLECT_FWD_LIKE(T, _68));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 69>) noexcept
         {
@@ -145,6 +150,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67), REFLECT_FWD_LIKE(T, _68),
                                    REFLECT_FWD_LIKE(T, _69));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 70>) noexcept
         {
@@ -170,6 +176,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67), REFLECT_FWD_LIKE(T, _68),
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 71>) noexcept
         {
@@ -196,6 +203,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67), REFLECT_FWD_LIKE(T, _68),
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 72>) noexcept
         {
@@ -222,6 +230,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _65), REFLECT_FWD_LIKE(T, _66), REFLECT_FWD_LIKE(T, _67), REFLECT_FWD_LIKE(T, _68),
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71), REFLECT_FWD_LIKE(T, _72));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 73>) noexcept
         {
@@ -249,6 +258,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71), REFLECT_FWD_LIKE(T, _72),
                                    REFLECT_FWD_LIKE(T, _73));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 74>) noexcept
         {
@@ -276,6 +286,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71), REFLECT_FWD_LIKE(T, _72),
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 75>) noexcept
         {
@@ -303,6 +314,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71), REFLECT_FWD_LIKE(T, _72),
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 76>) noexcept
         {
@@ -330,6 +342,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _69), REFLECT_FWD_LIKE(T, _70), REFLECT_FWD_LIKE(T, _71), REFLECT_FWD_LIKE(T, _72),
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75), REFLECT_FWD_LIKE(T, _76));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 77>) noexcept
         {
@@ -358,6 +371,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75), REFLECT_FWD_LIKE(T, _76),
                                    REFLECT_FWD_LIKE(T, _77));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 78>) noexcept
         {
@@ -386,6 +400,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75), REFLECT_FWD_LIKE(T, _76),
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 79>) noexcept
         {
@@ -414,6 +429,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75), REFLECT_FWD_LIKE(T, _76),
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 80>) noexcept
         {
@@ -442,6 +458,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _73), REFLECT_FWD_LIKE(T, _74), REFLECT_FWD_LIKE(T, _75), REFLECT_FWD_LIKE(T, _76),
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79), REFLECT_FWD_LIKE(T, _80));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 81>) noexcept
         {
@@ -471,6 +488,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79), REFLECT_FWD_LIKE(T, _80),
                                    REFLECT_FWD_LIKE(T, _81));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 82>) noexcept
         {
@@ -500,6 +518,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79), REFLECT_FWD_LIKE(T, _80),
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 83>) noexcept
         {
@@ -529,6 +548,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79), REFLECT_FWD_LIKE(T, _80),
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 84>) noexcept
         {
@@ -558,6 +578,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _77), REFLECT_FWD_LIKE(T, _78), REFLECT_FWD_LIKE(T, _79), REFLECT_FWD_LIKE(T, _80),
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83), REFLECT_FWD_LIKE(T, _84));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 85>) noexcept
         {
@@ -588,6 +609,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83), REFLECT_FWD_LIKE(T, _84),
                                    REFLECT_FWD_LIKE(T, _85));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 86>) noexcept
         {
@@ -618,6 +640,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83), REFLECT_FWD_LIKE(T, _84),
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 87>) noexcept
         {
@@ -648,6 +671,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83), REFLECT_FWD_LIKE(T, _84),
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 88>) noexcept
         {
@@ -678,6 +702,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _81), REFLECT_FWD_LIKE(T, _82), REFLECT_FWD_LIKE(T, _83), REFLECT_FWD_LIKE(T, _84),
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87), REFLECT_FWD_LIKE(T, _88));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 89>) noexcept
         {
@@ -709,6 +734,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87), REFLECT_FWD_LIKE(T, _88),
                                    REFLECT_FWD_LIKE(T, _89));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 90>) noexcept
         {
@@ -740,6 +766,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87), REFLECT_FWD_LIKE(T, _88),
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 91>) noexcept
         {
@@ -771,6 +798,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87), REFLECT_FWD_LIKE(T, _88),
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 92>) noexcept
         {
@@ -802,6 +830,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _85), REFLECT_FWD_LIKE(T, _86), REFLECT_FWD_LIKE(T, _87), REFLECT_FWD_LIKE(T, _88),
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91), REFLECT_FWD_LIKE(T, _92));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 93>) noexcept
         {
@@ -834,6 +863,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91), REFLECT_FWD_LIKE(T, _92),
                                    REFLECT_FWD_LIKE(T, _93));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 94>) noexcept
         {
@@ -866,6 +896,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91), REFLECT_FWD_LIKE(T, _92),
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 95>) noexcept
         {
@@ -899,6 +930,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91), REFLECT_FWD_LIKE(T, _92),
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 96>) noexcept
         {
@@ -932,6 +964,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _89), REFLECT_FWD_LIKE(T, _90), REFLECT_FWD_LIKE(T, _91), REFLECT_FWD_LIKE(T, _92),
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95), REFLECT_FWD_LIKE(T, _96));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 97>) noexcept
         {
@@ -966,6 +999,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95), REFLECT_FWD_LIKE(T, _96),
                                    REFLECT_FWD_LIKE(T, _97));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 98>) noexcept
         {
@@ -1000,6 +1034,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95), REFLECT_FWD_LIKE(T, _96),
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 99>) noexcept
         {
@@ -1034,6 +1069,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95), REFLECT_FWD_LIKE(T, _96),
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98), REFLECT_FWD_LIKE(T, _99));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 100>) noexcept
         {
@@ -1068,6 +1104,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _93), REFLECT_FWD_LIKE(T, _94), REFLECT_FWD_LIKE(T, _95), REFLECT_FWD_LIKE(T, _96),
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98), REFLECT_FWD_LIKE(T, _99), REFLECT_FWD_LIKE(T, _100));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 101>) noexcept
         {
@@ -1103,6 +1140,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98), REFLECT_FWD_LIKE(T, _99), REFLECT_FWD_LIKE(T, _100),
                                    REFLECT_FWD_LIKE(T, _101));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 102>) noexcept
         {
@@ -1138,6 +1176,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98), REFLECT_FWD_LIKE(T, _99), REFLECT_FWD_LIKE(T, _100),
                                    REFLECT_FWD_LIKE(T, _101), REFLECT_FWD_LIKE(T, _102));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 103>) noexcept
         {
@@ -1173,6 +1212,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _97), REFLECT_FWD_LIKE(T, _98), REFLECT_FWD_LIKE(T, _99), REFLECT_FWD_LIKE(T, _100),
                                    REFLECT_FWD_LIKE(T, _101), REFLECT_FWD_LIKE(T, _102), REFLECT_FWD_LIKE(T, _103));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 104>) noexcept
         {
@@ -1209,6 +1249,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _101), REFLECT_FWD_LIKE(T, _102), REFLECT_FWD_LIKE(T, _103),
                                    REFLECT_FWD_LIKE(T, _104));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 105>) noexcept
         {
@@ -1245,6 +1286,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _101), REFLECT_FWD_LIKE(T, _102), REFLECT_FWD_LIKE(T, _103),
                                    REFLECT_FWD_LIKE(T, _104), REFLECT_FWD_LIKE(T, _105));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 106>) noexcept
         {
@@ -1281,6 +1323,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _101), REFLECT_FWD_LIKE(T, _102), REFLECT_FWD_LIKE(T, _103),
                                    REFLECT_FWD_LIKE(T, _104), REFLECT_FWD_LIKE(T, _105), REFLECT_FWD_LIKE(T, _106));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 107>) noexcept
         {
@@ -1318,6 +1361,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _104), REFLECT_FWD_LIKE(T, _105), REFLECT_FWD_LIKE(T, _106),
                                    REFLECT_FWD_LIKE(T, _107));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 108>) noexcept
         {
@@ -1355,6 +1399,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _104), REFLECT_FWD_LIKE(T, _105), REFLECT_FWD_LIKE(T, _106),
                                    REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 109>) noexcept
         {
@@ -1392,6 +1437,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _104), REFLECT_FWD_LIKE(T, _105), REFLECT_FWD_LIKE(T, _106),
                                    REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108), REFLECT_FWD_LIKE(T, _109));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 110>) noexcept
         {
@@ -1430,6 +1476,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108), REFLECT_FWD_LIKE(T, _109),
                                    REFLECT_FWD_LIKE(T, _110));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 111>) noexcept
         {
@@ -1468,6 +1515,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108), REFLECT_FWD_LIKE(T, _109),
                                    REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 112>) noexcept
         {
@@ -1506,6 +1554,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108), REFLECT_FWD_LIKE(T, _109),
                                    REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 113>) noexcept
         {
@@ -1544,6 +1593,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _106), REFLECT_FWD_LIKE(T, _107), REFLECT_FWD_LIKE(T, _108), REFLECT_FWD_LIKE(T, _109),
                 REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112), REFLECT_FWD_LIKE(T, _113));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 114>) noexcept
         {
@@ -1583,6 +1633,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112),
                                    REFLECT_FWD_LIKE(T, _113), REFLECT_FWD_LIKE(T, _114));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 115>) noexcept
         {
@@ -1622,6 +1673,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112),
                                    REFLECT_FWD_LIKE(T, _113), REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 116>) noexcept
         {
@@ -1662,6 +1714,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112), REFLECT_FWD_LIKE(T, _113),
                 REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115), REFLECT_FWD_LIKE(T, _116));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 117>) noexcept
         {
@@ -1702,6 +1755,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _110), REFLECT_FWD_LIKE(T, _111), REFLECT_FWD_LIKE(T, _112), REFLECT_FWD_LIKE(T, _113),
                 REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115), REFLECT_FWD_LIKE(T, _116), REFLECT_FWD_LIKE(T, _117));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 118>) noexcept
         {
@@ -1743,6 +1797,7 @@ namespace reflect::inline v1_2_5
                                    REFLECT_FWD_LIKE(T, _113), REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115),
                                    REFLECT_FWD_LIKE(T, _116), REFLECT_FWD_LIKE(T, _117), REFLECT_FWD_LIKE(T, _118));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 119>) noexcept
         {
@@ -1784,6 +1839,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115), REFLECT_FWD_LIKE(T, _116), REFLECT_FWD_LIKE(T, _117),
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 120>) noexcept
         {
@@ -1825,6 +1881,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115), REFLECT_FWD_LIKE(T, _116), REFLECT_FWD_LIKE(T, _117),
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 121>) noexcept
         {
@@ -1866,6 +1923,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _114), REFLECT_FWD_LIKE(T, _115), REFLECT_FWD_LIKE(T, _116), REFLECT_FWD_LIKE(T, _117),
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120), REFLECT_FWD_LIKE(T, _121));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 122>) noexcept
         {
@@ -1908,6 +1966,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120), REFLECT_FWD_LIKE(T, _121),
                 REFLECT_FWD_LIKE(T, _122));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 123>) noexcept
         {
@@ -1950,6 +2009,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120), REFLECT_FWD_LIKE(T, _121),
                 REFLECT_FWD_LIKE(T, _122), REFLECT_FWD_LIKE(T, _123));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 124>) noexcept
         {
@@ -1992,6 +2052,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120), REFLECT_FWD_LIKE(T, _121),
                 REFLECT_FWD_LIKE(T, _122), REFLECT_FWD_LIKE(T, _123), REFLECT_FWD_LIKE(T, _124));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 125>) noexcept
         {
@@ -2034,6 +2095,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _118), REFLECT_FWD_LIKE(T, _119), REFLECT_FWD_LIKE(T, _120), REFLECT_FWD_LIKE(T, _121),
                 REFLECT_FWD_LIKE(T, _122), REFLECT_FWD_LIKE(T, _123), REFLECT_FWD_LIKE(T, _124), REFLECT_FWD_LIKE(T, _125));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 126>) noexcept
         {
@@ -2077,6 +2139,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _122), REFLECT_FWD_LIKE(T, _123), REFLECT_FWD_LIKE(T, _124), REFLECT_FWD_LIKE(T, _125),
                 REFLECT_FWD_LIKE(T, _126));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 127>) noexcept
         {
@@ -2120,6 +2183,7 @@ namespace reflect::inline v1_2_5
                 REFLECT_FWD_LIKE(T, _122), REFLECT_FWD_LIKE(T, _123), REFLECT_FWD_LIKE(T, _124), REFLECT_FWD_LIKE(T, _125),
                 REFLECT_FWD_LIKE(T, _126), REFLECT_FWD_LIKE(T, _127));
         }
+
         template <class Fn, class T>
         [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 128>) noexcept
         {

--- a/src/windows-emulator-fuzz/mock_emulator.hpp
+++ b/src/windows-emulator-fuzz/mock_emulator.hpp
@@ -29,13 +29,16 @@ namespace sogen::mock
         {
             return "mock";
         }
+
         bool supports_multiple_vcpus() const override
         {
             return false;
         }
+
         void serialize_state(utils::buffer_serializer&, bool) const override
         {
         }
+
         void deserialize_state(utils::buffer_deserializer&, bool) override
         {
         }
@@ -48,6 +51,7 @@ namespace sogen::mock
                 throw std::runtime_error("mock: read from unmapped guest memory");
             }
         }
+
         bool try_read_memory(uint64_t address, void* data, size_t size) const override
         {
             const region* r = nullptr;
@@ -59,6 +63,7 @@ namespace sogen::mock
             std::memcpy(data, r->data.data() + off, size);
             return true;
         }
+
         void write_memory(uint64_t address, const void* data, size_t size) override
         {
             if (!this->try_write_memory(address, data, size))
@@ -66,6 +71,7 @@ namespace sogen::mock
                 throw std::runtime_error("mock: write to unmapped guest memory");
             }
         }
+
         bool try_write_memory(uint64_t address, const void* data, size_t size) override
         {
             const region* r = nullptr;
@@ -84,13 +90,16 @@ namespace sogen::mock
         {
             return false;
         }
+
         void start(size_t = 0) override
         {
             throw std::runtime_error("mock: cannot execute code");
         }
+
         void stop() override
         {
         }
+
         size_t read_raw_register(int reg, void* value, size_t size) override
         {
             std::memset(value, 0, size);
@@ -101,27 +110,33 @@ namespace sogen::mock
             }
             return size;
         }
+
         size_t write_raw_register(int reg, const void* value, size_t size) override
         {
             const auto* bytes = static_cast<const std::byte*>(value);
             this->registers_[reg].assign(bytes, bytes + size);
             return size;
         }
+
         std::vector<std::byte> save_registers() const override
         {
             return {};
         }
+
         void restore_registers(const std::vector<std::byte>&) override
         {
         }
+
         bool has_violation() const override
         {
             return false;
         }
+
         bool supports_instruction_counting() const override
         {
             return false;
         }
+
         bool is_stop_thread_safe() const override
         {
             return true;
@@ -132,11 +147,13 @@ namespace sogen::mock
         {
             this->segment_bases_[static_cast<int>(reg)] = value;
         }
+
         pointer_type get_segment_base(register_type reg) override
         {
             const auto it = this->segment_bases_.find(static_cast<int>(reg));
             return it == this->segment_bases_.end() ? 0 : it->second;
         }
+
         void load_gdt(pointer_type, uint32_t) override
         {
         }
@@ -147,38 +164,47 @@ namespace sogen::mock
         {
             return nullptr;
         }
+
         emulator_hook* hook_memory_execution(uint64_t, memory_execution_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_memory_range_execution(uint64_t, uint64_t, memory_execution_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_memory_read(uint64_t, uint64_t, memory_access_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_memory_write(uint64_t, uint64_t, memory_access_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_instruction(int, instruction_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_interrupt(interrupt_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_memory_violation(memory_violation_hook_callback) override
         {
             return nullptr;
         }
+
         emulator_hook* hook_basic_block(basic_block_hook_callback) override
         {
             return nullptr;
         }
+
         void delete_hook(emulator_hook*) override
         {
         }
@@ -231,14 +257,17 @@ namespace sogen::mock
         {
             throw std::runtime_error("mock: mmio not supported");
         }
+
         void map_memory(uint64_t address, size_t size, memory_permission) override
         {
             this->regions_[address] = region{size, std::vector<std::byte>(size)};
         }
+
         void unmap_memory(uint64_t address, size_t) override
         {
             this->regions_.erase(address);
         }
+
         void apply_memory_protection(uint64_t, size_t, memory_permission) override
         {
         }

--- a/src/windows-emulator/apiset/apiset.hpp
+++ b/src/windows-emulator/apiset/apiset.hpp
@@ -10,6 +10,7 @@ namespace sogen
 {
 
     using apiset_map = std::map<std::u16string, std::u16string>;
+
     namespace apiset
     {
         enum class location : uint8_t

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -249,6 +249,7 @@ namespace sogen
                 uint64_t device{};
                 void* host_ptr{};
             };
+
             std::unordered_map<uint64_t, direct_mapping> direct_mappings_{};
 
             // Before the host GPU reads guest-produced data, make the guest's writes to every directly-aliased
@@ -1781,6 +1782,7 @@ namespace sogen
                 this->vulkan_.destroy_image_view(request.device, request.object);
                 return STATUS_SUCCESS;
             }
+
             NTSTATUS handle_create_buffer_view(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::create_buffer_view_request request{};
@@ -1793,6 +1795,7 @@ namespace sogen
                     this->vulkan_.create_buffer_view(request.device, request.buffer, request.format, request.offset, request.range, view);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = view});
             }
+
             NTSTATUS handle_destroy_buffer_view(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::device_child_request request{};
@@ -1803,6 +1806,7 @@ namespace sogen
                 this->vulkan_.destroy_buffer_view(request.device, request.object);
                 return STATUS_SUCCESS;
             }
+
             NTSTATUS handle_create_query_pool(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::create_query_pool_request request{};
@@ -1815,6 +1819,7 @@ namespace sogen
                                                                        request.pipeline_statistics, pool);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = pool});
             }
+
             NTSTATUS handle_destroy_query_pool(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::device_child_request request{};
@@ -1825,6 +1830,7 @@ namespace sogen
                 this->vulkan_.destroy_query_pool(request.device, request.object);
                 return STATUS_SUCCESS;
             }
+
             NTSTATUS handle_reset_query_pool(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::reset_query_pool_request request{};
@@ -1836,6 +1842,7 @@ namespace sogen
                     this->vulkan_.reset_query_pool(request.device, request.query_pool, request.first_query, request.query_count);
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
+
             NTSTATUS handle_get_query_pool_results(windows_emulator& win_emu, const io_device_context& context)
             {
                 using request_t = gpu_bridge::get_query_pool_results_request;

--- a/src/windows-emulator/devices/named_pipe.hpp
+++ b/src/windows-emulator/devices/named_pipe.hpp
@@ -33,9 +33,11 @@ namespace sogen
         void create(windows_emulator&, const io_device_creation_data&) override
         {
         }
+
         void work(windows_emulator&) override
         {
         }
+
         NTSTATUS io_control(windows_emulator& win_emu, const io_device_context& c) override
         {
             if (c.io_control_code == FSCTL_PIPE_PEEK)
@@ -50,6 +52,7 @@ namespace sogen
         void serialize_object(utils::buffer_serializer&) const override
         {
         }
+
         void deserialize_object(utils::buffer_deserializer&) override
         {
         }

--- a/src/windows-emulator/devices/steam_bridge.cpp
+++ b/src/windows-emulator/devices/steam_bridge.cpp
@@ -50,20 +50,24 @@ namespace sogen
             {
                 return sb::null_interface;
             }
+
             void release_interface(sb::interface_handle) override
             {
             }
+
             int32_t invoke(sb::interface_handle, uint32_t, std::span<const std::byte>, std::vector<std::byte>&, uint64_t& ret,
                            uint32_t) override
             {
                 ret = 0;
                 return static_cast<int32_t>(sb::invoke_status::unknown_interface);
             }
+
             void run_callbacks(int32_t, std::vector<std::byte>&, uint32_t& normal_count, uint32_t& normal_bytes,
                                uint32_t& reverse_count) override
             {
                 normal_count = normal_bytes = reverse_count = 0;
             }
+
             bool get_api_call_result(int32_t, uint64_t, int32_t, uint32_t, std::vector<std::byte>&, bool& io_failure) override
             {
                 io_failure = false;
@@ -81,10 +85,12 @@ namespace sogen
                 const std::string v{version};
                 return sogen_steam_backend_create_interface(v.c_str());
             }
+
             void release_interface(const sb::interface_handle handle) override
             {
                 sogen_steam_backend_release(handle);
             }
+
             int32_t invoke(const sb::interface_handle handle, const uint32_t method_index, std::span<const std::byte> args,
                            std::vector<std::byte>& out, uint64_t& ret, const uint32_t out_cap) override
             {
@@ -108,6 +114,7 @@ namespace sogen
                 out.assign(reinterpret_cast<const std::byte*>(buffer.data()), reinterpret_cast<const std::byte*>(buffer.data()) + out_len);
                 return status;
             }
+
             void run_callbacks(int32_t pipe, std::vector<std::byte>& out, uint32_t& normal_count, uint32_t& normal_bytes,
                                uint32_t& reverse_count) override
             {
@@ -119,6 +126,7 @@ namespace sogen
                 out.assign(reinterpret_cast<const std::byte*>(buffer.data()),
                            reinterpret_cast<const std::byte*>(buffer.data()) + normal_len + rev_len);
             }
+
             bool get_api_call_result(int32_t pipe, uint64_t call, int32_t callback_id, uint32_t data_bytes, std::vector<std::byte>& out,
                                      bool& io_failure) override
             {
@@ -183,6 +191,7 @@ namespace sogen
             void serialize_object(utils::buffer_serializer&) const override
             {
             }
+
             void deserialize_object(utils::buffer_deserializer&) override
             {
             }

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -368,6 +368,7 @@ namespace sogen
         std::unordered_map<uint64_t, instance_data> instances;
         std::unordered_map<uint64_t, physical_device_data> physical_devices;
         std::unordered_map<VkPhysicalDevice, uint64_t> physical_device_ids;
+
         struct queue_data
         {
             VkQueue handle{};
@@ -456,16 +457,19 @@ namespace sogen
             VkShaderModule handle{};
             uint64_t device_id{};
         };
+
         struct image_view_data
         {
             VkImageView handle{};
             uint64_t device_id{};
         };
+
         struct buffer_view_data
         {
             VkBufferView handle{};
             uint64_t device_id{};
         };
+
         struct query_pool_data
         {
             VkQueryPool handle{};
@@ -473,37 +477,44 @@ namespace sogen
             uint32_t query_type{};
             uint32_t pipeline_statistics{};
         };
+
         struct render_pass_data
         {
             VkRenderPass handle{};
             uint64_t device_id{};
             bool has_depth{};
         };
+
         struct framebuffer_data
         {
             VkFramebuffer handle{};
             uint64_t device_id{};
         };
+
         struct pipeline_layout_data
         {
             VkPipelineLayout handle{};
             uint64_t device_id{};
         };
+
         struct pipeline_data
         {
             VkPipeline handle{};
             uint64_t device_id{};
         };
+
         struct descriptor_set_layout_data
         {
             VkDescriptorSetLayout handle{};
             uint64_t device_id{};
         };
+
         struct descriptor_pool_data
         {
             VkDescriptorPool handle{};
             uint64_t device_id{};
         };
+
         struct bound_buffer_info
         {
             uint64_t buffer_id{};

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -59,6 +59,7 @@ namespace sogen
             uint32_t max_extent_depth;
             uint64_t max_resource_size;
         };
+
         int32_t get_physical_device_image_format_properties(uint64_t physical_device, uint32_t format, uint32_t type, uint32_t tiling,
                                                             uint32_t usage, uint32_t flags, image_format_properties& out);
 
@@ -258,6 +259,7 @@ namespace sogen
         // Copies mip 0 / layer 0 of the image (tightly packed) into the buffer at offset 0.
         int32_t cmd_copy_image_to_buffer(uint64_t command_buffer, uint64_t image, uint32_t image_layout, uint64_t buffer, uint32_t width,
                                          uint32_t height, uint32_t aspect_mask);
+
         // Copies tightly-packed pixel data from the buffer (offset 0) into mip 0 / layer 0 of the image.
         // One VkBufferImageCopy region. DXVK sub-allocates uploads from a shared staging buffer, so
         // buffer_offset (and mip/layer/image_offset) are routinely non-zero and must be honoured.
@@ -280,6 +282,7 @@ namespace sogen
 
         int32_t cmd_copy_buffer_to_image(uint64_t command_buffer, uint64_t buffer, uint64_t image, uint32_t image_layout,
                                          const buffer_image_copy_region& region);
+
         // One VkImageCopy region of an image-to-image copy (vkCmdCopyImage[2]).
         struct image_copy_region
         {
@@ -301,6 +304,7 @@ namespace sogen
             uint32_t height;
             uint32_t depth;
         };
+
         struct image_blit_region
         {
             uint32_t src_aspect_mask;
@@ -325,6 +329,7 @@ namespace sogen
             int32_t dst_offset_z1;
             uint32_t filter;
         };
+
         int32_t cmd_copy_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image, uint32_t dst_layout,
                                const image_copy_region& region);
         int32_t cmd_blit_image(uint64_t command_buffer, uint64_t src_image, uint32_t src_layout, uint64_t dst_image, uint32_t dst_layout,
@@ -432,12 +437,14 @@ namespace sogen
             uint32_t descriptor_count;
             uint32_t stage_flags;
         };
+
         // VkDescriptorPoolSize as plain integers.
         struct descriptor_pool_size
         {
             uint32_t descriptor_type;
             uint32_t descriptor_count;
         };
+
         // A single descriptor write (one descriptor). For buffer types buffer/offset/range apply; for
         // image types (combined image sampler) sampler/image_view/image_layout apply.
         struct descriptor_write
@@ -479,6 +486,7 @@ namespace sogen
             uint32_t stride;
             uint32_t input_rate;
         };
+
         struct vertex_attribute
         {
             uint32_t location;

--- a/src/windows-emulator/exception_dispatch.hpp
+++ b/src/windows-emulator/exception_dispatch.hpp
@@ -23,6 +23,7 @@ namespace sogen
 
     void dispatch_exception(windows_emulator& win_emu, vcpu_context& vcpu, DWORD status,
                             const std::vector<EmulatorTraits<Emu64>::ULONG_PTR>& parameters);
+
     template <typename T>
         requires(std::is_integral_v<T> && !std::is_same_v<T, DWORD>)
     void dispatch_exception(windows_emulator& win_emu, vcpu_context& vcpu, const T status,

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -43,6 +43,7 @@ namespace sogen
 
 #pragma pack(push)
 #pragma pack(1)
+
     struct handle_value
     {
         uint64_t id : 23;
@@ -51,6 +52,7 @@ namespace sogen
         uint64_t is_pseudo : 1;
         uint64_t high_bits : 32;
     };
+
 #pragma pack(pop)
 
     static_assert(sizeof(handle_value) == 8);

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -50,10 +50,12 @@ namespace sogen
         {
             return std::make_unique<dummy_device>();
         }
+
         std::unique_ptr<io_device> create_transport_stub_device(const device_creation_context&)
         {
             return std::make_unique<transport_stub_device>();
         }
+
         std::unique_ptr<io_device> create_named_pipe_device(const device_creation_context&)
         {
             return std::make_unique<named_pipe>();

--- a/src/windows-emulator/memory_permission_ext.hpp
+++ b/src/windows-emulator/memory_permission_ext.hpp
@@ -66,11 +66,13 @@ namespace sogen
               extended(memory_permission_ext::none)
         {
         }
+
         constexpr nt_memory_permission(memory_permission common)
             : common(common),
               extended(memory_permission_ext::none)
         {
         }
+
         constexpr nt_memory_permission(memory_permission common, memory_permission_ext ext)
             : common(common),
               extended(ext)
@@ -82,6 +84,7 @@ namespace sogen
         {
             return common;
         }
+
         operator memory_permission_ext() const
         {
             return extended;

--- a/src/windows-emulator/module/module_manager.hpp
+++ b/src/windows-emulator/module/module_manager.hpp
@@ -107,6 +107,7 @@ namespace sogen
                                         bool is_static = false, bool allow_duplicate = false, uint64_t relocation_base = 0);
         mapped_module* map_memory_module(uint64_t base_address, uint64_t image_size, windows_path module_path, const logger& logger,
                                          bool is_static = false, bool allow_duplicate = false);
+
         mapped_module* find_by_address(const uint64_t address)
         {
             const auto entry = this->get_module(address);
@@ -146,6 +147,7 @@ namespace sogen
         void deserialize(utils::buffer_deserializer& buffer);
 
         bool unmap(uint64_t address);
+
         const module_map& modules() const
         {
             return modules_;
@@ -156,6 +158,7 @@ namespace sogen
         {
             return current_execution_mode_;
         }
+
         bool is_wow64_process() const
         {
             return current_execution_mode_ == execution_mode::wow64_32bit;

--- a/src/windows-emulator/port.hpp
+++ b/src/windows-emulator/port.hpp
@@ -18,6 +18,7 @@ namespace sogen
 
     class windows_emulator;
     struct process_context;
+
     namespace utils
     {
         class aligned_binary_writer;

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -49,6 +49,7 @@ namespace sogen
     class windows_version_manager;
 
     using knowndlls_map = std::map<std::u16string, section>;
+
     struct file_lock_range
     {
         uint64_t offset{};
@@ -434,6 +435,7 @@ namespace sogen
         // Keyboard raw input registration (HID usage page 0x01, usage 0x06), mirroring the mouse fields above.
         bool raw_keyboard_registered{};
         hwnd raw_keyboard_target{};
+
         // One pending raw-input payload (mouse motion + buttons, or a keyboard make/break) keyed by the
         // HRAWINPUT token posted in WM_INPUT's lParam; consumed by NtUserGetRawInputData.
         struct raw_input_payload
@@ -448,6 +450,7 @@ namespace sogen
             uint32_t key_message{};       // corresponding WM_KEY* or WM_SYSKEY* message
             bool key_extended{};          // true when the key's scan code has an E0 prefix (lParam bit 24)
         };
+
         std::map<uint32_t, raw_input_payload> raw_inputs{};
         uint32_t next_raw_input_token{1};
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -159,6 +159,7 @@ namespace sogen
                 uint64_t font{};
                 FLONG text_align{};
                 POINTL viewport_org{};
+
                 union
                 {
                     std::array<WCHAR, 2> string;
@@ -3277,6 +3278,7 @@ namespace sogen
                     int32_t x{};
                     int32_t y{};
                 } current_point;
+
                 if (c.win_emu.memory.try_read_memory(dc_attr + k_gdi_dc_attr_pt_current_offset, &current_point, sizeof(current_point)))
                 {
                     dc_state->current_x = current_point.x;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -92,11 +92,13 @@ namespace sogen
             pointer pwnd{};
             UINT msg{};
             wparam wParam{};
+
             union
             {
                 EMU_MINMAXINFO point5;
                 EMU_WINDOWPOS window_pos;
             } data{};
+
             pointer xParam{};
             pointer xpfnProc{};
         };
@@ -114,9 +116,11 @@ namespace sogen
             wparam wParam{};
             pointer xParam{};
             pointer xpfnProc{};
+
             union
             {
                 RECT rect;
+
                 struct
                 {
                     EMU_NCCALCSIZE_PARAMS params;
@@ -1761,6 +1765,7 @@ namespace sogen
                     uint32_t type;
                     std::array<uint32_t, 6> details;
                 };
+
                 static_assert(sizeof(raw_input_device_info) == 32);
 
                 constexpr uint32_t required_bytes = sizeof(raw_input_device_info);
@@ -3693,6 +3698,7 @@ namespace sogen
                 uint32_t width;
                 uint32_t height;
             };
+
             static constexpr std::array<display_mode, 8> modes = {{
                 {.width = 640, .height = 480},
                 {.width = 800, .height = 600},
@@ -5142,6 +5148,7 @@ namespace sogen
         {
             return TRUE;
         }
+
         BOOL handle_NtUserDestroyCaret()
         {
             return TRUE;

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -609,6 +609,7 @@ namespace sogen
                 ui_surface_format texture_format{ui_surface_format::bgra8};
                 bool has_surface{};
             };
+
             ~sdl_ui_backend() override
             {
                 this->reset();

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -571,14 +571,17 @@ namespace sogen
         {
             return this->store_.begin();
         }
+
         value_map::const_iterator begin() const
         {
             return this->store_.begin();
         }
+
         value_map::iterator end()
         {
             return this->store_.end();
         }
+
         value_map::const_iterator end() const
         {
             return this->store_.end();

--- a/src/windows-emulator/version/windows_version_manager.hpp
+++ b/src/windows-emulator/version/windows_version_manager.hpp
@@ -39,6 +39,7 @@ namespace sogen
         {
             return info_.system_root;
         }
+
         void set_system_root(const windows_path& value)
         {
             info_.system_root = value;
@@ -48,6 +49,7 @@ namespace sogen
         {
             return info_.major_version;
         }
+
         void set_major_version(uint32_t value)
         {
             info_.major_version = value;
@@ -57,6 +59,7 @@ namespace sogen
         {
             return info_.minor_version;
         }
+
         void set_minor_version(uint32_t value)
         {
             info_.minor_version = value;
@@ -66,6 +69,7 @@ namespace sogen
         {
             return info_.windows_build_number;
         }
+
         void set_windows_build_number(uint32_t value)
         {
             info_.windows_build_number = value;
@@ -75,6 +79,7 @@ namespace sogen
         {
             return info_.windows_update_build_revision;
         }
+
         void set_windows_update_build_revision(uint32_t value)
         {
             info_.windows_update_build_revision = value;

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -96,6 +96,7 @@ namespace sogen
                 std::u16string_view text;
                 uint32_t id;
             };
+
             static constexpr std::array<mb_string, 11> entries = {{
                 {.text = u"OK", .id = 1},          // IDOK
                 {.text = u"Cancel", .id = 2},      // IDCANCEL

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -625,6 +625,7 @@ namespace sogen
 
             return std::make_unique<utils::clock>();
         }
+
         std::unique_ptr<network::dns_lookup> get_dns_lookup(emulator_interfaces& interfaces)
         {
             if (interfaces.dns_lookup)

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -192,6 +192,7 @@ namespace sogen
         {
             return *this->clock_;
         }
+
         network::dns_lookup& dns_lookup()
         {
             return *this->dns_lookup_;

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -56,6 +56,7 @@ namespace sogen
         uint16_t key{};
         uint16_t command{};
     };
+
     static_assert(sizeof(accelerator_table_entry) == 6);
 
     template <typename GuestType>

--- a/src/windows-gdb-stub/windows_filesystem.cpp
+++ b/src/windows-gdb-stub/windows_filesystem.cpp
@@ -26,6 +26,7 @@ namespace sogen
     constexpr auto FILEIO_O_EXCL = 0x800u;
 
 #pragma pack(push, 1)
+
     struct gdb_stat
     {
         uint32_t st_dev;


### PR DESCRIPTION
Adds two formatting rules to `.clang-format`:

- `InsertBraces: true` — auto-braces single-statement `if`/`for`/`while` bodies (what clang-tidy's `readability-braces-around-statements` already flags).
- `SeparateDefinitionBlocks: Always` — a blank line between every top-level definition.

**Rule change only — the tree is intentionally not reformatted in this PR**, so the formatting check will fail. The repo-wide reformat is deferred until the in-flight PRs (#1213 and others) merge, so it doesn't conflict with their diffs; we'll rebase this and run the reformat then.