### PR TITLE
Add `--gdb-arch` CLI option

### DIFF
--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -53,6 +53,7 @@ namespace sogen
             mutable bool use_gdb{false};
             std::string gdb_host{"127.0.0.1"};
             uint16_t gdb_port{28960};
+            std::string gdb_architecture{"64bits"};
             bool log_executable_access{false};
             bool log_foreign_module_access{false};
             bool tenet_trace{false};
@@ -99,6 +100,26 @@ namespace sogen
             {
                 container.emplace(str.substr(current_start));
             }
+        }
+
+        gdb_target_architecture parse_gdb_target_architecture(const std::string_view value)
+        {
+            if (value == "auto")
+            {
+                return gdb_target_architecture::automatic;
+            }
+
+            if (value == "32bits")
+            {
+                return gdb_target_architecture::bits_32;
+            }
+
+            if (value == "64bits")
+            {
+                return gdb_target_architecture::bits_64;
+            }
+
+            throw std::invalid_argument("Invalid GDB target architecture");
         }
 
         struct analysis_state
@@ -385,7 +406,7 @@ namespace sogen
 
                     const auto should_stop = [&] { return signals_received > 0; };
 
-                    win_x86_64_gdb_stub_handler handler{win_emu, should_stop};
+                    win_x86_64_gdb_stub_handler handler{win_emu, should_stop, parse_gdb_target_architecture(options.gdb_architecture)};
                     gdb_stub::run_gdb_stub(address, handler);
                 }
                 else if (!options.minidump_path.empty())
@@ -838,6 +859,10 @@ namespace sogen
             auto* const debug_option = app.add_flag("-d,--debug", options.use_gdb, "Enable GDB debugging mode");
             app.add_option("--bind", options.gdb_host, "IP or hostname to bind to in GDB mode")->capture_default_str()->needs(debug_option);
             app.add_option("--port", options.gdb_port, "Port to listen to in GDB mode")->capture_default_str()->needs(debug_option);
+            app.add_option("--gdb-arch", options.gdb_architecture, "GDB target architecture: auto, 64bits or 32bits")
+                ->capture_default_str()
+                ->check(CLI::IsMember({"auto", "64bits", "32bits"}))
+                ->needs(debug_option);
             app.add_option("--break-call", options.break_call, "In GDB mode, stop before the specified traced function/syscall call")
                 ->needs(debug_option);
 

--- a/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/win_x86_64_gdb_stub_handler.hpp
@@ -10,14 +10,23 @@
 namespace sogen
 {
 
+    enum class gdb_target_architecture
+    {
+        automatic,
+        bits_64,
+        bits_32,
+    };
+
     class win_x86_64_gdb_stub_handler : public x86_64_gdb_stub_handler
     {
       public:
-        win_x86_64_gdb_stub_handler(windows_emulator& win_emu, utils::optional_function<bool()> should_stop = {})
+        win_x86_64_gdb_stub_handler(windows_emulator& win_emu, utils::optional_function<bool()> should_stop = {},
+                                    const gdb_target_architecture target_architecture = gdb_target_architecture::bits_64)
             : x86_64_gdb_stub_handler(win_emu.emu()),
               win_emu_(&win_emu),
               should_stop_(std::move(should_stop)),
-              windows_filesystem_(win_emu)
+              windows_filesystem_(win_emu),
+              target_architecture_(target_architecture)
         {
             auto hook = [this](mapped_module&) {
                 library_stop_pending_ = true;
@@ -207,9 +216,17 @@ namespace sogen
 
         bool is_32_bit() const override
         {
-            // Later IDA versions support debugging 32 bit applications in 64 bit environments
-            // If debugger doesn't support that, enable that
-            return false; // win_emu_->process.is_wow64_process;
+            switch (target_architecture_)
+            {
+            case gdb_target_architecture::automatic:
+                return win_emu_->process.is_wow64_process;
+            case gdb_target_architecture::bits_32:
+                return true;
+            case gdb_target_architecture::bits_64:
+                return false;
+            }
+
+            throw std::runtime_error("Invalid GDB target architecture");
         }
 
         gdb_stub::filesystem_interface* get_filesystem() override
@@ -221,6 +238,7 @@ namespace sogen
         windows_emulator* win_emu_{};
         utils::optional_function<bool()> should_stop_{};
         windows_filesystem windows_filesystem_;
+        gdb_target_architecture target_architecture_{gdb_target_architecture::bits_64};
 
         // Track library stop events
         std::atomic<bool> library_stop_pending_{true};


### PR DESCRIPTION
This PR adds the `--gdb-arch` option, which changes the architecture reported by the GDB stub. The default remains x64, as before, but the option allows users to select x86 for a much better debugging experience with x86 applications (proper stack traces, locals, etc...), at the cost of being unable to cross into x64 code.