### PR TITLE
registry: tolerate EOF when reading fixed-size structs over variable hive cells

### DIFF
--- a/src/windows-emulator/registry/hive_parser.cpp
+++ b/src/windows-emulator/registry/hive_parser.cpp
@@ -62,6 +62,14 @@ namespace sogen
 
         bool read_file_data_safe(std::ifstream& file, const uint64_t offset, void* buffer, const size_t size)
         {
+            // The parser maps fixed-size structs (key/value/subkey-list blocks) onto variable-size hive
+            // cells, so a full-size read of a cell near the end of the hive legitimately runs past EOF --
+            // uncompacted hives leave trailing slack that absorbs it, but a compacted hive (e.g. produced
+            // by REG SAVE, which drops that slack) does not. Read whatever is available and zero-fill the
+            // remainder; callers only consume the real cell fields, and an offset wholly past EOF yields a
+            // zeroed block that parses as empty rather than crashing.
+            std::memset(buffer, 0, size);
+
             if (file.bad())
             {
                 return false;
@@ -69,21 +77,30 @@ namespace sogen
 
             file.clear();
 
+            file.seekg(0, std::ios::end);
             if (!file.good())
             {
                 return false;
             }
+
+            const auto file_size = static_cast<uint64_t>(file.tellg());
+            if (offset >= file_size)
+            {
+                return true; // wholly past EOF: leave the buffer zero-filled
+            }
+
+            const auto available = static_cast<size_t>(file_size - offset);
+            const auto to_read = size < available ? size : available;
 
             file.seekg(static_cast<std::streamoff>(offset));
-
             if (!file.good())
             {
                 return false;
             }
 
-            file.read(static_cast<char*>(buffer), static_cast<std::streamsize>(size));
+            file.read(static_cast<char*>(buffer), static_cast<std::streamsize>(to_read));
 
-            return file.good();
+            return !file.bad();
         }
 
         void read_file_data(std::ifstream& file, const uint64_t offset, void* buffer, const size_t size)


### PR DESCRIPTION
## Problem

The registry `hive_parser` maps **fixed-size structs** (`key_block_t` ~336 B, `value_block_t`, subkey-list
blocks) onto the hive's **variable-size cells**. A real `nk`/`vk` cell is only as large as its header plus
its (short) name, so reading a full fixed-size struct off a cell near the **end of the hive** legitimately
runs past EOF.

Uncompacted hives carry trailing free space that absorbs the over-read, so it went unnoticed. A **compacted
hive** — e.g. one produced by `REG SAVE`, which drops that trailing slack — has cells right up against EOF,
so `read_file_data` threw `Failed to read file data` and the guest was terminated on its first registry
access.

This surfaced as **every emulation test failing on Windows Server 2022** (all guest `NtOpenKeyEx` calls on
the compacted `NTUSER.DAT` failed); Server 2025 happened to lay the same cells out with enough slack to hide
it.

## Fix

Make `read_file_data_safe` **EOF-tolerant**: read whatever bytes are actually available and zero-fill the
remainder, instead of failing. Callers only consume the real cell fields, and an offset wholly past EOF now
yields a zeroed block that parses as empty rather than crashing. **In-bounds reads are byte-for-byte
unchanged**, so normal (uncompacted) hives are unaffected.

## Validation

Reproduced and fixed against the **actual Windows-2022 emulation-root hive** pulled from CI: a `key_block_t`
read of `0x150` bytes landing 56 bytes past a `0x102a000`-byte hive. With the fix the guest boots cleanly
through registry init; a normal uncompacted registry is unaffected (verified locally on Server 2025).

This is a general parser-robustness fix, independent of the Steam bridge work that happened to trigger it.
