### PR TITLE
build: suppress -Wunused-template on clang toolchains

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -247,6 +247,10 @@ function(sogen_target_set_warnings_as_errors target)
 
   if(MSVC)
     set(compile_options /W4 /WX)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # A newer clang (notably the emscripten toolchain) fires -Wunused-template on legitimate uninstantiated
+    # fallback templates (e.g. a generic default overload); it is not a warning this project opts into.
+    list(APPEND compile_options -Wno-unused-template)
   endif()
 
   target_compile_options(${target} PRIVATE


### PR DESCRIPTION
## What

A newer clang (notably the **emscripten SDK's**) fires `-Wunused-template` under the project's `-Wall -Wextra -pedantic -Werror` build, breaking multiple Clang-based jobs (emscripten, Linux Clang, macOS, …). Examples from CI:

```
module_mapping.cpp:46: error: unused function template 'collect_imports' [-Werror,-Wunused-template]
analysis_reporter.cpp:271: error: unused function template 'event_name'
```

`-Wunused-template` is **not** part of `-Wall`/`-Wextra` — the newer toolchain pulls it in — and it flags **legitimate uninstantiated fallback templates**, e.g. `analysis_reporter`'s generic `event_name(const Event&)` default that sits beside the per-type `EVENT_NAME(...)` overloads (removing it would break the moment a new event type is added without an overload). So this is warning noise, not a per-file class of bug to chase.

## Fix

Disable `-Wunused-template` for clang/AppleClang in the warnings-as-errors flags (GCC doesn't have the flag; MSVC uses `/W4 /WX` and is unaffected). One-line, scoped to the compilers that emit it.