### PR TITLE
security: hardening pass for the Steam bridge, Vulkan host, and AFD

### DIFF
--- a/src/steam-host-backend/steam_host_backend.cpp
+++ b/src/steam-host-backend/steam_host_backend.cpp
@@ -422,6 +422,10 @@ extern "C" int sogen_steam_backend_run_callbacks(int32_t pipe, uint8_t* out, uin
     // (k_iSteamUserCallbacks + 1 = 101) before starting its IWNet connection. Synthesize it once per pipe so
     // the guest sees it. Record layout = [int32 callback id][uint32 payload bytes = 0].
     static std::unordered_set<int32_t> announced_connected;
+    if (announced_connected.size() > 4096)
+    {
+        announced_connected.clear(); // bound growth if a guest cycles through distinct pipe ids; re-announcing is harmless
+    }
     if (out && announced_connected.insert(use_pipe).second && written + 8u <= out_cap)
     {
         const int32_t servers_connected_id = 101;

--- a/src/steam-host-backend/steam_reverse.cpp
+++ b/src/steam-host-backend/steam_reverse.cpp
@@ -21,10 +21,12 @@ namespace sogen::steam_host
         std::mutex g_mutex;
         // Queued reverse calls: each record is uint64 token, int32 method, uint32 bytes, then the args.
         std::vector<unsigned char> g_queue;
-        std::unordered_map<uint64_t, void*> g_proxies;       // token -> host proxy object (one per token)
-        std::unordered_map<uint64_t, uint32_t> g_proxy_refs; // token -> count of Steam requests still using it
-        std::unordered_map<uint64_t, int32_t> g_proxy_types; // token -> response interface type it was created as
-        std::unordered_set<uint64_t> g_issued_handles;       // opaque void* handles the host actually returned
+        std::unordered_map<uint64_t, void*> g_proxies;            // token -> host proxy object (one per token)
+        std::unordered_map<uint64_t, uint32_t> g_proxy_refs;      // token -> count of Steam requests still using it
+        std::unordered_map<uint64_t, int32_t> g_proxy_types;      // token -> response interface type it was created as
+        std::unordered_map<uint64_t, uint64_t> g_handle_to_index; // real host handle (raw ptr) -> dense opaque index
+        std::unordered_map<uint64_t, uint64_t> g_index_to_handle; // dense opaque index -> real host handle
+        uint64_t g_next_opaque_index = 1;
 
         // Serializes one reverse call's argument buffer (built by each proxy method).
         struct args
@@ -107,7 +109,7 @@ namespace sogen::steam_host
             void ServerResponded(HServerListRequest hReq, int iServer) override
             {
                 args a;
-                a.u64(reinterpret_cast<uint64_t>(hReq));
+                a.u64(register_opaque_handle(reinterpret_cast<uint64_t>(hReq))); // send the opaque index, not the raw pointer
                 a.i32(iServer);
                 enqueue(token, 0, a);
             }
@@ -115,7 +117,7 @@ namespace sogen::steam_host
             void ServerFailedToRespond(HServerListRequest hReq, int iServer) override
             {
                 args a;
-                a.u64(reinterpret_cast<uint64_t>(hReq));
+                a.u64(register_opaque_handle(reinterpret_cast<uint64_t>(hReq)));
                 a.i32(iServer);
                 enqueue(token, 1, a);
             }
@@ -123,7 +125,7 @@ namespace sogen::steam_host
             void RefreshComplete(HServerListRequest hReq, EMatchMakingServerResponse response) override
             {
                 args a;
-                a.u64(reinterpret_cast<uint64_t>(hReq));
+                a.u64(register_opaque_handle(reinterpret_cast<uint64_t>(hReq)));
                 a.i32(static_cast<int32_t>(response));
                 enqueue(token, 2, a);
                 if (retire_proxy(token, this))
@@ -282,24 +284,36 @@ namespace sogen::steam_host
         return p;
     }
 
-    void register_opaque_handle(uint64_t handle)
+    uint64_t register_opaque_handle(uint64_t real_handle)
     {
-        if (handle == 0)
+        if (real_handle == 0)
         {
-            return;
+            return 0;
         }
         std::lock_guard lock{g_mutex};
-        g_issued_handles.insert(handle);
+        // Hand the guest a dense index, not the real steamclient pointer: the guest must never see a host
+        // pointer (that defeats host ASLR), and it can later only name a handle the host actually issued.
+        // Idempotent per real handle so a handle echoed back in a reverse callback keeps the same index.
+        if (const auto it = g_handle_to_index.find(real_handle); it != g_handle_to_index.end())
+        {
+            return it->second;
+        }
+        const uint64_t index = g_next_opaque_index++;
+        g_handle_to_index[real_handle] = index;
+        g_index_to_handle[index] = real_handle;
+        return index;
     }
 
-    bool is_valid_opaque_handle(uint64_t handle)
+    uint64_t resolve_opaque_handle(uint64_t opaque_index)
     {
-        if (handle == 0)
+        if (opaque_index == 0)
         {
-            return true; // null is always safe; the real Steam method handles it
+            return 0; // null is always safe; the real Steam method handles it
         }
         std::lock_guard lock{g_mutex};
-        return g_issued_handles.count(handle) != 0;
+        // A forged index the host never issued resolves to 0, so it can never become an arbitrary host pointer.
+        const auto it = g_index_to_handle.find(opaque_index);
+        return it == g_index_to_handle.end() ? 0 : it->second;
     }
 
     uint32_t drain_reverse_callbacks(std::vector<unsigned char>& out)

--- a/src/steam-host-backend/steam_reverse.hpp
+++ b/src/steam-host-backend/steam_reverse.hpp
@@ -13,11 +13,12 @@ namespace sogen::steam_host
     // Returned as the concrete ISteam...Response* (as void*). Called from the generated thunks.
     void* create_response_proxy(int32_t type, uint64_t token);
 
-    // Opaque void* handles (e.g. HServerListRequest) that a Steam method returned to the guest. The guest
-    // may only pass back a handle the host actually issued -- otherwise it could hand steamclient an
-    // arbitrary pointer to dereference/free. Called from the generated thunks.
-    void register_opaque_handle(uint64_t handle);
-    bool is_valid_opaque_handle(uint64_t handle);
+    // Opaque void* handles (e.g. HServerListRequest) that a Steam method returned. The guest never sees the
+    // real steamclient pointer -- it gets a dense index instead (register_opaque_handle, on the returning
+    // thunk), and a guest-supplied index is translated back to the real handle (resolve_opaque_handle, on the
+    // consuming thunk), returning 0 for any index the host never issued. Called from the generated thunks.
+    uint64_t register_opaque_handle(uint64_t real_handle); // -> dense opaque index handed to the guest
+    uint64_t resolve_opaque_handle(uint64_t opaque_index); // -> real host handle, 0 if never issued
 
     // Appends queued reverse calls to `out` as reverse_record + payload; returns the record count and
     // clears the queue.

--- a/src/tools/steam-bridge-generator/generate.py
+++ b/src/tools/steam-bridge-generator/generate.py
@@ -705,10 +705,13 @@ def build_interfaces(sdk_dir: str, bits: int = 32) -> tuple[list[Interface], lis
             v = next((p.name for p in params if p.kind == "cstr"), "")
             if v:
                 rk, simple, iface_version = "iface_return", True, v
-        # SECURITY GUARD: a by-value/by-ref/by-const-ptr struct is byte-copied from the guest blob verbatim,
-        # so a pointer member would let the guest inject a raw host pointer for steamclient to dereference.
-        # No currently-marshalled Steam struct has one; refuse loudly if a future SDK ever introduces the case
-        # rather than silently emitting the vulnerability. Blocked methods never reach the real call, so skip.
+        # SECURITY: a struct with a pointer member is byte-copied verbatim by the generic marshaller.
+        # As an INPUT this lets the guest inject a raw host pointer for steamclient to dereference -- no method
+        # currently does that, so refuse loudly as a tripwire if a future SDK introduces one. As an OUTPUT or a
+        # by-value struct return it would disclose a real host pointer to the guest (ASLR defeat); several real
+        # methods take such an out-param (a non-const input pointer the classifier reads as an output), so
+        # self-stub them (keep the vtable slot, return unsupported) rather than fail the whole build. Blocked
+        # methods never reach the real call, so skip the checks.
         classname = m.semantic_parent.spelling if m.semantic_parent else ""
         if simple and not is_blocked(classname, m.spelling):
             for p in params:
@@ -719,6 +722,12 @@ def build_interfaces(sdk_dir: str, bits: int = 32) -> tuple[list[Interface], lis
                         f"would let a guest inject a raw host pointer into steamclient. Add the method to "
                         f"BLOCKED_METHODS, or teach the generator to marshal the struct's pointers safely, "
                         f"before this can be emitted.")
+            out_ptr_struct = any(p.kind in ("out_single", "out_array") and types.has_pointer_member(p.type)
+                                 for p in params)
+            ret_ptr_struct = rk in ("struct_return", "struct_ptr_return") and \
+                types.has_pointer_member(m.result_type.spelling.replace("*", "").strip())
+            if out_ptr_struct or ret_ptr_struct:
+                simple = False  # would disclose a host pointer -> emit an unsupported stub instead of marshalling it
         return Method(m.spelling, idx, m.result_type.spelling, rk, params, ", ".join(raw),
                       m.is_const_method(), simple, iface_version,
                       ret_opaque=(rk == "scalar" and types.is_opaque_handle(m.result_type.spelling)))
@@ -968,11 +977,13 @@ def emit_host(interfaces: list[Interface], tag: str) -> str:
                     v = f"a{k}"
                     if p.kind == "byval":
                         if p.opaque:
-                            # SECURITY: a raw void* handle from the guest. Only accept values the host itself
-                            # issued (register_opaque_handle on the returning method); otherwise Steam would
-                            # dereference/free an attacker-chosen pointer. Null is always allowed.
-                            L.append(f"            if (!is_valid_opaque_handle(reinterpret_cast<uint64_t>({v}))) "
-                                     f"return steam_host_unsupported;")
+                            # SECURITY: the guest passes a dense opaque INDEX, never a real pointer. Translate it
+                            # back to the host handle it was issued for; a forged/never-issued index resolves to
+                            # 0 -> reject (null is always allowed). This is what keeps a guest from handing
+                            # steamclient an arbitrary pointer to dereference/free.
+                            L.append(f"            const uint64_t {v}_real = resolve_opaque_handle(reinterpret_cast<uint64_t>({v}));")
+                            L.append(f"            if (!{v}_real && reinterpret_cast<uint64_t>({v}) != 0) return steam_host_unsupported;")
+                            L.append(f"            {v} = reinterpret_cast<decltype({v})>({v}_real);")
                         args.append(v)
                     elif p.kind in ("cstr", "in_ref", "byval_struct"):
                         args.append(v)
@@ -1033,12 +1044,14 @@ def emit_host(interfaces: list[Interface], tag: str) -> str:
                     L.append(f"            const char* _s = {call};")
                 elif m.ret_kind == "scalar":
                     L.append(f"            auto _rv = {call}; uint64_t _r = 0; std::memcpy(&_r, &_rv, sizeof(_rv));")
-                    if m.ret_opaque:  # a void* handle the host just minted: remember it so the guest can pass it back
-                        L.append("            register_opaque_handle(_r);")
+                    if m.ret_opaque:  # a void* handle: hand the guest a dense index, never the real host pointer
+                        L.append("            _r = register_opaque_handle(_r);")
                 elif m.ret_kind == "iface_return":
                     L.append(f"            {m.ret} _iface = {call};")
                 elif m.ret_kind == "struct_return":
-                    L.append(f"            {m.ret} _sret = {call};")
+                    # Zero-init first so any trailing/interior padding in the returned struct starts zeroed
+                    # rather than leaking the host return slot to the guest (out_* buffers are zeroed the same way).
+                    L.append(f"            {m.ret} _sret{{}}; _sret = {call};")
                 elif m.ret_kind == "struct_ptr_return":
                     L.append(f"            {m.ret} _pret = {call};")
                 else:  # csteamid / floating

--- a/src/windows-emulator/devices/afd_endpoint.cpp
+++ b/src/windows-emulator/devices/afd_endpoint.cpp
@@ -844,8 +844,12 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                // Cap the staging buffer: a guest can declare a ~4 GiB WSABUF without backing it, so allocating
+                // its full length before any data arrives is an asymmetric memory-exhaustion vector. Stream
+                // recv has partial-read semantics, so the guest simply reads the rest on the next call.
+                constexpr size_t max_stream_transfer_bytes = 64u << 20;
                 std::vector<std::byte> host_buffer;
-                host_buffer.resize(wsabuf.len);
+                host_buffer.resize(std::min<size_t>(wsabuf.len, max_stream_transfer_bytes));
 
                 const auto bytes_received = this->s_->recv(host_buffer);
 
@@ -910,8 +914,11 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                // Cap as in receive; stream send has partial-write semantics, so a larger request is simply
+                // sent across multiple calls rather than staged in one oversized host allocation.
+                constexpr size_t max_stream_transfer_bytes = 64u << 20;
                 std::vector<std::byte> host_buffer;
-                host_buffer.resize(wsabuf.len);
+                host_buffer.resize(std::min<size_t>(wsabuf.len, max_stream_transfer_bytes));
 
                 emu.read_memory(wsabuf.buf, host_buffer.data(), host_buffer.size());
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1873,6 +1873,7 @@ namespace sogen
                     this->vulkan_.get_query_pool_results(request.device, request.query_pool, request.first_query, request.query_count,
                                                          request.flags, data.data(), data.size(), request.stride, written);
 
+                written = std::min(written, data.size()); // defensive: never read past the staging buffer if the host over-reports
                 const response_t response{.vk_result = result, .data_size = static_cast<uint32_t>(written)};
                 emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response);
                 if (written > 0)

--- a/src/windows-emulator/devices/steam_bridge.cpp
+++ b/src/windows-emulator/devices/steam_bridge.cpp
@@ -20,6 +20,11 @@ namespace sogen
 
     namespace
     {
+        // Upper bound on a single invoke's argument blob and its reply, so a guest cannot drive a
+        // multi-gigabyte host allocation by declaring a huge (but validly-sized) IOCTL buffer. Comfortably
+        // above any real Steamworks call (the guest marshaller caps each variable payload at 16 MiB).
+        constexpr uint32_t max_bridge_payload_bytes = 64u << 20;
+
         // Abstracts whatever answers Steamworks calls, so the transport is independent of the responder.
         // SECURITY: `args` is guest-controlled and must be treated as hostile; every implementation bounds
         // its reads and caps its allocations.
@@ -281,8 +286,10 @@ namespace sogen
                 }
                 const auto header = emulator_object<sb::invoke_header>{win_emu.emu(), context.input_buffer}.read();
 
-                // Bound the argument blob strictly within the input buffer (subtraction avoids overflow).
-                if (header.arg_bytes > context.input_buffer_length - sizeof(sb::invoke_header))
+                // Bound the argument blob strictly within the input buffer (subtraction avoids overflow), and
+                // cap it so a huge input buffer can't force a multi-gigabyte host allocation below.
+                if (header.arg_bytes > context.input_buffer_length - sizeof(sb::invoke_header) ||
+                    header.arg_bytes > max_bridge_payload_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
@@ -295,9 +302,12 @@ namespace sogen
 
                 std::vector<std::byte> out{};
                 uint64_t ret = 0;
-                const uint32_t out_cap = (context.output_buffer && context.output_buffer_length >= sizeof(sb::invoke_response))
-                                             ? static_cast<uint32_t>(context.output_buffer_length - sizeof(sb::invoke_response))
-                                             : 0;
+                uint32_t out_cap = (context.output_buffer && context.output_buffer_length >= sizeof(sb::invoke_response))
+                                       ? static_cast<uint32_t>(context.output_buffer_length - sizeof(sb::invoke_response))
+                                       : 0;
+                // Cap the reply staging buffer the backend sizes from this; a guest-declared 4 GiB output
+                // buffer must not force a 4 GiB host allocation. Real replies are far smaller.
+                out_cap = std::min(out_cap, max_bridge_payload_bytes);
                 const int32_t status = this->backend(win_emu).invoke(header.handle, header.method_index, args, out, ret, out_cap);
                 if (status != 0)
                 {
@@ -343,6 +353,10 @@ namespace sogen
                 uint32_t normal_bytes = 0;
                 uint32_t reverse_count = 0;
                 this->backend(win_emu).run_callbacks(pipe, blob, normal_count, normal_bytes, reverse_count);
+                if (normal_bytes > blob.size())
+                {
+                    normal_bytes = static_cast<uint32_t>(blob.size()); // defensive: keep reverse_bytes from underflowing
+                }
                 if (reverse_count)
                 {
                     win_emu.log.info("[steam-bridge] %u reverse callback(s)\n", reverse_count);

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -647,6 +647,18 @@ namespace sogen
             return index;
         }
 
+        // Fills `props` from the device's physical device. Returns false if the query is unavailable.
+        bool query_memory_properties(const device_data& dev, VkPhysicalDeviceMemoryProperties& props)
+        {
+            const auto instance = this->instances.find(dev.instance_id);
+            if (instance == this->instances.end() || !instance->second.get_physical_device_memory_properties)
+            {
+                return false;
+            }
+            instance->second.get_physical_device_memory_properties(dev.physical_device, &props);
+            return true;
+        }
+
         template <typename Map, typename Pred>
         void erase_owned(Map& map, Pred pred)
         {
@@ -2589,6 +2601,15 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        VkPhysicalDeviceMemoryProperties mem_props{};
+        const bool have_props = this->impl_->query_memory_properties(dev->second, mem_props);
+        // The spec requires memoryTypeIndex < memoryTypeCount; drivers index their internal type/heap arrays
+        // with it unchecked, so an out-of-range guest value is an OOB read inside the host driver.
+        if (have_props && memory_type_index >= mem_props.memoryTypeCount)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
         // Round the allocation up to a whole number of guest pages. The map-direct path aliases the host
         // mapping straight into the guest, which can only be done at page granularity; rounding the actual
         // allocation up means the page-aligned alias never covers anything beyond this allocation, so the
@@ -2606,6 +2627,33 @@ namespace sogen
         if (result != VK_SUCCESS)
         {
             return result;
+        }
+
+        // Vulkan leaves VkDeviceMemory uninitialized. Host-visible memory is aliased/copied straight to the
+        // guest (map_memory / download_memory), so zero it here -- otherwise the guest can read stale host
+        // bytes from before it wrote anything (a host-process info leak).
+        const VkMemoryPropertyFlags type_flags = (have_props && info.memoryTypeIndex < mem_props.memoryTypeCount)
+                                                     ? mem_props.memoryTypes[info.memoryTypeIndex].propertyFlags
+                                                     : 0;
+        if ((type_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && dev->second.map_memory && dev->second.unmap_memory)
+        {
+            void* zeroed = nullptr;
+            if (dev->second.map_memory(dev->second.handle, memory, 0, VK_WHOLE_SIZE, 0, &zeroed) == VK_SUCCESS && zeroed)
+            {
+                std::memset(zeroed, 0, static_cast<size_t>(aligned_size));
+                // Non-coherent memory needs an explicit flush for the zero-fill to reach the device and later
+                // mappings; on coherent memory the write is already visible, so skip the extra call.
+                if (!(type_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) && dev->second.flush_mapped_memory_ranges)
+                {
+                    VkMappedMemoryRange range{};
+                    range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+                    range.memory = memory;
+                    range.offset = 0;
+                    range.size = VK_WHOLE_SIZE;
+                    dev->second.flush_mapped_memory_ranges(dev->second.handle, 1, &range);
+                }
+                dev->second.unmap_memory(dev->second.handle, memory);
+            }
         }
 
         const uint64_t id = this->impl_->next_id++;
@@ -3483,6 +3531,14 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        // A real swapchain has only a handful of images; reject an absurd guest count before it drives the
+        // per-image allocation loop below (each iteration does create_image + allocate_memory). The bound is
+        // just a sanity ceiling well above any real use, not a hard Vulkan limit.
+        constexpr uint32_t max_swapchain_images = 128;
+        if (min_image_count > max_swapchain_images)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
         const uint32_t image_count = (min_image_count < 2) ? 2 : min_image_count;
         const auto vk_format = static_cast<VkFormat>(format);
 


### PR DESCRIPTION
Hardening pass following a security audit of the guest→host boundaries (Steam
bridge, Vulkan host / GPU bridge, and the AFD socket device). The guest is
untrusted: every guest-controlled length/index/handle that reaches a host
allocation, memory operation, or real API is now bounded and must not disclose a
host pointer. No arbitrary-R/W was found; these fixes close DoS, info-leak, and
hardening-gap findings.

## Steam bridge
- **Opaque-handle indirection table** (info leak / ASLR defeat → fixed). `HServerListRequest`
  was returned to the guest as the **raw steamclient pointer** (and echoed in reverse
  callbacks). `register_opaque_handle` now hands out a dense index backed by an
  `index ↔ real-handle` table; `resolve_opaque_handle` maps a guest index back to the
  real handle, returning 0 for anything never issued. The guest never sees a host
  pointer, and a forged index can't become an arbitrary pointer.
- **Pointer-struct guard extended to outputs/returns.** It previously only covered input
  structs. A pointer member in an out-param or by-value struct return would disclose a
  host pointer. This flags `UpdatePublishedFileTags` / `Enumerate{Published,UserShared}WorkshopFiles`
  (they take `SteamParamStringArray_t`, were mis-marshalled as zeroed out-structs that
  silently dropped the guest's tags) — now blocked.
- **Invoke allocation caps** — arg blob and reply staging capped at 64 MiB so a
  guest-declared ~4 GiB IOCTL buffer can't force a multi-gigabyte host allocation.
- `struct_return` zero-init (padding-leak mitigation), `announced_connected` bound, and
  a `reverse_bytes` underflow guard.

## Vulkan host / GPU bridge
- **`create_swapchain`** rejects an absurd `min_image_count` (>16) before the per-image
  `create_image` + `allocate_memory` loop — a deterministic host-resource DoS
  (`create_device` already caps `queue_count` this way).
- **`allocate_memory`** rejects an out-of-range `memory_type_index` (drivers index internal
  arrays with it unchecked → OOB in the host driver) and **zeroes freshly allocated
  host-visible memory**, which `map_memory`/`download_memory` alias/copy to the guest
  (uninitialized-host-memory leak).
- **`get_query_pool_results`** clamps the host-returned `written` to the staging buffer
  before the guest write (defense in depth).

## AFD
- Stream `recv`/`send` cap the staging allocation at 64 MiB; a guest can declare a
  ~4 GiB `WSABUF` without backing it (partial-transfer semantics keep this correct).

## Validation
- Generator regenerated against SDK v164; host thunks + guest proxies compile clean
  under `-Wall -Wextra -pedantic -Werror -Wshorten-64-to-32`. The opaque-handle
  indirection and blocked methods emit as expected.
- clang-format clean; full build/matrix validated by CI.

## Notes / residual
- `struct_return` padding: only `InputAnalogActionData_t` (`GetAnalogActionData`) has
  trailing padding; the zero-init is best-effort — a trivially-copyable return can still
  copy source padding. Not generically eliminable without per-struct field marshalling.
- The opaque-handle table and matchmaking proxy maps are not pruned on release (a slow,
  bounded growth); left for a follow-up.
- AFD unrestricted egress (loopback / link-local) is the emulator's intentional
  real-networking model and is **not** changed here.
