### PR TITLE
Run Unity/D3D11 games: D3DKMT Render, Vulkan extension filtering, Steam interface versions

### DIFF
--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -382,6 +382,31 @@ namespace sogen
         UINT64 CommandBuffer;
     };
 
+    struct EMU_D3DKMT_RENDER
+    {
+        UINT32 hContext;
+        UINT32 CommandOffset;
+        UINT32 CommandLength;
+        UINT32 AllocationCount;
+        UINT32 PatchLocationCount;
+        UINT64 pNewCommandBuffer;
+        UINT32 NewCommandBufferSize;
+        UINT64 pNewAllocationList;
+        UINT32 NewAllocationListSize;
+        UINT64 pNewPatchLocationList;
+        UINT32 NewPatchLocationListSize;
+        UINT32 Flags;
+        UINT64 PresentHistoryToken;
+        UINT32 BroadcastContextCount;
+        UINT32 BroadcastContext[64];
+        UINT32 QueuedBufferCount;
+        UINT64 NewCommandBuffer;
+        UINT64 pPrivateDriverData;
+        UINT32 PrivateDriverDataSize;
+    };
+
+    static_assert(sizeof(EMU_D3DKMT_RENDER) == 368);
+
     struct EMU_D3DDDI_ALLOCATIONINFO
     {
         UINT32 hAllocation;

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -379,6 +379,22 @@ namespace sogen
     static_assert(offsetof(USER_MENU_ITEM, hbmpItem) == 0x60);
     static_assert(sizeof(USER_MENU_ITEM) == 0x70);
 
+    enum USER_WINDOWCOMPOSITIONATTRIB : uint32_t
+    {
+        WCA_NCRENDERING_ENABLED = 1,
+        WCA_EXTENDED_FRAME_BOUNDS = 8,
+        WCA_CLOAKED = 18,
+    };
+
+    struct USER_WINDOWCOMPOSITIONATTRIBDATA
+    {
+        uint32_t Attrib;
+        uint64_t pvData;
+        uint64_t cbData;
+    };
+
+    static_assert(sizeof(USER_WINDOWCOMPOSITIONATTRIBDATA) == 0x18);
+
     struct USER_DESKTOPINFO
     {
         uint8_t unknown0[0x8];

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -4667,6 +4667,20 @@ extern "C"
 
     __declspec(dllexport) VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice, const char* pName);
 
+    // The bridge cannot hand a host memory export to the guest: a guest HANDLE is an emulator object with no
+    // meaning to the host driver. DXVK asks for the export unconditionally once a resource requests sharing,
+    // even after its own capability check failed, so answer with a clean failure instead of a null jump.
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL
+    vkGetMemoryWin32HandleKHR(VkDevice /*device*/, const VkMemoryGetWin32HandleInfoKHR* /*pGetWin32HandleInfo*/, HANDLE* pHandle)
+    {
+        if (pHandle)
+        {
+            *pHandle = nullptr;
+        }
+
+        return VK_ERROR_FEATURE_NOT_PRESENT;
+    }
+
     __declspec(dllexport) VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
     {
         if (!pName)
@@ -4966,6 +4980,7 @@ extern "C"
             {.name = "vkCmdSetDepthBiasEnableEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetDepthBiasEnable)},
             {.name = "vkCmdSetPrimitiveRestartEnable", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetPrimitiveRestartEnable)},
             {.name = "vkCmdSetPrimitiveRestartEnableEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetPrimitiveRestartEnable)},
+            {.name = "vkGetMemoryWin32HandleKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetMemoryWin32HandleKHR)},
         };
 
         for (const auto& e : table)

--- a/src/tools/steam-bridge-generator/generate.py
+++ b/src/tools/steam-bridge-generator/generate.py
@@ -673,11 +673,26 @@ def build_interfaces(sdk_dir: str, bits: int = 32) -> tuple[list[Interface], lis
     errors = sum(1 for d in tu.diagnostics if d.severity >= cx.Diagnostic.Error)
     types = _build_types(tu)
 
-    ver_strings = re.findall(r'_INTERFACE_VERSION\s+"([^"]+)"', "".join(
+    headers = "".join(
         open(os.path.join(sdk_dir, fn), encoding="utf-8", errors="replace").read()
-        for fn in sorted(os.listdir(sdk_dir)) if fn.startswith("isteam") and fn.endswith(".h")))
+        for fn in sorted(os.listdir(sdk_dir)) if fn.startswith("isteam") and fn.endswith(".h"))
+
+    ver_strings = re.findall(r'_INTERFACE_VERSION\s+"([^"]+)"', headers)
+
+    # The accessor macros state the class <-> version-macro pairing the SDK itself uses, which the name
+    # heuristic below cannot always recover: ISteamGameSearch's version is "SteamMatchGameSearch001", and
+    # ISteamInventory's is "STEAMINVENTORY_INTERFACE_V003". A class with no version cannot be proxied in
+    # the guest, so SteamAPI_Init fails the moment a game asks for one of them.
+    ver_macros = dict(re.findall(r'#\s*define\s+(\w*_INTERFACE_VERSION\w*)\s+"([^"]+)"', headers))
+    accessors = {
+        cls: ver_macros[macro]
+        for cls, macro in re.findall(r'STEAM_DEFINE_\w*INTERFACE_ACCESSOR\(\s*(\w+)\s*\*\s*,\s*\w+\s*,\s*(\w+)\s*\)', headers)
+        if macro in ver_macros
+    }
 
     def version_of(classname: str) -> str:
+        if classname in accessors:
+            return accessors[classname]
         target = family_key(classname[1:])  # drop leading 'I'
         return next((v for v in ver_strings if family_key(v) == target), "")
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstring>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <ranges>
@@ -34,6 +35,24 @@ namespace sogen
 {
     namespace
     {
+        // Extensions whose entry points the bridge does not marshal. They must never reach the guest: a guest
+        // that sees them enables them and then calls into nothing. DXVK, for instance, creates shared textures
+        // as soon as it sees VK_KHR_external_memory_win32 and crashes when the shim has no implementation.
+        // HANDLE-based interop cannot work across the bridge anyway - guest handles are emulator objects.
+        constexpr std::array unsupported_device_extensions{
+            std::string_view{"VK_KHR_external_memory_win32"},    //
+            std::string_view{"VK_KHR_external_semaphore_win32"}, //
+            std::string_view{"VK_KHR_external_fence_win32"},     //
+            std::string_view{"VK_KHR_win32_keyed_mutex"},        //
+            std::string_view{"VK_EXT_full_screen_exclusive"},    //
+        };
+
+        bool is_unsupported_device_extension(const VkExtensionProperties& extension)
+        {
+            const std::string_view name{static_cast<const char*>(extension.extensionName)};
+            return std::ranges::find(unsupported_device_extensions, name) != unsupported_device_extensions.end();
+        }
+
 #ifdef _WIN32
         using library_handle = HMODULE;
 
@@ -1339,9 +1358,14 @@ namespace sogen
             {
                 return result;
             }
+
+            extensions.resize(count);
         }
 
-        out_count = count;
+        const auto removed = std::ranges::remove_if(extensions, is_unsupported_device_extension);
+        extensions.erase(removed.begin(), removed.end());
+
+        out_count = static_cast<uint32_t>(extensions.size());
 
         const size_t copy_bytes = std::min(out_size, extensions.size() * sizeof(VkExtensionProperties));
         if (copy_bytes > 0)

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -47,10 +47,14 @@ namespace sogen
             std::string_view{"VK_EXT_full_screen_exclusive"},    //
         };
 
+        bool is_unsupported_extension_name(const std::string_view name)
+        {
+            return std::ranges::find(unsupported_device_extensions, name) != unsupported_device_extensions.end();
+        }
+
         bool is_unsupported_device_extension(const VkExtensionProperties& extension)
         {
-            const std::string_view name{static_cast<const char*>(extension.extensionName)};
-            return std::ranges::find(unsupported_device_extensions, name) != unsupported_device_extensions.end();
+            return is_unsupported_extension_name(std::string_view{static_cast<const char*>(extension.extensionName)});
         }
 
 #ifdef _WIN32
@@ -1604,7 +1608,9 @@ namespace sogen
         }
         const uint32_t primary_family = queue_infos.front().queueFamilyIndex;
 
-        // Rebuild the enabled-extension name list from the blob (count NUL-terminated strings).
+        // Rebuild the enabled-extension name list from the blob (count NUL-terminated strings). Strip the same
+        // extensions enumeration hides from the guest -- a guest is untrusted and may enable one we never
+        // advertised, and we cannot marshal them across the bridge.
         std::vector<const char*> extensions;
         extensions.reserve(extension_count);
         {
@@ -1617,7 +1623,10 @@ namespace sogen
                 {
                     break;
                 }
-                extensions.push_back(cursor);
+                if (!is_unsupported_extension_name(std::string_view{cursor}))
+                {
+                    extensions.push_back(cursor);
+                }
                 cursor = terminator + 1;
             }
         }

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -224,9 +224,52 @@ namespace sogen
                 }
             };
 
+            struct dxgk_buffer
+            {
+                uint64_t address{};
+                uint32_t size{};
+
+                void serialize(utils::buffer_serializer& buffer) const
+                {
+                    buffer.write(this->address);
+                    buffer.write(this->size);
+                }
+
+                void deserialize(utils::buffer_deserializer& buffer)
+                {
+                    buffer.read(this->address);
+                    buffer.read(this->size);
+                }
+            };
+
             uint32_t next_resource_handle{0x8000};
             uint32_t next_allocation_handle{0x9000};
             std::map<uint32_t, dxgk_allocation> allocations{};
+
+            dxgk_buffer command_buffer{};
+            dxgk_buffer allocation_list{};
+            dxgk_buffer patch_location_list{};
+
+            static void reserve_buffer(memory_manager& memory, dxgk_buffer& buffer, const uint32_t size)
+            {
+                if (buffer.address != 0 && buffer.size >= size)
+                {
+                    return;
+                }
+
+                if (buffer.address != 0)
+                {
+                    memory.release_memory(buffer.address, 0);
+                }
+
+                const auto aligned_size = static_cast<uint32_t>(page_align_up(size));
+
+                buffer.address = memory.allocate_memory(aligned_size, memory_permission::read_write);
+                buffer.size = aligned_size;
+
+                const std::vector<uint8_t> zeros(aligned_size, 0);
+                memory.write_memory(buffer.address, zeros.data(), zeros.size());
+            }
 
             uint32_t create_resource()
             {
@@ -311,6 +354,9 @@ namespace sogen
                 buffer.write(this->next_resource_handle);
                 buffer.write(this->next_allocation_handle);
                 buffer.write_map(this->allocations);
+                buffer.write(this->command_buffer);
+                buffer.write(this->allocation_list);
+                buffer.write(this->patch_location_list);
             }
 
             void deserialize(utils::buffer_deserializer& buffer)
@@ -318,6 +364,9 @@ namespace sogen
                 buffer.read(this->next_resource_handle);
                 buffer.read(this->next_allocation_handle);
                 buffer.read_map(this->allocations);
+                buffer.read(this->command_buffer);
+                buffer.read(this->allocation_list);
+                buffer.read(this->patch_location_list);
             }
         };
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -205,6 +205,8 @@ namespace sogen
                                                    WAIT_TYPE wait_type, BOOLEAN alertable, emulator_object<LARGE_INTEGER> timeout);
         NTSTATUS handle_NtWaitForSingleObject(const syscall_context& c, handle h, BOOLEAN alertable,
                                               emulator_object<LARGE_INTEGER> timeout);
+        NTSTATUS handle_NtSignalAndWaitForSingleObject(const syscall_context& c, handle signal_handle, handle wait_handle,
+                                                       BOOLEAN alertable, emulator_object<LARGE_INTEGER> timeout);
         NTSTATUS handle_NtSetInformationObject();
         NTSTATUS handle_NtQuerySecurityObject(const syscall_context& c, handle /*h*/, SECURITY_INFORMATION /*security_information*/,
                                               emulator_pointer security_descriptor, ULONG length, emulator_object<ULONG> length_needed);
@@ -1362,6 +1364,7 @@ namespace sogen
         add_handler(NtCreateThreadEx);
         add_handler(NtQueryDebugFilterState);
         add_handler(NtWaitForSingleObject);
+        add_handler(NtSignalAndWaitForSingleObject);
         add_handler(NtTerminateThread);
         add_handler(NtDelayExecution);
         add_handler(NtWaitForAlertByThreadId);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -494,6 +494,8 @@ namespace sogen
         uint32_t handle_NtUserGetKeyState(const syscall_context& c, int32_t virtual_key);
         uint32_t handle_NtUserGetAsyncKeyState(const syscall_context& c, int32_t virtual_key);
         BOOL handle_NtUserClipCursor(const syscall_context& c, emulator_pointer rect);
+        BOOL handle_NtUserGetWindowCompositionAttribute(const syscall_context& c, hwnd window,
+                                                        emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data);
         BOOL handle_NtUserSetCursorPos(const syscall_context& c, int32_t x, int32_t y);
         hcursor handle_NtUserSetCursor(const syscall_context& c, hcursor cursor);
         hcursor handle_NtUserGetCursor(const syscall_context& c);
@@ -804,6 +806,7 @@ namespace sogen
         NTSTATUS handle_NtGdiDdDDICreateDevice(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEDEVICE> device_desc);
         NTSTATUS handle_NtGdiDdDDIEscape(const syscall_context& c, emulator_object<EMU_D3DKMT_ESCAPE> escape_desc);
         NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATECONTEXT> context_desc);
+        NTSTATUS handle_NtGdiDdDDIRender(const syscall_context& c, emulator_object<EMU_D3DKMT_RENDER> render_desc);
         NTSTATUS handle_NtGdiDdDDICreateAllocation(const syscall_context& c, emulator_object<EMU_D3DKMT_CREATEALLOCATION> allocation_desc);
         NTSTATUS handle_NtGdiDdDDIQueryResourceInfo(const syscall_context& c, emulator_object<EMU_D3DKMT_QUERYRESOURCEINFO> resource_info);
         NTSTATUS handle_NtGdiDdDDIOpenResource(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENRESOURCE> open_resource);
@@ -1433,6 +1436,7 @@ namespace sogen
         add_handler(NtUserTransformPoint);
         add_handler(NtUserShowCursor);
         add_handler(NtUserClipCursor);
+        add_handler(NtUserGetWindowCompositionAttribute);
         add_handler(NtUserSetCursorPos);
         add_handler(NtUserGetKeyState);
         add_handler(NtUserGetAsyncKeyState);
@@ -1574,6 +1578,7 @@ namespace sogen
         add_handler(NtGdiDdDDICreateDevice);
         add_handler(NtGdiDdDDIEscape);
         add_handler(NtGdiDdDDICreateContext);
+        add_handler(NtGdiDdDDIRender);
         add_handler(NtGdiDdDDICreateAllocation);
         add_handler(NtGdiDdDDIQueryResourceInfo);
         add_handler(NtGdiDdDDIOpenResource);

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -4,6 +4,7 @@
 #include "utils/io.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <iostream>
 #include <utils/finally.hpp>
 #include <utils/wildcard.hpp>

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -56,6 +56,45 @@ namespace sogen
                 return filename;
             }
 
+            // The counterpart of windows_path::to_device_path. Sogen reports file names in volume-device form
+            // (NtQueryObject, NtQueryVirtualMemory, ...) and code that consumes them - ntmarta walking a
+            // directory's parents for an ACL check, for one - opens them again as-is. Rewrite the volume back
+            // into its drive letter so the path reaches the file system instead of the device registry. A bare
+            // volume with no path behind it is a real volume handle and stays a device.
+            std::u16string resolve_volume_device_path(std::u16string filename)
+            {
+                constexpr std::u16string_view volume_prefix = u"\\Device\\HarddiskVolume";
+                if (!filename.starts_with(volume_prefix))
+                {
+                    return filename;
+                }
+
+                const std::u16string_view remainder{filename};
+                const auto separator = remainder.find(u'\\', volume_prefix.size());
+                if (separator == std::u16string_view::npos)
+                {
+                    return filename;
+                }
+
+                const auto number = u16_to_u8(remainder.substr(volume_prefix.size(), separator - volume_prefix.size()));
+
+                int volume_index{};
+                const auto* number_start = number.data();
+                const auto* number_end = number_start + number.size();
+                const auto [parse_end, parse_error] = std::from_chars(number_start, number_end, volume_index);
+                if (parse_error != std::errc{} || parse_end != number_end || volume_index < 1 || volume_index > 26)
+                {
+                    return filename;
+                }
+
+                std::u16string path = u"\\??\\";
+                path.push_back(static_cast<char16_t>(u'a' + volume_index - 1));
+                path.push_back(u':');
+                path.append(remainder.substr(separator));
+
+                return path;
+            }
+
             std::pair<utils::file_handle, NTSTATUS> open_file(const file_system& file_sys, const windows_path& path,
                                                               const std::u16string& mode)
             {
@@ -1713,7 +1752,7 @@ namespace sogen
             std::u16string filename_upper = filename;
             std::ranges::transform(filename_upper, filename_upper.begin(), ::towupper);
 
-            filename = resolve_system_root_path(c, std::move(filename));
+            filename = resolve_volume_device_path(resolve_system_root_path(c, std::move(filename)));
 
             // Handle console output device
             if (filename_upper == u"\\??\\CONOUT$" || filename_upper == u"\\DEVICE\\CONOUT$" || filename_upper == u"CONOUT$" ||
@@ -1968,7 +2007,7 @@ namespace sogen
                 filename = root->name + (has_separator ? u"" : u"\\") + filename;
             }
 
-            filename = resolve_system_root_path(c, std::move(filename));
+            filename = resolve_volume_device_path(resolve_system_root_path(c, std::move(filename)));
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 
@@ -2034,7 +2073,7 @@ namespace sogen
                 filename = root->name + (has_separator ? u"" : u"\\") + filename;
             }
 
-            filename = resolve_system_root_path(c, std::move(filename));
+            filename = resolve_volume_device_path(resolve_system_root_path(c, std::move(filename)));
 
             c.win_emu.callbacks.on_generic_access("Querying file attributes", filename);
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -204,6 +204,12 @@ namespace sogen
             constexpr uint32_t k_dxgk_patch_location_list_entry_size = 24;
             constexpr uint32_t k_dxgk_allocation_list_count = 512;
             constexpr uint32_t k_dxgk_patch_location_list_count = 512;
+            // Upper bounds on the guest-requested submission-buffer sizes. The guest is untrusted, so cap the
+            // NewCommandBufferSize / New*ListSize fields before they size a host allocation -- otherwise a
+            // crafted D3DKMT_RENDER can force a multi-gigabyte host allocation, and count * entry_size can
+            // overflow uint32. With these caps the byte sizes stay well under 4 GiB.
+            constexpr uint32_t k_dxgk_max_command_buffer_size = 0x4000000; // 64 MiB
+            constexpr uint32_t k_dxgk_max_list_count = 0x10000;            // 64k entries (<= 1.5 MiB of list bytes)
             constexpr uint64_t k_dxgk_dedicated_video_memory_size = 4ull * 1024 * 1024 * 1024;
             constexpr uint64_t k_dxgk_shared_system_memory_size = 8ull * 1024 * 1024 * 1024;
             constexpr uint32_t k_dxgk_fake_vendor_id = 0x10DE;
@@ -4308,9 +4314,11 @@ namespace sogen
                     dxgk_warn(c, "NtGdiDdDDIRender: Unknown context 0x%X", render.hContext);
                 }
 
-                reserve_dxgk_submission_buffers(c, std::max(render.NewCommandBufferSize, k_dxgk_command_buffer_size),
-                                                std::max(render.NewAllocationListSize, k_dxgk_allocation_list_count),
-                                                std::max(render.NewPatchLocationListSize, k_dxgk_patch_location_list_count));
+                // Clamp the guest-controlled sizes: at least the defaults, but never above the caps above.
+                reserve_dxgk_submission_buffers(
+                    c, std::clamp(render.NewCommandBufferSize, k_dxgk_command_buffer_size, k_dxgk_max_command_buffer_size),
+                    std::clamp(render.NewAllocationListSize, k_dxgk_allocation_list_count, k_dxgk_max_list_count),
+                    std::clamp(render.NewPatchLocationListSize, k_dxgk_patch_location_list_count, k_dxgk_max_list_count));
 
                 const auto& dxgk = c.proc.dxgk;
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -199,7 +199,11 @@ namespace sogen
             constexpr uint32_t k_dxgk_shared_primary_handle = 0x7000;
             constexpr LUID k_dxgk_adapter_luid = {0x1000, 0};
             constexpr uint32_t k_dxgk_adapter_source_count = 1;
-            constexpr size_t k_dxgk_command_buffer_size = 0x1000;
+            constexpr uint32_t k_dxgk_command_buffer_size = 0x1000;
+            constexpr uint32_t k_dxgk_allocation_list_entry_size = 8;
+            constexpr uint32_t k_dxgk_patch_location_list_entry_size = 24;
+            constexpr uint32_t k_dxgk_allocation_list_count = 512;
+            constexpr uint32_t k_dxgk_patch_location_list_count = 512;
             constexpr uint64_t k_dxgk_dedicated_video_memory_size = 4ull * 1024 * 1024 * 1024;
             constexpr uint64_t k_dxgk_shared_system_memory_size = 8ull * 1024 * 1024 * 1024;
             constexpr uint32_t k_dxgk_fake_vendor_id = 0x10DE;
@@ -4243,6 +4247,19 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        void reserve_dxgk_submission_buffers(const syscall_context& c, const uint32_t command_buffer_size,
+                                             const uint32_t allocation_list_count, const uint32_t patch_location_list_count)
+        {
+            auto& dxgk = c.proc.dxgk;
+            auto& memory = c.win_emu.memory;
+
+            using dxgk_state = process_context::dxgk_state;
+
+            dxgk_state::reserve_buffer(memory, dxgk.command_buffer, command_buffer_size);
+            dxgk_state::reserve_buffer(memory, dxgk.allocation_list, allocation_list_count * k_dxgk_allocation_list_entry_size);
+            dxgk_state::reserve_buffer(memory, dxgk.patch_location_list, patch_location_list_count * k_dxgk_patch_location_list_entry_size);
+        }
+
         NTSTATUS handle_NtGdiDdDDICreateContext(const syscall_context& c, const emulator_object<EMU_D3DKMT_CREATECONTEXT> context_desc)
         {
             if (!context_desc)
@@ -4258,21 +4275,56 @@ namespace sogen
 
                 create_context.hContext = k_dxgk_context_handle;
 
-                const auto cmd_buffer_size = k_dxgk_command_buffer_size;
-                const auto cmd_buffer_ptr = c.win_emu.memory.allocate_memory(cmd_buffer_size, memory_permission::read_write);
+                reserve_dxgk_submission_buffers(c, k_dxgk_command_buffer_size, k_dxgk_allocation_list_count,
+                                                k_dxgk_patch_location_list_count);
 
-                std::vector<uint8_t> zeros(cmd_buffer_size, 0);
-                c.win_emu.memory.write_memory(cmd_buffer_ptr, zeros.data(), cmd_buffer_size);
+                const auto& dxgk = c.proc.dxgk;
 
-                create_context.pCommandBuffer = cmd_buffer_ptr;
-                create_context.CommandBufferSize = cmd_buffer_size;
-                create_context.pAllocationList = 0;
-                create_context.AllocationListSize = 0;
-                create_context.pPatchLocationList = 0;
-                create_context.PatchLocationListSize = 0;
+                create_context.pCommandBuffer = dxgk.command_buffer.address;
+                create_context.CommandBuffer = dxgk.command_buffer.address;
+                create_context.CommandBufferSize = dxgk.command_buffer.size;
+                create_context.pAllocationList = dxgk.allocation_list.address;
+                create_context.AllocationListSize = dxgk.allocation_list.size / k_dxgk_allocation_list_entry_size;
+                create_context.pPatchLocationList = dxgk.patch_location_list.address;
+                create_context.PatchLocationListSize = dxgk.patch_location_list.size / k_dxgk_patch_location_list_entry_size;
 
                 dxgk_info(c, "NtGdiDdDDICreateContext: Created Context 0x%X on Device 0x%X (CmdBuf: 0x%llX)", create_context.hContext,
-                          create_context.hDevice, cmd_buffer_ptr);
+                          create_context.hDevice, dxgk.command_buffer.address);
+            });
+
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIRender(const syscall_context& c, const emulator_object<EMU_D3DKMT_RENDER> render_desc)
+        {
+            if (!render_desc)
+            {
+                return STATUS_INVALID_PARAMETER;
+            }
+
+            render_desc.access([&](EMU_D3DKMT_RENDER& render) {
+                if (render.hContext != k_dxgk_context_handle && render.hContext != k_dxgk_device_handle)
+                {
+                    dxgk_warn(c, "NtGdiDdDDIRender: Unknown context 0x%X", render.hContext);
+                }
+
+                reserve_dxgk_submission_buffers(c, std::max(render.NewCommandBufferSize, k_dxgk_command_buffer_size),
+                                                std::max(render.NewAllocationListSize, k_dxgk_allocation_list_count),
+                                                std::max(render.NewPatchLocationListSize, k_dxgk_patch_location_list_count));
+
+                const auto& dxgk = c.proc.dxgk;
+
+                render.pNewCommandBuffer = dxgk.command_buffer.address;
+                render.NewCommandBuffer = dxgk.command_buffer.address;
+                render.NewCommandBufferSize = dxgk.command_buffer.size;
+                render.pNewAllocationList = dxgk.allocation_list.address;
+                render.NewAllocationListSize = dxgk.allocation_list.size / k_dxgk_allocation_list_entry_size;
+                render.pNewPatchLocationList = dxgk.patch_location_list.address;
+                render.NewPatchLocationListSize = dxgk.patch_location_list.size / k_dxgk_patch_location_list_entry_size;
+                render.QueuedBufferCount = 0;
+
+                dxgk_info(c, "NtGdiDdDDIRender: Context 0x%X CommandOffset=0x%X CommandLength=0x%X Allocations=%u Patches=%u",
+                          render.hContext, render.CommandOffset, render.CommandLength, render.AllocationCount, render.PatchLocationCount);
             });
 
             return STATUS_SUCCESS;

--- a/src/windows-emulator/syscalls/object.cpp
+++ b/src/windows-emulator/syscalls/object.cpp
@@ -8,6 +8,11 @@ namespace sogen
 
     namespace syscalls
     {
+        NTSTATUS handle_NtSetEvent(const syscall_context& c, uint64_t handle, emulator_object<LONG> previous_state);
+        NTSTATUS handle_NtReleaseMutant(const syscall_context& c, handle mutant_handle, emulator_object<LONG> previous_count);
+        NTSTATUS handle_NtReleaseSemaphore(const syscall_context& c, handle semaphore_handle, ULONG release_count,
+                                           emulator_object<LONG> previous_count);
+
         NTSTATUS handle_NtClose(const syscall_context& c, const handle h)
         {
             const auto value = h.value;
@@ -750,6 +755,39 @@ namespace sogen
 
             c.win_emu.yield_thread(c.vcpu, alertable);
             return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtSignalAndWaitForSingleObject(const syscall_context& c, const handle signal_handle, const handle wait_handle,
+                                                       const BOOLEAN alertable, const emulator_object<LARGE_INTEGER> timeout)
+        {
+            const emulator_object<LONG> no_previous_state{c.emu.memory()};
+
+            NTSTATUS signal_status{};
+
+            switch (signal_handle.value.type)
+            {
+            case handle_types::event:
+                signal_status = handle_NtSetEvent(c, signal_handle.bits, no_previous_state);
+                break;
+
+            case handle_types::mutant:
+                signal_status = handle_NtReleaseMutant(c, signal_handle, no_previous_state);
+                break;
+
+            case handle_types::semaphore:
+                signal_status = handle_NtReleaseSemaphore(c, signal_handle, 1, no_previous_state);
+                break;
+
+            default:
+                return STATUS_OBJECT_TYPE_MISMATCH;
+            }
+
+            if (!NT_SUCCESS(signal_status))
+            {
+                return signal_status;
+            }
+
+            return handle_NtWaitForSingleObject(c, wait_handle, alertable, timeout);
         }
 
         NTSTATUS handle_NtSetInformationObject()

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2134,8 +2134,35 @@ namespace sogen
                 return FALSE;
             }
 
-            const auto data = attribute_data.read();
-            if (data.pvData == 0 || data.cbData == 0)
+            // The struct carries pointer/size_t fields, so a 32-bit (WoW64) guest passes a 12-byte layout, not
+            // the native 24-byte one; read the matching width.
+            uint32_t attrib = 0;
+            uint64_t pv_data = 0;
+            uint64_t cb_data = 0;
+            if (c.proc.is_wow64_process)
+            {
+                struct wow64_composition_data
+                {
+                    uint32_t attrib;
+                    uint32_t pv_data;
+                    uint32_t cb_data;
+                };
+
+                static_assert(sizeof(wow64_composition_data) == 12);
+                const auto data = emulator_object<wow64_composition_data>{c.emu, attribute_data.value()}.read();
+                attrib = data.attrib;
+                pv_data = data.pv_data;
+                cb_data = data.cb_data;
+            }
+            else
+            {
+                const auto data = attribute_data.read();
+                attrib = data.Attrib;
+                pv_data = data.pvData;
+                cb_data = data.cbData;
+            }
+
+            if (pv_data == 0 || cb_data == 0)
             {
                 return FALSE;
             }
@@ -2146,33 +2173,33 @@ namespace sogen
                 return FALSE;
             }
 
-            switch (data.Attrib)
+            switch (attrib)
             {
             case WCA_NCRENDERING_ENABLED:
             case WCA_CLOAKED: {
-                if (data.cbData < sizeof(uint32_t))
+                if (cb_data < sizeof(uint32_t))
                 {
                     return FALSE;
                 }
 
                 constexpr uint32_t value = 0;
-                c.emu.write_memory(data.pvData, &value, sizeof(value));
+                c.emu.write_memory(pv_data, &value, sizeof(value));
                 return TRUE;
             }
 
             case WCA_EXTENDED_FRAME_BOUNDS: {
-                if (data.cbData < sizeof(RECT))
+                if (cb_data < sizeof(RECT))
                 {
                     return FALSE;
                 }
 
                 const auto rect = get_window_rect(*win);
-                c.emu.write_memory(data.pvData, &rect, sizeof(rect));
+                c.emu.write_memory(pv_data, &rect, sizeof(rect));
                 return TRUE;
             }
 
             default:
-                c.win_emu.log.warn("Unsupported window composition attribute: %u\n", data.Attrib);
+                c.win_emu.log.warn("Unsupported window composition attribute: %u\n", attrib);
                 return FALSE;
             }
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2124,6 +2124,59 @@ namespace sogen
             return TRUE;
         }
 
+        // DwmGetWindowAttribute funnels into this. There is no DWM in the emulated session, so windows are never
+        // composed, never cloaked, and their extended frame equals the plain window rect.
+        BOOL handle_NtUserGetWindowCompositionAttribute(const syscall_context& c, const hwnd window,
+                                                        const emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data)
+        {
+            if (!attribute_data)
+            {
+                return FALSE;
+            }
+
+            const auto data = attribute_data.read();
+            if (data.pvData == 0 || data.cbData == 0)
+            {
+                return FALSE;
+            }
+
+            const auto* win = c.proc.windows.get(window);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            switch (data.Attrib)
+            {
+            case WCA_NCRENDERING_ENABLED:
+            case WCA_CLOAKED: {
+                if (data.cbData < sizeof(uint32_t))
+                {
+                    return FALSE;
+                }
+
+                constexpr uint32_t value = 0;
+                c.emu.write_memory(data.pvData, &value, sizeof(value));
+                return TRUE;
+            }
+
+            case WCA_EXTENDED_FRAME_BOUNDS: {
+                if (data.cbData < sizeof(RECT))
+                {
+                    return FALSE;
+                }
+
+                const auto rect = get_window_rect(*win);
+                c.emu.write_memory(data.pvData, &rect, sizeof(rect));
+                return TRUE;
+            }
+
+            default:
+                c.win_emu.log.warn("Unsupported window composition attribute: %u\n", data.Attrib);
+                return FALSE;
+            }
+        }
+
         // GetKeyState / GetAsyncKeyState report whether a virtual key (or mouse button) is currently down.
         // Games poll these for in-game input instead of consuming WM_KEYDOWN messages. GetKeyState reports the
         // high down bit; GetAsyncKeyState additionally returns the low pressed-since-last-query bit.


### PR DESCRIPTION
Getting Paleo Pines (Unity 2022, D3D11, Steamworks.NET) to run surfaced four independent bugs.

## Unimplemented syscalls (aborted the emulation)

- **`NtGdiDdDDIRender`** — the D3D11 runtime submits a command buffer as soon as it renders, so any title that reaches the real D3DKMT path died here. The context's command buffer, allocation list and patch-location list now live in `dxgk_state`, so `CreateContext` and `Render` hand them back and grow them on request. Struct layout verified against the SDK's `D3DKMT_RENDER`.
- **`NtUserGetWindowCompositionAttribute`** — `DwmGetWindowAttribute` funnels into it. There is no DWM in the emulated session, so windows are never composed, never cloaked, and the extended frame equals the window rect.

## GPU bridge advertised extensions it cannot marshal

The bridge passed the host driver's full device extension list to the guest, including the Win32 interop extensions. DXVK saw `VK_KHR_external_memory_win32`, enabled it, created a shared texture, and jumped to a null `vkGetMemoryWin32HandleKHR` (RIP=0). HANDLE-based interop cannot work across the bridge anyway — guest handles are emulator objects — so those extensions are now filtered out of the enumeration. The shim additionally implements `vkGetMemoryWin32HandleKHR` as a clean failure, because DXVK asks for the export even after its own capability check has already failed.

## Steam interface versions were silently empty

The bridge generator matched an interface class to its version string by name similarity, which yields an empty version for every interface Valve did not name after its class:

| Interface | Version string |
|---|---|
| `ISteamGameSearch` | `SteamMatchGameSearch001` |
| `ISteamInventory` | `STEAMINVENTORY_INTERFACE_V003` |
| `ISteamVideo` | `STEAMVIDEO_INTERFACE_V002` |

The version string is the key the guest proxy factory looks up, so those three could not be proxied. `steam_api64` walks the `ISteamClient` vtable during `SteamAPI_Init`, got a null back from `GetISteamGameSearch`, and aborted — no error, no further calls. Every game using the interface context failed to init Steam.

`STEAM_DEFINE_*_INTERFACE_ACCESSOR` states the class ↔ version-macro pairing authoritatively; the generator now reads it and keeps the name heuristic only as a fallback for snapshots predating the accessors.

## Testing

- `analyzer -s test-sample.exe` passes.
- Paleo Pines boots, DXVK comes up on the host GPU, Unity initializes URP, DXVK creates a 1920x1080 swapchain, `SteamAPI_Init` succeeds, and the game runs.