### PR TITLE
Assorted emulator fixes (split from audio work)

### DIFF
--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -77,6 +77,10 @@ namespace sogen
             {u"ConDrv\\Server"sv, create_dummy_device},
             // Generic
             {u"Console"sv, create_console_device},
+            // Multimedia Class Scheduler. avrt!AvSetMmThreadCharacteristics opens this to raise the audio
+            // render worker's scheduling priority; the emulator has no priority classes, so accepting the open
+            // and succeeding its ioctls is enough for the worker to proceed.
+            {u"MMCSS\\MmThread"sv, create_dummy_device},
             {u"Nsi"sv, create_network_store_interface},
             {u"MountPointManager"sv, create_mount_point_manager},
             {u"KsecDD"sv, create_security_support_provider},

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -560,6 +560,11 @@ namespace sogen
             window.processId = process_context::process_id;
         });
 
+        // Seed the shared foreground window with the desktop so the guest's client-side GetForegroundWindow
+        // never returns null before an app window activates (UI activation events later refine it).
+        this->user_handles.get_server_info().access(
+            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = this->default_desktop_window_handle.bits; });
+
         const auto create_shell_window = [&](const std::u16string_view class_name, const std::u16string_view title, const int32_t x,
                                              const int32_t y, const int32_t width, const int32_t height) {
             auto [handle, shell_win] = this->windows.create(win_emu.memory);

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -562,8 +562,9 @@ namespace sogen
 
         // Seed the shared foreground window with the desktop so the guest's client-side GetForegroundWindow
         // never returns null before an app window activates (UI activation events later refine it).
-        this->user_handles.get_server_info().access(
-            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = this->default_desktop_window_handle.bits; });
+        this->user_handles.get_server_info().access([&](USER_SERVERINFO& server_info) {
+            server_info.foregroundWindow = this->default_desktop_window_handle.bits; //
+        });
 
         const auto create_shell_window = [&](const std::u16string_view class_name, const std::u16string_view title, const int32_t x,
                                              const int32_t y, const int32_t width, const int32_t height) {

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -514,7 +514,7 @@ namespace sogen
         handle_store<handle_types::event, event> events{};
         handle_store<handle_types::file, file> files{};
         utils::insensitive_u16string_map<file_lock_ranges> file_locks{};
-        handle_store<handle_types::section, section> sections{};
+        handle_store<handle_types::section, section, 2> sections{};
         handle_store<handle_types::device, io_device_container> devices{};
         handle console_handle{};
         handle_store<handle_types::semaphore, semaphore> semaphores{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -255,6 +255,7 @@ namespace sogen
                                                   emulator_object<ALPC_MESSAGE_ATTRIBUTES>
                                                   /*receive_message_attributes*/,
                                                   emulator_object<LARGE_INTEGER> /*timeout*/);
+        NTSTATUS handle_NtAlpcDisconnectPort(const syscall_context& c, handle port_handle, ULONG flags);
         NTSTATUS handle_NtAlpcQueryInformation();
         NTSTATUS handle_NtAlpcSetInformation();
         NTSTATUS handle_NtAlpcCreateSecurityContext();
@@ -1431,6 +1432,7 @@ namespace sogen
         add_handler(NtAlpcCreatePort);
         add_handler(NtAlpcConnectPortEx);
         add_handler(NtAlpcConnectPort);
+        add_handler(NtAlpcDisconnectPort);
         add_handler(NtAlpcQueryInformation);
         add_handler(NtGetNextThread);
         add_handler(NtSetInformationObject);

--- a/src/windows-emulator/syscalls/port.cpp
+++ b/src/windows-emulator/syscalls/port.cpp
@@ -134,8 +134,6 @@ namespace sogen
 
         NTSTATUS handle_NtAlpcDisconnectPort(const syscall_context& c, const handle port_handle, const ULONG /*flags*/)
         {
-            // Tear down the ALPC connection. The handle itself is released separately via NtClose; just drop our
-            // port state if we track it.
             c.proc.ports.erase(port_handle);
             return STATUS_SUCCESS;
         }

--- a/src/windows-emulator/syscalls/port.cpp
+++ b/src/windows-emulator/syscalls/port.cpp
@@ -132,6 +132,14 @@ namespace sogen
                                             connection_message, buffer_length, out_message_attributes, in_message_attributes, timeout);
         }
 
+        NTSTATUS handle_NtAlpcDisconnectPort(const syscall_context& c, const handle port_handle, const ULONG /*flags*/)
+        {
+            // Tear down the ALPC connection. The handle itself is released separately via NtClose; just drop our
+            // port state if we track it.
+            c.proc.ports.erase(port_handle);
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtAlpcSendWaitReceivePort(const syscall_context& c, const handle port_handle, const ULONG /*flags*/,
                                                   const emulator_object<PORT_MESSAGE64> send_message,
                                                   const emulator_object<ALPC_MESSAGE_ATTRIBUTES>

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -268,12 +268,13 @@ namespace sogen
                 constexpr auto base_size = offsetof(KEY_VALUE_FULL_INFORMATION, Name);
                 const auto name_size = original_name.size() * 2;
                 const auto value_size = value->data.size();
-                const auto required_size = base_size + name_size + value_size + -1;
+                const auto required_size = base_size + name_size + value_size;
                 result_length.write(static_cast<ULONG>(required_size));
 
                 KEY_VALUE_FULL_INFORMATION info{};
                 info.TitleIndex = 0;
                 info.Type = value->type;
+                info.DataOffset = static_cast<ULONG>(base_size + name_size);
                 info.DataLength = static_cast<ULONG>(value->data.size());
                 info.NameLength = static_cast<ULONG>(original_name.size() * 2);
 

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -594,12 +594,7 @@ namespace sogen
                 return_length.write(required_size);
             }
 
-            if (buffer == 0)
-            {
-                return STATUS_INVALID_PARAMETER;
-            }
-
-            if (buffer_length < required_size)
+            if (buffer == 0 || buffer_length < required_size)
             {
                 return STATUS_BUFFER_TOO_SMALL;
             }

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1556,11 +1556,11 @@ namespace sogen
         // Fall back to the desktop window when no app window is active: real Windows always has a
         // foreground window, and code that needs a valid HWND (e.g. DirectSound's SetCooperativeLevel,
         // which Miles feeds from GetForegroundWindow) breaks on a null one.
-        const auto foreground = this->process.foreground_window != 0
-                                    ? this->process.foreground_window
-                                    : this->process.default_desktop_window_handle.bits;
-        this->process.user_handles.get_server_info().access(
-            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = foreground; });
+        const auto foreground =
+            this->process.foreground_window != 0 ? this->process.foreground_window : this->process.default_desktop_window_handle.bits;
+        this->process.user_handles.get_server_info().access([&](USER_SERVERINFO& server_info) {
+            server_info.foregroundWindow = foreground; //
+        });
 
         // Maintain the polled key state from key and mouse-button transitions. GetKeyState reports the high
         // down bit; GetAsyncKeyState also reports a low edge bit that is set once when a key transitions from

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1553,8 +1553,14 @@ namespace sogen
 
         // Mirror the foreground window into the shared SERVERINFO so the guest's client-side
         // GetForegroundWindow (which reads gpsi directly, never syscalling) returns the active window.
+        // Fall back to the desktop window when no app window is active: real Windows always has a
+        // foreground window, and code that needs a valid HWND (e.g. DirectSound's SetCooperativeLevel,
+        // which Miles feeds from GetForegroundWindow) breaks on a null one.
+        const auto foreground = this->process.foreground_window != 0
+                                    ? this->process.foreground_window
+                                    : this->process.default_desktop_window_handle.bits;
         this->process.user_handles.get_server_info().access(
-            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = this->process.foreground_window; });
+            [&](USER_SERVERINFO& server_info) { server_info.foregroundWindow = foreground; });
 
         // Maintain the polled key state from key and mouse-button transitions. GetKeyState reports the high
         // down bit; GetAsyncKeyState also reports a low edge bit that is set once when a key transitions from


### PR DESCRIPTION
A set of self-contained emulator fixes, split out of the WASAPI/DirectSound audio work (#1235) so they can land independently. Each was found while bringing audio up, but none of them depend on the audio code — they are general correctness fixes.

- **`NtQueryValueKey`: set `DataOffset` for `KeyValueFullInformation`** — the field was left unset, so callers that locate the value data through it (`GetComputerNameW`/`GetComputerNameExW` among others) read the struct header instead and saw an empty string. This unblocks rpcrt4's `RpcStringBindingComposeW`, and with it RPC binding for clients such as mmdevapi.

  The same commit also drops a stray `-1` from the reported `required_size`. That is a small out-of-bounds write fix, not just a cosmetic one: a buffer exactly one byte short of the true size passed the `required_size > length` guard, after which the handler still wrote `base_size + name_size + value_size` bytes — one byte past the caller's buffer.
- **4-align section handles** — rpcrt4's system-handle import requires section handle values to be 4-byte aligned; unaligned values were rejected. Uses the existing `handle_store` index shift, so encoding/decoding stay self-consistent.
- **Stub the MMCSS scheduler device** — `avrt!AvSetMmThreadCharacteristics` opens `\Device\MMCSS\MmThread` to raise a worker's scheduling priority. The emulator has no priority classes, so accepting the open and succeeding its ioctls lets the caller proceed instead of failing. Follows the existing `create_dummy_device` pattern.
- **Default the foreground window to the desktop** — the shared `SERVERINFO` foreground window started out null, so a client-side `GetForegroundWindow()` (which reads `gpsi` directly and never syscalls) returned null before any window activated. Callers that pass the result on — e.g. `IDirectSound::SetCooperativeLevel`, which Miles feeds from `GetForegroundWindow` — then failed with `E_INVALIDARG`. Seeded at construction and re-applied as a fallback on UI events, so a deactivation cannot re-null it.
- **`NtQuerySecurityAttributesToken`: report `BUFFER_TOO_SMALL` for size queries** — a null output buffer is how a caller asks for the required size, so it should be answered like any other undersized buffer rather than rejected as an invalid parameter.
- **Implement `NtAlpcDisconnectPort`** — the syscall was unimplemented, so a guest tearing down an ALPC connection terminated emulation.

## Verification

Builds clean; `analyzer -s test-sample.exe` smoke test passes; `clang-format` check clean.
