### PR TITLE
Fix KSecDD RNG query

### DIFF
--- a/src/emulator/memory_interface.hpp
+++ b/src/emulator/memory_interface.hpp
@@ -62,6 +62,14 @@ namespace sogen
         }
 
         template <typename T>
+        T read_memory(const uint64_t address, const size_t size) const
+        {
+            T value{};
+            this->read_memory(address, &value, std::min(size, sizeof(T)));
+            return value;
+        }
+
+        template <typename T>
         T read_memory(const void* address) const
         {
             return this->read_memory<T>(reinterpret_cast<uint64_t>(address));

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -10,8 +10,16 @@ namespace sogen
 
     namespace
     {
-        // Partial layout of the KsecDD ioctl 0x390400 request, covering the two fields the handler
-        // consumes: the operation selector and the requested algorithm name.
+        struct ksec_base_algorithm_request
+        {
+            std::array<uint8_t, 6> reserved0;
+            uint16_t operation;
+            std::array<uint8_t, 0x28> reserved1;
+        };
+
+        static_assert(offsetof(ksec_base_algorithm_request, operation) == 6);
+        static_assert(sizeof(ksec_base_algorithm_request) == 0x30);
+
         struct ksec_algorithm_request
         {
             std::array<uint8_t, 6> reserved0;
@@ -64,49 +72,52 @@ namespace sogen
                     return STATUS_NOT_SUPPORTED;
                 }
 
-                // The input buffer and its length are guest-controlled; require the full request layout
-                // before reading any field out of it.
-                if (!c.input_buffer || c.input_buffer_length < sizeof(ksec_algorithm_request))
+                if (!c.input_buffer || c.input_buffer_length < sizeof(ksec_base_algorithm_request))
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto request = win_emu.emu().read_memory<ksec_algorithm_request>(c.input_buffer);
+                const auto request = win_emu.emu().read_memory<ksec_base_algorithm_request>(c.input_buffer);
 
-                if (request.operation == 2)
+                if (request.operation != 2)
                 {
-                    // algorithm_name is guest-controlled and may not be NUL-terminated; the util bounds the
-                    // view to the fixed array so we never scan past it looking for a terminator.
-                    const auto algorithm_name = utils::string::to_string_view<char16_t>(request.algorithm_name);
-
-                    // The response is a fixed-size record; never write past the guest-declared output buffer.
-                    const auto write_response = [&](const auto& output_data) -> NTSTATUS {
-                        if (!c.output_buffer || c.output_buffer_length < sizeof(output_data))
-                        {
-                            return STATUS_BUFFER_TOO_SMALL;
-                        }
-
-                        win_emu.emu().write_memory(c.output_buffer, output_data);
-
-                        if (c.io_status_block)
-                        {
-                            IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
-                            block.Information = sizeof(output_data);
-                            c.io_status_block.write(block);
-                        }
-
-                        return STATUS_SUCCESS;
-                    };
-
-                    if (algorithm_name == u"SHA256")
-                    {
-                        return write_response(sha256_output_data);
-                    }
-
-                    return write_response(rng_output_data);
+                    return STATUS_SUCCESS;
                 }
 
-                return STATUS_SUCCESS;
+                std::u16string_view algorithm_name{};
+
+                if (c.input_buffer_length >= sizeof(ksec_algorithm_request))
+                {
+                    const auto algorithm_request = win_emu.emu().read_memory<ksec_algorithm_request>(c.input_buffer);
+
+                    // The field is guest-controlled and may not be NUL-terminated.
+                    algorithm_name = utils::string::to_string_view<char16_t>(algorithm_request.algorithm_name);
+                }
+
+                const auto write_response = [&](const auto& output_data) -> NTSTATUS {
+                    if (!c.output_buffer || c.output_buffer_length < sizeof(output_data))
+                    {
+                        return STATUS_BUFFER_TOO_SMALL;
+                    }
+
+                    win_emu.emu().write_memory(c.output_buffer, output_data);
+
+                    if (c.io_status_block)
+                    {
+                        IO_STATUS_BLOCK<EmulatorTraits<Emu64>> block{};
+                        block.Information = sizeof(output_data);
+                        c.io_status_block.write(block);
+                    }
+
+                    return STATUS_SUCCESS;
+                };
+
+                if (algorithm_name == u"SHA256")
+                {
+                    return write_response(sha256_output_data);
+                }
+
+                return write_response(rng_output_data);
             }
         };
     }

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -10,16 +10,6 @@ namespace sogen
 
     namespace
     {
-        struct ksec_base_algorithm_request
-        {
-            std::array<uint8_t, 6> reserved0;
-            uint16_t operation;
-            std::array<uint8_t, 0x28> reserved1;
-        };
-
-        static_assert(offsetof(ksec_base_algorithm_request, operation) == 6);
-        static_assert(sizeof(ksec_base_algorithm_request) == 0x30);
-
         struct ksec_algorithm_request
         {
             std::array<uint8_t, 6> reserved0;
@@ -31,6 +21,8 @@ namespace sogen
         static_assert(offsetof(ksec_algorithm_request, operation) == 6);
         static_assert(offsetof(ksec_algorithm_request, algorithm_name) == 0x30);
         static_assert(sizeof(ksec_algorithm_request) == 0x40);
+
+        constexpr std::size_t ksec_algorithm_request_min_size = offsetof(ksec_algorithm_request, algorithm_name);
 
         struct security_support_provider : stateless_device
         {
@@ -72,12 +64,13 @@ namespace sogen
                     return STATUS_NOT_SUPPORTED;
                 }
 
-                if (!c.input_buffer || c.input_buffer_length < sizeof(ksec_base_algorithm_request))
+                if (!c.input_buffer || c.input_buffer_length < ksec_algorithm_request_min_size)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto request = win_emu.emu().read_memory<ksec_base_algorithm_request>(c.input_buffer);
+                const auto request =
+                    win_emu.emu().read_memory<ksec_algorithm_request>(c.input_buffer, static_cast<size_t>(c.input_buffer_length));
 
                 if (request.operation != 2)
                 {
@@ -88,10 +81,8 @@ namespace sogen
 
                 if (c.input_buffer_length >= sizeof(ksec_algorithm_request))
                 {
-                    const auto algorithm_request = win_emu.emu().read_memory<ksec_algorithm_request>(c.input_buffer);
-
                     // The field is guest-controlled and may not be NUL-terminated.
-                    algorithm_name = utils::string::to_string_view<char16_t>(algorithm_request.algorithm_name);
+                    algorithm_name = utils::string::to_string_view<char16_t>(request.algorithm_name);
                 }
 
                 const auto write_response = [&](const auto& output_data) -> NTSTATUS {


### PR DESCRIPTION
This PR fixes a regression in the KSecDD device introduced by https://github.com/momo5502/sogen/pull/1186, which assumed that the algorithm name would always be provided. However, an RNG query can be made without writing an algorithm name.
