### PR TITLE
sandbox: mount host directories into the guest via -p

### DIFF
--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace sogen::sandbox
@@ -57,7 +59,7 @@ namespace sogen::sandbox
             return wide_args;
         }
 
-        int run(const std::span<const std::string_view> args)
+        int run(const std::span<const std::string_view> args, std::unordered_map<windows_path, std::filesystem::path> path_mappings)
         {
             application_settings app_settings{
                 .application = std::u8string(args[0].begin(), args[0].end()),
@@ -82,6 +84,8 @@ namespace sogen::sandbox
             {
                 settings.emulation_root = root;
             }
+
+            settings.path_mappings = std::move(path_mappings);
 
             emulator_callbacks callbacks{};
             callbacks.on_stdout = [](const std::string_view data) {
@@ -127,6 +131,11 @@ namespace sogen::sandbox
             // On Windows this resolves the UTF-8 arguments from the wide command line.
             argv = app.ensure_utf8(argv);
 
+            // Map a guest Windows path to a host path (repeatable, two values each), mirroring
+            // the analyzer's -p option. Parsed before the first positional (the application).
+            std::vector<std::pair<std::string, std::string>> path_mappings{};
+            app.add_option("-p,--path", path_mappings, "Map a Windows path to a host path")->type_name("SRC DST")->allow_extra_args(false);
+
             // Stop parsing at the first positional (the application) and forward everything after it to the
             // emulated program.
             app.prefix_command();
@@ -142,8 +151,14 @@ namespace sogen::sandbox
                     return 1;
                 }
 
+                std::unordered_map<windows_path, std::filesystem::path> mappings{};
+                for (const auto& [source, target] : path_mappings)
+                {
+                    mappings[windows_path(source)] = std::filesystem::absolute(target);
+                }
+
                 const std::vector<std::string_view> views{application.begin(), application.end()};
-                return run(views);
+                return run(views, std::move(mappings));
             }
             catch (const std::exception& e)
             {

--- a/src/windows-emulator-test/file_system_test.cpp
+++ b/src/windows-emulator-test/file_system_test.cpp
@@ -14,4 +14,26 @@ namespace sogen::test
         EXPECT_EQ(current_dir / "a", fs.translate(windows_path('a', {u"b", u"..", u"..", u"b", u"..", u"a.txt"})));
         EXPECT_EQ(current_dir / "a", fs.translate(windows_path('a', {u"..", u"b"})));
     }
+
+    TEST(FileSystemTest, DirectoryMappingMountsSubtree)
+    {
+        const auto current_dir = std::filesystem::current_path();
+
+        file_system fs{current_dir};
+        fs.map(windows_path('c', {u"mnt"}), current_dir);
+
+        // A file under the mounted directory resolves to the same file under the host directory.
+        EXPECT_EQ(current_dir / "sub" / "a.txt", fs.translate(windows_path('c', {u"mnt", u"sub", u"a.txt"})));
+
+        // ".." cannot escape the mount; it is confined to the mounted directory.
+        EXPECT_EQ(current_dir, fs.translate(windows_path('c', {u"mnt", u"..", u"..", u"etc"})));
+
+        // The deepest matching mount wins.
+        fs.map(windows_path('c', {u"mnt", u"deep"}), current_dir / "other");
+        EXPECT_EQ(current_dir / "other" / "x.txt", fs.translate(windows_path('c', {u"mnt", u"deep", u"x.txt"})));
+
+        // An exact file mapping still takes precedence over the directory mount.
+        fs.map(windows_path('c', {u"mnt", u"exact.txt"}), current_dir / "elsewhere.txt");
+        EXPECT_EQ(current_dir / "elsewhere.txt", fs.translate(windows_path('c', {u"mnt", u"exact.txt"})));
+    }
 } // namespace sogen::test

--- a/src/windows-emulator/file_system.hpp
+++ b/src/windows-emulator/file_system.hpp
@@ -75,6 +75,38 @@ namespace sogen
                 return mapping->second;
             }
 
+            // Directory (subtree) mappings: if a mapped directory is an ancestor of the
+            // requested path, resolve the remainder against the mapped host directory. The
+            // deepest matching mapping wins, so nested mounts behave intuitively.
+            {
+                const std::filesystem::path* best_dest = nullptr;
+                windows_path best_remainder{};
+                size_t best_depth = 0;
+
+                for (const auto& [src, dest] : this->mappings_)
+                {
+                    auto remainder = win_path.relative_to(src);
+                    if (remainder.has_value() && (best_dest == nullptr || src.depth() > best_depth))
+                    {
+                        best_dest = &dest;
+                        best_remainder = std::move(*remainder);
+                        best_depth = src.depth();
+                    }
+                }
+
+                if (best_dest != nullptr)
+                {
+                    const auto host_path = *best_dest / best_remainder.to_portable_path();
+                    // Prevent ".." in the guest path from escaping the mounted directory.
+                    if (is_subpath(best_dest->lexically_normal(), host_path.lexically_normal()))
+                    {
+                        return weakly_canonical(host_path);
+                    }
+
+                    return *best_dest;
+                }
+            }
+
 #ifdef OS_WINDOWS
             if (this->root_.empty())
             {

--- a/src/windows-emulator/file_system.hpp
+++ b/src/windows-emulator/file_system.hpp
@@ -69,42 +69,16 @@ namespace sogen
                 throw std::runtime_error("Only absolute paths can be translated: " + win_path.string());
             }
 
-            const auto mapping = this->mappings_.find(win_path);
-            if (mapping != this->mappings_.end())
+            // Exact file mapping (fast path).
+            if (const auto mapping = this->mappings_.find(win_path); mapping != this->mappings_.end())
             {
                 return mapping->second;
             }
 
-            // Directory (subtree) mappings: if a mapped directory is an ancestor of the
-            // requested path, resolve the remainder against the mapped host directory. The
-            // deepest matching mapping wins, so nested mounts behave intuitively.
+            // Directory mapping: a mapped ancestor directory mounts its whole subtree.
+            if (auto mapped = this->translate_directory_mapping(win_path))
             {
-                const std::filesystem::path* best_dest = nullptr;
-                windows_path best_remainder{};
-                size_t best_depth = 0;
-
-                for (const auto& [src, dest] : this->mappings_)
-                {
-                    auto remainder = win_path.relative_to(src);
-                    if (remainder.has_value() && (best_dest == nullptr || src.depth() > best_depth))
-                    {
-                        best_dest = &dest;
-                        best_remainder = std::move(*remainder);
-                        best_depth = src.depth();
-                    }
-                }
-
-                if (best_dest != nullptr)
-                {
-                    const auto host_path = *best_dest / best_remainder.to_portable_path();
-                    // Prevent ".." in the guest path from escaping the mounted directory.
-                    if (is_subpath(best_dest->lexically_normal(), host_path.lexically_normal()))
-                    {
-                        return weakly_canonical(host_path);
-                    }
-
-                    return *best_dest;
-                }
+                return std::move(*mapped);
             }
 
 #ifdef OS_WINDOWS
@@ -114,20 +88,9 @@ namespace sogen
             }
 #endif
 
+            // Emulation-root translation, confined to the drive root.
             const std::array<char, 2> root_drive{win_path.get_drive().value_or('c'), 0};
-            auto root = this->root_ / root_drive.data();
-
-            auto path = this->root_ / win_path.to_portable_path();
-            // Confine the guest-controlled path to the drive root by resolving "." and ".."
-            // lexically, without following symlinks, so a crafted path cannot escape. Host-side
-            // symlinks placed inside the root may still point elsewhere (e.g. a mounted game
-            // directory); the OS resolves them when the file is opened.
-            if (is_subpath(root, path.lexically_normal()))
-            {
-                return weakly_canonical(path);
-            }
-
-            return root;
+            return confine(this->root_ / root_drive.data(), this->root_ / win_path.to_portable_path());
         }
 
         template <typename F>
@@ -149,6 +112,47 @@ namespace sogen
         }
 
       private:
+        // Resolve a host path built from a guest-controlled path, but keep it inside `base`: a ".." in the
+        // guest path that would escape `base` falls back to `base` itself. The check is purely lexical (it
+        // does not follow symlinks), so a crafted path cannot escape. Host-side symlinks placed inside `base`
+        // may still point elsewhere (e.g. a mounted game directory); the OS resolves those at open time.
+        static std::filesystem::path confine(const std::filesystem::path& base, const std::filesystem::path& candidate)
+        {
+            if (is_subpath(base.lexically_normal(), candidate.lexically_normal()))
+            {
+                return weakly_canonical(candidate);
+            }
+
+            return base;
+        }
+
+        // If a mapped directory is an ancestor of `win_path`, resolve the remaining path against the mapped
+        // host directory. The deepest matching mount wins, so nested mounts behave intuitively.
+        std::optional<std::filesystem::path> translate_directory_mapping(const windows_path& win_path) const
+        {
+            const std::filesystem::path* best_dest = nullptr;
+            windows_path best_remainder{};
+            size_t best_depth = 0;
+
+            for (const auto& [src, dest] : this->mappings_)
+            {
+                auto remainder = win_path.relative_to(src);
+                if (remainder.has_value() && (best_dest == nullptr || src.depth() > best_depth))
+                {
+                    best_dest = &dest;
+                    best_remainder = std::move(*remainder);
+                    best_depth = src.depth();
+                }
+            }
+
+            if (best_dest == nullptr)
+            {
+                return std::nullopt;
+            }
+
+            return confine(*best_dest, *best_dest / best_remainder.to_portable_path());
+        }
+
         std::filesystem::path root_{};
         std::unordered_map<windows_path, std::filesystem::path> mappings_{};
     };

--- a/src/windows-emulator/windows_path.hpp
+++ b/src/windows-emulator/windows_path.hpp
@@ -228,6 +228,35 @@ namespace sogen
             return {this->drive_, std::move(folders)};
         }
 
+        // Number of path components (excluding the drive).
+        size_t depth() const
+        {
+            return this->folders_.size();
+        }
+
+        // If `base` equals this path or is one of its ancestor directories (same drive,
+        // case-insensitive since components are canonicalized to lower case), returns the
+        // portion of this path below `base` as a relative windows_path. Otherwise nullopt.
+        std::optional<windows_path> relative_to(const windows_path& base) const
+        {
+            if (this->drive_ != base.drive_ || base.folders_.size() > this->folders_.size())
+            {
+                return std::nullopt;
+            }
+
+            auto self_it = this->folders_.begin();
+            for (const auto& base_folder : base.folders_)
+            {
+                if (*self_it != base_folder)
+                {
+                    return std::nullopt;
+                }
+                ++self_it;
+            }
+
+            return windows_path{std::nullopt, std::list<std::u16string>(self_it, this->folders_.end())};
+        }
+
         std::u16string leaf() const
         {
             if (this->folders_.empty())


### PR DESCRIPTION
## Motivation

The `sandbox` tool could only be configured through environment variables and had no way to expose a host directory to the emulated program (unlike the analyzer's `-p`). More fundamentally, path mappings were **exact-match only** (`file -> file`): children of a mapped directory fell through to the emulation-root translation, so even the analyzer couldn't mount a whole directory.

This came up building a Steam-game launcher on top of Sogen — it needs to mount a game's install directory (on the host, often another drive) into the guest without copying it.

## Changes

- **sandbox**: add a `-p/--path SRC DST` option (repeatable), mirroring the analyzer, populating `emulator_settings.path_mappings`. Parsed before the target thanks to `prefix_command()`.
- **`file_system::translate`**: after the exact-match lookup, fall back to the **deepest mapped ancestor directory** and resolve the remainder against the mapped host directory. A lexical subpath check prevents `..` in a guest path from escaping the mount. This makes directory mounts work for the **analyzer** too.
- **`windows_path`**: add `relative_to()` and `depth()` helpers used by the subtree match.

## Testing

With `-p C:\mnt <hostdir>`, `C:\mnt\test-sample.exe` loads and runs entirely from the mounted directory — executable load plus all file / registry / socket I/O — exit code 0. Existing exact-file mappings are unaffected (checked first).