### PR TITLE
Implement some missing information classes

### DIFF
--- a/src/emulator-platform/platform/kernel_mapped.hpp
+++ b/src/emulator-platform/platform/kernel_mapped.hpp
@@ -1703,10 +1703,12 @@ namespace sogen
 
     typedef struct _GROUP_AFFINITY
     {
-        KAFFINITY Mask;
+        EMULATOR_CAST(EmulatorTraits<Emu64>::ULONG_PTR, KAFFINITY) Mask;
         WORD Group;
         WORD Reserved[3];
     } GROUP_AFFINITY, *PGROUP_AFFINITY;
+
+    static_assert(sizeof(GROUP_AFFINITY) == 0x10);
 
     struct THREAD_TLS_INFORMATION
     {

--- a/src/emulator-platform/platform/kernel_mapped.hpp
+++ b/src/emulator-platform/platform/kernel_mapped.hpp
@@ -1701,6 +1701,13 @@ namespace sogen
         LARGE_INTEGER UserTime;
     } KERNEL_USER_TIMES, *PKERNEL_USER_TIMES;
 
+    typedef struct _GROUP_AFFINITY
+    {
+        KAFFINITY Mask;
+        WORD Group;
+        WORD Reserved[3];
+    } GROUP_AFFINITY, *PGROUP_AFFINITY;
+
     struct THREAD_TLS_INFORMATION
     {
         ULONG Flags;

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -323,11 +323,19 @@ namespace sogen
         // SYSTEM_MEMORY_NUMA_PERFORMANCE_INFORMATION_OUTPUT // since 24H2 // 240
         SystemCodeIntegritySignedPoliciesFullInformation,
         SystemSecureSecretsInformation,
-        SystemTrustedAppsRuntimeInformation,          // SYSTEM_TRUSTEDAPPS_RUNTIME_INFORMATION
-        SystemBadPageInformationEx,                   // SYSTEM_BAD_PAGE_INFORMATION
-        SystemResourceDeadlockTimeout,                // ULONG
-        SystemBreakOnContextUnwindFailureInformation, // ULONG (requires SeDebugPrivilege)
-        SystemOslRamdiskInformation,                  // SYSTEM_OSL_RAMDISK_INFORMATION
+        SystemTrustedAppsRuntimeInformation,           // SYSTEM_TRUSTEDAPPS_RUNTIME_INFORMATION
+        SystemBadPageInformationEx,                    // SYSTEM_BAD_PAGE_INFORMATION
+        SystemResourceDeadlockTimeout,                 // ULONG
+        SystemBreakOnContextUnwindFailureInformation,  // ULONG (requires SeDebugPrivilege)
+        SystemOslRamdiskInformation,                   // SYSTEM_OSL_RAMDISK_INFORMATION
+        ystemCodeIntegrityPolicyManagementInformation, // SYSTEM_CODEINTEGRITYPOLICY_MANAGEMENT // since 25H2
+        SystemMemoryNumaCacheInformation,              // SYSTEM_MEMORY_NUMA_CACHE_INFORMATION
+        SystemProcessorFeaturesBitMapInformation,      // ULONG64[2] // RTL_BITMAP_EX // RtlInitializeBitMapEx // 250
+        SystemRefTraceInformationEx,                   // SYSTEM_REF_TRACE_INFORMATION_EX
+        SystemBasicProcessInformation,                 // SYSTEM_BASICPROCESS_INFORMATION
+        SystemHandleCountInformation,                  // SYSTEM_HANDLECOUNT_INFORMATION
+        SystemRuntimeAttestationReport,                // SYSTEM_RUNTIME_REPORT_INPUT
+        SystemPoolTagInformation2,                     // SYSTEM_POOLTAG_INFORMATION2 // since 26H1
         MaxSystemInfoClass
     };
 

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -323,19 +323,19 @@ namespace sogen
         // SYSTEM_MEMORY_NUMA_PERFORMANCE_INFORMATION_OUTPUT // since 24H2 // 240
         SystemCodeIntegritySignedPoliciesFullInformation,
         SystemSecureSecretsInformation,
-        SystemTrustedAppsRuntimeInformation,           // SYSTEM_TRUSTEDAPPS_RUNTIME_INFORMATION
-        SystemBadPageInformationEx,                    // SYSTEM_BAD_PAGE_INFORMATION
-        SystemResourceDeadlockTimeout,                 // ULONG
-        SystemBreakOnContextUnwindFailureInformation,  // ULONG (requires SeDebugPrivilege)
-        SystemOslRamdiskInformation,                   // SYSTEM_OSL_RAMDISK_INFORMATION
-        ystemCodeIntegrityPolicyManagementInformation, // SYSTEM_CODEINTEGRITYPOLICY_MANAGEMENT // since 25H2
-        SystemMemoryNumaCacheInformation,              // SYSTEM_MEMORY_NUMA_CACHE_INFORMATION
-        SystemProcessorFeaturesBitMapInformation,      // ULONG64[2] // RTL_BITMAP_EX // RtlInitializeBitMapEx // 250
-        SystemRefTraceInformationEx,                   // SYSTEM_REF_TRACE_INFORMATION_EX
-        SystemBasicProcessInformation,                 // SYSTEM_BASICPROCESS_INFORMATION
-        SystemHandleCountInformation,                  // SYSTEM_HANDLECOUNT_INFORMATION
-        SystemRuntimeAttestationReport,                // SYSTEM_RUNTIME_REPORT_INPUT
-        SystemPoolTagInformation2,                     // SYSTEM_POOLTAG_INFORMATION2 // since 26H1
+        SystemTrustedAppsRuntimeInformation,            // SYSTEM_TRUSTEDAPPS_RUNTIME_INFORMATION
+        SystemBadPageInformationEx,                     // SYSTEM_BAD_PAGE_INFORMATION
+        SystemResourceDeadlockTimeout,                  // ULONG
+        SystemBreakOnContextUnwindFailureInformation,   // ULONG (requires SeDebugPrivilege)
+        SystemOslRamdiskInformation,                    // SYSTEM_OSL_RAMDISK_INFORMATION
+        SystemCodeIntegrityPolicyManagementInformation, // SYSTEM_CODEINTEGRITYPOLICY_MANAGEMENT // since 25H2
+        SystemMemoryNumaCacheInformation,               // SYSTEM_MEMORY_NUMA_CACHE_INFORMATION
+        SystemProcessorFeaturesBitMapInformation,       // ULONG64[2] // RTL_BITMAP_EX // RtlInitializeBitMapEx // 250
+        SystemRefTraceInformationEx,                    // SYSTEM_REF_TRACE_INFORMATION_EX
+        SystemBasicProcessInformation,                  // SYSTEM_BASICPROCESS_INFORMATION
+        SystemHandleCountInformation,                   // SYSTEM_HANDLECOUNT_INFORMATION
+        SystemRuntimeAttestationReport,                 // SYSTEM_RUNTIME_REPORT_INPUT
+        SystemPoolTagInformation2,                      // SYSTEM_POOLTAG_INFORMATION2 // since 26H1
         MaxSystemInfoClass
     };
 
@@ -565,6 +565,12 @@ namespace sogen
         USHORT ProcessorRevision;
         USHORT MaximumProcessors;
         ULONG ProcessorFeatureBits;
+    };
+
+    struct SYSTEM_PROCESSOR_FEATURES_INFORMATION64
+    {
+        ULONGLONG ProcessorFeatureBits;
+        ULONGLONG Reserved[3];
     };
 
 #if !defined(OS_WINDOWS) || !defined(_WIN64)

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -1268,6 +1268,18 @@ namespace sogen
     };
 
     template <typename Traits>
+    struct SYSTEM_BASICPROCESS_INFORMATION
+    {
+        ULONG NextEntryOffset;
+        Traits::HANDLE UniqueProcessId;
+        Traits::HANDLE InheritedFromUniqueProcessId;
+        ULONG64 SequenceNumber;
+        UNICODE_STRING<Traits> ImageName;
+    };
+
+    static_assert(sizeof(SYSTEM_BASICPROCESS_INFORMATION<EmulatorTraits<Emu64>>) == 0x30);
+
+    template <typename Traits>
     struct SYSTEM_PROCESS_INFORMATION
     {
         ULONG NextEntryOffset;

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -62,7 +62,29 @@ namespace sogen
                     constexpr ULONG dep_disabled_execute_flags = 0x32;
                     flags = c.win_emu.memory.is_dep_enabled() ? dep_enabled_execute_flags : dep_disabled_execute_flags;
                 });
-            case ProcessGroupInformation:
+            case ProcessGroupInformation: {
+                constexpr uint32_t group_count = 1;
+                constexpr uint32_t required_length = group_count * sizeof(USHORT);
+
+                if (return_length)
+                {
+                    return_length.write(required_length);
+                }
+
+                // ProcessGroupInformation is a variable-length USHORT array,
+                // so a larger buffer is valid.
+                if (process_information_length < required_length)
+                {
+                    return STATUS_INFO_LENGTH_MISMATCH;
+                }
+
+                const emulator_object<USHORT> info{c.emu, process_information};
+                info.access([](USHORT& group) {
+                    group = 0; // The process belongs to processor group 0.
+                });
+
+                return STATUS_SUCCESS;
+            }
             case ProcessMitigationPolicy: {
                 // ProcessMitigationPolicy requires special handling because the caller
                 // specifies which policy to query via the Policy field in the input buffer.

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -193,6 +193,9 @@ namespace sogen
             case ProcessBasicInformation: {
                 const auto init_basic_info = [&](PROCESS_BASIC_INFORMATION64& basic_info) {
                     basic_info.PebBaseAddress = c.proc.peb64.value();
+                    const auto processor_count =
+                        c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; });
+                    basic_info.AffinityMask = processor_count >= 64 ? ~0ull : ((1ull << processor_count) - 1);
                     basic_info.UniqueProcessId = process_context::process_id;
                 };
 

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -235,6 +235,7 @@ namespace sogen
 
         constexpr uint64_t FAKE_KERNEL_BASE = 0xFFFFF80000000000ULL;
         constexpr uint32_t FAKE_KERNEL_SIZE = 0x00A00000;
+        constexpr uint64_t PROCESSOR_FEATURE_BITS = 0x421993DFEULL;
 
         template <typename Traits>
         void fill_ntoskrnl_module(RTL_PROCESS_MODULE_INFORMATION<Traits>& m)
@@ -438,7 +439,6 @@ namespace sogen
             case SystemProcessInformation:
                 return handle_system_process_information(c, system_information, system_information_length, return_length);
 
-            case 250: // Build 27744
             case SystemFlushInformation:
             case SystemCodeIntegrityPolicyInformation:
             case SystemHypervisorSharedPageInformation:
@@ -593,7 +593,29 @@ namespace sogen
                         info.MaximumProcessors = 2;
                         info.ProcessorArchitecture =
                             (info_class == SystemProcessorInformation ? PROCESSOR_ARCHITECTURE_AMD64 : PROCESSOR_ARCHITECTURE_INTEL);
+                        info.ProcessorFeatureBits = static_cast<ULONG>(PROCESSOR_FEATURE_BITS);
                     });
+
+            case SystemProcessorFeaturesInformation:
+                return handle_query<uint64_t>(c.emu, system_information, system_information_length, return_length, [&](uint64_t& bits) { //
+                    bits = PROCESSOR_FEATURE_BITS;
+                });
+
+            case SystemProcessorFeaturesBitMapInformation:
+                return handle_query<std::array<ULONG64, 2>>(c.emu, system_information, system_information_length, return_length,
+                                                            [&](std::array<ULONG64, 2>& bitmap) {
+                                                                bitmap = {};
+
+                                                                c.proc.kusd.access([&](KUSER_SHARED_DATA64& kusd) {
+                                                                    for (size_t index = 0; index < 128; ++index)
+                                                                    {
+                                                                        if (kusd.ProcessorFeatures.arr[index])
+                                                                        {
+                                                                            bitmap.at(index / 64) |= ULONG64{1} << (index % 64);
+                                                                        }
+                                                                    }
+                                                                });
+                                                            });
 
             case SystemNumaProcessorMap:
                 return handle_query<SYSTEM_NUMA_INFORMATION64>(c.emu, system_information, system_information_length, return_length,

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -327,7 +327,10 @@ namespace sogen
                 c.vcpu.active_thread->teb64->access([&](const TEB64& teb) { process_id = teb.ClientId.UniqueProcess; });
             }
 
-            constexpr auto required = static_cast<uint32_t>(sizeof(proc_t));
+            const auto image_name = u8_to_u16(c.win_emu.mod_manager.executable->name);
+            const auto image_name_length = image_name.size() * sizeof(char16_t);
+            const auto image_name_buffer_length = image_name_length + sizeof(char16_t);
+            const auto required = static_cast<uint32_t>(sizeof(proc_t) + image_name_buffer_length);
 
             if (return_length)
             {
@@ -350,7 +353,13 @@ namespace sogen
             // when no separate sequence number is available.
             proc.SequenceNumber = process_id;
 
+            const auto image_name_buffer = system_information + sizeof(proc);
+            proc.ImageName.Length = static_cast<USHORT>(image_name_length);
+            proc.ImageName.MaximumLength = static_cast<USHORT>(image_name_buffer_length);
+            proc.ImageName.Buffer = image_name_buffer;
+
             c.emu.write_memory(system_information, &proc, sizeof(proc));
+            c.emu.write_memory(image_name_buffer, image_name.c_str(), image_name_buffer_length);
 
             return STATUS_SUCCESS;
         }
@@ -389,7 +398,11 @@ namespace sogen
                 thread_ids.push_back(active_tid);
             }
 
-            const auto required = static_cast<uint32_t>(sizeof(proc_t) + thread_ids.size() * sizeof(thread_t));
+            const auto image_name = u8_to_u16(c.win_emu.mod_manager.executable->name);
+            const auto image_name_length = image_name.size() * sizeof(char16_t);
+            const auto image_name_buffer_length = image_name_length + sizeof(char16_t);
+            const auto thread_information_length = thread_ids.size() * sizeof(thread_t);
+            const auto required = static_cast<uint32_t>(sizeof(proc_t) + thread_information_length + image_name_buffer_length);
 
             if (return_length)
             {
@@ -409,6 +422,12 @@ namespace sogen
             proc.UniqueProcessId = process_id;
             proc.HandleCount = 0;
             proc.SessionId = 0;
+
+            const auto image_name_buffer = system_information + sizeof(proc) + thread_information_length;
+            proc.ImageName.Length = static_cast<USHORT>(image_name_length);
+            proc.ImageName.MaximumLength = static_cast<USHORT>(image_name_buffer_length);
+            proc.ImageName.Buffer = image_name_buffer;
+
             c.emu.write_memory(system_information, &proc, sizeof(proc));
 
             for (size_t i = 0; i < thread_ids.size(); ++i)
@@ -423,6 +442,8 @@ namespace sogen
                 info.WaitReason = 6;  // WrQueue
                 c.emu.write_memory(system_information + sizeof(proc_t) + i * sizeof(thread_t), &info, sizeof(info));
             }
+
+            c.emu.write_memory(image_name_buffer, image_name.c_str(), image_name_buffer_length);
 
             return STATUS_SUCCESS;
         }
@@ -593,29 +614,37 @@ namespace sogen
                         info.MaximumProcessors = 2;
                         info.ProcessorArchitecture =
                             (info_class == SystemProcessorInformation ? PROCESSOR_ARCHITECTURE_AMD64 : PROCESSOR_ARCHITECTURE_INTEL);
+                        // TODO: Figure out the best way to derive this from 'kusd.ProcessorFeatures'
                         info.ProcessorFeatureBits = static_cast<ULONG>(PROCESSOR_FEATURE_BITS);
                     });
 
             case SystemProcessorFeaturesInformation:
-                return handle_query<uint64_t>(c.emu, system_information, system_information_length, return_length, [&](uint64_t& bits) { //
-                    bits = PROCESSOR_FEATURE_BITS;
-                });
+                return handle_query<SYSTEM_PROCESSOR_FEATURES_INFORMATION64>(c.emu, system_information, system_information_length,
+                                                                             return_length,
+                                                                             [&](SYSTEM_PROCESSOR_FEATURES_INFORMATION64& info) {
+                                                                                 // TODO: Figure out the best way to derive this from
+                                                                                 //       'kusd.ProcessorFeatures'
+                                                                                 info.ProcessorFeatureBits = PROCESSOR_FEATURE_BITS;
+                                                                             });
 
             case SystemProcessorFeaturesBitMapInformation:
-                return handle_query<std::array<ULONG64, 2>>(c.emu, system_information, system_information_length, return_length,
-                                                            [&](std::array<ULONG64, 2>& bitmap) {
-                                                                bitmap = {};
+                return handle_query<std::array<ULONG64, 2>>(
+                    c.emu, system_information, system_information_length, return_length, [&](std::array<ULONG64, 2>& bitmap) {
+                        bitmap = {};
 
-                                                                c.proc.kusd.access([&](KUSER_SHARED_DATA64& kusd) {
-                                                                    for (size_t index = 0; index < 128; ++index)
-                                                                    {
-                                                                        if (kusd.ProcessorFeatures.arr[index])
-                                                                        {
-                                                                            bitmap.at(index / 64) |= ULONG64{1} << (index % 64);
-                                                                        }
-                                                                    }
-                                                                });
-                                                            });
+                        c.proc.kusd.access([&](KUSER_SHARED_DATA64& kusd) {
+                            const auto& features = kusd.ProcessorFeatures.arr;
+                            const std::size_t count = std::min<std::size_t>(128, std::size(features));
+
+                            for (std::size_t index = 0; index < count; ++index)
+                            {
+                                if (features[index])
+                                {
+                                    bitmap[index / 64] |= ULONG64{1} << (index % 64);
+                                }
+                            }
+                        });
+                    });
 
             case SystemNumaProcessorMap:
                 return handle_query<SYSTEM_NUMA_INFORMATION64>(c.emu, system_information, system_information_length, return_length,

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -312,6 +312,48 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_system_basicprocess_information(const syscall_context& c, const uint64_t system_information,
+                                                        const uint32_t system_information_length,
+                                                        const emulator_object<uint32_t> return_length)
+        {
+            using Traits = EmulatorTraits<Emu64>;
+            using proc_t = SYSTEM_BASICPROCESS_INFORMATION<Traits>;
+
+            uint64_t process_id = process_context::process_id;
+
+            if (c.vcpu.active_thread && c.vcpu.active_thread->teb64)
+            {
+                c.vcpu.active_thread->teb64->access([&](const TEB64& teb) { process_id = teb.ClientId.UniqueProcess; });
+            }
+
+            constexpr auto required = static_cast<uint32_t>(sizeof(proc_t));
+
+            if (return_length)
+            {
+                return_length.write(required);
+            }
+
+            if (system_information_length < required)
+            {
+                return STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            proc_t proc{};
+
+            proc.NextEntryOffset = 0; // Single process; terminator
+            proc.UniqueProcessId = process_id;
+            proc.InheritedFromUniqueProcessId = 0;
+
+            // Ideally this should be a monotonically increasing value assigned when
+            // the emulated process is created. The process ID is a reasonable fallback
+            // when no separate sequence number is available.
+            proc.SequenceNumber = process_id;
+
+            c.emu.write_memory(system_information, &proc, sizeof(proc));
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_system_process_information(const syscall_context& c, const uint64_t system_information,
                                                    const uint32_t system_information_length, const emulator_object<uint32_t> return_length)
         {
@@ -390,11 +432,13 @@ namespace sogen
         {
             switch (info_class)
             {
+            case SystemBasicProcessInformation:
+                return handle_system_basicprocess_information(c, system_information, system_information_length, return_length);
+
             case SystemProcessInformation:
                 return handle_system_process_information(c, system_information, system_information_length, return_length);
 
             case 250: // Build 27744
-            case 252:
             case SystemFlushInformation:
             case SystemCodeIntegrityPolicyInformation:
             case SystemHypervisorSharedPageInformation:

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -467,7 +467,29 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            c.win_emu.log.error("Unsupported thread query info class: %X\n", info_class);
+            if (info_class == ThreadGroupInformation)
+            {
+                if (return_length)
+                {
+                    return_length.write(sizeof(GROUP_AFFINITY));
+                }
+
+                if (thread_information_length != sizeof(GROUP_AFFINITY))
+                {
+                    return STATUS_BUFFER_OVERFLOW;
+                }
+
+                const emulator_object<GROUP_AFFINITY> info{c.emu, thread_information};
+                info.access([&](GROUP_AFFINITY& ga) {
+                    const auto processor_count =
+                        c.proc.kusd.access([](const KUSER_SHARED_DATA64& kusd) { return kusd.ActiveProcessorCount; });
+                    ga.Mask = processor_count >= 64 ? ~0ull : ((1ull << processor_count) - 1);
+                });
+
+                return STATUS_SUCCESS;
+            }
+
+            c.win_emu.log.error("Unsupported thread query info class: 0x%X\n", info_class);
             c.emu.stop();
 
             return STATUS_NOT_SUPPORTED;


### PR DESCRIPTION
This PR improves support for some process, thread, and system information queries:

- `NtQueryInformationProcess`: Adds support for `ProcessGroupInformation` and reports the process affinity mask through `ProcessBasicInformation`. 
- `NtQueryInformationThread`: Adds support for `ThreadGroupInformation`.
- `NtQuerySystemInformation`: Adds support for `SystemBasicProcessInformation`, `SystemProcessorFeaturesInformation`, and `SystemProcessorFeaturesBitMapInformation`.

These changes fix a regression in an app that previously ran on sogen but broke after the `NtOpenProcess` change introduced in commit 6ae1a1204b5f28bb9cd699049a9e3aa1cf1d7d08. (That change exposed an execution path that had not been exercised before)