### PR TITLE
Fix NtTerminateProcess

### DIFF
--- a/src/emulator/memory_interface.hpp
+++ b/src/emulator/memory_interface.hpp
@@ -56,6 +56,7 @@ namespace sogen
         template <typename T>
         T read_memory(const uint64_t address) const
         {
+            static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable!");
             T value{};
             this->read_memory(address, &value, sizeof(value));
             return value;
@@ -64,6 +65,7 @@ namespace sogen
         template <typename T>
         T read_memory(const uint64_t address, const size_t size) const
         {
+            static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable!");
             T value{};
             this->read_memory(address, &value, std::min(size, sizeof(T)));
             return value;
@@ -72,6 +74,7 @@ namespace sogen
         template <typename T>
         T read_memory(const void* address) const
         {
+            static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable!");
             return this->read_memory<T>(reinterpret_cast<uint64_t>(address));
         }
 
@@ -93,12 +96,14 @@ namespace sogen
         template <typename T>
         void write_memory(const uint64_t address, const T& value)
         {
+            static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable!");
             this->write_memory(address, &value, sizeof(value));
         }
 
         template <typename T>
         void write_memory(void* address, const T& value)
         {
+            static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable!");
             this->write_memory(reinterpret_cast<uint64_t>(address), &value, sizeof(value));
         }
 

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -593,7 +593,7 @@ namespace sogen
             if (c.proc.is_current_process_handle(process_handle))
             {
                 c.proc.exit_status = exit_status;
-                c.emu.stop();
+                c.win_emu.stop();
                 return STATUS_SUCCESS;
             }
 


### PR DESCRIPTION
This PR is another follow-up to https://github.com/momo5502/sogen/pull/1232 and https://github.com/momo5502/sogen/pull/1240. It ensures that the emulator actually stops when the process is terminated.

This appears to have been a pervasive issue in the multi-vCPU implementation. I suspect that most, if not all, current uses of `c.emu.stop();` should instead be `c.win_emu.stop();`. I may open a PR for this in the future if I encounter this kind of issue again, but of course, if anyone wants to tackle it sooner, feel free!

This PR also adds trivially copyable assertions to the `memory_interface` helpers.
