### PR TITLE
Make WM_CLOSE destroy windows

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1183,7 +1183,8 @@ namespace
 
     bool test_message_queue()
     {
-        static thread_local UINT wnd_proc_num = 0;
+        thread_local UINT wnd_proc_num = 0;
+        thread_local UINT destroy_count = 0;
         static const UINT wnd_msg_id = WM_APP + 2;
 
         WNDCLASSEXA wc = {};
@@ -1206,6 +1207,19 @@ namespace
                     wnd_proc_num += 1;
                     return 777;
                 }
+            }
+            else if (msg == WM_CLOSE)
+            {
+                wnd_proc_num += 1;
+                if (wnd_proc_num == 2)
+                {
+                    return 0;
+                }
+            }
+            else if (msg == WM_DESTROY)
+            {
+                ++destroy_count;
+                PostQuitMessage(42);
             }
             return DefWindowProcA(hwnd, msg, wp, lp);
         };
@@ -1272,8 +1286,30 @@ namespace
             return false;
         }
 
-        constexpr int quit_code = 42;
-        PostQuitMessage(quit_code);
+        SendMessageA(hwnd, WM_CLOSE, 0, 0);
+        if (!IsWindow(hwnd) || destroy_count != 0)
+        {
+            puts("WndProc unexpectedly destroyed the window on cancelled WM_CLOSE");
+            if (IsWindow(hwnd))
+            {
+                DestroyWindow(hwnd);
+            }
+            UnregisterClassA(wc.lpszClassName, wc.hInstance);
+            return false;
+        }
+
+        SendMessageA(hwnd, WM_CLOSE, 0, 0);
+        if (IsWindow(hwnd) || destroy_count != 1)
+        {
+            puts("DefWindowProc did not destroy the window on WM_CLOSE");
+            if (IsWindow(hwnd))
+            {
+                DestroyWindow(hwnd);
+            }
+            UnregisterClassA(wc.lpszClassName, wc.hInstance);
+            return false;
+        }
+        hwnd = nullptr;
 
         const BOOL quit_result = GetMessageA(&msg, nullptr, 0, 0);
         if (quit_result != 0)
@@ -1292,15 +1328,13 @@ namespace
             return false;
         }
 
-        if (msg.wParam != quit_code)
+        if (msg.wParam != 42)
         {
             puts("WM_QUIT exit code mismatch");
-            DestroyWindow(hwnd);
             UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
-        DestroyWindow(hwnd);
         UnregisterClassA(wc.lpszClassName, wc.hInstance);
         return true;
     }

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1230,22 +1230,23 @@ namespace
             return false;
         }
 
+        const auto unregister_class = sogen::utils::finally([&] { UnregisterClassA(wc.lpszClassName, wc.hInstance); });
+
         HWND hwnd = CreateWindowExA(0, wc.lpszClassName, nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, wc.hInstance,
                                     reinterpret_cast<void*>(0x1337));
         if (!hwnd || wnd_proc_num != 1)
         {
             puts("Failed to create message window");
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
+
+        const auto destroy_window = sogen::utils::finally([&] { DestroyWindow(hwnd); });
 
         const LRESULT send_res = SendMessageA(hwnd, wnd_msg_id, 123, 456);
 
         if (send_res != 777 || wnd_proc_num != 2)
         {
             puts("SendMessage failed");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
@@ -1253,8 +1254,6 @@ namespace
         if (!PostMessageA(hwnd, wnd_msg_id, 123, 456))
         {
             puts("PostMessage failed");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
@@ -1262,16 +1261,12 @@ namespace
         if (GetMessageA(&msg, hwnd, 0, 0) <= 0)
         {
             puts("GetMessage failed or returned WM_QUIT unexpectedly");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
         if (msg.message != wnd_msg_id)
         {
             puts("Retrieved message is not the expected custom message");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
@@ -1281,8 +1276,6 @@ namespace
         if (wnd_proc_num != 1)
         {
             puts("Posted window message did not execute WndProc");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
@@ -1290,11 +1283,6 @@ namespace
         if (!IsWindow(hwnd) || destroy_count != 0)
         {
             puts("WndProc unexpectedly destroyed the window on cancelled WM_CLOSE");
-            if (IsWindow(hwnd))
-            {
-                DestroyWindow(hwnd);
-            }
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
@@ -1302,11 +1290,6 @@ namespace
         if (IsWindow(hwnd) || destroy_count != 1)
         {
             puts("DefWindowProc did not destroy the window on WM_CLOSE");
-            if (IsWindow(hwnd))
-            {
-                DestroyWindow(hwnd);
-            }
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
         hwnd = nullptr;
@@ -1315,27 +1298,21 @@ namespace
         if (quit_result != 0)
         {
             puts("GetMessage did not return 0 for WM_QUIT");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
         if (msg.message != WM_QUIT)
         {
             puts("Message is not WM_QUIT");
-            DestroyWindow(hwnd);
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
         if (msg.wParam != 42)
         {
             puts("WM_QUIT exit code mismatch");
-            UnregisterClassA(wc.lpszClassName, wc.hInstance);
             return false;
         }
 
-        UnregisterClassA(wc.lpszClassName, wc.hInstance);
         return true;
     }
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -135,25 +135,40 @@ namespace sogen
         }
     };
 
-    struct window_destroy_state : completion_state
+    struct window_destroy_data
     {
         std::vector<window_destroy_frame> frames{};
         std::vector<window_destroy_frame> nc_destroy_frames{};
         uint32_t nc_destroy_index{};
 
-      private:
-        void serialize_object(utils::buffer_serializer& buffer) const override
+        void serialize(utils::buffer_serializer& buffer) const
         {
             buffer.write_vector(this->frames);
             buffer.write_vector(this->nc_destroy_frames);
             buffer.write(this->nc_destroy_index);
         }
 
-        void deserialize_object(utils::buffer_deserializer& buffer) override
+        void deserialize(utils::buffer_deserializer& buffer)
         {
             buffer.read_vector(this->frames);
             buffer.read_vector(this->nc_destroy_frames);
             buffer.read(this->nc_destroy_index);
+        }
+    };
+
+    struct window_destroy_state : completion_state
+    {
+        window_destroy_data destruction{};
+
+      private:
+        void serialize_object(utils::buffer_serializer& buffer) const override
+        {
+            this->destruction.serialize(buffer);
+        }
+
+        void deserialize_object(utils::buffer_deserializer& buffer) override
+        {
+            this->destruction.deserialize(buffer);
         }
     };
 
@@ -194,6 +209,8 @@ namespace sogen
         UINT message{};
         uint64_t scratch_text{}; // guest buffer holding a re-encoded text payload; freed on completion
         bool dispatching_result_callback{};
+        bool destroying_window{};
+        window_destroy_data destruction{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -202,6 +219,8 @@ namespace sogen
             buffer.write(this->message);
             buffer.write(this->scratch_text);
             buffer.write(this->dispatching_result_callback);
+            buffer.write(this->destroying_window);
+            this->destruction.serialize(buffer);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -210,6 +229,8 @@ namespace sogen
             buffer.read(this->message);
             buffer.read(this->scratch_text);
             buffer.read(this->dispatching_result_callback);
+            buffer.read(this->destroying_window);
+            this->destruction.deserialize(buffer);
         }
     };
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1036,9 +1036,32 @@ namespace sogen
             dispatch_window_message(c, id, std::forward<T>(state), win, m.message, m.wParam, m.lParam);
         }
 
-        BOOL advance_window_destroy(const syscall_context& c, window_destroy_state& state)
+        void complete_window_destroy_step(const syscall_context& c, window_destroy_data& state)
         {
-            window_destroy_orchestrator orchestrator{state, c};
+            if (state.frames.empty())
+            {
+                return;
+            }
+
+            auto& frame = state.frames.back();
+            if (frame.pending_window_pos_address == 0)
+            {
+                return;
+            }
+
+            if (auto* win = c.proc.windows.get(frame.handle))
+            {
+                complete_window_position_change(c, *win, frame.pending_window_pos_address, frame.changed_window_pos_alloc,
+                                                frame.message_queue, true);
+            }
+            frame.pending_window_pos_address = 0;
+        }
+
+        template <typename State>
+        BOOL advance_window_destroy(const syscall_context& c, State& completion_state, window_destroy_data& destruction,
+                                    const callback_id completion_callback)
+        {
+            window_destroy_orchestrator orchestrator{destruction, c};
             const auto step = orchestrator.advance();
             if (!step)
             {
@@ -1048,11 +1071,11 @@ namespace sogen
             auto* win = c.proc.windows.get(step->handle);
             if (!win)
             {
-                return advance_window_destroy(c, state);
+                return advance_window_destroy(c, completion_state, destruction, completion_callback);
             }
 
-            dispatch_window_message(c, callback_id::NtUserDestroyWindow, std::move(state), *win, step->message.message,
-                                    step->message.wParam, step->message.lParam);
+            dispatch_window_message(c, completion_callback, std::move(completion_state), *win, step->message.message, step->message.wParam,
+                                    step->message.lParam);
             return {};
         }
 
@@ -3293,27 +3316,15 @@ namespace sogen
             }
 
             window_destroy_state state{};
-            window_destroy_orchestrator{state, c}.start(*win);
-            return advance_window_destroy(c, state);
+            window_destroy_orchestrator{state.destruction, c}.start(*win);
+            return advance_window_destroy(c, state, state.destruction, callback_id::NtUserDestroyWindow);
         }
 
         BOOL completion_NtUserDestroyWindow(const syscall_context& c, const hwnd /*window*/)
         {
             auto& s = c.get_completion_state<window_destroy_state>();
-            if (!s.frames.empty())
-            {
-                auto& frame = s.frames.back();
-                if (frame.pending_window_pos_address != 0)
-                {
-                    if (auto* win = c.proc.windows.get(frame.handle))
-                    {
-                        complete_window_position_change(c, *win, frame.pending_window_pos_address, frame.changed_window_pos_alloc,
-                                                        frame.message_queue, true);
-                    }
-                    frame.pending_window_pos_address = 0;
-                }
-            }
-            return advance_window_destroy(c, s);
+            complete_window_destroy_step(c, s.destruction);
+            return advance_window_destroy(c, s, s.destruction, callback_id::NtUserDestroyWindow);
         }
 
         BOOL handle_NtUserSetProp(const syscall_context& c, const hwnd window, const uint16_t atom, const uint64_t data)
@@ -3594,6 +3605,16 @@ namespace sogen
 
             if (type == FNID_DEFWINDOW)
             {
+                if (msg == WM_CLOSE)
+                {
+                    message_call_state state{};
+                    state.window = hwnd;
+                    state.message = msg;
+                    state.destroying_window = true;
+                    window_destroy_orchestrator{state.destruction, c}.start(*win);
+                    return advance_window_destroy(c, state, state.destruction, callback_id::NtUserMessageCall);
+                }
+
                 const auto result = handle_default_window_proc_message(c, *win, msg, w_param, l_param, ansi);
                 return write_message_call_result(c, result_info, result) ? TRUE : FALSE;
             }
@@ -3675,6 +3696,17 @@ namespace sogen
                                               const uint64_t /*l_param*/, const uint64_t result_info, const DWORD type, const BOOL /*ansi*/)
         {
             auto& state = c.get_completion_state<message_call_state>();
+
+            if (state.destroying_window)
+            {
+                complete_window_destroy_step(c, state.destruction);
+                if (!advance_window_destroy(c, state, state.destruction, callback_id::NtUserMessageCall))
+                {
+                    return {};
+                }
+                return write_message_call_result(c, result_info, 0) ? TRUE : FALSE;
+            }
+
             if (state.scratch_text != 0)
             {
                 c.win_emu.memory.release_memory(state.scratch_text, 0);

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -5,7 +5,7 @@
 namespace sogen
 {
 
-    window_destroy_orchestrator::window_destroy_orchestrator(window_destroy_state& state, const syscall_context& c)
+    window_destroy_orchestrator::window_destroy_orchestrator(window_destroy_data& state, const syscall_context& c)
         : state_(state),
           emu_(c.emu),
           proc_(c.proc),

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -303,11 +303,38 @@ namespace sogen
         return dependents;
     }
 
+    static void clear_cached_window(const emulator_thread& thread, const hwnd handle, const uint64_t guest_pointer)
+    {
+        if (thread.teb64)
+        {
+            thread.teb64->access([&](TEB64& teb) {
+                if (teb.Win32ClientInfo.arr[8] == handle && teb.Win32ClientInfo.arr[9] == guest_pointer)
+                {
+                    teb.Win32ClientInfo.arr[8] = 0;
+                    teb.Win32ClientInfo.arr[9] = 0;
+                }
+            });
+        }
+
+        if (thread.teb32)
+        {
+            thread.teb32->access([&](TEB32& teb) {
+                if (teb.Win32ClientInfo[8] == static_cast<uint32_t>(handle) &&
+                    teb.Win32ClientInfo[9] == static_cast<uint32_t>(guest_pointer))
+                {
+                    teb.Win32ClientInfo[8] = 0;
+                    teb.Win32ClientInfo[9] = 0;
+                }
+            });
+        }
+    }
+
     void window_destroy_orchestrator::finalize_frame(window_destroy_frame& frame, const window& win) const
     {
         this->pop_frame_allocation(frame);
         this->thread_.remove_window_messages(frame.handle);
 
+        clear_cached_window(this->thread_, win.handle, win.guest.value());
         win.guest.access([&](USER_WINDOW& guest_win) {
             guest_win.spwndParent = 0;
             guest_win.spwndChild = 0;

--- a/src/windows-emulator/window_destroy_orchestrator.hpp
+++ b/src/windows-emulator/window_destroy_orchestrator.hpp
@@ -23,7 +23,7 @@ namespace sogen
     class window_destroy_orchestrator
     {
       public:
-        window_destroy_orchestrator(window_destroy_state& state, const syscall_context& c);
+        window_destroy_orchestrator(window_destroy_data& state, const syscall_context& c);
 
         void start(window& root) const;
         std::optional<window_destroy_step> advance() const;
@@ -37,7 +37,7 @@ namespace sogen
         std::vector<hwnd> collect_dependents(const window& win) const;
         void finalize_frame(window_destroy_frame& frame, const window& win) const;
 
-        window_destroy_state& state_;
+        window_destroy_data& state_;
         x86_64_cpu& emu_;
         process_context& proc_;
         emulator_thread& thread_;


### PR DESCRIPTION
This PR changes the default handling of `WM_CLOSE` so that it results in the window being destroyed, consistent with the [documented Win32 default behavior](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-close).