### PR TITLE
gdb: fix single-step executing the wrong thread

### DIFF
--- a/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
@@ -68,7 +68,16 @@ namespace sogen
         {
             try
             {
-                this->win_emu_->start(1);
+                auto& vcpu = this->win_emu_->vcpu(0);
+
+                // Bypass the emulator scheduler: the GDB protocol already
+                // selected the target thread via switch_to_thread(). Going
+                // through windows_emulator::start() would let the scheduler
+                // redirect to a different "ready" thread (e.g. when the
+                // stepped thread is in NtDelayExecution), causing IDA to
+                // receive a T05 for an unexpected tid → SIGTRAP error.
+                vcpu.switch_thread = false;
+                vcpu.cpu.start(1);
             }
             catch (const std::exception& e)
             {

--- a/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
@@ -77,6 +77,7 @@ namespace sogen
                 // stepped thread is in NtDelayExecution), causing IDA to
                 // receive a T05 for an unexpected tid → SIGTRAP error.
                 vcpu.switch_thread = false;
+                vcpu.thread().setup_if_necessary(vcpu.cpu, this->win_emu_->process);
                 vcpu.cpu.start(1);
             }
             catch (const std::exception& e)


### PR DESCRIPTION
## Summary

- When a thread is paused inside a blocking syscall (e.g. `NtDelayExecution` from `Sleep()`), the emulator's scheduler considers it "not ready"
- A GDB single-step via `windows_emulator::start(1)` enters the scheduler loop, which redirects execution to a different ready thread
- The `T05` stop reply reports that other thread's ID, but the debugger (IDA) only set `asked_step` for the stepped thread — causing a spurious SIGTRAP error
- Fix: bypass the scheduler in `singlestep()` by calling `vcpu.cpu.start(1)` directly and clearing the stale `switch_thread` flag. The GDB protocol already selected the target thread via `switch_to_thread()`

## Repro

1. Debug a binary that calls `Sleep()` in a loop
2. Press Suspend while the thread is inside `NtDelayExecution`
3. Press Step — RIP doesn't advance, eventually errors with "got SIGTRAP signal"

## Test plan

- [x] Reproduced the SIGTRAP error with IDA connected to sogen
- [x] Verified single-step now advances RIP correctly and stays on the correct thread