### PR TITLE
emulator: read PE headers from minidump memory

### DIFF
--- a/src/emulator-platform/platform/win_pefile.hpp
+++ b/src/emulator-platform/platform/win_pefile.hpp
@@ -10,7 +10,6 @@
 #include <array>
 #include <limits>
 #include "common/utils/buffer_accessor.hpp"
-#include <emulator/memory_interface.hpp>
 
 #include "primitives.hpp"
 
@@ -612,8 +611,8 @@ namespace sogen
             return std::make_error_code(std::errc::executable_format_error);
         }
 
-        inline std::variant<pe_arch, std::error_code> get_pe_arch(const memory_interface& memory, uint64_t base_address,
-                                                                  uint64_t image_size)
+        template <typename MemoryReader>
+        inline std::variant<pe_arch, std::error_code> get_pe_arch(MemoryReader&& read_memory, uint64_t base_address, uint64_t image_size)
         {
             auto read = [&](const uint64_t offset, void* destination, const size_t size) -> bool {
                 if (offset > image_size || static_cast<uint64_t>(size) > image_size - offset)
@@ -631,7 +630,7 @@ namespace sogen
                     return false;
                 }
 
-                return memory.try_read_memory(address, destination, size);
+                return read_memory(address, destination, size);
             };
 
             PEDosHeader_t dos{};

--- a/src/emulator-platform/platform/win_pefile.hpp
+++ b/src/emulator-platform/platform/win_pefile.hpp
@@ -613,7 +613,7 @@ namespace sogen
         }
 
         inline std::variant<pe_arch, std::error_code> get_pe_arch(const memory_interface& memory, uint64_t base_address,
-                                                                   uint64_t image_size)
+                                                                  uint64_t image_size)
         {
             auto read = [&](const uint64_t offset, void* destination, const size_t size) -> bool {
                 if (offset > image_size || static_cast<uint64_t>(size) > image_size - offset)

--- a/src/emulator-platform/platform/win_pefile.hpp
+++ b/src/emulator-platform/platform/win_pefile.hpp
@@ -10,7 +10,7 @@
 #include <array>
 #include <limits>
 #include "common/utils/buffer_accessor.hpp"
-#include "../../emulator/memory_interface.hpp"
+#include <emulator/memory_interface.hpp>
 
 #include "primitives.hpp"
 

--- a/src/emulator-platform/platform/win_pefile.hpp
+++ b/src/emulator-platform/platform/win_pefile.hpp
@@ -8,7 +8,9 @@
 #include <system_error>
 #include <variant>
 #include <array>
+#include <limits>
 #include "common/utils/buffer_accessor.hpp"
+#include "../../emulator/memory_interface.hpp"
 
 #include "primitives.hpp"
 
@@ -610,22 +612,26 @@ namespace sogen
             return std::make_error_code(std::errc::executable_format_error);
         }
 
-        inline std::variant<pe_arch, std::error_code> get_pe_arch(uint64_t base_address, uint64_t image_size)
+        inline std::variant<pe_arch, std::error_code> get_pe_arch(const memory_interface& memory, uint64_t base_address,
+                                                                   uint64_t image_size)
         {
-            const auto* base = reinterpret_cast<const std::byte*>(reinterpret_cast<const void*>(static_cast<uintptr_t>(base_address)));
-            const uint64_t size = image_size;
+            auto read = [&](const uint64_t offset, void* destination, const size_t size) -> bool {
+                if (offset > image_size || static_cast<uint64_t>(size) > image_size - offset)
+                {
+                    return false;
+                }
+                if (offset > std::numeric_limits<uint64_t>::max() - base_address)
+                {
+                    return false;
+                }
 
-            auto read = [&](uint64_t off, void* dst, size_t n) -> bool {
-                if (off > size)
+                const auto address = base_address + offset;
+                if (size != 0 && static_cast<uint64_t>(size - 1) > std::numeric_limits<uint64_t>::max() - address)
                 {
                     return false;
                 }
-                if (n > size - off)
-                {
-                    return false;
-                }
-                memcpy(dst, base + off, n);
-                return true;
+
+                return memory.try_read_memory(address, destination, size);
             };
 
             PEDosHeader_t dos{};

--- a/src/windows-emulator-test/minidump_memory_module_test.cpp
+++ b/src/windows-emulator-test/minidump_memory_module_test.cpp
@@ -103,7 +103,7 @@ namespace sogen::test
         constexpr uint32_t nt_offset = 0x1800;
         constexpr uint64_t image_size = 0x2000;
 
-        for (const auto [magic, expected_arch] : {
+        for (const auto& [magic, expected_arch] : {
                  std::pair{static_cast<uint16_t>(PEOptionalHeader_t<uint32_t>::k_Magic), winpe::pe_arch::pe32},
                  std::pair{static_cast<uint16_t>(PEOptionalHeader_t<uint64_t>::k_Magic), winpe::pe_arch::pe64},
              })

--- a/src/windows-emulator-test/minidump_memory_module_test.cpp
+++ b/src/windows-emulator-test/minidump_memory_module_test.cpp
@@ -1,0 +1,166 @@
+#include "emulation_test_utils.hpp"
+#include "module/module_manager.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sogen::test
+{
+    class sparse_memory final : public memory_interface
+    {
+      public:
+        void add(const uint64_t address, const void* data, const size_t size)
+        {
+            std::vector<std::byte> bytes(size);
+            std::memcpy(bytes.data(), data, size);
+            this->regions.emplace(address, std::move(bytes));
+        }
+
+        size_t read_count() const
+        {
+            return this->read_count_;
+        }
+
+        size_t largest_read() const
+        {
+            return this->largest_read_;
+        }
+
+        void read_memory(const uint64_t address, void* data, const size_t size) const override
+        {
+            if (!this->try_read_memory(address, data, size))
+            {
+                throw std::out_of_range{"unreadable sparse guest memory"};
+            }
+        }
+
+        bool try_read_memory(const uint64_t address, void* data, const size_t size) const override
+        {
+            ++this->read_count_;
+            this->largest_read_ = std::max(this->largest_read_, size);
+
+            const auto entry = this->regions.upper_bound(address);
+            if (entry == this->regions.begin())
+            {
+                return false;
+            }
+
+            const auto& bytes = std::prev(entry)->second;
+            const auto region_address = std::prev(entry)->first;
+            const auto offset = address - region_address;
+            if (offset > bytes.size() || size > bytes.size() - offset)
+            {
+                return false;
+            }
+
+            std::memcpy(data, bytes.data() + offset, size);
+            return true;
+        }
+
+        void write_memory(uint64_t, const void*, size_t) override
+        {
+        }
+
+        bool try_write_memory(uint64_t, const void*, size_t) override
+        {
+            return false;
+        }
+
+      private:
+        void map_mmio(uint64_t, size_t, mmio_read_callback, mmio_write_callback) override
+        {
+        }
+
+        void map_memory(uint64_t, size_t, memory_permission) override
+        {
+        }
+
+        void unmap_memory(uint64_t, size_t) override
+        {
+        }
+
+        void apply_memory_protection(uint64_t, size_t, memory_permission) override
+        {
+        }
+
+        std::map<uint64_t, std::vector<std::byte>> regions;
+        mutable size_t read_count_{0};
+        mutable size_t largest_read_{0};
+    };
+
+    TEST(MinidumpMemoryModuleTest, DetectsSparsePe32AndPe64ThroughGuestMemory)
+    {
+        constexpr uint64_t base_address = 0x700000000000ULL;
+        constexpr uint32_t nt_offset = 0x1800;
+        constexpr uint64_t image_size = 0x2000;
+
+        for (const auto [magic, expected_arch] : {
+                 std::pair{static_cast<uint16_t>(PEOptionalHeader_t<uint32_t>::k_Magic), winpe::pe_arch::pe32},
+                 std::pair{static_cast<uint16_t>(PEOptionalHeader_t<uint64_t>::k_Magic), winpe::pe_arch::pe64},
+             })
+        {
+            sparse_memory memory;
+            PEDosHeader_t dos_header{};
+            dos_header.e_magic = PEDosHeader_t::k_Magic;
+            dos_header.e_lfanew = nt_offset;
+            memory.add(base_address, &dos_header, sizeof(dos_header));
+
+            const uint32_t signature = PENTHeaders_t<uint32_t>::k_Signature;
+            memory.add(base_address + nt_offset, &signature, sizeof(signature));
+            PEFileHeader_t file_header{};
+            memory.add(base_address + nt_offset + sizeof(signature), &file_header, sizeof(file_header));
+            memory.add(base_address + nt_offset + sizeof(signature) + sizeof(file_header), &magic, sizeof(magic));
+
+            const auto result = pe_architecture_detector::detect_from_memory(memory, base_address, image_size);
+
+            ASSERT_TRUE(result.is_valid());
+            ASSERT_EQ(result.architecture, expected_arch);
+            EXPECT_EQ(result.suggested_mode, pe_architecture_detector::determine_execution_mode(expected_arch));
+            EXPECT_EQ(memory.read_count(), 4u);
+            EXPECT_LE(memory.largest_read(), sizeof(PEDosHeader_t));
+        }
+    }
+
+    TEST(MinidumpMemoryModuleTest, RejectsUnreadableAndOutOfRangeHeaders)
+    {
+        constexpr uint64_t base_address = 0x700000000000ULL;
+        constexpr uint32_t nt_offset = 0x1800;
+
+        sparse_memory unreadable_memory;
+        PEDosHeader_t dos_header{};
+        dos_header.e_magic = PEDosHeader_t::k_Magic;
+        dos_header.e_lfanew = nt_offset;
+        unreadable_memory.add(base_address, &dos_header, sizeof(dos_header));
+        EXPECT_FALSE(pe_architecture_detector::detect_from_memory(unreadable_memory, base_address, 0x2000).is_valid());
+
+        sparse_memory out_of_range_memory;
+        const uint32_t signature = PENTHeaders_t<uint64_t>::k_Signature;
+        out_of_range_memory.add(base_address, &dos_header, sizeof(dos_header));
+        out_of_range_memory.add(base_address + nt_offset, &signature, sizeof(signature));
+        EXPECT_FALSE(pe_architecture_detector::detect_from_memory(out_of_range_memory, base_address, 0x1000).is_valid());
+    }
+
+    TEST(MinidumpMemoryModuleTest, RejectsAddressOverflow)
+    {
+        constexpr uint64_t base_address = std::numeric_limits<uint64_t>::max() - 128;
+        sparse_memory memory;
+        PEDosHeader_t dos_header{};
+        dos_header.e_magic = PEDosHeader_t::k_Magic;
+        dos_header.e_lfanew = 128;
+        memory.add(base_address, &dos_header, sizeof(dos_header));
+
+        const auto result = pe_architecture_detector::detect_from_memory(memory, base_address, 0x1000);
+
+        EXPECT_FALSE(result.is_valid());
+        EXPECT_EQ(memory.read_count(), 1u);
+    }
+} // namespace sogen::test

--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -159,7 +159,9 @@ namespace sogen
     pe_detection_result pe_architecture_detector::detect_from_memory(const memory_interface& memory, uint64_t base_address,
                                                                      uint64_t image_size)
     {
-        auto variant_result = winpe::get_pe_arch(memory, base_address, image_size);
+        auto variant_result = winpe::get_pe_arch([&](const uint64_t address, void* destination,
+                                                     const size_t size) { return memory.try_read_memory(address, destination, size); },
+                                                 base_address, image_size);
 
         if (std::holds_alternative<std::error_code>(variant_result))
         {

--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -156,9 +156,10 @@ namespace sogen
         return result;
     }
 
-    pe_detection_result pe_architecture_detector::detect_from_memory(uint64_t base_address, uint64_t image_size)
+    pe_detection_result pe_architecture_detector::detect_from_memory(const memory_interface& memory, uint64_t base_address,
+                                                                      uint64_t image_size)
     {
-        auto variant_result = winpe::get_pe_arch(base_address, image_size);
+        auto variant_result = winpe::get_pe_arch(memory, base_address, image_size);
 
         if (std::holds_alternative<std::error_code>(variant_result))
         {
@@ -555,7 +556,7 @@ namespace sogen
             }
         }
 
-        auto detection_result = pe_architecture_detector::detect_from_memory(base_address, image_size);
+        auto detection_result = pe_architecture_detector::detect_from_memory(*this->memory_, base_address, image_size);
 
         return map_module_core(
             detection_result,

--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -157,7 +157,7 @@ namespace sogen
     }
 
     pe_detection_result pe_architecture_detector::detect_from_memory(const memory_interface& memory, uint64_t base_address,
-                                                                      uint64_t image_size)
+                                                                     uint64_t image_size)
     {
         auto variant_result = winpe::get_pe_arch(memory, base_address, image_size);
 

--- a/src/windows-emulator/module/module_manager.hpp
+++ b/src/windows-emulator/module/module_manager.hpp
@@ -78,7 +78,7 @@ namespace sogen
     {
       public:
         static pe_detection_result detect_from_file(const std::filesystem::path& file);
-        static pe_detection_result detect_from_memory(uint64_t base_address, uint64_t image_size);
+        static pe_detection_result detect_from_memory(const memory_interface& memory, uint64_t base_address, uint64_t image_size);
         static execution_mode determine_execution_mode(winpe::pe_arch executable_arch);
     };
 


### PR DESCRIPTION
## Summary

Read PE header bytes from dump-backed module memory before detecting the PE architecture. This fixes module loading from minidumps, including sparse or unreadable header cases, using fixed-size header reads bounded by the image size.

## Related issue

https://github.com/momo5502/sogen/issues/1001