### PR TITLE
Fixes for WOW64 callbacks

### DIFF
--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -127,6 +127,17 @@ namespace sogen
         uint32_t flags;
     };
 
+    struct EMU_WINDOWPOS32
+    {
+        uint32_t hwnd;
+        uint32_t hwndInsertAfter;
+        int x;
+        int y;
+        int cx;
+        int cy;
+        uint32_t flags;
+    };
+
     struct EMU_CREATESTRUCT
     {
         pointer lpCreateParams;

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1378,6 +1378,96 @@ namespace
         return true;
     }
 
+    bool test_mutable_callbacks()
+    {
+        struct test_state
+        {
+            int changing_count{};
+            int size_width{};
+            int size_height{};
+            UINT changed_flags{};
+            bool mutate{true};
+            bool saw_size{};
+            bool saw_changed{};
+        };
+
+        thread_local test_state* active_state{};
+        test_state state{};
+        active_state = &state;
+
+        WNDCLASSEXA wc{};
+        wc.cbSize = sizeof(wc);
+        wc.lpszClassName = "TestMutMsgQueueClass";
+        wc.hInstance = GetModuleHandleA(nullptr);
+        wc.lpfnWndProc = [](HWND hwnd, const UINT msg, const WPARAM wp, const LPARAM lp) -> LRESULT {
+            if (active_state && msg == WM_WINDOWPOSCHANGING && active_state->mutate)
+            {
+                auto& position = *reinterpret_cast<WINDOWPOS*>(lp);
+                position.x = -123;
+                position.y = -456;
+                position.cx = 800;
+                position.cy = 600;
+                position.flags &= ~(SWP_NOMOVE | SWP_NOSIZE);
+                ++active_state->changing_count;
+            }
+            else if (active_state && msg == WM_WINDOWPOSCHANGED)
+            {
+                active_state->changed_flags = reinterpret_cast<const WINDOWPOS*>(lp)->flags;
+                active_state->saw_changed = true;
+            }
+            else if (active_state && msg == WM_SIZE)
+            {
+                active_state->size_width = LOWORD(lp);
+                active_state->size_height = HIWORD(lp);
+                active_state->saw_size = true;
+            }
+
+            return DefWindowProcA(hwnd, msg, wp, lp);
+        };
+
+        if (!RegisterClassExA(&wc))
+        {
+            active_state = nullptr;
+            return false;
+        }
+
+        HWND hwnd{};
+        const auto cleanup = sogen::utils::finally([&] {
+            state.mutate = false;
+            if (hwnd)
+            {
+                DestroyWindow(hwnd);
+            }
+            UnregisterClassA(wc.lpszClassName, wc.hInstance);
+            active_state = nullptr;
+        });
+
+        hwnd = CreateWindowExA(0, wc.lpszClassName, nullptr, WS_OVERLAPPEDWINDOW | WS_VISIBLE, 10, 20, 320, 240, nullptr, nullptr,
+                               wc.hInstance, nullptr);
+        state.mutate = false;
+        if (!hwnd)
+        {
+            return false;
+        }
+
+        RECT window_rect{};
+        RECT client_rect{};
+        if (!GetWindowRect(hwnd, &window_rect) || !GetClientRect(hwnd, &client_rect))
+        {
+            return false;
+        }
+
+        const auto window_width = window_rect.right - window_rect.left;
+        const auto window_height = window_rect.bottom - window_rect.top;
+        const auto client_width = client_rect.right - client_rect.left;
+        const auto client_height = client_rect.bottom - client_rect.top;
+
+        return state.changing_count == 2 && state.saw_changed && (state.changed_flags & SWP_SHOWWINDOW) != 0 && state.saw_size &&
+               window_rect.left == -123 && window_rect.top == -456 && window_width == 800 && window_height == 600 &&
+               client_width < window_width && client_height < window_height && state.size_width == client_width &&
+               state.size_height == client_height;
+    }
+
     bool test_private_namespace()
     {
         auto create_boundary_descriptor = [](const wchar_t* name) -> HANDLE {
@@ -1691,6 +1781,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_socket, "Socket")
     RUN_TEST(test_apc, "APC")
     RUN_TEST(test_user_callback, "User Callback")
+    RUN_TEST(test_mutable_callbacks, "Mutable User Callback")
     RUN_TEST(test_message_queue, "Message Queue (General)")
     RUN_TEST(test_paint_message_queue, "Message Queue (Paint)")
     RUN_TEST(test_settimer, "User Timer")

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -1391,6 +1391,7 @@ namespace sogen
         buffer.write(this->es);
         buffer.write(this->fs);
         buffer.write(this->gs);
+        buffer.write(this->callback_output_target);
 
         buffer.write(static_cast<bool>(this->state));
         if (this->state)
@@ -1425,6 +1426,7 @@ namespace sogen
         buffer.read(this->es);
         buffer.read(this->fs);
         buffer.read(this->gs);
+        buffer.read(this->callback_output_target);
 
         bool has_state{};
         buffer.read(has_state);

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -975,6 +975,33 @@ namespace sogen
         message_queue.push_back(msg);
     }
 
+    void emulator_thread::remove_window_messages(const hwnd window)
+    {
+        for (auto it = this->message_queue.begin(); it != this->message_queue.end();)
+        {
+            if (it->window != window)
+            {
+                ++it;
+                continue;
+            }
+
+            const auto removed_bits = get_message_queue_status_bits(*it);
+            for_each_queue_status_bit(removed_bits, [this](const uint32_t bit, const size_t index) {
+                if (this->message_queue_status_bit_counts[index] <= 1)
+                {
+                    this->message_queue_status_bit_counts[index] = 0;
+                    this->message_queue_status_bits &= ~bit;
+                }
+                else
+                {
+                    --this->message_queue_status_bit_counts[index];
+                }
+            });
+
+            it = this->message_queue.erase(it);
+        }
+    }
+
     bool emulator_thread::is_terminated() const
     {
         return this->exit_status.has_value();

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -1391,6 +1391,7 @@ namespace sogen
         buffer.write(this->es);
         buffer.write(this->fs);
         buffer.write(this->gs);
+
         buffer.write(static_cast<bool>(this->state));
         if (this->state)
         {
@@ -1424,6 +1425,7 @@ namespace sogen
         buffer.read(this->es);
         buffer.read(this->fs);
         buffer.read(this->gs);
+
         bool has_state{};
         buffer.read(has_state);
 

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -1391,8 +1391,6 @@ namespace sogen
         buffer.write(this->es);
         buffer.write(this->fs);
         buffer.write(this->gs);
-        buffer.write(this->callback_output_target);
-
         buffer.write(static_cast<bool>(this->state));
         if (this->state)
         {
@@ -1426,8 +1424,6 @@ namespace sogen
         buffer.read(this->es);
         buffer.read(this->fs);
         buffer.read(this->gs);
-        buffer.read(this->callback_output_target);
-
         bool has_state{};
         buffer.read(has_state);
 

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -371,6 +371,7 @@ namespace sogen
         std::optional<msg> peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter = 0, UINT filter_min = 0, UINT filter_max = 0,
                                                 bool remove = false);
         void post_message(windows_emulator& win_emu, msg msg, bool try_coalesce = false);
+        void remove_window_messages(hwnd window);
 
         bool is_terminated() const;
 

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -217,6 +217,7 @@ namespace sogen
         uint16_t es{};
         uint16_t fs{};
         uint16_t gs{};
+        uint64_t callback_output_target{};
         std::unique_ptr<completion_state> state{};
 
         callback_frame();

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -217,7 +217,6 @@ namespace sogen
         uint16_t es{};
         uint16_t fs{};
         uint16_t gs{};
-        uint64_t callback_output_target{};
         std::unique_ptr<completion_state> state{};
 
         callback_frame();

--- a/src/windows-emulator/syscall_dispatcher.cpp
+++ b/src/windows-emulator/syscall_dispatcher.cpp
@@ -155,7 +155,7 @@ namespace sogen
     }
 
     dispatch_result syscall_dispatcher::dispatch_completion(windows_emulator& win_emu, vcpu_context& vcpu, callback_id callback_id,
-                                                            completion_state* completion_state, uint64_t callback_result)
+                                                            completion_state* completion_state, const user_callback_result& callback_result)
     {
         auto& emu = vcpu.cpu;
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -6,6 +6,7 @@ namespace sogen
 {
 
     struct syscall_context;
+    struct user_callback_result;
     using syscall_handler = void (*)(const syscall_context& c);
 
     struct syscall_handler_entry
@@ -235,7 +236,7 @@ namespace sogen
         void dispatch(windows_emulator& win_emu, vcpu_context& vcpu);
         static void dispatch_callback(windows_emulator& win_emu, std::string& syscall_name);
         dispatch_result dispatch_completion(windows_emulator& win_emu, vcpu_context& vcpu, callback_id callback_id,
-                                            completion_state* completion_state, uint64_t callback_result);
+                                            completion_state* completion_state, const user_callback_result& callback_result);
 
         void serialize(utils::buffer_serializer& buffer) const;
         void deserialize(utils::buffer_deserializer& buffer);

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -26,8 +26,6 @@ namespace sogen
     {
         virtual ~completion_state() = default;
 
-        uint64_t callback_output_target{};
-
         void serialize(utils::buffer_serializer& buffer) const
         {
             this->serialize_object(buffer);
@@ -61,6 +59,7 @@ namespace sogen
         emulator_stack_allocation changed_window_pos_alloc{};
 
         std::vector<qmsg> message_queue{};
+        uint64_t pending_window_pos_address{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -74,6 +73,7 @@ namespace sogen
             buffer.write(this->activation_window_pos_alloc);
             buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
+            buffer.write(this->pending_window_pos_address);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -87,6 +87,7 @@ namespace sogen
             buffer.read(this->activation_window_pos_alloc);
             buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
+            buffer.read(this->pending_window_pos_address);
         }
     };
 
@@ -107,6 +108,7 @@ namespace sogen
         std::vector<qmsg> message_queue{};
         window_destroy_phase phase{window_destroy_phase::messages};
         bool unlink_pending{true};
+        uint64_t pending_window_pos_address{};
 
         void serialize(utils::buffer_serializer& buffer) const
         {
@@ -117,6 +119,7 @@ namespace sogen
             buffer.write_vector(this->message_queue);
             buffer.write(this->phase);
             buffer.write(this->unlink_pending);
+            buffer.write(this->pending_window_pos_address);
         }
 
         void deserialize(utils::buffer_deserializer& buffer)
@@ -128,6 +131,7 @@ namespace sogen
             buffer.read_vector(this->message_queue);
             buffer.read(this->phase);
             buffer.read(this->unlink_pending);
+            buffer.read(this->pending_window_pos_address);
         }
     };
 
@@ -160,6 +164,7 @@ namespace sogen
         emulator_stack_allocation activation_window_pos_alloc{};
         emulator_stack_allocation changed_window_pos_alloc{};
         std::vector<qmsg> message_queue{};
+        uint64_t pending_window_pos_address{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -169,6 +174,7 @@ namespace sogen
             buffer.write(this->activation_window_pos_alloc);
             buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
+            buffer.write(this->pending_window_pos_address);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -178,6 +184,7 @@ namespace sogen
             buffer.read(this->activation_window_pos_alloc);
             buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
+            buffer.read(this->pending_window_pos_address);
         }
     };
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -25,6 +25,8 @@ namespace sogen
     {
         virtual ~completion_state() = default;
 
+        uint64_t callback_output_target{};
+
         void serialize(utils::buffer_serializer& buffer) const
         {
             this->serialize_object(buffer);

--- a/src/windows-emulator/syscall_utils.hpp
+++ b/src/windows-emulator/syscall_utils.hpp
@@ -51,7 +51,7 @@ namespace sogen
             return static_cast<T>(this->previous_callback_result.value);
         }
 
-        const user_callback_result& get_user_callback_result() const
+        const user_callback_result& get_callback_result_object() const
         {
             if (!this->is_callback_completion)
             {

--- a/src/windows-emulator/syscall_utils.hpp
+++ b/src/windows-emulator/syscall_utils.hpp
@@ -10,6 +10,16 @@ namespace sogen
 
     struct completion_state;
 
+    struct user_callback_result
+    {
+        uint64_t value{};
+        uint32_t output_size{};
+        uint64_t output{};
+    };
+
+    static_assert(sizeof(user_callback_result) == 24);
+    static_assert(offsetof(user_callback_result, output) == 16);
+
     struct syscall_context
     {
         windows_emulator& win_emu;
@@ -24,7 +34,7 @@ namespace sogen
         mutable bool run_callback{false};
         bool is_callback_completion{false};
         completion_state* current_completion_state{};
-        uint64_t previous_callback_result{};
+        user_callback_result previous_callback_result{};
 
         emulator_thread& thread() const
         {
@@ -38,7 +48,16 @@ namespace sogen
             {
                 throw std::runtime_error("Attempted to get callback result in a non-completion context");
             }
-            return static_cast<T>(this->previous_callback_result);
+            return static_cast<T>(this->previous_callback_result.value);
+        }
+
+        const user_callback_result& get_user_callback_result() const
+        {
+            if (!this->is_callback_completion)
+            {
+                throw std::runtime_error("Attempted to get callback result in a non-completion context");
+            }
+            return this->previous_callback_result;
         }
 
         template <typename T>

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -2,7 +2,6 @@
 #include "../cpu_context.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
-#include "../user_callback_dispatch.hpp"
 
 #include <algorithm>
 #include <utils/finally.hpp>
@@ -1015,6 +1014,7 @@ namespace sogen
 
             if (callback_result_ptr != 0 && callback_result_length != 0)
             {
+                // When present, the callback result pointer always contains the actual callback result value!
                 user_callback_result result_data{};
                 const auto read_length = std::min<ULONG>(callback_result_length, sizeof(result_data));
                 if (c.win_emu.memory.try_read_memory(callback_result_ptr, &result_data, read_length))

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -1001,16 +1001,6 @@ namespace sogen
         NTSTATUS handle_NtCallbackReturn(const syscall_context& c, const emulator_pointer callback_result_ptr,
                                          const ULONG callback_result_length, const NTSTATUS /*callback_status*/)
         {
-            struct callback_result_data
-            {
-                uint64_t result{};
-                uint32_t output_size{};
-                uint32_t reserved{};
-                uint64_t output{};
-            };
-
-            static_assert(sizeof(callback_result_data) == 24);
-
             auto& t = c.thread();
 
             if (t.callback_stack.empty())
@@ -1018,50 +1008,57 @@ namespace sogen
                 throw std::runtime_error("Unexpected callback return");
             }
 
-            uint64_t callback_result = t.callback_return_rax.value_or(c.emu.reg<uint64_t>(x86_register::rax));
+            user_callback_result callback_result{
+                .value = t.callback_return_rax.value_or(c.emu.reg<uint64_t>(x86_register::rax)),
+            };
             t.callback_return_rax.reset();
 
             if (callback_result_ptr != 0 && callback_result_length != 0)
             {
-                callback_result_data result_data{};
+                user_callback_result result_data{};
                 const auto read_length = std::min<ULONG>(callback_result_length, sizeof(result_data));
                 if (c.win_emu.memory.try_read_memory(callback_result_ptr, &result_data, read_length))
                 {
-                    callback_result = result_data.result;
-
-                    auto& frame = t.callback_stack.back();
-                    if (frame.callback_output_target != 0 && callback_result_length >= sizeof(result_data) && result_data.output != 0)
+                    callback_result.value = result_data.value;
+                    if (callback_result_length >= sizeof(result_data))
                     {
-                        EMU_WINDOWPOS window_pos{};
-                        bool copied{};
-                        if (c.proc.is_wow64_process && result_data.output_size >= sizeof(wow64_window_pos_callback_data))
-                        {
-                            wow64_window_pos_callback_data window_pos32{};
-                            if (c.win_emu.memory.try_read_memory(result_data.output, &window_pos32, sizeof(window_pos32)))
-                            {
-                                window_pos = {
-                                    .hwnd = window_pos32.hwnd,
-                                    .hwndInsertAfter = window_pos32.hwndInsertAfter,
-                                    .x = window_pos32.x,
-                                    .y = window_pos32.y,
-                                    .cx = window_pos32.cx,
-                                    .cy = window_pos32.cy,
-                                    .flags = window_pos32.flags,
-                                };
-                                copied = true;
-                            }
-                        }
-                        else if (!c.proc.is_wow64_process && result_data.output_size >= sizeof(window_pos))
-                        {
-                            copied = c.win_emu.memory.try_read_memory(result_data.output, &window_pos, sizeof(window_pos));
-                        }
+                        callback_result.output_size = result_data.output_size;
+                        callback_result.output = result_data.output;
 
-                        if (copied)
+                        auto& frame = t.callback_stack.back();
+                        if (frame.callback_output_target != 0 && result_data.output != 0)
                         {
-                            c.win_emu.memory.write_memory(frame.callback_output_target, &window_pos, sizeof(window_pos));
-                            if (frame.state)
+                            EMU_WINDOWPOS window_pos{};
+                            bool copied{};
+                            if (c.proc.is_wow64_process && result_data.output_size >= sizeof(wow64_window_pos_callback_data))
                             {
-                                frame.state->callback_output_target = frame.callback_output_target;
+                                wow64_window_pos_callback_data window_pos32{};
+                                if (c.win_emu.memory.try_read_memory(result_data.output, &window_pos32, sizeof(window_pos32)))
+                                {
+                                    window_pos = {
+                                        .hwnd = window_pos32.hwnd,
+                                        .hwndInsertAfter = window_pos32.hwndInsertAfter,
+                                        .x = window_pos32.x,
+                                        .y = window_pos32.y,
+                                        .cx = window_pos32.cx,
+                                        .cy = window_pos32.cy,
+                                        .flags = window_pos32.flags,
+                                    };
+                                    copied = true;
+                                }
+                            }
+                            else if (!c.proc.is_wow64_process && result_data.output_size >= sizeof(window_pos))
+                            {
+                                copied = c.win_emu.memory.try_read_memory(result_data.output, &window_pos, sizeof(window_pos));
+                            }
+
+                            if (copied)
+                            {
+                                c.win_emu.memory.write_memory(frame.callback_output_target, &window_pos, sizeof(window_pos));
+                                if (frame.state)
+                                {
+                                    frame.state->callback_output_target = frame.callback_output_target;
+                                }
                             }
                         }
                     }

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -1024,43 +1024,6 @@ namespace sogen
                     {
                         callback_result.output_size = result_data.output_size;
                         callback_result.output = result_data.output;
-
-                        auto& frame = t.callback_stack.back();
-                        if (frame.callback_output_target != 0 && result_data.output != 0)
-                        {
-                            EMU_WINDOWPOS window_pos{};
-                            bool copied{};
-                            if (c.proc.is_wow64_process && result_data.output_size >= sizeof(wow64_window_pos_callback_data))
-                            {
-                                wow64_window_pos_callback_data window_pos32{};
-                                if (c.win_emu.memory.try_read_memory(result_data.output, &window_pos32, sizeof(window_pos32)))
-                                {
-                                    window_pos = {
-                                        .hwnd = window_pos32.hwnd,
-                                        .hwndInsertAfter = window_pos32.hwndInsertAfter,
-                                        .x = window_pos32.x,
-                                        .y = window_pos32.y,
-                                        .cx = window_pos32.cx,
-                                        .cy = window_pos32.cy,
-                                        .flags = window_pos32.flags,
-                                    };
-                                    copied = true;
-                                }
-                            }
-                            else if (!c.proc.is_wow64_process && result_data.output_size >= sizeof(window_pos))
-                            {
-                                copied = c.win_emu.memory.try_read_memory(result_data.output, &window_pos, sizeof(window_pos));
-                            }
-
-                            if (copied)
-                            {
-                                c.win_emu.memory.write_memory(frame.callback_output_target, &window_pos, sizeof(window_pos));
-                                if (frame.state)
-                                {
-                                    frame.state->callback_output_target = frame.callback_output_target;
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -2,6 +2,7 @@
 #include "../cpu_context.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
+#include "../user_callback_dispatch.hpp"
 
 #include <algorithm>
 #include <utils/finally.hpp>
@@ -1000,6 +1001,16 @@ namespace sogen
         NTSTATUS handle_NtCallbackReturn(const syscall_context& c, const emulator_pointer callback_result_ptr,
                                          const ULONG callback_result_length, const NTSTATUS /*callback_status*/)
         {
+            struct callback_result_data
+            {
+                uint64_t result{};
+                uint32_t output_size{};
+                uint32_t reserved{};
+                uint64_t output{};
+            };
+
+            static_assert(sizeof(callback_result_data) == 24);
+
             auto& t = c.thread();
 
             if (t.callback_stack.empty())
@@ -1012,16 +1023,48 @@ namespace sogen
 
             if (callback_result_ptr != 0 && callback_result_length != 0)
             {
-                // user32's SFI-table-driven dispatch stubs (the __guard_xfg_dispatch_icall_fptr family
-                // used for e.g. NtUserMessageCall completions) always pass a real result pointer with
-                // ResultLength=0x18 - a 24-byte structure whose first 8 bytes are the actual LRESULT the
-                // callback computed.
-                const auto read_length = std::min<ULONG>(callback_result_length, sizeof(callback_result));
-                std::array<std::byte, sizeof(callback_result)> result_bytes{};
-                if (c.win_emu.memory.try_read_memory(callback_result_ptr, result_bytes.data(), read_length))
+                callback_result_data result_data{};
+                const auto read_length = std::min<ULONG>(callback_result_length, sizeof(result_data));
+                if (c.win_emu.memory.try_read_memory(callback_result_ptr, &result_data, read_length))
                 {
-                    callback_result = 0;
-                    memcpy(&callback_result, result_bytes.data(), read_length);
+                    callback_result = result_data.result;
+
+                    auto& frame = t.callback_stack.back();
+                    if (frame.callback_output_target != 0 && callback_result_length >= sizeof(result_data) && result_data.output != 0)
+                    {
+                        EMU_WINDOWPOS window_pos{};
+                        bool copied{};
+                        if (c.proc.is_wow64_process && result_data.output_size >= sizeof(wow64_window_pos_callback_data))
+                        {
+                            wow64_window_pos_callback_data window_pos32{};
+                            if (c.win_emu.memory.try_read_memory(result_data.output, &window_pos32, sizeof(window_pos32)))
+                            {
+                                window_pos = {
+                                    .hwnd = window_pos32.hwnd,
+                                    .hwndInsertAfter = window_pos32.hwndInsertAfter,
+                                    .x = window_pos32.x,
+                                    .y = window_pos32.y,
+                                    .cx = window_pos32.cx,
+                                    .cy = window_pos32.cy,
+                                    .flags = window_pos32.flags,
+                                };
+                                copied = true;
+                            }
+                        }
+                        else if (!c.proc.is_wow64_process && result_data.output_size >= sizeof(window_pos))
+                        {
+                            copied = c.win_emu.memory.try_read_memory(result_data.output, &window_pos, sizeof(window_pos));
+                        }
+
+                        if (copied)
+                        {
+                            c.win_emu.memory.write_memory(frame.callback_output_target, &window_pos, sizeof(window_pos));
+                            if (frame.state)
+                            {
+                                frame.state->callback_output_target = frame.callback_output_target;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -87,19 +87,6 @@ namespace sogen
             pointer xpfnProc{};
         };
 
-        struct wow64_window_pos_callback_data
-        {
-            uint32_t hwnd{};
-            uint32_t hwndInsertAfter{};
-            int32_t x{};
-            int32_t y{};
-            int32_t cx{};
-            int32_t cy{};
-            uint32_t flags{};
-        };
-
-        static_assert(sizeof(wow64_window_pos_callback_data) == 28);
-
         struct fn_inout_lp_point5_message
         {
             pointer pwnd{};
@@ -110,7 +97,7 @@ namespace sogen
             {
                 EMU_MINMAXINFO point5;
                 EMU_WINDOWPOS window_pos;
-                wow64_window_pos_callback_data window_pos32;
+                EMU_WINDOWPOS32 window_pos32;
             } data{};
 
             pointer xParam{};
@@ -410,7 +397,7 @@ namespace sogen
 
         std::optional<EMU_WINDOWPOS> read_window_pos_callback_output(const syscall_context& c)
         {
-            const auto& result = c.get_user_callback_result();
+            const auto& result = c.get_callback_result_object();
             if (result.output == 0)
             {
                 return std::nullopt;
@@ -418,12 +405,12 @@ namespace sogen
 
             if (c.proc.is_wow64_process)
             {
-                if (result.output_size < sizeof(wow64_window_pos_callback_data))
+                if (result.output_size < sizeof(EMU_WINDOWPOS32))
                 {
                     return std::nullopt;
                 }
 
-                wow64_window_pos_callback_data position{};
+                EMU_WINDOWPOS32 position{};
                 if (!c.win_emu.memory.try_read_memory(result.output, &position, sizeof(position)))
                 {
                     return std::nullopt;
@@ -454,7 +441,8 @@ namespace sogen
         }
 
         void complete_window_position_change(const syscall_context& c, window& win, const uint64_t window_pos_address,
-                                              emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue)
+                                             emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
+                                             const bool update_changed_window_position)
         {
             EMU_WINDOWPOS position{};
             c.emu.read_memory(window_pos_address, &position, sizeof(position));
@@ -490,6 +478,14 @@ namespace sogen
 
             if (changed_window_pos_alloc)
             {
+                if (!update_changed_window_position)
+                {
+                    EMU_WINDOWPOS previous_changed_position{};
+                    c.emu.read_memory(changed_window_pos_alloc.address(), &previous_changed_position, sizeof(previous_changed_position));
+                    changed_position.hwnd = previous_changed_position.hwnd;
+                    changed_position.hwndInsertAfter = previous_changed_position.hwndInsertAfter;
+                    changed_position.flags = previous_changed_position.flags;
+                }
                 c.emu.write_memory(changed_window_pos_alloc.address(), &changed_position, sizeof(changed_position));
             }
             else
@@ -508,7 +504,7 @@ namespace sogen
                     message.lParam = static_cast<uint64_t>(((win.y & 0xFFFF) << 16) | (win.x & 0xFFFF));
                     break;
                 case WM_SIZE:
-                    message.lParam = static_cast<uint64_t>(((win.height & 0xFFFF) << 16) | (win.width & 0xFFFF));
+                    message.lParam = static_cast<uint64_t>(((win.client_height() & 0xFFFF) << 16) | (win.client_width() & 0xFFFF));
                     break;
                 default:
                     break;
@@ -1036,10 +1032,6 @@ namespace sogen
         {
             const auto m = message_queue.back();
             message_queue.pop_back();
-            if (m.message == WM_WINDOWPOSCHANGING)
-            {
-                state.pending_window_pos_address = m.lParam;
-            }
 
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
         }
@@ -3138,7 +3130,7 @@ namespace sogen
                 invalidate_window(c, win);
 
                 const auto move_lparam = static_cast<uint64_t>(((y & 0xFFFF) << 16) | (x & 0xFFFF));
-                const auto size_lparam = static_cast<uint64_t>(((height & 0xFFFF) << 16) | (width & 0xFFFF));
+                const auto size_lparam = static_cast<uint64_t>(((win.client_height() & 0xFFFF) << 16) | (win.client_width() & 0xFFFF));
 
                 if (has_child_parent)
                 {
@@ -3253,7 +3245,10 @@ namespace sogen
 
             if (s.pending_window_pos_address != 0)
             {
-                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue);
+                const bool activation_position =
+                    s.activation_window_pos_alloc && s.pending_window_pos_address == s.activation_window_pos_alloc.address();
+                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue,
+                                                !activation_position);
                 s.pending_window_pos_address = 0;
             }
 
@@ -3269,6 +3264,10 @@ namespace sogen
                         return {};
                     }
                     s.message_queue.pop_back();
+                }
+                else if (next.message == WM_WINDOWPOSCHANGING)
+                {
+                    s.pending_window_pos_address = next.lParam;
                 }
 
                 dispatch_next_message(c, callback_id::NtUserCreateWindowEx, std::move(s), *win, s.message_queue);
@@ -3301,18 +3300,18 @@ namespace sogen
         BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd /*window*/)
         {
             auto& s = c.get_completion_state<window_destroy_state>();
-            const auto pending_frame = std::ranges::find_if(s.frames, [](const window_destroy_frame& frame) {
-                return frame.pending_window_pos_address != 0;
-            });
-            if (pending_frame != s.frames.end())
+            if (!s.frames.empty())
             {
-                if (auto* win = c.proc.windows.get(pending_frame->handle))
+                auto& frame = s.frames.back();
+                if (frame.pending_window_pos_address != 0)
                 {
-                    complete_window_position_change(c, *win, pending_frame->pending_window_pos_address,
-                                                    pending_frame->changed_window_pos_alloc,
-                                                    pending_frame->message_queue);
+                    if (auto* win = c.proc.windows.get(frame.handle))
+                    {
+                        complete_window_position_change(c, *win, frame.pending_window_pos_address, frame.changed_window_pos_alloc,
+                                                        frame.message_queue, true);
+                    }
+                    frame.pending_window_pos_address = 0;
                 }
-                pending_frame->pending_window_pos_address = 0;
             }
             return advance_window_destroy(c, s);
         }
@@ -3476,7 +3475,7 @@ namespace sogen
             if (want_visible)
             {
                 const auto move_lparam = static_cast<uint64_t>(((win->y & 0xFFFF) << 16) | (win->x & 0xFFFF));
-                const auto size_lparam = static_cast<uint64_t>(((win->height & 0xFFFF) << 16) | (win->width & 0xFFFF));
+                const auto size_lparam = static_cast<uint64_t>(((win->client_height() & 0xFFFF) << 16) | (win->client_width() & 0xFFFF));
 
                 state.message_queue = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
@@ -3555,12 +3554,21 @@ namespace sogen
 
             if (s.pending_window_pos_address != 0)
             {
-                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue);
+                const bool activation_position =
+                    s.activation_window_pos_alloc && s.pending_window_pos_address == s.activation_window_pos_alloc.address();
+                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue,
+                                                !activation_position);
                 s.pending_window_pos_address = 0;
             }
 
             if (!s.message_queue.empty())
             {
+                const auto& next = s.message_queue.back();
+                if (next.message == WM_WINDOWPOSCHANGING)
+                {
+                    s.pending_window_pos_address = next.lParam;
+                }
+
                 dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(s), *win, s.message_queue);
                 return {};
             }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -408,17 +408,112 @@ namespace sogen
             }
         }
 
-        void apply_window_pos_callback_result(const syscall_context& c, window& win,
-                                              const emulator_stack_allocation& window_pos_alloc)
+        std::optional<EMU_WINDOWPOS> read_window_pos_callback_output(const syscall_context& c)
+        {
+            const auto& result = c.get_user_callback_result();
+            if (result.output == 0)
+            {
+                return std::nullopt;
+            }
+
+            if (c.proc.is_wow64_process)
+            {
+                if (result.output_size < sizeof(wow64_window_pos_callback_data))
+                {
+                    return std::nullopt;
+                }
+
+                wow64_window_pos_callback_data position{};
+                if (!c.win_emu.memory.try_read_memory(result.output, &position, sizeof(position)))
+                {
+                    return std::nullopt;
+                }
+
+                return EMU_WINDOWPOS{
+                    .hwnd = position.hwnd,
+                    .hwndInsertAfter = position.hwndInsertAfter,
+                    .x = position.x,
+                    .y = position.y,
+                    .cx = position.cx,
+                    .cy = position.cy,
+                    .flags = position.flags,
+                };
+            }
+
+            if (result.output_size < sizeof(EMU_WINDOWPOS))
+            {
+                return std::nullopt;
+            }
+
+            EMU_WINDOWPOS position{};
+            if (!c.win_emu.memory.try_read_memory(result.output, &position, sizeof(position)))
+            {
+                return std::nullopt;
+            }
+            return position;
+        }
+
+        void complete_window_position_change(const syscall_context& c, window& win, const uint64_t window_pos_address,
+                                              emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue)
         {
             EMU_WINDOWPOS position{};
-            c.emu.read_memory(window_pos_alloc.address(), &position, sizeof(position));
+            c.emu.read_memory(window_pos_address, &position, sizeof(position));
+            if (const auto callback_position = read_window_pos_callback_output(c))
+            {
+                position = *callback_position;
+                c.emu.write_memory(window_pos_address, &position, sizeof(position));
+            }
 
             const auto x = (position.flags & SWP_NOMOVE) != 0 ? win.x : position.x;
             const auto y = (position.flags & SWP_NOMOVE) != 0 ? win.y : position.y;
             const auto width = (position.flags & SWP_NOSIZE) != 0 ? win.width : position.cx;
             const auto height = (position.flags & SWP_NOSIZE) != 0 ? win.height : position.cy;
             update_window_geometry(c, win, x, y, width, height, false);
+
+            EMU_WINDOWPOS changed_position{
+                .hwnd = position.hwnd,
+                .hwndInsertAfter = position.hwndInsertAfter,
+                .x = win.x,
+                .y = win.y,
+                .cx = win.width,
+                .cy = win.height,
+                .flags = position.flags,
+            };
+            if ((position.flags & SWP_NOMOVE) != 0)
+            {
+                changed_position.flags |= SWP_NOCLIENTMOVE;
+            }
+            if ((position.flags & SWP_NOSIZE) != 0)
+            {
+                changed_position.flags |= SWP_NOCLIENTSIZE;
+            }
+
+            if (changed_window_pos_alloc)
+            {
+                c.emu.write_memory(changed_window_pos_alloc.address(), &changed_position, sizeof(changed_position));
+            }
+            else
+            {
+                changed_window_pos_alloc = c.emu.push_stack(changed_position);
+            }
+
+            for (auto& message : message_queue)
+            {
+                switch (message.message)
+                {
+                case WM_WINDOWPOSCHANGED:
+                    message.lParam = changed_window_pos_alloc.address();
+                    break;
+                case WM_MOVE:
+                    message.lParam = static_cast<uint64_t>(((win.y & 0xFFFF) << 16) | (win.x & 0xFFFF));
+                    break;
+                case WM_SIZE:
+                    message.lParam = static_cast<uint64_t>(((win.height & 0xFFFF) << 16) | (win.width & 0xFFFF));
+                    break;
+                default:
+                    break;
+                }
+            }
         }
 
         RECT union_update_rect(const RECT& a, const RECT& b)
@@ -878,10 +973,6 @@ namespace sogen
                 }
 
                 dispatch_user_callback(c, id, k_fn_inout_lp_point5_callback_id, std::forward<T>(state), args);
-                if (message == WM_WINDOWPOSCHANGING)
-                {
-                    c.thread().callback_stack.back().callback_output_target = l_param;
-                }
                 return;
             }
 
@@ -945,6 +1036,10 @@ namespace sogen
         {
             const auto m = message_queue.back();
             message_queue.pop_back();
+            if (m.message == WM_WINDOWPOSCHANGING)
+            {
+                state.pending_window_pos_address = m.lParam;
+            }
 
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
         }
@@ -3092,7 +3187,7 @@ namespace sogen
                     std::vector<qmsg> show_messages = {
                         {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                         {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                        {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
+                        {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
                         {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
                         {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
                         {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
@@ -3156,13 +3251,10 @@ namespace sogen
                 return 0;
             }
 
-            if (s.callback_output_target != 0)
+            if (s.pending_window_pos_address != 0)
             {
-                if (s.callback_output_target == s.window_pos_alloc.address())
-                {
-                    apply_window_pos_callback_result(c, *win, s.window_pos_alloc);
-                }
-                s.callback_output_target = 0;
+                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue);
+                s.pending_window_pos_address = 0;
             }
 
             if (!s.message_queue.empty())
@@ -3209,25 +3301,18 @@ namespace sogen
         BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd /*window*/)
         {
             auto& s = c.get_completion_state<window_destroy_state>();
-            if (s.callback_output_target != 0)
+            const auto pending_frame = std::ranges::find_if(s.frames, [](const window_destroy_frame& frame) {
+                return frame.pending_window_pos_address != 0;
+            });
+            if (pending_frame != s.frames.end())
             {
-                const auto apply_result = [&](std::vector<window_destroy_frame>& frames) {
-                    for (auto& frame : frames)
-                    {
-                        if (frame.window_pos_alloc && frame.window_pos_alloc.address() == s.callback_output_target)
-                        {
-                            if (auto* win = c.proc.windows.get(frame.handle))
-                            {
-                                apply_window_pos_callback_result(c, *win, frame.window_pos_alloc);
-                            }
-                            return true;
-                        }
-                    }
-                    return false;
-                };
-
-                apply_result(s.frames);
-                s.callback_output_target = 0;
+                if (auto* win = c.proc.windows.get(pending_frame->handle))
+                {
+                    complete_window_position_change(c, *win, pending_frame->pending_window_pos_address,
+                                                    pending_frame->changed_window_pos_alloc,
+                                                    pending_frame->message_queue);
+                }
+                pending_frame->pending_window_pos_address = 0;
             }
             return advance_window_destroy(c, s);
         }
@@ -3396,7 +3481,7 @@ namespace sogen
                 state.message_queue = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                     {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
                 };
 
                 if (activate_window)
@@ -3440,7 +3525,7 @@ namespace sogen
                     {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
                     {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                     {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()},
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
                     {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
                     {.message = WM_SHOWWINDOW, .wParam = FALSE, .lParam = 0},
                 };
@@ -3468,13 +3553,10 @@ namespace sogen
             auto& s = c.get_completion_state<window_show_state>();
             auto* win = c.proc.windows.get(hwnd);
 
-            if (s.callback_output_target != 0)
+            if (s.pending_window_pos_address != 0)
             {
-                if (s.callback_output_target == s.window_pos_alloc.address())
-                {
-                    apply_window_pos_callback_result(c, *win, s.window_pos_alloc);
-                }
-                s.callback_output_target = 0;
+                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue);
+                s.pending_window_pos_address = 0;
             }
 
             if (!s.message_queue.empty())

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -87,6 +87,19 @@ namespace sogen
             pointer xpfnProc{};
         };
 
+        struct wow64_window_pos_callback_data
+        {
+            uint32_t hwnd{};
+            uint32_t hwndInsertAfter{};
+            int32_t x{};
+            int32_t y{};
+            int32_t cx{};
+            int32_t cy{};
+            uint32_t flags{};
+        };
+
+        static_assert(sizeof(wow64_window_pos_callback_data) == 28);
+
         struct fn_inout_lp_point5_message
         {
             pointer pwnd{};
@@ -97,6 +110,7 @@ namespace sogen
             {
                 EMU_MINMAXINFO point5;
                 EMU_WINDOWPOS window_pos;
+                wow64_window_pos_callback_data window_pos32;
             } data{};
 
             pointer xParam{};
@@ -392,6 +406,19 @@ namespace sogen
             {
                 invalidate_window(c, win, std::nullopt, false);
             }
+        }
+
+        void apply_window_pos_callback_result(const syscall_context& c, window& win,
+                                              const emulator_stack_allocation& window_pos_alloc)
+        {
+            EMU_WINDOWPOS position{};
+            c.emu.read_memory(window_pos_alloc.address(), &position, sizeof(position));
+
+            const auto x = (position.flags & SWP_NOMOVE) != 0 ? win.x : position.x;
+            const auto y = (position.flags & SWP_NOMOVE) != 0 ? win.y : position.y;
+            const auto width = (position.flags & SWP_NOSIZE) != 0 ? win.width : position.cx;
+            const auto height = (position.flags & SWP_NOSIZE) != 0 ? win.height : position.cy;
+            update_window_geometry(c, win, x, y, width, height, false);
         }
 
         RECT union_update_rect(const RECT& a, const RECT& b)
@@ -825,7 +852,24 @@ namespace sogen
                 {
                     if (message == WM_WINDOWPOSCHANGING)
                     {
-                        c.emu.read_memory(l_param, &args.data.window_pos, sizeof(args.data.window_pos));
+                        EMU_WINDOWPOS window_pos{};
+                        c.emu.read_memory(l_param, &window_pos, sizeof(window_pos));
+                        if (c.proc.is_wow64_process)
+                        {
+                            args.data.window_pos32 = {
+                                .hwnd = static_cast<uint32_t>(window_pos.hwnd),
+                                .hwndInsertAfter = static_cast<uint32_t>(window_pos.hwndInsertAfter),
+                                .x = window_pos.x,
+                                .y = window_pos.y,
+                                .cx = window_pos.cx,
+                                .cy = window_pos.cy,
+                                .flags = window_pos.flags,
+                            };
+                        }
+                        else
+                        {
+                            args.data.window_pos = window_pos;
+                        }
                     }
                     else
                     {
@@ -834,6 +878,10 @@ namespace sogen
                 }
 
                 dispatch_user_callback(c, id, k_fn_inout_lp_point5_callback_id, std::forward<T>(state), args);
+                if (message == WM_WINDOWPOSCHANGING)
+                {
+                    c.thread().callback_stack.back().callback_output_target = l_param;
+                }
                 return;
             }
 
@@ -3087,7 +3135,7 @@ namespace sogen
                                              const DWORD /*flags*/, const pointer /*acbi_buffer*/)
         {
             auto& s = c.get_completion_state<window_create_state>();
-            const auto* win = c.proc.windows.get(s.handle);
+            auto* win = c.proc.windows.get(s.handle);
 
             const auto release_window_create_allocations = [&] {
                 if (s.window_pos_alloc)
@@ -3106,6 +3154,15 @@ namespace sogen
             {
                 release_window_create_allocations();
                 return 0;
+            }
+
+            if (s.callback_output_target != 0)
+            {
+                if (s.callback_output_target == s.window_pos_alloc.address())
+                {
+                    apply_window_pos_callback_result(c, *win, s.window_pos_alloc);
+                }
+                s.callback_output_target = 0;
             }
 
             if (!s.message_queue.empty())
@@ -3152,6 +3209,26 @@ namespace sogen
         BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd /*window*/)
         {
             auto& s = c.get_completion_state<window_destroy_state>();
+            if (s.callback_output_target != 0)
+            {
+                const auto apply_result = [&](std::vector<window_destroy_frame>& frames) {
+                    for (auto& frame : frames)
+                    {
+                        if (frame.window_pos_alloc && frame.window_pos_alloc.address() == s.callback_output_target)
+                        {
+                            if (auto* win = c.proc.windows.get(frame.handle))
+                            {
+                                apply_window_pos_callback_result(c, *win, frame.window_pos_alloc);
+                            }
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                apply_result(s.frames);
+                s.callback_output_target = 0;
+            }
             return advance_window_destroy(c, s);
         }
 
@@ -3389,7 +3466,16 @@ namespace sogen
         BOOL completion_NtUserShowWindow(const syscall_context& c, const hwnd hwnd, const LONG /*cmd_show*/)
         {
             auto& s = c.get_completion_state<window_show_state>();
-            const auto* win = c.proc.windows.get(hwnd);
+            auto* win = c.proc.windows.get(hwnd);
+
+            if (s.callback_output_target != 0)
+            {
+                if (s.callback_output_target == s.window_pos_alloc.address())
+                {
+                    apply_window_pos_callback_result(c, *win, s.window_pos_alloc);
+                }
+                s.callback_output_target = 0;
+            }
 
             if (!s.message_queue.empty())
             {

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -306,6 +306,7 @@ namespace sogen
     void window_destroy_orchestrator::finalize_frame(window_destroy_frame& frame, const window& win) const
     {
         this->pop_frame_allocation(frame);
+        this->thread_.remove_window_messages(frame.handle);
 
         win.guest.access([&](USER_WINDOW& guest_win) {
             guest_win.spwndParent = 0;

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -42,6 +42,10 @@ namespace sogen
             {
                 const auto m = frame.message_queue.back();
                 frame.message_queue.pop_back();
+                if (m.message == WM_WINDOWPOSCHANGING)
+                {
+                    frame.pending_window_pos_address = m.lParam;
+                }
                 const auto target = m.message == WM_PARENTNOTIFY ? frame.parent_notify_handle : frame.handle;
                 return window_destroy_step{.handle = target, .message = m};
             }
@@ -206,7 +210,7 @@ namespace sogen
             const std::initializer_list<qmsg> hide_messages = {
                 {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
                 {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = frame.changed_window_pos_alloc.address()},
+                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
                 {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = frame.window_pos_alloc.address()},
                 {.message = WM_UAHDESTROYWINDOW, .wParam = 0, .lParam = 0},
             };

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -40,7 +40,7 @@ namespace sogen
         window_destroy_state& state_;
         x86_64_cpu& emu_;
         process_context& proc_;
-        const emulator_thread& thread_;
+        emulator_thread& thread_;
         ui_backend& ui_;
     };
 


### PR DESCRIPTION
This PR improves `WINDOWPOS` callback handling to more closely match native Windows behavior:

* Changes made by applications during `WM_WINDOWPOSCHANGING` are now read back from the callback output and applied to the window.
* Window creation, show/hide transitions, and destruction now use the position, size, and `SetWindowPos` flags returned from `WM_WINDOWPOSCHANGING`.
* `WM_WINDOWPOSCHANGED`, `WM_MOVE`, and `WM_SIZE` now report the final window geometry after any callback changes have been applied.
* `WM_WINDOWPOSCHANGED` now receives its own `WINDOWPOS` payload, including the appropriate `SWP_NOCLIENTMOVE` and `SWP_NOCLIENTSIZE` flags.
* `WM_WINDOWPOSCHANGING` callback data is now handled correctly for both native 64-bit and WOW64 processes.
