### PR TITLE
steam: make bridge codegen incremental (skip regen + recompile when unchanged)

### DIFF
--- a/cmake/steam-bridge.cmake
+++ b/cmake/steam-bridge.cmake
@@ -56,18 +56,42 @@ if(SOGEN_ENABLE_STEAM AND SOGEN_STEAM_HOST_PLATFORM)
     else()
       math(EXPR _bits "${CMAKE_SIZEOF_VOID_P} * 8")
       set(SOGEN_STEAM_GEN_DIR "${CMAKE_BINARY_DIR}/steam-generated")
+      set(_gen_py "${CMAKE_CURRENT_SOURCE_DIR}/tools/steam-bridge-generator/generate.py")
       list(LENGTH SOGEN_STEAM_TAG_LIST _tag_count)
-      message(STATUS "Steam bridge: generating ${_bits}-bit marshalling for ${_tag_count} SDK snapshot(s)...")
-      execute_process(
-        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/steam-bridge-generator/generate.py"
-                ${_gen_args} --out-dir "${SOGEN_STEAM_GEN_DIR}" --bits "${_bits}"
-        RESULT_VARIABLE _gen_res ERROR_VARIABLE _gen_err)
-      if(NOT _gen_res EQUAL 0)
-        message(WARNING "Steam bridge generator failed (is the 'libclang' pip package installed?):\n${_gen_err}\n"
-                        "Steam bridge disabled.")
-      else()
-        message(STATUS "Steam bridge enabled (base ${SOGEN_STEAM_BASE_DIR}).")
+
+      # The generated output is fully determined by the generator script, the target width, and the SDK
+      # snapshot set (which only changes when the Proton headers are re-fetched for a new ref). Fingerprint
+      # those into a stamp and skip the run -- libclang parses every snapshot, so it is by far the slowest
+      # part of configure -- whenever the stamp is unchanged since the last successful generation.
+      file(SHA256 "${_gen_py}" _gen_py_hash)
+      set(_gen_stamp "gen=${_gen_py_hash};bits=${_bits};repo=${SOGEN_STEAMWORKS_PROTON_REPO}")
+      string(APPEND _gen_stamp ";ref=${SOGEN_STEAMWORKS_PROTON_TAG};tags=${SOGEN_STEAM_TAG_LIST}")
+      set(_gen_stamp_file "${SOGEN_STEAM_GEN_DIR}/.inputs.stamp")
+      set(_do_generate TRUE)
+      if(EXISTS "${_gen_stamp_file}" AND EXISTS "${SOGEN_STEAM_GEN_DIR}/steam_tags.generated.hxx")
+        file(READ "${_gen_stamp_file}" _prev_stamp)
+        if(_prev_stamp STREQUAL _gen_stamp)
+          set(_do_generate FALSE)
+        endif()
+      endif()
+
+      if(NOT _do_generate)
+        message(STATUS "Steam bridge: generated marshalling up to date for ${_tag_count} snapshot(s); skipping codegen.")
         set(SOGEN_STEAM_ENABLED TRUE)
+      else()
+        message(STATUS "Steam bridge: generating ${_bits}-bit marshalling for ${_tag_count} SDK snapshot(s)...")
+        execute_process(
+          COMMAND "${Python3_EXECUTABLE}" "${_gen_py}"
+                  ${_gen_args} --out-dir "${SOGEN_STEAM_GEN_DIR}" --bits "${_bits}"
+          RESULT_VARIABLE _gen_res ERROR_VARIABLE _gen_err)
+        if(NOT _gen_res EQUAL 0)
+          message(WARNING "Steam bridge generator failed (is the 'libclang' pip package installed?):\n${_gen_err}\n"
+                          "Steam bridge disabled.")
+        else()
+          file(WRITE "${_gen_stamp_file}" "${_gen_stamp}")
+          message(STATUS "Steam bridge enabled (base ${SOGEN_STEAM_BASE_DIR}).")
+          set(SOGEN_STEAM_ENABLED TRUE)
+        endif()
       endif()
     endif()
   endif()

--- a/src/tools/steam-bridge-generator/generate.py
+++ b/src/tools/steam-bridge-generator/generate.py
@@ -1128,6 +1128,20 @@ def emit_tags(tags: list[str]) -> str:
     ])
 
 
+def write_if_changed(path: str, text: str) -> None:
+    """Write `text` to `path` only if it differs from the current contents. Codegen runs at CMake
+    configure time; rewriting an unchanged file would bump its mtime and force every TU that includes
+    it to recompile on the next build. Leaving identical files untouched keeps those builds incremental."""
+    try:
+        with open(path, "r", encoding="utf-8", newline="") as f:
+            if f.read() == text:
+                return
+    except OSError:
+        pass  # missing/unreadable -> (re)write it below
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+
+
 def generate_tag(tag: str, sdk_dir: str, out_dir: str, bits: int) -> tuple[int, int, int]:
     interfaces, skipped, errors = build_interfaces(sdk_dir, bits)
     tag_dir = os.path.join(out_dir, tag)
@@ -1138,8 +1152,7 @@ def generate_tag(tag: str, sdk_dir: str, out_dir: str, bits: int) -> tuple[int, 
         "steam_host_thunks.generated.hxx": emit_host(interfaces, tag),
     }
     for name, text in outputs.items():
-        with open(os.path.join(tag_dir, name), "w", encoding="utf-8", newline="\n") as f:
-            f.write(text)
+        write_if_changed(os.path.join(tag_dir, name), text)
     total = sum(len(i.methods) for i in interfaces)
     simple = sum(1 for i in interfaces for m in i.methods if m.simple)
     return total, simple, errors
@@ -1166,8 +1179,7 @@ def main() -> None:
         print(f"[{name}] parse-errors {errors}; methods {total}; marshalled {simple} "
               f"({100 * simple // max(total, 1)}%), stubbed {total - simple}")
 
-    with open(os.path.join(args.out_dir, "steam_tags.generated.hxx"), "w", encoding="utf-8", newline="\n") as f:
-        f.write(emit_tags(tags))
+    write_if_changed(os.path.join(args.out_dir, "steam_tags.generated.hxx"), emit_tags(tags))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The Steam bridge marshalling code was **regenerated on every configure** and **recompiled on every build**, even when nothing had changed. Two independent causes:

1. `generate.py` rewrote every output header unconditionally (`open(..., "w")`), bumping their mtimes — so every TU that `#include`s them recompiled even when the content was byte-for-byte identical.
2. The codegen runs at CMake configure time via `execute_process`, and libclang parses **all 90 SDK snapshots** — by far the slowest part of configure — every single reconfigure.

## Fix

**`generate.py` — write-if-different.** All output writes now go through a `write_if_changed()` helper that leaves byte-identical files untouched. It reads with `newline=""` so CRLF translation on Windows doesn't cause spurious rewrites. Even if the generator runs, unchanged headers keep their mtime and downstream compilation is skipped.

**`steam-bridge.cmake` — input stamp.** The output is fully determined by the generator script, the target bit width, and the SDK snapshot set (which only changes when Proton headers are re-fetched for a new ref). We now stamp those into `steam-generated/.inputs.stamp` (SHA256 of `generate.py` + bits + Proton repo/ref + resolved tag list) and skip the Python run when the stamp is unchanged since the last successful generation. The stamp re-triggers exactly when it should: editing `generate.py` or updating Proton.

## Verification

- Running the generator twice against the fetched snapshots: all output mtimes unchanged on the second run; a genuine content change still rewrites.
- Standalone CMake test of the stamp logic: fresh → generate, unchanged → skip, generator edited → generate, Proton ref changed → generate.
- Full project reconfigure twice:
  - Configure #1: `Steam bridge: generating 64-bit marshalling for 90 SDK snapshot(s)...` → `enabled`
  - Configure #2: `Steam bridge: generated marshalling up to date for 90 snapshot(s); skipping codegen.`

Net effect: after the first generation, plain rebuilds do no Steam regeneration and no Steam recompilation; reconfigures skip the Python run; and both correctly re-trigger when the generator or the SDK snapshots actually change.