### PR TITLE
fix(sandbox): restrict the KVM backend link to Linux x86_64

### DIFF
--- a/src/tools/sandbox/CMakeLists.txt
+++ b/src/tools/sandbox/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Windows uses the WHP backend, Linux x64 uses the KVM backend. Both are 64-bit only.
-if((NOT WIN AND NOT LINUX) OR MINGW OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+if((NOT WIN AND NOT (LINUX AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")) OR MINGW OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   return()
 endif()
 


### PR DESCRIPTION
## Summary
- `kvm-emulator` is only added as a subdirectory on Linux x86_64 (see `src/backends/CMakeLists.txt`), since KVM-based x86_64 guest virtualization requires a matching x86_64 host.
- `src/tools/sandbox/CMakeLists.txt` builds on any Windows-or-Linux 64-bit target and unconditionally links `kvm-emulator` on the non-Windows branch, so on other Linux architectures (e.g. arm64) this resolves to a raw linker flag instead of a real CMake target, silently losing the include directory.
- This breaks a full ARM64 Linux build with `src/tools/sandbox/main.cpp: fatal error: 'kvm_x86_64_emulator.hpp' file not found`, reproduced on a `ubuntu-24.04-arm` CI runner.

Fix mirrors the same `CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64"` guard already used in `backend-selection` and `backends/CMakeLists.txt`.

## Test plan
- [x] Verified full `cmake --build --preset=release` (no target restriction) succeeds on a native `ubuntu-24.04-arm` GitHub Actions runner with this fix applied.
- [x] `sandbox` still builds correctly on Windows and Linux x86_64 (guard is unchanged for those paths).