### PR TITLE
Add stdout cli option

### DIFF
--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -13,6 +13,7 @@
 #include "analysis.hpp"
 #include "analysis_reporter.hpp"
 #include "jsonl_reporter.hpp"
+#include "stdout_file_reporter.hpp"
 #include "tenet_tracer.hpp"
 
 #include <utils/finally.hpp>
@@ -63,6 +64,7 @@ namespace sogen
             std::filesystem::path dump{};
             std::filesystem::path minidump_path{};
             std::filesystem::path report_path{};
+            std::filesystem::path stdout_path{};
             std::string report_format{"jsonl"};
             std::string whp_execution_hook_mode{"auto"};
             std::optional<backend_type> backend{};
@@ -601,6 +603,11 @@ namespace sogen
                 reporters.emplace_back(create_jsonl_reporter(options.report_path));
             }
 
+            if (!options.stdout_path.empty())
+            {
+                reporters.emplace_back(create_stdout_file_reporter(options.stdout_path));
+            }
+
             context.reporters.reserve(reporters.size());
             for (const auto& reporter : reporters)
             {
@@ -865,6 +872,7 @@ namespace sogen
             app.add_option("--minidump", options.minidump_path, "Load minidump from path");
             app.add_option("--report", options.report_path, "Write machine-readable analysis events to a file");
             app.add_option("--report-format", options.report_format, "Report format (supported: jsonl)")->capture_default_str();
+            app.add_option("--stdout", options.stdout_path, "Write guest console output to a file");
             app.add_option("--whp-exec-hook", options.whp_execution_hook_mode, "WHP memory execution hook mode")
                 ->capture_default_str()
                 ->check(CLI::IsMember({"auto", "int3"}));

--- a/src/windows-analyzer/stdout_file_reporter.cpp
+++ b/src/windows-analyzer/stdout_file_reporter.cpp
@@ -1,0 +1,58 @@
+#include "std_include.hpp"
+
+#include "analysis_reporter.hpp"
+#include "analysis_reporter_common.hpp"
+#include "stdout_file_reporter.hpp"
+
+namespace sogen
+{
+
+    namespace
+    {
+        using analysis_reporter_detail::make_overloaded;
+
+        class stdout_file_analysis_reporter final : public analysis_reporter
+        {
+          public:
+            explicit stdout_file_analysis_reporter(const std::filesystem::path& path)
+            {
+                this->file_.rdbuf()->pubsetbuf(this->buffer_.data(), static_cast<std::streamsize>(this->buffer_.size()));
+                this->file_.open(path, std::ios::binary | std::ios::out | std::ios::trunc);
+
+                if (!this->file_)
+                {
+                    throw std::runtime_error("Failed to open guest console output file: " + path.string());
+                }
+            }
+
+            void report(const analysis_event& event) override
+            {
+                std::visit(make_overloaded(
+                               [this](const stdout_chunk_event& e) {
+                                   this->file_.write(e.data.data(), static_cast<std::streamsize>(e.data.size()));
+                                   if (e.data.find('\n') != std::string::npos)
+                                   {
+                                       this->file_.flush();
+                                   }
+                               },
+                               [](const auto&) {}),
+                           event);
+            }
+
+            void flush() override
+            {
+                this->file_.flush();
+            }
+
+          private:
+            std::array<char, 64 * 1024> buffer_{};
+            std::ofstream file_{};
+        };
+    }
+
+    std::unique_ptr<analysis_reporter> create_stdout_file_reporter(const std::filesystem::path& path)
+    {
+        return std::make_unique<stdout_file_analysis_reporter>(path);
+    }
+
+} // namespace sogen

--- a/src/windows-analyzer/stdout_file_reporter.hpp
+++ b/src/windows-analyzer/stdout_file_reporter.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+
+namespace sogen
+{
+
+    class analysis_reporter;
+
+    std::unique_ptr<analysis_reporter> create_stdout_file_reporter(const std::filesystem::path& path);
+
+} // namespace sogen


### PR DESCRIPTION
This PR proposes a CLI option (`--stdout`) that writes the emulated app’s console output to a file. This is useful when you want to read the app’s output while it’s running but syscall traces are too noisy.