### PR TITLE
tests: construct the env-selected backend in the emulation tests

### DIFF
--- a/src/windows-emulator-test/emulation_test_utils.hpp
+++ b/src/windows-emulator-test/emulation_test_utils.hpp
@@ -134,7 +134,7 @@ namespace sogen::test
         }
 
         return windows_emulator{
-            create_x86_64_emulator(),
+            create_x86_64_emulator_from_environment(),
             settings,
             std::move(callbacks),
             std::move(interfaces),
@@ -169,7 +169,11 @@ namespace sogen::test
         }
 
         return windows_emulator{
-            create_x86_64_emulator(), get_sample_app_settings(config), settings, std::move(callbacks), std::move(interfaces),
+            create_x86_64_emulator_from_environment(),
+            get_sample_app_settings(config),
+            settings,
+            std::move(callbacks),
+            std::move(interfaces),
         };
     }
 


### PR DESCRIPTION
The SerializationTest/EmulationTest helpers built the backend with the no-arg
create_x86_64_emulator(), which always returns unicorn and ignores
EMULATOR_ICICLE. host_memory_test and the analyzer already use
create_x86_64_emulator_from_environment(); do the same here so the icicle CI job
actually exercises icicle for these tests instead of silently running unicorn.

With instruction precision on (the default for tests), icicle runs the
deterministic per-instruction path, so the previously flaky
SerializationTest.ResettingEmulatorWorks is stable there (48/48 locally).
