### PR TITLE
Match the native window creation message flow hierarchy

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -171,6 +171,9 @@ namespace sogen
 
 #define EMU_HWND_MESSAGE ((hwnd) - 3)
 
+#define SWP_NOCLIENTSIZE 0x0800
+#define SWP_NOCLIENTMOVE 0x1000
+
 #ifndef OS_WINDOWS
 #define MAXINTATOM                  0xC000
 
@@ -188,17 +191,26 @@ namespace sogen
 #define WS_MINIMIZEBOX              0x00020000L
 #define WS_MAXIMIZEBOX              0x00010000L
 
+#define WS_EX_NOPARENTNOTIFY        0x00000004L
+
 #define SWP_NOSIZE                  0x0001
 #define SWP_NOMOVE                  0x0002
+#define SWP_NOZORDER                0x0004
 #define SWP_NOREDRAW                0x0008
+#define SWP_NOACTIVATE              0x0010
 #define SWP_SHOWWINDOW              0x0040
 #define SWP_HIDEWINDOW              0x0080
+
+#define SW_SHOWNOACTIVATE           4
+#define SW_SHOWMINNOACTIVE          7
+#define SW_SHOWNA                   8
 
 #define WM_CREATE                   0x0001
 #define WM_DESTROY                  0x0002
 #define WM_MOVE                     0x0003
 #define WM_SIZE                     0x0005
 #define WM_ACTIVATE                 0x0006
+#define WM_ACTIVATEAPP              0x001C
 #define WM_SETFOCUS                 0x0007
 #define WM_KILLFOCUS                0x0008
 #define WM_QUIT                     0x0012
@@ -221,6 +233,7 @@ namespace sogen
 #define WM_SYSDEADCHAR              0x0107
 #define WM_UNICHAR                  0x0109
 #define WM_MOUSEMOVE                0x0200
+#define WM_PARENTNOTIFY             0x0210
 #define WM_LBUTTONDOWN              0x0201
 #define WM_LBUTTONUP                0x0202
 #define WM_LBUTTONDBLCLK            0x0203

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1305,6 +1305,79 @@ namespace
         return true;
     }
 
+    bool test_paint_message_queue()
+    {
+        WNDCLASSEXA wc = {};
+        wc.cbSize = sizeof(wc);
+        wc.lpszClassName = "TestPaintMsgQueueClass";
+        wc.hInstance = GetModuleHandleA(nullptr);
+        wc.lpfnWndProc = DefWindowProcA;
+
+        if (!RegisterClassExA(&wc))
+        {
+            puts("Failed to register paint window class");
+            return false;
+        }
+
+        const auto unregister_class = sogen::utils::finally([&] { UnregisterClassA(wc.lpszClassName, wc.hInstance); });
+
+        const HWND hwnd = CreateWindowExA(0, wc.lpszClassName, nullptr, WS_OVERLAPPEDWINDOW | WS_VISIBLE, 0, 0, 100, 100, nullptr, nullptr,
+                                          wc.hInstance, nullptr);
+        if (!hwnd)
+        {
+            puts("Failed to create paint window");
+            return false;
+        }
+
+        const auto destroy_window = sogen::utils::finally([&] { DestroyWindow(hwnd); });
+
+        UpdateWindow(hwnd);
+        RedrawWindow(hwnd, nullptr, nullptr, RDW_NOINTERNALPAINT | RDW_VALIDATE);
+        ValidateRect(hwnd, nullptr);
+
+        MSG msg = {};
+        while (PeekMessageA(&msg, hwnd, WM_PAINT, WM_PAINT, PM_REMOVE))
+        {
+            ValidateRect(hwnd, nullptr);
+        }
+
+        if (!RedrawWindow(hwnd, nullptr, nullptr, RDW_INTERNALPAINT))
+        {
+            puts("Failed to request internal paint");
+            return false;
+        }
+
+        if (!PeekMessageA(&msg, hwnd, WM_PAINT, WM_PAINT, PM_NOREMOVE))
+        {
+            puts("Internal WM_PAINT was not available");
+            return false;
+        }
+
+        if (PeekMessageA(&msg, hwnd, WM_PAINT, WM_PAINT, PM_NOREMOVE))
+        {
+            puts("PM_NOREMOVE did not consume internal WM_PAINT");
+            return false;
+        }
+
+        InvalidateRect(hwnd, nullptr, FALSE);
+        RedrawWindow(hwnd, nullptr, nullptr, RDW_INTERNALPAINT);
+
+        if (!PeekMessageA(&msg, hwnd, WM_PAINT, WM_PAINT, PM_REMOVE))
+        {
+            puts("Combined WM_PAINT was not available");
+            return false;
+        }
+
+        if (!PeekMessageA(&msg, hwnd, WM_PAINT, WM_PAINT, PM_NOREMOVE))
+        {
+            puts("PM_REMOVE consumed the invalid update region");
+            return false;
+        }
+
+        ValidateRect(hwnd, nullptr);
+        return true;
+    }
+
     bool test_private_namespace()
     {
         auto create_boundary_descriptor = [](const wchar_t* name) -> HANDLE {
@@ -1618,7 +1691,8 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_socket, "Socket")
     RUN_TEST(test_apc, "APC")
     RUN_TEST(test_user_callback, "User Callback")
-    RUN_TEST(test_message_queue, "Message Queue")
+    RUN_TEST(test_message_queue, "Message Queue (General)")
+    RUN_TEST(test_paint_message_queue, "Message Queue (Paint)")
     RUN_TEST(test_settimer, "User Timer")
     RUN_TEST(test_private_namespace, "Private Namespace")
     RUN_TEST(test_actctx, "Activation Context")

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -884,6 +884,32 @@ namespace sogen
         return std::nullopt;
     }
 
+    bool emulator_thread::remove_pending_message(const hwnd window, const UINT message)
+    {
+        const auto it = std::ranges::find_if(
+            this->message_queue, [window, message](const msg& queued) { return queued.window == window && queued.message == message; });
+        if (it == this->message_queue.end())
+        {
+            return false;
+        }
+
+        const auto removed_bits = get_message_queue_status_bits(*it);
+        for_each_queue_status_bit(removed_bits, [this](const uint32_t bit, const size_t index) {
+            if (this->message_queue_status_bit_counts[index] <= 1)
+            {
+                this->message_queue_status_bit_counts[index] = 0;
+                this->message_queue_status_bits &= ~bit;
+            }
+            else
+            {
+                --this->message_queue_status_bit_counts[index];
+            }
+        });
+
+        this->message_queue.erase(it);
+        return true;
+    }
+
     bool emulator_thread::can_coalesce_message(const msg& msg) const
     {
         if (message_queue.empty())

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -805,13 +805,22 @@ namespace sogen
             (void)this->synthesize_due_user_timer(win_emu);
         }
 
-        return this->message_queue_status_bits;
+        auto status = this->message_queue_status_bits;
+        const auto has_pending_paint = std::ranges::any_of(win_emu.process.windows, [this, &win_emu](const auto& entry) {
+            const auto& win = entry.second;
+            return win.thread_id == this->id && (win.update_pending || win.internal_paint_pending) &&
+                   win_emu.process.is_window_effectively_visible(win.handle);
+        });
+        if (has_pending_paint)
+        {
+            status |= QS_PAINT;
+        }
+
+        return status;
     }
 
     namespace
     {
-        // GetMessage(hWnd) retrieves messages for hWnd and all of its children (IsChild semantics),
-        // so a message targeted at a child control must match a filter naming any of its ancestors.
         bool window_matches_filter(const process_context& process, const hwnd target, const hwnd filter)
         {
             auto current = target;
@@ -881,33 +890,39 @@ namespace sogen
             return msg;
         }
 
-        return std::nullopt;
-    }
-
-    bool emulator_thread::remove_pending_message(const hwnd window, const UINT message)
-    {
-        const auto it = std::ranges::find_if(
-            this->message_queue, [window, message](const msg& queued) { return queued.window == window && queued.message == message; });
-        if (it == this->message_queue.end())
+        if ((filter_min == 0 && filter_max == 0) || (filter_min <= WM_PAINT && WM_PAINT <= filter_max))
         {
-            return false;
+            for (auto& [index, win] : win_emu.process.windows)
+            {
+                (void)index;
+                if (win.thread_id != this->id || (!win.update_pending && !win.internal_paint_pending) ||
+                    !win_emu.process.is_window_effectively_visible(win.handle))
+                {
+                    continue;
+                }
+
+                if (hwnd_filter == static_cast<hwnd>(-1))
+                {
+                    continue;
+                }
+                if (hwnd_filter != 0 && !window_matches_filter(win_emu.process, win.handle, hwnd_filter))
+                {
+                    continue;
+                }
+
+                win.internal_paint_pending = false;
+                return msg{
+                    .window = win.handle,
+                    .message = WM_PAINT,
+                    .wParam = 0,
+                    .lParam = 0,
+                    .time = get_current_message_time(win_emu.clock()),
+                    .pt = {.x = win_emu.process.cursor_x, .y = win_emu.process.cursor_y},
+                };
+            }
         }
 
-        const auto removed_bits = get_message_queue_status_bits(*it);
-        for_each_queue_status_bit(removed_bits, [this](const uint32_t bit, const size_t index) {
-            if (this->message_queue_status_bit_counts[index] <= 1)
-            {
-                this->message_queue_status_bit_counts[index] = 0;
-                this->message_queue_status_bits &= ~bit;
-            }
-            else
-            {
-                --this->message_queue_status_bit_counts[index];
-            }
-        });
-
-        this->message_queue.erase(it);
-        return true;
+        return std::nullopt;
     }
 
     bool emulator_thread::can_coalesce_message(const msg& msg) const

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -370,7 +370,6 @@ namespace sogen
         uint32_t get_message_queue_status(windows_emulator& win_emu);
         std::optional<msg> peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0,
                                                 bool remove = false);
-        bool remove_pending_message(hwnd window, UINT message);
         void post_message(windows_emulator& win_emu, msg msg, bool try_coalesce = false);
 
         bool is_terminated() const;

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -370,6 +370,7 @@ namespace sogen
         uint32_t get_message_queue_status(windows_emulator& win_emu);
         std::optional<msg> peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0,
                                                 bool remove = false);
+        bool remove_pending_message(hwnd window, UINT message);
         void post_message(windows_emulator& win_emu, msg msg, bool try_coalesce = false);
 
         bool is_terminated() const;

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -897,6 +897,27 @@ namespace sogen
         return nullptr;
     }
 
+    bool process_context::is_window_effectively_visible(const hwnd window) const
+    {
+        const auto* current = this->windows.get(window);
+        if (!current)
+        {
+            return false;
+        }
+
+        while (current)
+        {
+            if (current->message_only || (current->style & WS_VISIBLE) == 0)
+            {
+                return false;
+            }
+
+            current = current->parent_handle != 0 ? this->windows.get(current->parent_handle) : nullptr;
+        }
+
+        return true;
+    }
+
     // NOLINTNEXTLINE(cert-dcl50-cpp,readability-convert-member-functions-to-static)
     bool process_context::is_current_process_handle(const handle handle) const
     {

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -905,7 +905,7 @@ namespace sogen
             return false;
         }
 
-        while (current)
+        for (size_t guard = 0; current && guard < this->windows.size(); ++guard)
         {
             if (current->message_only || (current->style & WS_VISIBLE) == 0)
             {
@@ -915,7 +915,7 @@ namespace sogen
             current = current->parent_handle != 0 ? this->windows.get(current->parent_handle) : nullptr;
         }
 
-        return true;
+        return current == nullptr;
     }
 
     // NOLINTNEXTLINE(cert-dcl50-cpp,readability-convert-member-functions-to-static)

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -409,6 +409,7 @@ namespace sogen
         generic_handle_store* get_handle_store(handle handle);
         emulator_thread* find_thread_by_id(uint32_t thread_id);
         const emulator_thread* find_thread_by_id(uint32_t thread_id) const;
+        bool is_window_effectively_visible(hwnd window) const;
         bool is_current_process_handle(handle handle) const;
         bool is_current_thread_handle(handle handle, const emulator_thread* active_thread) const;
         bool is_object_pseudo_handle(handle handle) const;

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -48,11 +48,14 @@ namespace sogen
     struct window_create_state : completion_state
     {
         hwnd handle{};
+        hwnd parent_handle{};
 
         emulator_stack_allocation min_max_info_alloc{};
         emulator_stack_allocation window_rect_alloc{};
         emulator_stack_allocation create_struct_alloc{};
         emulator_stack_allocation window_pos_alloc{};
+        emulator_stack_allocation activation_window_pos_alloc{};
+        emulator_stack_allocation changed_window_pos_alloc{};
 
         std::vector<qmsg> message_queue{};
 
@@ -60,20 +63,26 @@ namespace sogen
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write(this->handle);
+            buffer.write(this->parent_handle);
             buffer.write(this->min_max_info_alloc);
             buffer.write(this->window_rect_alloc);
             buffer.write(this->create_struct_alloc);
             buffer.write(this->window_pos_alloc);
+            buffer.write(this->activation_window_pos_alloc);
+            buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read(this->handle);
+            buffer.read(this->parent_handle);
             buffer.read(this->min_max_info_alloc);
             buffer.read(this->window_rect_alloc);
             buffer.read(this->create_struct_alloc);
             buffer.read(this->window_pos_alloc);
+            buffer.read(this->activation_window_pos_alloc);
+            buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
         }
     };
@@ -89,40 +98,55 @@ namespace sogen
     struct window_destroy_frame
     {
         hwnd handle{};
+        hwnd parent_notify_handle{};
         emulator_stack_allocation window_pos_alloc{};
+        emulator_stack_allocation changed_window_pos_alloc{};
         std::vector<qmsg> message_queue{};
         window_destroy_phase phase{window_destroy_phase::messages};
+        bool unlink_pending{true};
 
         void serialize(utils::buffer_serializer& buffer) const
         {
             buffer.write(this->handle);
+            buffer.write(this->parent_notify_handle);
             buffer.write(this->window_pos_alloc);
+            buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
             buffer.write(this->phase);
+            buffer.write(this->unlink_pending);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
         {
             buffer.read(this->handle);
+            buffer.read(this->parent_notify_handle);
             buffer.read(this->window_pos_alloc);
+            buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
             buffer.read(this->phase);
+            buffer.read(this->unlink_pending);
         }
     };
 
     struct window_destroy_state : completion_state
     {
         std::vector<window_destroy_frame> frames{};
+        std::vector<window_destroy_frame> nc_destroy_frames{};
+        uint32_t nc_destroy_index{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write_vector(this->frames);
+            buffer.write_vector(this->nc_destroy_frames);
+            buffer.write(this->nc_destroy_index);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read_vector(this->frames);
+            buffer.read_vector(this->nc_destroy_frames);
+            buffer.read(this->nc_destroy_index);
         }
     };
 
@@ -130,6 +154,8 @@ namespace sogen
     {
         bool was_visible{};
         emulator_stack_allocation window_pos_alloc{};
+        emulator_stack_allocation activation_window_pos_alloc{};
+        emulator_stack_allocation changed_window_pos_alloc{};
         std::vector<qmsg> message_queue{};
 
       private:
@@ -137,6 +163,8 @@ namespace sogen
         {
             buffer.write(this->was_visible);
             buffer.write(this->window_pos_alloc);
+            buffer.write(this->activation_window_pos_alloc);
+            buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
         }
 
@@ -144,6 +172,8 @@ namespace sogen
         {
             buffer.read(this->was_visible);
             buffer.read(this->window_pos_alloc);
+            buffer.read(this->activation_window_pos_alloc);
+            buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
         }
     };

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2989,10 +2989,6 @@ namespace sogen
             {
                 state.message_queue.push_back({.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address()});
             }
-            else if (notify_parent)
-            {
-                state.parent_handle = parent_win->handle;
-            }
 
             if ((style & WS_VISIBLE) != 0)
             {

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -901,20 +901,6 @@ namespace sogen
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
         }
 
-        void release_window_create_allocations(const syscall_context& c, window_create_state& state)
-        {
-            if (state.window_pos_alloc)
-            {
-                c.emu.pop_stack(state.changed_window_pos_alloc);
-                c.emu.pop_stack(state.activation_window_pos_alloc);
-                c.emu.pop_stack(state.window_pos_alloc);
-            }
-
-            c.emu.pop_stack(state.min_max_info_alloc);
-            c.emu.pop_stack(state.window_rect_alloc);
-            c.emu.pop_stack(state.create_struct_alloc);
-        }
-
         BOOL advance_window_destroy(const syscall_context& c, window_destroy_state& state)
         {
             window_destroy_orchestrator orchestrator{state, c};
@@ -3107,9 +3093,22 @@ namespace sogen
             auto& s = c.get_completion_state<window_create_state>();
             const auto* win = c.proc.windows.get(s.handle);
 
+            const auto release_window_create_allocations = [&] {
+                if (s.window_pos_alloc)
+                {
+                    c.emu.pop_stack(s.changed_window_pos_alloc);
+                    c.emu.pop_stack(s.activation_window_pos_alloc);
+                    c.emu.pop_stack(s.window_pos_alloc);
+                }
+
+                c.emu.pop_stack(s.min_max_info_alloc);
+                c.emu.pop_stack(s.window_rect_alloc);
+                c.emu.pop_stack(s.create_struct_alloc);
+            };
+
             if (!win)
             {
-                release_window_create_allocations(c, s);
+                release_window_create_allocations();
                 return 0;
             }
 
@@ -3131,7 +3130,7 @@ namespace sogen
                 return {};
             }
 
-            release_window_create_allocations(c, s);
+            release_window_create_allocations();
 
             return s.handle;
         }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -322,6 +322,12 @@ namespace sogen
             set_thread_window_context(c, active_handle, active_window_ptr);
         }
 
+        bool is_application_active(const syscall_context& c)
+        {
+            const auto* foreground = c.proc.windows.get(c.proc.foreground_window);
+            return foreground != nullptr && !foreground->message_only;
+        }
+
         void set_user_handle_owner(const syscall_context& c, const handle h, const uint64_t owner)
         {
             if (owner == 0)
@@ -890,6 +896,20 @@ namespace sogen
             message_queue.pop_back();
 
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
+        }
+
+        void release_window_create_allocations(const syscall_context& c, window_create_state& state)
+        {
+            if (state.window_pos_alloc)
+            {
+                c.emu.pop_stack(state.changed_window_pos_alloc);
+                c.emu.pop_stack(state.activation_window_pos_alloc);
+                c.emu.pop_stack(state.window_pos_alloc);
+            }
+
+            c.emu.pop_stack(state.min_max_info_alloc);
+            c.emu.pop_stack(state.window_rect_alloc);
+            c.emu.pop_stack(state.create_struct_alloc);
         }
 
         BOOL advance_window_destroy(const syscall_context& c, window_destroy_state& state)
@@ -2764,6 +2784,7 @@ namespace sogen
             win.height = height;
             win.thread_id = c.thread().id;
             win.handle = handle.bits;
+            win.message_only = is_message_only;
             // Record the owning thread in the shared handle entry so client-side GetWindowThreadProcessId works.
             c.proc.user_handles.set_owner(static_cast<uint32_t>(handle.value.id), win.thread_id);
             if (!is_message_only)
@@ -2942,6 +2963,7 @@ namespace sogen
 
             window_create_state state{};
             state.handle = handle.bits;
+            state.parent_handle = has_child_parent && parent_win ? parent_win->handle : 0;
 
             EMU_CREATESTRUCT cs{};
             cs.lpCreateParams = l_param;
@@ -2970,38 +2992,94 @@ namespace sogen
                 {.message = WM_CREATE, .wParam = 0, .lParam = state.create_struct_alloc.address()},
                 {.message = WM_NCCALCSIZE, .wParam = 0, .lParam = state.window_rect_alloc.address()},
                 {.message = WM_NCCREATE, .wParam = 0, .lParam = state.create_struct_alloc.address()},
-                {.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address()},
             };
+            const bool notify_parent = has_child_parent && (ex_style & WS_EX_NOPARENTNOTIFY) == 0;
+            const auto parent_notify_wparam = static_cast<uint64_t>(WM_CREATE) | (static_cast<uint64_t>(menu & 0xFFFF) << 16);
+            if (!has_child_parent)
+            {
+                state.message_queue.push_back({.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address()});
+            }
+            else if (notify_parent)
+            {
+                state.parent_handle = parent_win->handle;
+            }
 
             if ((style & WS_VISIBLE) != 0)
             {
                 invalidate_window(c, win);
 
-                EMU_WINDOWPOS wp{};
-                wp.hwnd = handle.bits;
-                wp.hwndInsertAfter = 0;
-                wp.x = x;
-                wp.y = y;
-                wp.cx = width;
-                wp.cy = height;
-                wp.flags = SWP_SHOWWINDOW;
-                state.window_pos_alloc = c.emu.push_stack(wp);
-
                 const auto move_lparam = static_cast<uint64_t>(((y & 0xFFFF) << 16) | (x & 0xFFFF));
                 const auto size_lparam = static_cast<uint64_t>(((height & 0xFFFF) << 16) | (width & 0xFFFF));
 
-                const std::initializer_list<qmsg> sw_messages = {
-                    {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
-                    {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
-                    {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
-                    {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_SHOWWINDOW, .wParam = 1, .lParam = 0},
-                };
-                state.message_queue.insert(state.message_queue.begin(), sw_messages);
+                if (has_child_parent)
+                {
+                    std::vector<qmsg> child_messages{{.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0}};
+                    if (notify_parent)
+                    {
+                        child_messages.push_back({.message = WM_PARENTNOTIFY, .wParam = parent_notify_wparam, .lParam = handle.bits});
+                    }
+                    child_messages.push_back({.message = WM_MOVE, .wParam = 0, .lParam = move_lparam});
+                    child_messages.push_back({.message = WM_SIZE, .wParam = 0, .lParam = size_lparam});
+                    state.message_queue.insert(state.message_queue.begin(), child_messages.begin(), child_messages.end());
+                }
+                else
+                {
+                    const EMU_WINDOWPOS show_position{
+                        .hwnd = handle.bits,
+                        .hwndInsertAfter = 0,
+                        .x = 0,
+                        .y = 0,
+                        .cx = 0,
+                        .cy = 0,
+                        .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW,
+                    };
+                    const EMU_WINDOWPOS activation_position{
+                        .hwnd = handle.bits,
+                        .hwndInsertAfter = 0,
+                        .x = 0,
+                        .y = 0,
+                        .cx = 0,
+                        .cy = 0,
+                        .flags = SWP_NOMOVE | SWP_NOSIZE,
+                    };
+                    const EMU_WINDOWPOS changed_position{
+                        .hwnd = handle.bits,
+                        .hwndInsertAfter = 0,
+                        .x = x,
+                        .y = y,
+                        .cx = width,
+                        .cy = height,
+                        .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
+                    };
+                    state.window_pos_alloc = c.emu.push_stack(show_position);
+                    state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
+                    state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
+
+                    std::vector<qmsg> show_messages = {
+                        {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
+                        {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
+                        {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
+                        {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
+                        {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
+                        {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
+                    };
+                    if (!is_message_only && !is_application_active(c))
+                    {
+                        show_messages.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
+                    }
+                    const std::initializer_list<qmsg> position_messages = {
+                        {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.activation_window_pos_alloc.address()},
+                        {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                        {.message = WM_SHOWWINDOW, .wParam = 1, .lParam = 0},
+                    };
+                    show_messages.insert(show_messages.end(), position_messages);
+                    state.message_queue.insert(state.message_queue.begin(), show_messages.begin(), show_messages.end());
+                }
+            }
+            else if (notify_parent)
+            {
+                state.message_queue.insert(state.message_queue.begin(),
+                                           {.message = WM_PARENTNOTIFY, .wParam = parent_notify_wparam, .lParam = handle.bits});
             }
 
             if (c.win_emu.callbacks.on_generic_activity)
@@ -3025,20 +3103,31 @@ namespace sogen
             auto& s = c.get_completion_state<window_create_state>();
             const auto* win = c.proc.windows.get(s.handle);
 
+            if (!win)
+            {
+                release_window_create_allocations(c, s);
+                return 0;
+            }
+
             if (!s.message_queue.empty())
             {
+                const auto& next = s.message_queue.back();
+                if (next.message == WM_PARENTNOTIFY)
+                {
+                    const auto* parent_win = c.proc.windows.get(s.parent_handle);
+                    if (parent_win)
+                    {
+                        dispatch_next_message(c, callback_id::NtUserCreateWindowEx, std::move(s), *parent_win, s.message_queue);
+                        return {};
+                    }
+                    s.message_queue.pop_back();
+                }
+
                 dispatch_next_message(c, callback_id::NtUserCreateWindowEx, std::move(s), *win, s.message_queue);
                 return {};
             }
 
-            if (s.window_pos_alloc)
-            {
-                c.emu.pop_stack(s.window_pos_alloc);
-            }
-
-            c.emu.pop_stack(s.min_max_info_alloc);
-            c.emu.pop_stack(s.window_rect_alloc);
-            c.emu.pop_stack(s.create_struct_alloc);
+            release_window_create_allocations(c, s);
 
             return s.handle;
         }
@@ -3181,6 +3270,7 @@ namespace sogen
 
             const bool want_visible = (cmd_show != 0); // SW_HIDE
             const bool was_visible = (win->style & WS_VISIBLE) != 0;
+            const bool activate_window = cmd_show != SW_SHOWNOACTIVATE && cmd_show != SW_SHOWMINNOACTIVE && cmd_show != SW_SHOWNA;
 
             if (want_visible == was_visible)
             {
@@ -3190,15 +3280,28 @@ namespace sogen
             window_show_state state{};
             state.was_visible = was_visible;
 
-            EMU_WINDOWPOS wp{};
-            wp.hwnd = hwnd;
-            wp.hwndInsertAfter = 0;
-            wp.x = win->x;
-            wp.y = win->y;
-            wp.cx = win->width;
-            wp.cy = win->height;
-            wp.flags = want_visible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW;
-            state.window_pos_alloc = c.emu.push_stack(wp);
+            const auto visibility_flags = static_cast<uint32_t>(want_visible ? SWP_SHOWWINDOW | (activate_window ? 0 : SWP_NOACTIVATE)
+                                                                             : SWP_HIDEWINDOW | SWP_NOZORDER | SWP_NOACTIVATE);
+            const EMU_WINDOWPOS changing_position{
+                .hwnd = hwnd,
+                .hwndInsertAfter = 0,
+                .x = 0,
+                .y = 0,
+                .cx = 0,
+                .cy = 0,
+                .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags,
+            };
+            const EMU_WINDOWPOS changed_position{
+                .hwnd = hwnd,
+                .hwndInsertAfter = 0,
+                .x = win->x,
+                .y = win->y,
+                .cx = win->width,
+                .cy = win->height,
+                .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
+            };
+            state.window_pos_alloc = c.emu.push_stack(changing_position);
+            state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
 
             if (win->host_surface_window)
             {
@@ -3217,14 +3320,41 @@ namespace sogen
                 state.message_queue = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                     {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
-                    {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
-                    {.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
+                };
+
+                if (activate_window)
+                {
+                    const EMU_WINDOWPOS activation_position{
+                        .hwnd = hwnd,
+                        .hwndInsertAfter = 0,
+                        .x = 0,
+                        .y = 0,
+                        .cx = 0,
+                        .cy = 0,
+                        .flags = SWP_NOMOVE | SWP_NOSIZE,
+                    };
+                    state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
+
+                    state.message_queue.push_back({.message = WM_SETFOCUS, .wParam = 0, .lParam = 0});
+                    state.message_queue.push_back({.message = WM_ACTIVATE, .wParam = 1, .lParam = 0});
+                    state.message_queue.push_back({.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0});
+                    if (!win->message_only && !is_application_active(c))
+                    {
+                        state.message_queue.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
+                    }
+                    state.message_queue.push_back({
+                        .message = WM_WINDOWPOSCHANGING,
+                        .wParam = 0,
+                        .lParam = state.activation_window_pos_alloc.address(),
+                    });
+                }
+
+                const std::initializer_list<qmsg> show_messages = {
                     {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0},
                 };
+                state.message_queue.insert(state.message_queue.end(), show_messages);
 
                 win->style |= WS_VISIBLE;
             }
@@ -3234,7 +3364,7 @@ namespace sogen
                     {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
                     {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                     {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
                     {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = FALSE, .lParam = 0},
                 };
@@ -3268,6 +3398,11 @@ namespace sogen
                 return {};
             }
 
+            if (s.activation_window_pos_alloc)
+            {
+                c.emu.pop_stack(s.activation_window_pos_alloc);
+            }
+            c.emu.pop_stack(s.changed_window_pos_alloc);
             c.emu.pop_stack(s.window_pos_alloc);
 
             return s.was_visible ? TRUE : FALSE;
@@ -3592,6 +3727,7 @@ namespace sogen
             {
                 if (auto* win = c.proc.windows.get(static_cast<hwnd>(state.pending.back())))
                 {
+                    c.thread().remove_pending_message(win->handle, WM_PAINT);
                     // Painting continues asynchronously through completion_NtUserUpdateWindow; the guest is
                     // suspended here, so this immediate return value is unused (matches handle_NtUserShowWindow).
                     dispatch_window_message(c, callback_id::NtUserUpdateWindow, std::move(state), *win, WM_PAINT);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -394,20 +394,6 @@ namespace sogen
             }
         }
 
-        void queue_window_paint(const syscall_context& c, window& win)
-        {
-            if (win.paint_message_posted)
-            {
-                return;
-            }
-
-            if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
-            {
-                thread->post_message(c.win_emu, msg{.window = win.handle, .message = WM_PAINT, .wParam = 0, .lParam = 0});
-                win.paint_message_posted = true;
-            }
-        }
-
         RECT union_update_rect(const RECT& a, const RECT& b)
         {
             const auto empty_rect = [](const RECT& r) { //
@@ -454,7 +440,25 @@ namespace sogen
                 c.win_emu.ui().invalidate(win.handle, update_rect);
             }
 
-            queue_window_paint(c, win);
+            if (c.proc.is_window_effectively_visible(win.handle))
+            {
+                if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
+                {
+                    thread->queue_status_changed_bits |= QS_PAINT;
+                }
+            }
+        }
+
+        void set_internal_paint_pending(const syscall_context& c, window& win, const bool pending)
+        {
+            win.internal_paint_pending = pending;
+            if (pending && c.proc.is_window_effectively_visible(win.handle))
+            {
+                if (auto* thread = c.proc.find_thread_by_id(win.thread_id))
+                {
+                    thread->queue_status_changed_bits |= QS_PAINT;
+                }
+            }
         }
 
         // Invalidate a window together with its visible descendant controls. Used when a window
@@ -731,7 +735,6 @@ namespace sogen
         void validate_window(window& win)
         {
             win.update_pending = false;
-            win.paint_message_posted = false;
             win.erase_pending = false;
             win.update_rect = {};
         }
@@ -2003,7 +2006,7 @@ namespace sogen
 
         hdc handle_NtUserBeginPaint(const syscall_context& c, const hwnd window, const emulator_object<EMU_PAINTSTRUCT> paint_struct)
         {
-            const auto* win = c.proc.windows.get(window);
+            auto* win = c.proc.windows.get(window);
             if (!win)
             {
                 return 0;
@@ -2020,12 +2023,14 @@ namespace sogen
                 EMU_PAINTSTRUCT ps{};
                 ps.paint_hdc = dc;
                 ps.fErase = win->erase_pending ? TRUE : FALSE;
-                ps.rcPaint = win->update_pending ? win->update_rect : get_client_rect(*win);
+                ps.rcPaint = win->update_pending ? win->update_rect : RECT{};
                 ps.fRestore = FALSE;
                 ps.fIncUpdate = FALSE;
                 paint_struct.write(ps);
             }
 
+            validate_window(*win);
+            win->internal_paint_pending = false;
             return dc;
         }
 
@@ -2061,7 +2066,6 @@ namespace sogen
                 (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(ps.paint_hdc));
             }
 
-            validate_window(*win);
             return TRUE;
         }
 
@@ -3510,7 +3514,6 @@ namespace sogen
                 {
                     (void)handle_NtGdiFlush(c);
                     present_existing_guest_window_surface(c, *win);
-                    validate_window(*win);
                 }
             }
 
@@ -3706,6 +3709,11 @@ namespace sogen
 
         void collect_pending_paint_tree(const syscall_context& c, window& win, std::vector<uint64_t>& order)
         {
+            if (!c.proc.is_window_effectively_visible(win.handle))
+            {
+                return;
+            }
+
             if (win.update_pending && win.thread_id == c.vcpu.active_thread->id)
             {
                 order.push_back(static_cast<uint64_t>(win.handle));
@@ -3714,7 +3722,7 @@ namespace sogen
             for (auto& [index, child] : c.proc.windows)
             {
                 (void)index;
-                if (child.parent_handle == win.handle && (child.style & WS_VISIBLE) != 0)
+                if (child.parent_handle == win.handle)
                 {
                     collect_pending_paint_tree(c, child, order);
                 }
@@ -3727,9 +3735,6 @@ namespace sogen
             {
                 if (auto* win = c.proc.windows.get(static_cast<hwnd>(state.pending.back())))
                 {
-                    c.thread().remove_pending_message(win->handle, WM_PAINT);
-                    // Painting continues asynchronously through completion_NtUserUpdateWindow; the guest is
-                    // suspended here, so this immediate return value is unused (matches handle_NtUserShowWindow).
                     dispatch_window_message(c, callback_id::NtUserUpdateWindow, std::move(state), *win, WM_PAINT);
                     return {};
                 }
@@ -3746,16 +3751,8 @@ namespace sogen
                 return FALSE;
             }
 
-            // UpdateWindow paints synchronously, bypassing the message queue. Apps such as the open-iw5 splash
-            // rely on this to display content without running a message loop, so a merely queued WM_PAINT would
-            // never be pumped. Dispatch WM_PAINT now to the window and its invalid visible child controls.
-            // Cross-thread windows cannot be painted on this thread, so fall back to posting the paint.
             if (win->thread_id != c.vcpu.active_thread->id)
             {
-                if (win->update_pending)
-                {
-                    queue_window_paint(c, *win);
-                }
                 return TRUE;
             }
 
@@ -3785,7 +3782,6 @@ namespace sogen
                 {
                     (void)handle_NtGdiFlush(c);
                     present_existing_guest_window_surface(c, *win);
-                    validate_window(*win);
                 }
             }
 
@@ -4551,7 +4547,7 @@ namespace sogen
                 validate_window(*win);
             }
 
-            if ((flags & (RDW_INVALIDATE | RDW_INTERNALPAINT)) != 0)
+            if ((flags & RDW_INVALIDATE) != 0)
             {
                 std::optional<RECT> rect{};
                 if (update_rect)
@@ -4562,9 +4558,14 @@ namespace sogen
                 invalidate_window(c, *win, rect, (flags & RDW_ERASE) != 0 && (flags & RDW_NOERASE) == 0);
             }
 
+            if ((flags & RDW_INTERNALPAINT) != 0)
+            {
+                set_internal_paint_pending(c, *win, true);
+            }
+
             if ((flags & RDW_NOINTERNALPAINT) != 0)
             {
-                win->paint_message_posted = false;
+                set_internal_paint_pending(c, *win, false);
             }
 
             return TRUE;

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -16,7 +16,7 @@ namespace sogen
 
     void window_destroy_orchestrator::start(window& root) const
     {
-        this->push_frame(root);
+        this->push_frame(root, true);
     }
 
     std::optional<window_destroy_step> window_destroy_orchestrator::advance() const
@@ -32,11 +32,18 @@ namespace sogen
                 continue;
             }
 
+            if (frame.unlink_pending && (frame.message_queue.empty() || frame.message_queue.back().message != WM_PARENTNOTIFY))
+            {
+                this->unlink_window_from_parent_and_siblings(*win);
+                frame.unlink_pending = false;
+            }
+
             if (!frame.message_queue.empty())
             {
                 const auto m = frame.message_queue.back();
                 frame.message_queue.pop_back();
-                return window_destroy_step{.handle = frame.handle, .message = m};
+                const auto target = m.message == WM_PARENTNOTIFY ? frame.parent_notify_handle : frame.handle;
+                return window_destroy_step{.handle = target, .message = m};
             }
 
             switch (frame.phase)
@@ -53,24 +60,48 @@ namespace sogen
                 {
                     if (auto* dependent_win = this->proc_.windows.get(dependent))
                     {
-                        this->push_frame(*dependent_win);
+                        this->push_frame(*dependent_win, false);
                     }
                 }
                 continue;
             }
 
             case window_destroy_phase::nc_destroy:
-                frame.phase = window_destroy_phase::finalize;
-                frame.message_queue = {{.message = WM_NCDESTROY, .wParam = 0, .lParam = 0}};
+                this->state_.nc_destroy_frames.push_back(std::move(frame));
+                this->state_.frames.pop_back();
                 continue;
 
             case window_destroy_phase::finalize:
-                this->finalize_frame(frame, *win);
-                this->state_.frames.pop_back();
-                continue;
+                throw std::runtime_error("Invalid window destruction phase");
             }
         }
 
+        while (this->state_.nc_destroy_index < this->state_.nc_destroy_frames.size())
+        {
+            auto& frame = this->state_.nc_destroy_frames[this->state_.nc_destroy_index];
+            auto* win = this->proc_.windows.get(frame.handle);
+            if (!win || win->thread_id != this->thread_.id)
+            {
+                this->pop_frame_allocation(frame);
+                ++this->state_.nc_destroy_index;
+                continue;
+            }
+
+            if (frame.phase == window_destroy_phase::nc_destroy)
+            {
+                frame.phase = window_destroy_phase::finalize;
+                return window_destroy_step{
+                    .handle = frame.handle,
+                    .message = {.message = WM_NCDESTROY, .wParam = 0, .lParam = 0},
+                };
+            }
+
+            this->finalize_frame(frame, *win);
+            ++this->state_.nc_destroy_index;
+        }
+
+        this->state_.nc_destroy_frames.clear();
+        this->state_.nc_destroy_index = 0;
         return std::nullopt;
     }
 
@@ -139,30 +170,52 @@ namespace sogen
         }
     }
 
-    window_destroy_frame window_destroy_orchestrator::make_frame(const window& win) const
+    window_destroy_frame window_destroy_orchestrator::make_frame(const window& win, const bool is_direct_target) const
     {
         window_destroy_frame frame{};
         frame.handle = win.handle;
 
-        if ((win.style & WS_VISIBLE) != 0)
+        if (is_direct_target && (win.style & WS_VISIBLE) != 0)
         {
-            EMU_WINDOWPOS wp{};
-            wp.hwnd = win.handle;
-            wp.hwndInsertAfter = 0;
-            wp.x = win.x;
-            wp.y = win.y;
-            wp.cx = win.width;
-            wp.cy = win.height;
-            wp.flags = SWP_HIDEWINDOW;
-            frame.window_pos_alloc = this->emu_.push_stack(wp);
+            const auto flags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_HIDEWINDOW;
+            const EMU_WINDOWPOS changing_position{
+                .hwnd = win.handle,
+                .hwndInsertAfter = 0,
+                .x = 0,
+                .y = 0,
+                .cx = 0,
+                .cy = 0,
+                .flags = flags,
+            };
+            const EMU_WINDOWPOS changed_position{
+                .hwnd = win.handle,
+                .hwndInsertAfter = 0,
+                .x = win.x,
+                .y = win.y,
+                .cx = win.width,
+                .cy = win.height,
+                .flags = flags | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
+            };
+            frame.window_pos_alloc = this->emu_.push_stack(changing_position);
+            frame.changed_window_pos_alloc = this->emu_.push_stack(changed_position);
 
             frame.message_queue = {
                 {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
                 {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
+            };
+            const std::initializer_list<qmsg> hide_messages = {
                 {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                 {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.window_pos_alloc.address()},
+                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.changed_window_pos_alloc.address()},
                 {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = frame.window_pos_alloc.address()},
+                {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
+            };
+            frame.message_queue.insert(frame.message_queue.end(), hide_messages);
+        }
+        else if (is_direct_target)
+        {
+            frame.message_queue = {
+                {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
                 {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
             };
         }
@@ -170,21 +223,35 @@ namespace sogen
         {
             frame.message_queue = {
                 {.message = WM_DESTROY, .wParam = 0, .lParam = 0},
-                {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
             };
+        }
+
+        if ((win.style & WS_CHILD) != 0 && (win.ex_style & WS_EX_NOPARENTNOTIFY) == 0)
+        {
+            uint64_t child_id{};
+            win.guest.access([&](const USER_WINDOW& guest_win) { child_id = guest_win.wID; });
+            frame.parent_notify_handle = win.parent_handle;
+            frame.message_queue.push_back({
+                .message = WM_PARENTNOTIFY,
+                .wParam = static_cast<uint64_t>(WM_DESTROY) | (static_cast<uint64_t>(child_id & 0xFFFF) << 16),
+                .lParam = win.handle,
+            });
         }
 
         return frame;
     }
 
-    void window_destroy_orchestrator::push_frame(const window& win) const
+    void window_destroy_orchestrator::push_frame(const window& win, const bool is_direct_target) const
     {
-        this->unlink_window_from_parent_and_siblings(win);
-        this->state_.frames.push_back(this->make_frame(win));
+        this->state_.frames.push_back(this->make_frame(win, is_direct_target));
     }
 
     void window_destroy_orchestrator::pop_frame_allocation(window_destroy_frame& frame) const
     {
+        if (frame.changed_window_pos_alloc)
+        {
+            this->emu_.pop_stack(frame.changed_window_pos_alloc);
+        }
         if (frame.window_pos_alloc)
         {
             this->emu_.pop_stack(frame.window_pos_alloc);

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -31,8 +31,8 @@ namespace sogen
       private:
         hwnd find_window_by_guest_pointer(uint64_t window_ptr) const;
         void unlink_window_from_parent_and_siblings(const window& win) const;
-        window_destroy_frame make_frame(const window& win) const;
-        void push_frame(const window& win) const;
+        window_destroy_frame make_frame(const window& win, bool is_direct_target) const;
+        void push_frame(const window& win, bool is_direct_target) const;
         void pop_frame_allocation(window_destroy_frame& frame) const;
         std::vector<hwnd> collect_dependents(const window& win) const;
         void finalize_frame(window_destroy_frame& frame, const window& win) const;

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -160,6 +160,7 @@ namespace sogen
         emulator_pointer wnd_proc{};
         hmenu system_menu_handle{};
         bool host_surface_window{};
+        bool message_only{};
         bool unicode_proc{};
 
         window(memory_interface& memory)
@@ -216,6 +217,7 @@ namespace sogen
             buffer.write(this->wnd_proc);
             buffer.write(this->system_menu_handle);
             buffer.write(this->host_surface_window);
+            buffer.write(this->message_only);
             buffer.write(this->unicode_proc);
         }
 
@@ -242,6 +244,7 @@ namespace sogen
             buffer.read(this->wnd_proc);
             buffer.read(this->system_menu_handle);
             buffer.read(this->host_surface_window);
+            buffer.read(this->message_only);
             buffer.read(this->unicode_proc);
         }
     };

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -13,6 +13,7 @@
 
 namespace sogen
 {
+
     struct timer : ref_counted_object
     {
         std::u16string name{};

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -13,7 +13,6 @@
 
 namespace sogen
 {
-
     struct timer : ref_counted_object
     {
         std::u16string name{};
@@ -154,7 +153,7 @@ namespace sogen
         uint32_t style{};
         RECT update_rect{};
         bool update_pending{};
-        bool paint_message_posted{};
+        bool internal_paint_pending{};
         bool erase_pending{};
         std::map<std::u16string, uint64_t> props{};
         emulator_pointer wnd_proc{};
@@ -211,7 +210,7 @@ namespace sogen
             buffer.write(this->style);
             buffer.write(this->update_rect);
             buffer.write(this->update_pending);
-            buffer.write(this->paint_message_posted);
+            buffer.write(this->internal_paint_pending);
             buffer.write(this->erase_pending);
             buffer.write_map(this->props);
             buffer.write(this->wnd_proc);
@@ -238,7 +237,7 @@ namespace sogen
             buffer.read(this->style);
             buffer.read(this->update_rect);
             buffer.read(this->update_pending);
-            buffer.read(this->paint_message_posted);
+            buffer.read(this->internal_paint_pending);
             buffer.read(this->erase_pending);
             buffer.read_map(this->props);
             buffer.read(this->wnd_proc);


### PR DESCRIPTION
This PR improves the Windows emulator’s window-message behavior, bringing it closer to native Win32 semantics through several key fixes:

* It distinguishes child, top-level, and message-only windows during creation and visibility changes:

  * Child windows no longer receive top-level-only messages.
  * Visible child windows now receive child-specific creation messages.
  * Parents are notified through `WM_PARENTNOTIFY` on child creation.

* It reworks paint scheduling around pending invalidation and internal-paint state:

  * `WM_PAINT` is synthesized during message retrieval instead of being persistently posted.
  * Queue-status handling reports paint work only for effectively visible windows.
  * Visibility checks now account for hidden ancestors.
  * `BeginPaint` validates the update region and clears internal-paint state.

* It refines the messages dispatched during creation and show/hide transitions:

  * `WINDOWPOS` values and `SWP_*` flags now more closely match native behavior.
  * Non-message-only windows now receive `WM_ACTIVATEAPP` during activation and deactivation.

* It makes recursive destruction more faithful to native behavior:

  * The full hide and deactivation sequence is limited to the directly destroyed window.
  * Dependent windows receive `WM_DESTROY` without the top-level hide sequence.
  * `WM_DESTROY` is delivered across the hierarchy before `WM_NCDESTROY`.
