### PR TITLE
icicle: reset volatile VM state when deserializing

### DIFF
--- a/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/icicle.rs
@@ -793,6 +793,15 @@ impl IcicleEmulator {
         };
     }
 
+    // Deserializing reuses the live VM, so any execution state that a freshly built VM would not carry must be
+    // dropped here. save_registers/restore_registers only round-trip the register space; the instruction counter
+    // and the translated (and recompiled) code cache persist otherwise, so a restored run continues on state left
+    // over from the previous one instead of matching a fresh VM.
+    pub fn reset_volatile_state(&mut self) {
+        self.vm.cpu.icount = 0;
+        self.vm.code.flush_code();
+    }
+
     fn read_generic_register(&mut self, reg: registers::X86Register, buffer: &mut [u8]) -> usize {
         let reg_node = self.reg.get_node(reg);
 

--- a/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
+++ b/src/backends/icicle-emulator/icicle-bridge/src/lib.rs
@@ -164,6 +164,14 @@ pub fn icicle_restore_registers(ptr: *mut c_void, data: *const c_void, size: usi
 }
 
 #[unsafe(no_mangle)]
+pub fn icicle_reset_volatile_state(ptr: *mut c_void) {
+    unsafe {
+        let emulator = &mut *(ptr as *mut IcicleEmulator);
+        emulator.reset_volatile_state();
+    }
+}
+
+#[unsafe(no_mangle)]
 pub fn icicle_create_snapshot(ptr: *mut c_void) -> u32 {
     unsafe {
         let emulator = &mut *(ptr as *mut IcicleEmulator);

--- a/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
+++ b/src/backends/icicle-emulator/icicle_x86_64_emulator.cpp
@@ -38,6 +38,7 @@ extern "C"
     int32_t icicle_write_memory(icicle_emulator*, uint64_t address, const void* data, size_t length);
     void icicle_save_registers(icicle_emulator*, data_accessor_func* accessor, void* accessor_data);
     void icicle_restore_registers(icicle_emulator*, const void* data, size_t length);
+    void icicle_reset_volatile_state(icicle_emulator*);
     uint32_t icicle_create_snapshot(icicle_emulator*);
     void icicle_restore_snapshot(icicle_emulator*, uint32_t id);
     uint32_t icicle_add_syscall_hook(icicle_emulator*, raw_func* callback, void* data);
@@ -511,6 +512,7 @@ namespace sogen::icicle
             }
             else
             {
+                icicle_reset_volatile_state(this->emu_);
                 const auto data = buffer.read_vector<std::byte>();
                 this->restore_registers(data);
             }


### PR DESCRIPTION
SerializationTest.ResettingEmulatorWorks intermittently failed on the icicle
backend: after serialize -> run -> restore-to-start -> run, the two end states
occasionally differed. The restore path only round-trips the register space via
save_registers/restore_registers, but deserialize reuses the live VM rather than
building a fresh one. The instruction counter and the translated/recompiled code
cache therefore survive the restore, so the second run continues on state left
over from the first instead of matching a fresh VM. The sibling serialization
tests all deserialize into a freshly built VM, which is why only the reuse case
regressed.

Drop that leftover state on restore: reset the instruction counter and flush the
code cache in deserialize_state before restoring the registers, so a restored VM
behaves like a fresh one.
