### PR TITLE
steam-bridge: compile the generated code with warnings-as-errors

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -196,10 +196,12 @@ function(sogen_target_disable_warnings target)
   sogen_target_remove_compile_options(${target} /W3 -W3 /W4 -W4)
 
   if(MSVC)
-  set(compile_options
-    /W0
-    /D_CRT_SECURE_NO_WARNINGS=1
-  )
+    set(compile_options
+      /W0
+      /D_CRT_SECURE_NO_WARNINGS=1
+    )
+  else()
+    set(compile_options -w) # GCC/Clang: actually silence warnings for third-party / generated code
   endif()
 
   sogen_target_c_and_cxx_compile_options(${target} PRIVATE ${compile_options})
@@ -213,6 +215,17 @@ function(sogen_targets_disable_warnings)
   foreach(target ${ARGV})
     sogen_target_disable_warnings(${target})
   endforeach()
+endfunction()
+
+##########################################
+
+# MSVC extras for a generated-Steam-code target whose SDK headers the caller marks SYSTEM. C4743/C4744 are
+# MSVC's cross-TU -Wodr analogue (ISteam* types differ across snapshots) and fire at LTCG link.
+function(sogen_target_generated_code_warnings target)
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /external:W0 /wd4743 /wd4744)
+    target_compile_definitions(${target} PRIVATE _CRT_SECURE_NO_WARNINGS=1)
+  endif()
 endfunction()
 
 ##########################################

--- a/src/samples/steam-shim/CMakeLists.txt
+++ b/src/samples/steam-shim/CMakeLists.txt
@@ -41,10 +41,11 @@ foreach(_entry ${SOGEN_STEAM_TAG_LIST})
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/steam_shim_tag.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/steam_shim_${_tag}.gen.cpp" @ONLY)
   add_library(steam-shim-${_tag} OBJECT EXCLUDE_FROM_ALL "${CMAKE_CURRENT_BINARY_DIR}/steam_shim_${_tag}.gen.cpp")
-  sogen_target_disable_warnings(steam-shim-${_tag})
   target_link_libraries(steam-shim-${_tag} PRIVATE steam-bridge-protocol)  # shared response_type ids
+  target_include_directories(steam-shim-${_tag} SYSTEM PRIVATE "${_dir}")  # SDK headers: not our warnings
   target_include_directories(steam-shim-${_tag} PRIVATE
-    "${_dir}" "${SOGEN_STEAM_GEN_DIR}/${_tag}" "${CMAKE_CURRENT_SOURCE_DIR}")
+    "${SOGEN_STEAM_GEN_DIR}/${_tag}" "${CMAKE_CURRENT_SOURCE_DIR}")
+  sogen_target_generated_code_warnings(steam-shim-${_tag})
   target_sources(steam-shim PRIVATE $<TARGET_OBJECTS:steam-shim-${_tag}>)
 endforeach()
 

--- a/src/samples/steam-shim/steam_shim_runtime.hpp
+++ b/src/samples/steam-shim/steam_shim_runtime.hpp
@@ -125,7 +125,7 @@ namespace sogen::steam_shim
             {
                 std::memcpy(dst, out_.data() + out_pos_, n);
             }
-            out_pos_ += n;
+            out_pos_ += static_cast<uint32_t>(n);
         }
 
         void call()

--- a/src/steam-host-backend/CMakeLists.txt
+++ b/src/steam-host-backend/CMakeLists.txt
@@ -26,9 +26,10 @@ foreach(_entry ${SOGEN_STEAM_TAG_LIST})
   configure_file("${CMAKE_CURRENT_LIST_DIR}/steam_host_tag.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/steam_host_${_tag}.gen.cpp" @ONLY)
   add_library(steam-host-${_tag} OBJECT "${CMAKE_CURRENT_BINARY_DIR}/steam_host_${_tag}.gen.cpp")
-  sogen_target_disable_warnings(steam-host-${_tag})
   target_link_libraries(steam-host-${_tag} PRIVATE steam-bridge-protocol)  # shared response_type ids
+  target_include_directories(steam-host-${_tag} SYSTEM PRIVATE "${_dir}")  # SDK headers: not our warnings
   target_include_directories(steam-host-${_tag} PRIVATE
-    "${_dir}" "${SOGEN_STEAM_GEN_DIR}/${_tag}" "${CMAKE_CURRENT_LIST_DIR}")
+    "${SOGEN_STEAM_GEN_DIR}/${_tag}" "${CMAKE_CURRENT_LIST_DIR}")
+  sogen_target_generated_code_warnings(steam-host-${_tag})
   target_sources(steam-host-backend PRIVATE $<TARGET_OBJECTS:steam-host-${_tag}>)
 endforeach()

--- a/src/steam-host-backend/steam_host_runtime.hpp
+++ b/src/steam-host-backend/steam_host_runtime.hpp
@@ -43,7 +43,7 @@ namespace sogen::steam_host
 
         void get(void* dst, size_t n)
         {
-            if (p + n <= end && p + n >= p)
+            if (p <= end && n <= static_cast<size_t>(end - p))
             {
                 std::memcpy(dst, p, n);
                 p += n;

--- a/src/tools/steam-bridge-generator/generate.py
+++ b/src/tools/steam-bridge-generator/generate.py
@@ -828,7 +828,8 @@ def emit_guest(interfaces: list[Interface], tag: str) -> str:
                         tid = response_type_id(p.type)
                         L.append(f"            inv.put_callback_token(sogen::steam_shim::register_response_object("
                                  f"{p.name}, {tid}), {tid});")
-                    # null_ptr: not marshalled; the host substitutes nullptr.
+                    elif p.kind == "null_ptr" and p.name:
+                        L.append(f"            (void){p.name}; // not marshalled; the host substitutes nullptr")
                 L.append("            inv.call();")
                 # Out-parameters come back in the out-blob, in parameter order (before any string return).
                 for p in m.params:
@@ -868,6 +869,9 @@ def emit_guest(interfaces: list[Interface], tag: str) -> str:
                         L.append("                return {};")
                     L.append("            }")
             else:
+                for p in m.params:
+                    if p.name:
+                        L.append(f"            (void){p.name};")
                 L.append(f'            sogen::steam_shim::report_unsupported("{i.classname}", "{m.name}");')
                 if m.ret_kind != "void":
                     L.append("            return {};")


### PR DESCRIPTION
## What

The Steam per-tag object libraries compile *only* our generated marshalling
thunks/proxies (plus the runtime headers), but they opted out of the project's
warnings-as-errors via `disable_warnings`. So warnings in the generated code went
unnoticed, and the GCC build spewed noise from the bundled SDK headers.

This holds the generated code to the same standard as the rest of `src/`:

- The Valve SDK headers are marked **SYSTEM** on the per-tag targets (generated
  headers stay on the normal include path). That suppresses the SDK's own warnings
  and the cross-snapshot `-Wodr` noise under LTO, while our generated code still warns.
- The per-tag libs drop the `disable_warnings` opt-out and inherit `-Werror`. On MSVC
  the external-header warning level is lowered (`/external:W0`) and
  `_CRT_SECURE_NO_WARNINGS` is defined. Hand-written base TUs are unchanged.

Enabling this surfaced (and this PR fixes) two generator issues in the guest proxies:
stub bodies for non-marshallable methods, and `null_ptr` params (double-pointer filter
lists the host substitutes with `nullptr`), both named their parameters without using
them → `-Wunused-parameter`. They're now cast to void.

Also fixes a real `-Wtautological-compare` in `steam_host_runtime.hpp` (the reader's
`p + n >= p` overflow guard is always true since pointer overflow is UB; replaced with
the equivalent `n <= end - p`), and makes `sogen_target_disable_warnings` actually
silence warnings on GCC/Clang (`-w`), which it previously only did on MSVC.

## Why nothing errored before

`sogen_targets_set_warnings_as_errors` skips any target with the
`SOGEN_WARNINGS_DISABLE` property, and every Steam target set it. So the generated
code (and the SDK headers) compiled without `-Werror`; the `-Wodr` lines are LTO
link-time diagnostics from linking many SDK-version object libs into one binary.

## Validation

Generated v164 host + guest TUs compiled with `-Wall -Wextra -pedantic -Werror`
and the SDK as `-isystem` — clean at 64-bit (host + guest) and 32-bit (guest).
Full matrix (GCC, MSVC, all ~90 snapshots) validated by CI.
