### PR TITLE
Further improve window message sequencing accuracy

### DIFF
--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -382,6 +382,7 @@ namespace sogen
     enum USER_WINDOWCOMPOSITIONATTRIB : uint32_t
     {
         WCA_NCRENDERING_ENABLED = 1,
+        WCA_NCRENDERING_POLICY = 2,
         WCA_EXTENDED_FRAME_BOUNDS = 8,
         WCA_CLOAKED = 18,
     };
@@ -399,7 +400,9 @@ namespace sogen
     {
         uint8_t unknown0[0x8];
         uint64_t spwndDesktop;
-        uint8_t unknown10[0xEF];
+        uint8_t unknown10[0x30];
+        uint32_t flags;
+        uint8_t unknown44[0xFF];
     };
 
     // NOLINTEND(modernize-use-using,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-use-enum-class)

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -262,11 +262,13 @@ namespace sogen
 #define WM_COMMAND                  0x0111
 #define WM_TIMER                    0x0113
 #define WM_HOTKEY                   0x0312
+#define WM_DWMNCRENDERINGCHANGED    0x031F
 #define WM_WINDOWPOSCHANGING        0x0046
 #define WM_WINDOWPOSCHANGED         0x0047
 #define WM_NCCREATE                 0x0081
 #define WM_NCDESTROY                0x0082
 #define WM_NCCALCSIZE               0x0083
+#define WM_NCPAINT                  0x0085
 #define WM_NCACTIVATE               0x0086
 #define WM_NCMOUSEMOVE              0x00A0
 #define WM_NCLBUTTONDOWN            0x00A1

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1307,11 +1307,47 @@ namespace
 
     bool test_paint_message_queue()
     {
+        struct paint_state
+        {
+            HWND window{};
+            int ncpaint{};
+            int erase{};
+            int paint{};
+        };
+
+        thread_local paint_state* active_paint_state{};
+
         WNDCLASSEXA wc = {};
         wc.cbSize = sizeof(wc);
         wc.lpszClassName = "TestPaintMsgQueueClass";
         wc.hInstance = GetModuleHandleA(nullptr);
-        wc.lpfnWndProc = DefWindowProcA;
+        wc.lpfnWndProc = [](const HWND hwnd, const UINT message, const WPARAM w_param, const LPARAM l_param) -> LRESULT {
+            if (active_paint_state && hwnd == active_paint_state->window)
+            {
+                if (message == WM_NCPAINT)
+                {
+                    ++active_paint_state->ncpaint;
+                }
+                else if (message == WM_ERASEBKGND)
+                {
+                    ++active_paint_state->erase;
+                    PAINTSTRUCT paint{};
+                    BeginPaint(hwnd, &paint);
+                    EndPaint(hwnd, &paint);
+                    return TRUE;
+                }
+                else if (message == WM_PAINT)
+                {
+                    ++active_paint_state->paint;
+                    PAINTSTRUCT paint{};
+                    BeginPaint(hwnd, &paint);
+                    EndPaint(hwnd, &paint);
+                    return 0;
+                }
+            }
+
+            return DefWindowProcA(hwnd, message, w_param, l_param);
+        };
 
         if (!RegisterClassExA(&wc))
         {
@@ -1321,8 +1357,8 @@ namespace
 
         const auto unregister_class = sogen::utils::finally([&] { UnregisterClassA(wc.lpszClassName, wc.hInstance); });
 
-        const HWND hwnd = CreateWindowExA(0, wc.lpszClassName, nullptr, WS_OVERLAPPEDWINDOW | WS_VISIBLE, 0, 0, 100, 100, nullptr, nullptr,
-                                          wc.hInstance, nullptr);
+        const HWND hwnd =
+            CreateWindowExA(0, wc.lpszClassName, nullptr, WS_OVERLAPPEDWINDOW, 0, 0, 100, 100, nullptr, nullptr, wc.hInstance, nullptr);
         if (!hwnd)
         {
             puts("Failed to create paint window");
@@ -1331,7 +1367,29 @@ namespace
 
         const auto destroy_window = sogen::utils::finally([&] { DestroyWindow(hwnd); });
 
-        UpdateWindow(hwnd);
+        paint_state state{.window = hwnd};
+        active_paint_state = &state;
+        const auto clear_paint_state = sogen::utils::finally([&] { active_paint_state = nullptr; });
+
+        ShowWindow(hwnd, SW_SHOWDEFAULT);
+
+        RECT update_rect{};
+        if (state.ncpaint != 1 || state.erase != 1)
+        {
+            puts("ShowWindow did not synthesize nonclient and background paint");
+            return false;
+        }
+        if (state.paint != 0 || !GetUpdateRect(hwnd, &update_rect, FALSE))
+        {
+            puts("ShowWindow background paint unexpectedly validated the window");
+            return false;
+        }
+        if (!UpdateWindow(hwnd) || state.paint != 1 || GetUpdateRect(hwnd, &update_rect, FALSE))
+        {
+            puts("UpdateWindow did not paint and validate the window after ShowWindow");
+            return false;
+        }
+
         RedrawWindow(hwnd, nullptr, nullptr, RDW_NOINTERNALPAINT | RDW_VALIDATE);
         ValidateRect(hwnd, nullptr);
 
@@ -1375,6 +1433,7 @@ namespace
         }
 
         ValidateRect(hwnd, nullptr);
+
         return true;
     }
 

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1331,9 +1331,9 @@ namespace
                 else if (message == WM_ERASEBKGND)
                 {
                     ++active_paint_state->erase;
-                    PAINTSTRUCT paint{};
-                    BeginPaint(hwnd, &paint);
-                    EndPaint(hwnd, &paint);
+                    RECT client_rect{};
+                    GetClientRect(hwnd, &client_rect);
+                    FillRect(reinterpret_cast<HDC>(w_param), &client_rect, reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1));
                     return TRUE;
                 }
                 else if (message == WM_PAINT)

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -846,11 +846,9 @@ namespace sogen
         }
     }
 
-    std::optional<msg> emulator_thread::peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
-                                                             bool remove)
+    std::optional<msg> emulator_thread::peek_queued_message(const process_context& process, const hwnd hwnd_filter, const UINT filter_min,
+                                                            const UINT filter_max, const bool remove)
     {
-        (void)this->synthesize_due_user_timer(win_emu, hwnd_filter, filter_min, filter_max);
-
         for (auto it = message_queue.begin(); it != message_queue.end(); ++it)
         {
             if (hwnd_filter == static_cast<hwnd>(-1))
@@ -860,7 +858,7 @@ namespace sogen
                     continue;
                 }
             }
-            else if (hwnd_filter != 0 && !window_matches_filter(win_emu.process, it->window, hwnd_filter))
+            else if (hwnd_filter != 0 && !window_matches_filter(process, it->window, hwnd_filter))
             {
                 continue;
             }
@@ -890,6 +888,17 @@ namespace sogen
                 message_queue.erase(it);
             }
             return msg;
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<msg> emulator_thread::peek_pending_message(windows_emulator& win_emu, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
+                                                             bool remove)
+    {
+        if (auto queued_message = this->peek_queued_message(win_emu.process, hwnd_filter, filter_min, filter_max, remove))
+        {
+            return queued_message;
         }
 
         if ((filter_min == 0 && filter_max == 0) || (filter_min <= WM_PAINT && WM_PAINT <= filter_max))
@@ -922,6 +931,11 @@ namespace sogen
                     .pt = {.x = win_emu.process.cursor_x, .y = win_emu.process.cursor_y},
                 };
             }
+        }
+
+        if (this->synthesize_due_user_timer(win_emu, hwnd_filter, filter_min, filter_max))
+        {
+            return this->peek_queued_message(win_emu.process, hwnd_filter, filter_min, filter_max, remove);
         }
 
         return std::nullopt;

--- a/src/windows-emulator/emulator_thread.cpp
+++ b/src/windows-emulator/emulator_thread.cpp
@@ -426,6 +426,7 @@ namespace sogen
                     if (const auto* wnd = context.windows.get(context.default_desktop_window_handle))
                     {
                         info.spwndDesktop = wnd->guest.value();
+                        info.flags = 0x1;
                     }
                 });
                 teb_obj.Win32ClientInfo.arr[4] = desktop_info_obj.value();
@@ -514,6 +515,7 @@ namespace sogen
                 if (const auto* wnd = context.windows.get(context.default_desktop_window_handle))
                 {
                     info.spwndDesktop = wnd->guest.value();
+                    info.flags = 0x1;
                 }
             });
             teb_obj.Win32ClientInfo.arr[4] = desktop_info_obj.value();

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -553,6 +553,8 @@ namespace sogen
 
       private:
         bool can_coalesce_message(const msg& msg) const;
+        std::optional<msg> peek_queued_message(const process_context& process, hwnd hwnd_filter, UINT filter_min, UINT filter_max,
+                                               bool remove);
 
         void setup_registers(x86_64_cpu& emu, const process_context& context) const;
         void refresh_execution_context(x86_64_cpu& emu) const;

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -60,6 +60,7 @@ namespace sogen
 
         std::vector<qmsg> message_queue{};
         uint64_t pending_window_pos_address{};
+        hdc erase_background_dc{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -74,6 +75,7 @@ namespace sogen
             buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
             buffer.write(this->pending_window_pos_address);
+            buffer.write(this->erase_background_dc);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -88,6 +90,7 @@ namespace sogen
             buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
             buffer.read(this->pending_window_pos_address);
+            buffer.read(this->erase_background_dc);
         }
     };
 
@@ -165,6 +168,7 @@ namespace sogen
         emulator_stack_allocation changed_window_pos_alloc{};
         std::vector<qmsg> message_queue{};
         uint64_t pending_window_pos_address{};
+        hdc erase_background_dc{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -175,6 +179,7 @@ namespace sogen
             buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
             buffer.write(this->pending_window_pos_address);
+            buffer.write(this->erase_background_dc);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -185,6 +190,7 @@ namespace sogen
             buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
             buffer.read(this->pending_window_pos_address);
+            buffer.read(this->erase_background_dc);
         }
     };
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -163,12 +163,21 @@ namespace sogen
     struct window_show_state : completion_state
     {
         bool was_visible{};
+
         emulator_stack_allocation window_pos_alloc{};
         emulator_stack_allocation activation_window_pos_alloc{};
         emulator_stack_allocation changed_window_pos_alloc{};
         std::vector<qmsg> message_queue{};
         uint64_t pending_window_pos_address{};
+
         hdc erase_background_dc{};
+        hwnd parent_erase_window{};
+        hdc parent_erase_background_dc{};
+        bool parent_erase_pending{};
+
+        std::vector<hwnd> visible_descendants{};
+        std::vector<qmsg> descendant_message_queue{};
+        hdc descendant_erase_background_dc{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -180,6 +189,12 @@ namespace sogen
             buffer.write_vector(this->message_queue);
             buffer.write(this->pending_window_pos_address);
             buffer.write(this->erase_background_dc);
+            buffer.write(this->parent_erase_window);
+            buffer.write(this->parent_erase_background_dc);
+            buffer.write(this->parent_erase_pending);
+            buffer.write_vector(this->visible_descendants);
+            buffer.write_vector(this->descendant_message_queue);
+            buffer.write(this->descendant_erase_background_dc);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -191,6 +206,12 @@ namespace sogen
             buffer.read_vector(this->message_queue);
             buffer.read(this->pending_window_pos_address);
             buffer.read(this->erase_background_dc);
+            buffer.read(this->parent_erase_window);
+            buffer.read(this->parent_erase_background_dc);
+            buffer.read(this->parent_erase_pending);
+            buffer.read_vector(this->visible_descendants);
+            buffer.read_vector(this->descendant_message_queue);
+            buffer.read(this->descendant_erase_background_dc);
         }
     };
 

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -46,6 +46,62 @@ namespace sogen
         }
     };
 
+    struct window_show_data
+    {
+        hwnd handle{};
+        emulator_stack_allocation window_pos_alloc{};
+        emulator_stack_allocation activation_window_pos_alloc{};
+        emulator_stack_allocation changed_window_pos_alloc{};
+        std::vector<qmsg> message_queue{};
+        uint64_t pending_window_pos_address{};
+        hwnd pending_erase_window{};
+
+        hdc erase_background_dc{};
+        hwnd parent_erase_window{};
+        hdc parent_erase_background_dc{};
+        bool parent_erase_pending{};
+
+        std::vector<hwnd> visible_descendants{};
+        std::vector<qmsg> descendant_message_queue{};
+        hdc descendant_erase_background_dc{};
+
+        void serialize(utils::buffer_serializer& buffer) const
+        {
+            buffer.write(this->handle);
+            buffer.write(this->window_pos_alloc);
+            buffer.write(this->activation_window_pos_alloc);
+            buffer.write(this->changed_window_pos_alloc);
+            buffer.write_vector(this->message_queue);
+            buffer.write(this->pending_window_pos_address);
+            buffer.write(this->pending_erase_window);
+            buffer.write(this->erase_background_dc);
+            buffer.write(this->parent_erase_window);
+            buffer.write(this->parent_erase_background_dc);
+            buffer.write(this->parent_erase_pending);
+            buffer.write_vector(this->visible_descendants);
+            buffer.write_vector(this->descendant_message_queue);
+            buffer.write(this->descendant_erase_background_dc);
+        }
+
+        void deserialize(utils::buffer_deserializer& buffer)
+        {
+            buffer.read(this->handle);
+            buffer.read(this->window_pos_alloc);
+            buffer.read(this->activation_window_pos_alloc);
+            buffer.read(this->changed_window_pos_alloc);
+            buffer.read_vector(this->message_queue);
+            buffer.read(this->pending_window_pos_address);
+            buffer.read(this->pending_erase_window);
+            buffer.read(this->erase_background_dc);
+            buffer.read(this->parent_erase_window);
+            buffer.read(this->parent_erase_background_dc);
+            buffer.read(this->parent_erase_pending);
+            buffer.read_vector(this->visible_descendants);
+            buffer.read_vector(this->descendant_message_queue);
+            buffer.read(this->descendant_erase_background_dc);
+        }
+    };
+
     struct window_create_state : completion_state
     {
         hwnd handle{};
@@ -54,13 +110,8 @@ namespace sogen
         emulator_stack_allocation min_max_info_alloc{};
         emulator_stack_allocation window_rect_alloc{};
         emulator_stack_allocation create_struct_alloc{};
-        emulator_stack_allocation window_pos_alloc{};
-        emulator_stack_allocation activation_window_pos_alloc{};
-        emulator_stack_allocation changed_window_pos_alloc{};
-
         std::vector<qmsg> message_queue{};
-        uint64_t pending_window_pos_address{};
-        hdc erase_background_dc{};
+        window_show_data show_data{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
@@ -70,12 +121,8 @@ namespace sogen
             buffer.write(this->min_max_info_alloc);
             buffer.write(this->window_rect_alloc);
             buffer.write(this->create_struct_alloc);
-            buffer.write(this->window_pos_alloc);
-            buffer.write(this->activation_window_pos_alloc);
-            buffer.write(this->changed_window_pos_alloc);
             buffer.write_vector(this->message_queue);
-            buffer.write(this->pending_window_pos_address);
-            buffer.write(this->erase_background_dc);
+            this->show_data.serialize(buffer);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
@@ -85,12 +132,8 @@ namespace sogen
             buffer.read(this->min_max_info_alloc);
             buffer.read(this->window_rect_alloc);
             buffer.read(this->create_struct_alloc);
-            buffer.read(this->window_pos_alloc);
-            buffer.read(this->activation_window_pos_alloc);
-            buffer.read(this->changed_window_pos_alloc);
             buffer.read_vector(this->message_queue);
-            buffer.read(this->pending_window_pos_address);
-            buffer.read(this->erase_background_dc);
+            this->show_data.deserialize(buffer);
         }
     };
 
@@ -163,55 +206,19 @@ namespace sogen
     struct window_show_state : completion_state
     {
         bool was_visible{};
-
-        emulator_stack_allocation window_pos_alloc{};
-        emulator_stack_allocation activation_window_pos_alloc{};
-        emulator_stack_allocation changed_window_pos_alloc{};
-        std::vector<qmsg> message_queue{};
-        uint64_t pending_window_pos_address{};
-
-        hdc erase_background_dc{};
-        hwnd parent_erase_window{};
-        hdc parent_erase_background_dc{};
-        bool parent_erase_pending{};
-
-        std::vector<hwnd> visible_descendants{};
-        std::vector<qmsg> descendant_message_queue{};
-        hdc descendant_erase_background_dc{};
+        window_show_data data{};
 
       private:
         void serialize_object(utils::buffer_serializer& buffer) const override
         {
             buffer.write(this->was_visible);
-            buffer.write(this->window_pos_alloc);
-            buffer.write(this->activation_window_pos_alloc);
-            buffer.write(this->changed_window_pos_alloc);
-            buffer.write_vector(this->message_queue);
-            buffer.write(this->pending_window_pos_address);
-            buffer.write(this->erase_background_dc);
-            buffer.write(this->parent_erase_window);
-            buffer.write(this->parent_erase_background_dc);
-            buffer.write(this->parent_erase_pending);
-            buffer.write_vector(this->visible_descendants);
-            buffer.write_vector(this->descendant_message_queue);
-            buffer.write(this->descendant_erase_background_dc);
+            this->data.serialize(buffer);
         }
 
         void deserialize_object(utils::buffer_deserializer& buffer) override
         {
             buffer.read(this->was_visible);
-            buffer.read(this->window_pos_alloc);
-            buffer.read(this->activation_window_pos_alloc);
-            buffer.read(this->changed_window_pos_alloc);
-            buffer.read_vector(this->message_queue);
-            buffer.read(this->pending_window_pos_address);
-            buffer.read(this->erase_background_dc);
-            buffer.read(this->parent_erase_window);
-            buffer.read(this->parent_erase_background_dc);
-            buffer.read(this->parent_erase_pending);
-            buffer.read_vector(this->visible_descendants);
-            buffer.read_vector(this->descendant_message_queue);
-            buffer.read(this->descendant_erase_background_dc);
+            this->data.deserialize(buffer);
         }
     };
 

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -503,6 +503,8 @@ namespace sogen
         BOOL handle_NtUserClipCursor(const syscall_context& c, emulator_pointer rect);
         BOOL handle_NtUserGetWindowCompositionAttribute(const syscall_context& c, hwnd window,
                                                         emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data);
+        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, hwnd window,
+                                                        emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data);
         BOOL handle_NtUserSetCursorPos(const syscall_context& c, int32_t x, int32_t y);
         hcursor handle_NtUserSetCursor(const syscall_context& c, hcursor cursor);
         hcursor handle_NtUserGetCursor(const syscall_context& c);
@@ -660,7 +662,6 @@ namespace sogen
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
         BOOL handle_NtUserDestroyMenu(const syscall_context& c, hmenu menu);
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
-        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, hwnd hwnd, emulator_pointer data);
         BOOL handle_NtUserCreateCaret();
         BOOL handle_NtUserDestroyCaret();
         BOOL handle_NtUserSetCaretPos();

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -448,7 +448,12 @@ namespace sogen
                 }
 
                 const uint64_t user_ptr = (type == k_gdi_font_type) ? 0 : attr;
-                return allocate_gdi_handle(c, type, user_ptr, attr);
+                const auto handle_value = allocate_gdi_handle(c, type, user_ptr, attr);
+                if (handle_value == 0)
+                {
+                    c.win_emu.memory.release_memory(attr, 0);
+                }
+                return handle_value;
             }
 
             bool get_gdi_object_address(const syscall_context& c, const uint32_t handle_value, const uint8_t expected_type, uint64_t& addr)
@@ -1248,6 +1253,11 @@ namespace sogen
                 if (handle_value != 0)
                 {
                     c.proc.gdi_dc_states[handle_value] = {};
+                }
+                else
+                {
+                    c.win_emu.memory.release_memory(dc_attr, 0);
+                    dc_attr = 0;
                 }
                 return handle_value;
             }
@@ -2405,6 +2415,10 @@ namespace sogen
                 bmp_it != c.proc.gdi_bitmap_surfaces.end() && bmp_it->second.guest_owns_memory && bmp_it->second.guest_bits != 0)
             {
                 c.win_emu.memory.release_memory(bmp_it->second.guest_bits, 0);
+            }
+            if (entry.Object != 0)
+            {
+                c.win_emu.memory.release_memory(entry.Object, 0);
             }
 
             c.proc.gdi_dc_states.erase(handle_value);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -38,6 +38,7 @@ namespace sogen
         constexpr uint32_t k_color_window = 5;
         constexpr uint32_t k_color_btnface = 15;
         constexpr auto k_user_timer_minimum = std::chrono::milliseconds{10};
+        constexpr uint64_t k_hrgn_window = 1;
 
         struct send_message_callback_info
         {
@@ -2967,7 +2968,7 @@ namespace sogen
                 guest_win.spwndOwner = parent_win && has_owner ? parent_win->guest.value() : 0;
                 guest_win.lpfnWndProc = win.wnd_proc;
                 guest_win.pcls = class_obj_addr;
-                guest_win.hrgnUpdate = !is_message_only ? 0x12345678 : 0;
+                guest_win.hrgnUpdate = !is_message_only ? k_hrgn_window : 0;
                 guest_win.cbWndExtra = wnd_class->cbWndExtra;
                 // Control id offset is build-specific: Win11 reads wID (WND+0x140), Server 2022 reads
                 // spmenu (WND+0x98). Populate both so builtin wndprocs emit the right WM_COMMAND id.

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -3,6 +3,7 @@
 #include "../syscall_utils.hpp"
 #include "../win32k_userconnect.hpp"
 #include "../window_destroy_orchestrator.hpp"
+#include "../window_show_orchestrator.hpp"
 #include "windows-emulator/user_callback_dispatch.hpp"
 #include <limits>
 
@@ -379,8 +380,7 @@ namespace sogen
         void update_window_geometry(const syscall_context& c, window& win, const int x, const int y, const int width, const int height,
                                     const bool repaint)
         {
-            const bool geometry_changed = x != win.x || y != win.y || width != win.width || height != win.height;
-
+            const bool geometry_changed = win.x != x || win.y != y || win.width != width || win.height != height;
             win.x = x;
             win.y = y;
             win.width = width;
@@ -392,6 +392,7 @@ namespace sogen
                 c.win_emu.ui().set_window_rect(win.handle, get_window_rect(win));
             }
 
+            // Native SetWindowPos and MoveWindow do not create an update region when the requested geometry is unchanged.
             if (repaint && geometry_changed)
             {
                 invalidate_window(c, win, std::nullopt, false);
@@ -597,22 +598,6 @@ namespace sogen
                 {
                     invalidate_window_tree(c, child);
                 }
-            }
-        }
-
-        void collect_visible_window_descendants(const syscall_context& c, const window& parent, std::vector<hwnd>& descendants)
-        {
-            for (auto& [index, child] : c.proc.windows)
-            {
-                (void)index;
-                if (child.parent_handle != parent.handle || (child.style & WS_VISIBLE) == 0 ||
-                    !c.proc.is_window_effectively_visible(child.handle))
-                {
-                    continue;
-                }
-
-                descendants.push_back(child.handle);
-                collect_visible_window_descendants(c, child, descendants);
             }
         }
 
@@ -1075,6 +1060,26 @@ namespace sogen
             return {};
         }
 
+        BOOL advance_window_show(const syscall_context& c, window_show_state& state)
+        {
+            window_show_orchestrator orchestrator{state.data, c};
+            const auto step = orchestrator.advance();
+            if (!step)
+            {
+                return state.was_visible ? TRUE : FALSE;
+            }
+
+            auto* win = c.proc.windows.get(step->handle);
+            if (!win)
+            {
+                return advance_window_show(c, state);
+            }
+
+            dispatch_window_message(c, callback_id::NtUserShowWindow, std::move(state), *win, step->message.message, step->message.wParam,
+                                    step->message.lParam);
+            return {};
+        }
+
         uint64_t ensure_win32_thread_info(const syscall_context& c)
         {
             auto* thread = c.vcpu.active_thread;
@@ -1465,46 +1470,6 @@ namespace sogen
             return static_cast<uint64_t>(static_cast<uint16_t>(low)) | (static_cast<uint64_t>(static_cast<uint16_t>(high)) << 16);
         }
 
-        std::vector<qmsg> build_show_window_messages(const syscall_context& c, const window& win, const hdc erase_background_dc,
-                                                     const uint64_t window_pos_address,
-                                                     const std::optional<uint64_t> activation_window_pos_address, const bool emit_size_move)
-        {
-            std::vector<qmsg> messages{};
-            if (emit_size_move)
-            {
-                messages.push_back({.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)});
-                messages.push_back(
-                    {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())});
-            }
-
-            messages.push_back({.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0});
-            messages.push_back({.message = WM_ERASEBKGND, .wParam = erase_background_dc, .lParam = 0});
-            messages.push_back({.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0});
-
-            if (activation_window_pos_address)
-            {
-                messages.push_back({.message = WM_SETFOCUS, .wParam = 0, .lParam = 0});
-                messages.push_back({.message = WM_ACTIVATE, .wParam = 1, .lParam = 0});
-                messages.push_back({.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0});
-                if (!win.message_only && !is_application_active(c))
-                {
-                    messages.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
-                }
-                messages.push_back({
-                    .message = WM_WINDOWPOSCHANGING,
-                    .wParam = 0,
-                    .lParam = *activation_window_pos_address,
-                });
-            }
-
-            messages.push_back({
-                .message = WM_WINDOWPOSCHANGING,
-                .wParam = 0,
-                .lParam = window_pos_address,
-            });
-            messages.push_back({.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0});
-            return messages;
-        }
     }
 
     namespace syscalls
@@ -3247,42 +3212,8 @@ namespace sogen
             else if (initially_visible)
             {
                 invalidate_window(c, win);
-
-                const EMU_WINDOWPOS show_position{
-                    .hwnd = handle.bits,
-                    .hwndInsertAfter = 0,
-                    .x = 0,
-                    .y = 0,
-                    .cx = 0,
-                    .cy = 0,
-                    .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW,
-                };
-                const EMU_WINDOWPOS activation_position{
-                    .hwnd = handle.bits,
-                    .hwndInsertAfter = 0,
-                    .x = 0,
-                    .y = 0,
-                    .cx = 0,
-                    .cy = 0,
-                    .flags = SWP_NOMOVE | SWP_NOSIZE,
-                };
-                const EMU_WINDOWPOS changed_position{
-                    .hwnd = handle.bits,
-                    .hwndInsertAfter = 0,
-                    .x = x,
-                    .y = y,
-                    .cx = width,
-                    .cy = height,
-                    .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
-                };
-                state.window_pos_alloc = c.emu.push_stack(show_position);
-                state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
-                state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
-                state.erase_background_dc = create_gdi_window_dc(c, handle.bits);
-
-                auto show_messages = build_show_window_messages(c, win, state.erase_background_dc, state.window_pos_alloc.address(),
-                                                                state.activation_window_pos_alloc.address(), true);
-                state.message_queue.insert(state.message_queue.begin(), show_messages.begin(), show_messages.end());
+                window_show_orchestrator{state.show_data, c}.start_show(win, SWP_SHOWWINDOW, true, true,
+                                                                        !win.message_only && !is_application_active(c));
             }
 
             if (c.win_emu.callbacks.on_generic_activity)
@@ -3305,23 +3236,16 @@ namespace sogen
         {
             auto& s = c.get_completion_state<window_create_state>();
             auto* win = c.proc.windows.get(s.handle);
+            auto show_orchestrator = window_show_orchestrator{s.show_data, c};
+
+            show_orchestrator.erase_background_completed(c.get_callback_result<uint64_t>());
 
             const auto release_window_create_allocations = [&] {
-                if (s.window_pos_alloc)
-                {
-                    c.emu.pop_stack(s.changed_window_pos_alloc);
-                    c.emu.pop_stack(s.activation_window_pos_alloc);
-                    c.emu.pop_stack(s.window_pos_alloc);
-                }
+                show_orchestrator.release();
 
                 c.emu.pop_stack(s.min_max_info_alloc);
                 c.emu.pop_stack(s.window_rect_alloc);
                 c.emu.pop_stack(s.create_struct_alloc);
-
-                if (s.erase_background_dc)
-                {
-                    (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.erase_background_dc));
-                }
             };
 
             if (!win)
@@ -3330,13 +3254,15 @@ namespace sogen
                 return 0;
             }
 
-            if (s.pending_window_pos_address != 0)
+            if (s.show_data.pending_window_pos_address != 0)
             {
                 const bool activation_position =
-                    s.activation_window_pos_alloc && s.pending_window_pos_address == s.activation_window_pos_alloc.address();
-                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue,
-                                                !activation_position);
-                s.pending_window_pos_address = 0;
+                    s.show_data.activation_window_pos_alloc &&
+                    s.show_data.pending_window_pos_address == s.show_data.activation_window_pos_alloc.address();
+                complete_window_position_change(c, *win, s.show_data.pending_window_pos_address, s.show_data.changed_window_pos_alloc,
+                                                s.show_data.message_queue, !activation_position);
+                s.show_data.pending_window_pos_address = 0;
+                show_orchestrator.window_position_completed(activation_position);
             }
 
             if (!s.message_queue.empty())
@@ -3354,14 +3280,26 @@ namespace sogen
                 }
                 else if (next.message == WM_WINDOWPOSCHANGING)
                 {
-                    s.pending_window_pos_address = next.lParam;
+                    s.show_data.pending_window_pos_address = next.lParam;
                 }
 
                 dispatch_next_message(c, callback_id::NtUserCreateWindowEx, std::move(s), *win, s.message_queue);
                 return {};
             }
 
-            release_window_create_allocations();
+            while (const auto step = show_orchestrator.advance())
+            {
+                if (auto* target = c.proc.windows.get(step->handle))
+                {
+                    dispatch_window_message(c, callback_id::NtUserCreateWindowEx, std::move(s), *target, step->message.message,
+                                            step->message.wParam, step->message.lParam);
+                    return {};
+                }
+            }
+
+            c.emu.pop_stack(s.min_max_info_alloc);
+            c.emu.pop_stack(s.window_rect_alloc);
+            c.emu.pop_stack(s.create_struct_alloc);
 
             return s.handle;
         }
@@ -3528,6 +3466,7 @@ namespace sogen
 
             window_show_state state{};
             state.was_visible = was_visible;
+            auto orchestrator = window_show_orchestrator{state.data, c};
 
             uint32_t visibility_flags{};
             if (want_visible)
@@ -3547,27 +3486,6 @@ namespace sogen
                 visibility_flags = SWP_HIDEWINDOW | SWP_NOZORDER | SWP_NOACTIVATE;
             }
 
-            const EMU_WINDOWPOS changing_position{
-                .hwnd = hwnd,
-                .hwndInsertAfter = 0,
-                .x = 0,
-                .y = 0,
-                .cx = 0,
-                .cy = 0,
-                .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags,
-            };
-            const EMU_WINDOWPOS changed_position{
-                .hwnd = hwnd,
-                .hwndInsertAfter = 0,
-                .x = win->x,
-                .y = win->y,
-                .cx = win->width,
-                .cy = win->height,
-                .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
-            };
-            state.window_pos_alloc = c.emu.push_stack(changing_position);
-            state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
-
             if (win->host_surface_window)
             {
                 if (want_visible && win->is_dialog())
@@ -3579,35 +3497,15 @@ namespace sogen
 
             if (want_visible)
             {
-                state.erase_background_dc = create_gdi_window_dc(c, hwnd);
-
-                std::optional<uint64_t> activation_window_pos_address{};
-                if (activate_window)
-                {
-                    const EMU_WINDOWPOS activation_position{
-                        .hwnd = hwnd,
-                        .hwndInsertAfter = 0,
-                        .x = 0,
-                        .y = 0,
-                        .cx = 0,
-                        .cy = 0,
-                        .flags = SWP_NOMOVE | SWP_NOSIZE,
-                    };
-                    state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
-                    activation_window_pos_address = state.activation_window_pos_alloc.address();
-                }
-
-                state.message_queue = build_show_window_messages(c, *win, state.erase_background_dc, state.window_pos_alloc.address(),
-                                                                 activation_window_pos_address, !is_child);
+                orchestrator.start_show(*win, visibility_flags, activate_window, !is_child,
+                                        activate_window && !win->message_only && !is_application_active(c));
 
                 if (is_child && win->parent_handle != 0)
                 {
                     if (auto* parent_win = c.proc.windows.get(win->parent_handle))
                     {
                         invalidate_window(c, *parent_win, std::nullopt, true);
-                        state.parent_erase_window = parent_win->handle;
-                        state.parent_erase_background_dc = create_gdi_window_dc(c, parent_win->handle);
-                        state.parent_erase_pending = true;
+                        orchestrator.set_parent_erase_window(parent_win->handle);
                     }
                 }
 
@@ -3615,15 +3513,7 @@ namespace sogen
             }
             else
             {
-                state.message_queue = {
-                    {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
-                    {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
-                    {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_SHOWWINDOW, .wParam = FALSE, .lParam = 0},
-                };
-
+                orchestrator.start_hide(*win, visibility_flags);
                 win->style &= ~WS_VISIBLE;
             }
 
@@ -3638,124 +3528,31 @@ namespace sogen
                 invalidate_window_tree(c, *win);
             }
 
-            dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(state), *win, state.message_queue);
-            return {};
+            return advance_window_show(c, state);
         }
 
-        BOOL completion_NtUserShowWindow(const syscall_context& c, const hwnd hwnd, const LONG /*cmd_show*/)
+        BOOL completion_NtUserShowWindow(const syscall_context& c, const hwnd /*hwnd*/, const LONG /*cmd_show*/)
         {
             auto& s = c.get_completion_state<window_show_state>();
-            auto* win = c.proc.windows.get(hwnd);
+            auto& data = s.data;
+            auto orchestrator = window_show_orchestrator{data, c};
 
-            if (s.pending_window_pos_address != 0)
+            orchestrator.erase_background_completed(c.get_callback_result<uint64_t>());
+
+            if (data.pending_window_pos_address != 0)
             {
                 const bool activation_position =
-                    s.activation_window_pos_alloc && s.pending_window_pos_address == s.activation_window_pos_alloc.address();
-                complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue,
-                                                !activation_position);
-                s.pending_window_pos_address = 0;
-
-                if (!activation_position && s.parent_erase_pending)
+                    data.activation_window_pos_alloc && data.pending_window_pos_address == data.activation_window_pos_alloc.address();
+                if (auto* win = c.proc.windows.get(data.handle))
                 {
-                    s.parent_erase_pending = false;
-                    if (auto* parent_win = c.proc.windows.get(s.parent_erase_window))
-                    {
-                        const auto parent_erase_background_dc = s.parent_erase_background_dc;
-                        dispatch_window_message(c, callback_id::NtUserShowWindow, std::move(s), *parent_win, WM_ERASEBKGND,
-                                                parent_erase_background_dc, 0);
-                        return {};
-                    }
+                    complete_window_position_change(c, *win, data.pending_window_pos_address, data.changed_window_pos_alloc,
+                                                    data.message_queue, !activation_position);
                 }
+                data.pending_window_pos_address = 0;
+                orchestrator.window_position_completed(activation_position);
             }
 
-            const auto release_descendant_dc = [&] {
-                if (s.descendant_erase_background_dc)
-                {
-                    (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.descendant_erase_background_dc));
-                    s.descendant_erase_background_dc = 0;
-                }
-            };
-
-            while (!s.visible_descendants.empty() || !s.descendant_message_queue.empty() || s.descendant_erase_background_dc)
-            {
-                if (s.descendant_message_queue.empty())
-                {
-                    release_descendant_dc();
-                    if (s.visible_descendants.empty())
-                    {
-                        break;
-                    }
-
-                    const auto descendant_handle = s.visible_descendants.back();
-                    auto* descendant = c.proc.windows.get(descendant_handle);
-                    if (!descendant || !c.proc.is_window_effectively_visible(descendant_handle))
-                    {
-                        s.visible_descendants.pop_back();
-                        continue;
-                    }
-
-                    s.descendant_erase_background_dc = create_gdi_window_dc(c, descendant_handle);
-                    s.descendant_message_queue = {
-                        {.message = WM_ERASEBKGND, .wParam = s.descendant_erase_background_dc, .lParam = 0},
-                        {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
-                    };
-                }
-
-                const auto descendant_handle = s.visible_descendants.back();
-                auto* descendant = c.proc.windows.get(descendant_handle);
-                if (!descendant || !c.proc.is_window_effectively_visible(descendant_handle))
-                {
-                    s.descendant_message_queue.clear();
-                    release_descendant_dc();
-                    s.visible_descendants.pop_back();
-                    continue;
-                }
-
-                if (s.descendant_message_queue.size() == 1)
-                {
-                    // The final message is removed before its callback runs, so retire this HWND now to avoid rebuilding its queue.
-                    s.visible_descendants.pop_back();
-                }
-
-                dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(s), *descendant, s.descendant_message_queue);
-                return {};
-            }
-
-            if (!s.message_queue.empty())
-            {
-                const auto& next = s.message_queue.back();
-                if (next.message == WM_WINDOWPOSCHANGING)
-                {
-                    s.pending_window_pos_address = next.lParam;
-                }
-
-                if (next.message == WM_ERASEBKGND)
-                {
-                    collect_visible_window_descendants(c, *win, s.visible_descendants);
-                    std::ranges::reverse(s.visible_descendants);
-                }
-
-                dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(s), *win, s.message_queue);
-                return {};
-            }
-
-            if (s.activation_window_pos_alloc)
-            {
-                c.emu.pop_stack(s.activation_window_pos_alloc);
-            }
-            c.emu.pop_stack(s.changed_window_pos_alloc);
-            c.emu.pop_stack(s.window_pos_alloc);
-
-            if (s.erase_background_dc)
-            {
-                (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.erase_background_dc));
-            }
-            if (s.parent_erase_background_dc)
-            {
-                (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.parent_erase_background_dc));
-            }
-
-            return s.was_visible ? TRUE : FALSE;
+            return advance_window_show(c, s);
         }
 
         uint64_t handle_NtUserMessageCall(const syscall_context& c, const hwnd hwnd, const UINT msg, const uint64_t w_param,
@@ -4586,7 +4383,8 @@ namespace sogen
             const auto new_y = (flags & SWP_NOMOVE) ? win->y : y;
             const auto new_width = (flags & SWP_NOSIZE) ? win->width : cx;
             const auto new_height = (flags & SWP_NOSIZE) ? win->height : cy;
-            const auto repaint = (flags & SWP_NOREDRAW) == 0;
+            const bool showing_hidden_window = (flags & SWP_SHOWWINDOW) != 0 && (win->style & WS_VISIBLE) == 0;
+            const bool repaint = (flags & SWP_NOREDRAW) == 0 && !showing_hidden_window;
 
             update_window_geometry(c, *win, new_x, new_y, new_width, new_height, repaint);
 
@@ -4599,7 +4397,7 @@ namespace sogen
                     c.win_emu.ui().set_window_visible(hWnd, false);
                 }
             }
-            else if ((flags & SWP_SHOWWINDOW) != 0 && (win->style & WS_VISIBLE) == 0)
+            else if (showing_hidden_window)
             {
                 win->style |= WS_VISIBLE;
                 win->guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win->style; });

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -600,6 +600,22 @@ namespace sogen
             }
         }
 
+        void collect_visible_window_descendants(const syscall_context& c, const window& parent, std::vector<hwnd>& descendants)
+        {
+            for (auto& [index, child] : c.proc.windows)
+            {
+                (void)index;
+                if (child.parent_handle != parent.handle || (child.style & WS_VISIBLE) == 0 ||
+                    !c.proc.is_window_effectively_visible(child.handle))
+                {
+                    continue;
+                }
+
+                descendants.push_back(child.handle);
+                collect_visible_window_descendants(c, child, descendants);
+            }
+        }
+
         void write_guest_window_text(const syscall_context& c, window& win, const std::u16string& title)
         {
             win.guest.access([&](USER_WINDOW& guest_win) {
@@ -1451,15 +1467,19 @@ namespace sogen
 
         std::vector<qmsg> build_show_window_messages(const syscall_context& c, const window& win, const hdc erase_background_dc,
                                                      const uint64_t window_pos_address,
-                                                     const std::optional<uint64_t> activation_window_pos_address)
+                                                     const std::optional<uint64_t> activation_window_pos_address, const bool emit_size_move)
         {
-            std::vector<qmsg> messages = {
-                {.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)},
-                {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())},
-                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
-                {.message = WM_ERASEBKGND, .wParam = erase_background_dc, .lParam = 0},
-                {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
-            };
+            std::vector<qmsg> messages{};
+            if (emit_size_move)
+            {
+                messages.push_back({.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)});
+                messages.push_back(
+                    {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())});
+            }
+
+            messages.push_back({.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0});
+            messages.push_back({.message = WM_ERASEBKGND, .wParam = erase_background_dc, .lParam = 0});
+            messages.push_back({.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0});
 
             if (activation_window_pos_address)
             {
@@ -3204,66 +3224,65 @@ namespace sogen
                 state.message_queue.push_back({.message = WM_GETMINMAXINFO, .wParam = 0, .lParam = state.min_max_info_alloc.address()});
             }
 
-            if ((style & WS_VISIBLE) != 0)
+            const bool initially_visible = (style & WS_VISIBLE) != 0;
+            if (has_child_parent)
+            {
+                const auto move_lparam = pack_message_lparam(x, y);
+                const auto size_lparam = pack_message_lparam(win.client_width(), win.client_height());
+                std::vector<qmsg> child_messages{};
+
+                if (initially_visible)
+                {
+                    invalidate_window(c, win);
+                    child_messages.push_back({.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0});
+                }
+                if (notify_parent)
+                {
+                    child_messages.push_back({.message = WM_PARENTNOTIFY, .wParam = parent_notify_wparam, .lParam = handle.bits});
+                }
+                child_messages.push_back({.message = WM_MOVE, .wParam = 0, .lParam = move_lparam});
+                child_messages.push_back({.message = WM_SIZE, .wParam = 0, .lParam = size_lparam});
+                state.message_queue.insert(state.message_queue.begin(), child_messages.begin(), child_messages.end());
+            }
+            else if (initially_visible)
             {
                 invalidate_window(c, win);
 
-                if (has_child_parent)
-                {
-                    const auto move_lparam = pack_message_lparam(x, y);
-                    const auto size_lparam = pack_message_lparam(win.client_width(), win.client_height());
-                    std::vector<qmsg> child_messages{{.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0}};
-                    if (notify_parent)
-                    {
-                        child_messages.push_back({.message = WM_PARENTNOTIFY, .wParam = parent_notify_wparam, .lParam = handle.bits});
-                    }
-                    child_messages.push_back({.message = WM_MOVE, .wParam = 0, .lParam = move_lparam});
-                    child_messages.push_back({.message = WM_SIZE, .wParam = 0, .lParam = size_lparam});
-                    state.message_queue.insert(state.message_queue.begin(), child_messages.begin(), child_messages.end());
-                }
-                else
-                {
-                    const EMU_WINDOWPOS show_position{
-                        .hwnd = handle.bits,
-                        .hwndInsertAfter = 0,
-                        .x = 0,
-                        .y = 0,
-                        .cx = 0,
-                        .cy = 0,
-                        .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW,
-                    };
-                    const EMU_WINDOWPOS activation_position{
-                        .hwnd = handle.bits,
-                        .hwndInsertAfter = 0,
-                        .x = 0,
-                        .y = 0,
-                        .cx = 0,
-                        .cy = 0,
-                        .flags = SWP_NOMOVE | SWP_NOSIZE,
-                    };
-                    const EMU_WINDOWPOS changed_position{
-                        .hwnd = handle.bits,
-                        .hwndInsertAfter = 0,
-                        .x = x,
-                        .y = y,
-                        .cx = width,
-                        .cy = height,
-                        .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
-                    };
-                    state.window_pos_alloc = c.emu.push_stack(show_position);
-                    state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
-                    state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
-                    state.erase_background_dc = create_gdi_window_dc(c, handle.bits);
+                const EMU_WINDOWPOS show_position{
+                    .hwnd = handle.bits,
+                    .hwndInsertAfter = 0,
+                    .x = 0,
+                    .y = 0,
+                    .cx = 0,
+                    .cy = 0,
+                    .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW,
+                };
+                const EMU_WINDOWPOS activation_position{
+                    .hwnd = handle.bits,
+                    .hwndInsertAfter = 0,
+                    .x = 0,
+                    .y = 0,
+                    .cx = 0,
+                    .cy = 0,
+                    .flags = SWP_NOMOVE | SWP_NOSIZE,
+                };
+                const EMU_WINDOWPOS changed_position{
+                    .hwnd = handle.bits,
+                    .hwndInsertAfter = 0,
+                    .x = x,
+                    .y = y,
+                    .cx = width,
+                    .cy = height,
+                    .flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
+                };
+                state.window_pos_alloc = c.emu.push_stack(show_position);
+                state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
+                state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
+                state.erase_background_dc = create_gdi_window_dc(c, handle.bits);
 
-                    auto show_messages = build_show_window_messages(c, win, state.erase_background_dc, state.window_pos_alloc.address(),
-                                                                    state.activation_window_pos_alloc.address());
-                    state.message_queue.insert(state.message_queue.begin(), show_messages.begin(), show_messages.end());
-                }
-            }
-            else if (notify_parent)
-            {
-                state.message_queue.insert(state.message_queue.begin(),
-                                           {.message = WM_PARENTNOTIFY, .wParam = parent_notify_wparam, .lParam = handle.bits});
+                auto show_messages = build_show_window_messages(c, win, state.erase_background_dc, state.window_pos_alloc.address(),
+                                                                state.activation_window_pos_alloc.address(), true);
+                state.message_queue.insert(state.message_queue.begin(), show_messages.begin(), show_messages.end());
             }
 
             if (c.win_emu.callbacks.on_generic_activity)
@@ -3498,7 +3517,9 @@ namespace sogen
 
             const bool want_visible = (cmd_show != 0); // SW_HIDE
             const bool was_visible = (win->style & WS_VISIBLE) != 0;
-            const bool activate_window = cmd_show != SW_SHOWNOACTIVATE && cmd_show != SW_SHOWMINNOACTIVE && cmd_show != SW_SHOWNA;
+            const bool is_child = (win->style & WS_CHILD) != 0 && (win->style & WS_POPUP) == 0;
+            const bool command_allows_activation = cmd_show != SW_SHOWNOACTIVATE && cmd_show != SW_SHOWMINNOACTIVE && cmd_show != SW_SHOWNA;
+            const bool activate_window = command_allows_activation && !is_child;
 
             if (want_visible == was_visible)
             {
@@ -3508,8 +3529,24 @@ namespace sogen
             window_show_state state{};
             state.was_visible = was_visible;
 
-            const auto visibility_flags = static_cast<uint32_t>(want_visible ? SWP_SHOWWINDOW | (activate_window ? 0 : SWP_NOACTIVATE)
-                                                                             : SWP_HIDEWINDOW | SWP_NOZORDER | SWP_NOACTIVATE);
+            uint32_t visibility_flags{};
+            if (want_visible)
+            {
+                visibility_flags = SWP_SHOWWINDOW;
+                if (is_child || !command_allows_activation)
+                {
+                    visibility_flags |= SWP_NOACTIVATE;
+                }
+                if (is_child)
+                {
+                    visibility_flags |= SWP_NOZORDER;
+                }
+            }
+            else
+            {
+                visibility_flags = SWP_HIDEWINDOW | SWP_NOZORDER | SWP_NOACTIVATE;
+            }
+
             const EMU_WINDOWPOS changing_position{
                 .hwnd = hwnd,
                 .hwndInsertAfter = 0,
@@ -3561,7 +3598,18 @@ namespace sogen
                 }
 
                 state.message_queue = build_show_window_messages(c, *win, state.erase_background_dc, state.window_pos_alloc.address(),
-                                                                 activation_window_pos_address);
+                                                                 activation_window_pos_address, !is_child);
+
+                if (is_child && win->parent_handle != 0)
+                {
+                    if (auto* parent_win = c.proc.windows.get(win->parent_handle))
+                    {
+                        invalidate_window(c, *parent_win, std::nullopt, true);
+                        state.parent_erase_window = parent_win->handle;
+                        state.parent_erase_background_dc = create_gdi_window_dc(c, parent_win->handle);
+                        state.parent_erase_pending = true;
+                    }
+                }
 
                 win->style |= WS_VISIBLE;
             }
@@ -3606,6 +3654,71 @@ namespace sogen
                 complete_window_position_change(c, *win, s.pending_window_pos_address, s.changed_window_pos_alloc, s.message_queue,
                                                 !activation_position);
                 s.pending_window_pos_address = 0;
+
+                if (!activation_position && s.parent_erase_pending)
+                {
+                    s.parent_erase_pending = false;
+                    if (auto* parent_win = c.proc.windows.get(s.parent_erase_window))
+                    {
+                        const auto parent_erase_background_dc = s.parent_erase_background_dc;
+                        dispatch_window_message(c, callback_id::NtUserShowWindow, std::move(s), *parent_win, WM_ERASEBKGND,
+                                                parent_erase_background_dc, 0);
+                        return {};
+                    }
+                }
+            }
+
+            const auto release_descendant_dc = [&] {
+                if (s.descendant_erase_background_dc)
+                {
+                    (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.descendant_erase_background_dc));
+                    s.descendant_erase_background_dc = 0;
+                }
+            };
+
+            while (!s.visible_descendants.empty() || !s.descendant_message_queue.empty() || s.descendant_erase_background_dc)
+            {
+                if (s.descendant_message_queue.empty())
+                {
+                    release_descendant_dc();
+                    if (s.visible_descendants.empty())
+                    {
+                        break;
+                    }
+
+                    const auto descendant_handle = s.visible_descendants.back();
+                    auto* descendant = c.proc.windows.get(descendant_handle);
+                    if (!descendant || !c.proc.is_window_effectively_visible(descendant_handle))
+                    {
+                        s.visible_descendants.pop_back();
+                        continue;
+                    }
+
+                    s.descendant_erase_background_dc = create_gdi_window_dc(c, descendant_handle);
+                    s.descendant_message_queue = {
+                        {.message = WM_ERASEBKGND, .wParam = s.descendant_erase_background_dc, .lParam = 0},
+                        {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
+                    };
+                }
+
+                const auto descendant_handle = s.visible_descendants.back();
+                auto* descendant = c.proc.windows.get(descendant_handle);
+                if (!descendant || !c.proc.is_window_effectively_visible(descendant_handle))
+                {
+                    s.descendant_message_queue.clear();
+                    release_descendant_dc();
+                    s.visible_descendants.pop_back();
+                    continue;
+                }
+
+                if (s.descendant_message_queue.size() == 1)
+                {
+                    // The final message is removed before its callback runs, so retire this HWND now to avoid rebuilding its queue.
+                    s.visible_descendants.pop_back();
+                }
+
+                dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(s), *descendant, s.descendant_message_queue);
+                return {};
             }
 
             if (!s.message_queue.empty())
@@ -3614,6 +3727,12 @@ namespace sogen
                 if (next.message == WM_WINDOWPOSCHANGING)
                 {
                     s.pending_window_pos_address = next.lParam;
+                }
+
+                if (next.message == WM_ERASEBKGND)
+                {
+                    collect_visible_window_descendants(c, *win, s.visible_descendants);
+                    std::ranges::reverse(s.visible_descendants);
                 }
 
                 dispatch_next_message(c, callback_id::NtUserShowWindow, std::move(s), *win, s.message_queue);
@@ -3630,6 +3749,10 @@ namespace sogen
             if (s.erase_background_dc)
             {
                 (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.erase_background_dc));
+            }
+            if (s.parent_erase_background_dc)
+            {
+                (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.parent_erase_background_dc));
             }
 
             return s.was_visible ? TRUE : FALSE;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -2270,8 +2270,6 @@ namespace sogen
             return TRUE;
         }
 
-        // DwmGetWindowAttribute funnels into this. There is no DWM in the emulated session, so windows are never
-        // composed, never cloaked, and their extended frame equals the plain window rect.
         BOOL handle_NtUserGetWindowCompositionAttribute(const syscall_context& c, const hwnd window,
                                                         const emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data)
         {
@@ -2280,33 +2278,10 @@ namespace sogen
                 return FALSE;
             }
 
-            // The struct carries pointer/size_t fields, so a 32-bit (WoW64) guest passes a 12-byte layout, not
-            // the native 24-byte one; read the matching width.
-            uint32_t attrib = 0;
-            uint64_t pv_data = 0;
-            uint64_t cb_data = 0;
-            if (c.proc.is_wow64_process)
-            {
-                struct wow64_composition_data
-                {
-                    uint32_t attrib;
-                    uint32_t pv_data;
-                    uint32_t cb_data;
-                };
-
-                static_assert(sizeof(wow64_composition_data) == 12);
-                const auto data = emulator_object<wow64_composition_data>{c.emu, attribute_data.value()}.read();
-                attrib = data.attrib;
-                pv_data = data.pv_data;
-                cb_data = data.cb_data;
-            }
-            else
-            {
-                const auto data = attribute_data.read();
-                attrib = data.Attrib;
-                pv_data = data.pvData;
-                cb_data = data.cbData;
-            }
+            const auto data = attribute_data.read();
+            uint32_t attrib = data.Attrib;
+            uint64_t pv_data = data.pvData;
+            uint64_t cb_data = data.cbData;
 
             if (pv_data == 0 || cb_data == 0)
             {
@@ -2321,7 +2296,16 @@ namespace sogen
 
             switch (attrib)
             {
-            case WCA_NCRENDERING_ENABLED:
+            case WCA_NCRENDERING_ENABLED: {
+                if (cb_data < sizeof(uint32_t))
+                {
+                    return FALSE;
+                }
+
+                constexpr BOOL value = TRUE;
+                c.emu.write_memory(pv_data, &value, sizeof(value));
+                return TRUE;
+            }
             case WCA_CLOAKED: {
                 if (cb_data < sizeof(uint32_t))
                 {
@@ -2348,6 +2332,44 @@ namespace sogen
                 c.win_emu.log.warn("Unsupported window composition attribute: %u\n", attrib);
                 return FALSE;
             }
+        }
+
+        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, const hwnd window,
+                                                        const emulator_object<USER_WINDOWCOMPOSITIONATTRIBDATA> attribute_data)
+        {
+            if (!attribute_data)
+            {
+                return FALSE;
+            }
+
+            const auto data = attribute_data.read();
+            uint32_t attrib = data.Attrib;
+            uint64_t pv_data = data.pvData;
+            uint64_t cb_data = data.cbData;
+
+            if (pv_data == 0 || cb_data == 0)
+            {
+                return FALSE;
+            }
+
+            const auto* win = c.proc.windows.get(window);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            if (attrib == WCA_NCRENDERING_ENABLED || attrib == WCA_NCRENDERING_POLICY)
+            {
+                // We don't track DWM state right now, so let's at least report the current hard-coded value.
+                sogen::msg queued_message{};
+                queued_message.window = window;
+                queued_message.message = WM_DWMNCRENDERINGCHANGED;
+                queued_message.wParam = 1;
+                queued_message.lParam = 0;
+                c.vcpu.active_thread->post_message(c.win_emu, queued_message);
+            }
+
+            return TRUE;
         }
 
         // GetKeyState / GetAsyncKeyState report whether a virtual key (or mouse button) is currently down.
@@ -3061,9 +3083,21 @@ namespace sogen
                     .top_level = !has_child_parent,
                 });
 
-                if (has_child_parent && parent_win && (style & WS_VISIBLE) != 0)
+                if (has_child_parent)
                 {
-                    invalidate_window(c, win);
+                    if (parent_win && (style & WS_VISIBLE) != 0)
+                    {
+                        invalidate_window(c, win);
+                    }
+                }
+                else
+                {
+                    sogen::msg queued_message{};
+                    queued_message.window = handle.bits;
+                    queued_message.message = WM_DWMNCRENDERINGCHANGED;
+                    queued_message.wParam = 1;
+                    queued_message.lParam = 0;
+                    c.vcpu.active_thread->post_message(c.win_emu, queued_message);
                 }
             }
 
@@ -5516,16 +5550,6 @@ namespace sogen
         }
 
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, const hwnd hwnd)
-        {
-            if (hwnd != 0 && !c.proc.windows.get(hwnd))
-            {
-                return FALSE;
-            }
-
-            return TRUE;
-        }
-
-        BOOL handle_NtUserSetWindowCompositionAttribute(const syscall_context& c, const hwnd hwnd, const emulator_pointer /*data*/)
         {
             if (hwnd != 0 && !c.proc.windows.get(hwnd))
             {

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -379,6 +379,8 @@ namespace sogen
         void update_window_geometry(const syscall_context& c, window& win, const int x, const int y, const int width, const int height,
                                     const bool repaint)
         {
+            const bool geometry_changed = x != win.x || y != win.y || width != win.width || height != win.height;
+
             win.x = x;
             win.y = y;
             win.width = width;
@@ -390,7 +392,7 @@ namespace sogen
                 c.win_emu.ui().set_window_rect(win.handle, get_window_rect(win));
             }
 
-            if (repaint)
+            if (repaint && geometry_changed)
             {
                 invalidate_window(c, win, std::nullopt, false);
             }
@@ -3210,11 +3212,14 @@ namespace sogen
                     state.window_pos_alloc = c.emu.push_stack(show_position);
                     state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
                     state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
+                    state.erase_background_dc = create_gdi_window_dc(c, handle.bits);
 
                     std::vector<qmsg> show_messages = {
                         {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                         {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
                         {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
+                        {.message = WM_ERASEBKGND, .wParam = state.erase_background_dc, .lParam = 0},
+                        {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
                         {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
                         {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
                         {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
@@ -3270,6 +3275,11 @@ namespace sogen
                 c.emu.pop_stack(s.min_max_info_alloc);
                 c.emu.pop_stack(s.window_rect_alloc);
                 c.emu.pop_stack(s.create_struct_alloc);
+
+                if (s.erase_background_dc)
+                {
+                    (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.erase_background_dc));
+                }
             };
 
             if (!win)
@@ -3512,10 +3522,13 @@ namespace sogen
                 const auto move_lparam = static_cast<uint64_t>(((win->y & 0xFFFF) << 16) | (win->x & 0xFFFF));
                 const auto size_lparam = static_cast<uint64_t>(((win->client_height() & 0xFFFF) << 16) | (win->client_width() & 0xFFFF));
 
+                state.erase_background_dc = create_gdi_window_dc(c, hwnd);
                 state.message_queue = {
                     {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
                     {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
                     {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
+                    {.message = WM_ERASEBKGND, .wParam = state.erase_background_dc, .lParam = 0},
+                    {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
                 };
 
                 if (activate_window)
@@ -3614,6 +3627,11 @@ namespace sogen
             }
             c.emu.pop_stack(s.changed_window_pos_alloc);
             c.emu.pop_stack(s.window_pos_alloc);
+
+            if (s.erase_background_dc)
+            {
+                (void)handle_NtGdiDeleteObjectApp(c, static_cast<uint32_t>(s.erase_background_dc));
+            }
 
             return s.was_visible ? TRUE : FALSE;
         }
@@ -4459,7 +4477,7 @@ namespace sogen
                     c.win_emu.ui().set_window_visible(hWnd, false);
                 }
             }
-            else if ((flags & SWP_SHOWWINDOW) != 0)
+            else if ((flags & SWP_SHOWWINDOW) != 0 && (win->style & WS_VISIBLE) == 0)
             {
                 win->style |= WS_VISIBLE;
                 win->guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win->style; });

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1443,6 +1443,48 @@ namespace sogen
                 item.text = read_menu_item_text(c, mi, item_text);
             }
         }
+
+        uint64_t pack_message_lparam(const int low, const int high)
+        {
+            return static_cast<uint64_t>(static_cast<uint16_t>(low)) | (static_cast<uint64_t>(static_cast<uint16_t>(high)) << 16);
+        }
+
+        std::vector<qmsg> build_show_window_messages(const syscall_context& c, const window& win, const hdc erase_background_dc,
+                                                     const uint64_t window_pos_address,
+                                                     const std::optional<uint64_t> activation_window_pos_address)
+        {
+            std::vector<qmsg> messages = {
+                {.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)},
+                {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())},
+                {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
+                {.message = WM_ERASEBKGND, .wParam = erase_background_dc, .lParam = 0},
+                {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
+            };
+
+            if (activation_window_pos_address)
+            {
+                messages.push_back({.message = WM_SETFOCUS, .wParam = 0, .lParam = 0});
+                messages.push_back({.message = WM_ACTIVATE, .wParam = 1, .lParam = 0});
+                messages.push_back({.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0});
+                if (!win.message_only && !is_application_active(c))
+                {
+                    messages.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
+                }
+                messages.push_back({
+                    .message = WM_WINDOWPOSCHANGING,
+                    .wParam = 0,
+                    .lParam = *activation_window_pos_address,
+                });
+            }
+
+            messages.push_back({
+                .message = WM_WINDOWPOSCHANGING,
+                .wParam = 0,
+                .lParam = window_pos_address,
+            });
+            messages.push_back({.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0});
+            return messages;
+        }
     }
 
     namespace syscalls
@@ -3166,11 +3208,10 @@ namespace sogen
             {
                 invalidate_window(c, win);
 
-                const auto move_lparam = static_cast<uint64_t>(((y & 0xFFFF) << 16) | (x & 0xFFFF));
-                const auto size_lparam = static_cast<uint64_t>(((win.client_height() & 0xFFFF) << 16) | (win.client_width() & 0xFFFF));
-
                 if (has_child_parent)
                 {
+                    const auto move_lparam = pack_message_lparam(x, y);
+                    const auto size_lparam = pack_message_lparam(win.client_width(), win.client_height());
                     std::vector<qmsg> child_messages{{.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0}};
                     if (notify_parent)
                     {
@@ -3214,26 +3255,8 @@ namespace sogen
                     state.changed_window_pos_alloc = c.emu.push_stack(changed_position);
                     state.erase_background_dc = create_gdi_window_dc(c, handle.bits);
 
-                    std::vector<qmsg> show_messages = {
-                        {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
-                        {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                        {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
-                        {.message = WM_ERASEBKGND, .wParam = state.erase_background_dc, .lParam = 0},
-                        {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
-                        {.message = WM_SETFOCUS, .wParam = 0, .lParam = 0},
-                        {.message = WM_ACTIVATE, .wParam = 1, .lParam = 0},
-                        {.message = WM_NCACTIVATE, .wParam = 1, .lParam = 0},
-                    };
-                    if (!is_message_only && !is_application_active(c))
-                    {
-                        show_messages.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
-                    }
-                    const std::initializer_list<qmsg> position_messages = {
-                        {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.activation_window_pos_alloc.address()},
-                        {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                        {.message = WM_SHOWWINDOW, .wParam = 1, .lParam = 0},
-                    };
-                    show_messages.insert(show_messages.end(), position_messages);
+                    auto show_messages = build_show_window_messages(c, win, state.erase_background_dc, state.window_pos_alloc.address(),
+                                                                    state.activation_window_pos_alloc.address());
                     state.message_queue.insert(state.message_queue.begin(), show_messages.begin(), show_messages.end());
                 }
             }
@@ -3519,18 +3542,9 @@ namespace sogen
 
             if (want_visible)
             {
-                const auto move_lparam = static_cast<uint64_t>(((win->y & 0xFFFF) << 16) | (win->x & 0xFFFF));
-                const auto size_lparam = static_cast<uint64_t>(((win->client_height() & 0xFFFF) << 16) | (win->client_width() & 0xFFFF));
-
                 state.erase_background_dc = create_gdi_window_dc(c, hwnd);
-                state.message_queue = {
-                    {.message = WM_MOVE, .wParam = 0, .lParam = move_lparam},
-                    {.message = WM_SIZE, .wParam = 0, .lParam = size_lparam},
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
-                    {.message = WM_ERASEBKGND, .wParam = state.erase_background_dc, .lParam = 0},
-                    {.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0},
-                };
 
+                std::optional<uint64_t> activation_window_pos_address{};
                 if (activate_window)
                 {
                     const EMU_WINDOWPOS activation_position{
@@ -3543,26 +3557,11 @@ namespace sogen
                         .flags = SWP_NOMOVE | SWP_NOSIZE,
                     };
                     state.activation_window_pos_alloc = c.emu.push_stack(activation_position);
-
-                    state.message_queue.push_back({.message = WM_SETFOCUS, .wParam = 0, .lParam = 0});
-                    state.message_queue.push_back({.message = WM_ACTIVATE, .wParam = 1, .lParam = 0});
-                    state.message_queue.push_back({.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0});
-                    if (!win->message_only && !is_application_active(c))
-                    {
-                        state.message_queue.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
-                    }
-                    state.message_queue.push_back({
-                        .message = WM_WINDOWPOSCHANGING,
-                        .wParam = 0,
-                        .lParam = state.activation_window_pos_alloc.address(),
-                    });
+                    activation_window_pos_address = state.activation_window_pos_alloc.address();
                 }
 
-                const std::initializer_list<qmsg> show_messages = {
-                    {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = state.window_pos_alloc.address()},
-                    {.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0},
-                };
-                state.message_queue.insert(state.message_queue.end(), show_messages);
+                state.message_queue = build_show_window_messages(c, *win, state.erase_background_dc, state.window_pos_alloc.address(),
+                                                                 activation_window_pos_address);
 
                 win->style |= WS_VISIBLE;
             }

--- a/src/windows-emulator/window_destroy_orchestrator.cpp
+++ b/src/windows-emulator/window_destroy_orchestrator.cpp
@@ -230,7 +230,7 @@ namespace sogen
             };
         }
 
-        if ((win.style & WS_CHILD) != 0 && (win.ex_style & WS_EX_NOPARENTNOTIFY) == 0)
+        if (is_direct_target && (win.style & WS_CHILD) != 0 && (win.ex_style & WS_EX_NOPARENTNOTIFY) == 0 && win.parent_handle != 0)
         {
             uint64_t child_id{};
             win.guest.access([&](const USER_WINDOW& guest_win) { child_id = guest_win.wID; });

--- a/src/windows-emulator/window_show_orchestrator.cpp
+++ b/src/windows-emulator/window_show_orchestrator.cpp
@@ -1,0 +1,303 @@
+#include "window_show_orchestrator.hpp"
+
+#include "syscall_utils.hpp"
+
+namespace sogen
+{
+    namespace
+    {
+        constexpr uint64_t k_hrgn_window = 1;
+
+        uint64_t pack_message_lparam(const int low, const int high)
+        {
+            return static_cast<uint64_t>(static_cast<uint16_t>(low)) | (static_cast<uint64_t>(static_cast<uint16_t>(high)) << 16);
+        }
+    }
+
+    namespace syscalls
+    {
+        hdc create_gdi_window_dc(const syscall_context& c, hwnd window);
+        uint32_t handle_NtGdiDeleteObjectApp(const syscall_context& c, uint32_t handle_value);
+    }
+
+    window_show_orchestrator::window_show_orchestrator(window_show_data& data, const syscall_context& c)
+        : data_(data),
+          context_(c)
+    {
+    }
+
+    void window_show_orchestrator::start_show(const window& win, const uint32_t visibility_flags, const bool activate_window,
+                                              const bool emit_size_move, const bool emit_activate_app) const
+    {
+        this->data_.handle = win.handle;
+        this->allocate_window_positions(win, visibility_flags);
+        this->data_.erase_background_dc = syscalls::create_gdi_window_dc(this->context_, win.handle);
+
+        if (activate_window)
+        {
+            const EMU_WINDOWPOS activation_position{
+                .hwnd = win.handle,
+                .hwndInsertAfter = 0,
+                .x = 0,
+                .y = 0,
+                .cx = 0,
+                .cy = 0,
+                .flags = SWP_NOMOVE | SWP_NOSIZE,
+            };
+            this->data_.activation_window_pos_alloc = this->context_.emu.push_stack(activation_position);
+        }
+
+        if (emit_size_move)
+        {
+            this->data_.message_queue.push_back({.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)});
+            this->data_.message_queue.push_back(
+                {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())});
+        }
+
+        this->data_.message_queue.push_back({.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0});
+        if (this->data_.erase_background_dc != 0)
+        {
+            this->data_.message_queue.push_back({.message = WM_ERASEBKGND, .wParam = this->data_.erase_background_dc, .lParam = 0});
+        }
+        this->data_.message_queue.push_back({.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0});
+
+        if (activate_window)
+        {
+            this->data_.message_queue.push_back({.message = WM_SETFOCUS, .wParam = 0, .lParam = 0});
+            this->data_.message_queue.push_back({.message = WM_ACTIVATE, .wParam = 1, .lParam = 0});
+            this->data_.message_queue.push_back({.message = WM_NCACTIVATE, .wParam = TRUE, .lParam = 0});
+            if (emit_activate_app)
+            {
+                this->data_.message_queue.push_back({.message = WM_ACTIVATEAPP, .wParam = TRUE, .lParam = 0});
+            }
+            this->data_.message_queue.push_back({
+                .message = WM_WINDOWPOSCHANGING,
+                .wParam = 0,
+                .lParam = this->data_.activation_window_pos_alloc.address(),
+            });
+        }
+
+        this->data_.message_queue.push_back({
+            .message = WM_WINDOWPOSCHANGING,
+            .wParam = 0,
+            .lParam = this->data_.window_pos_alloc.address(),
+        });
+        this->data_.message_queue.push_back({.message = WM_SHOWWINDOW, .wParam = TRUE, .lParam = 0});
+    }
+
+    void window_show_orchestrator::start_hide(const window& win, const uint32_t visibility_flags) const
+    {
+        this->data_.handle = win.handle;
+        this->allocate_window_positions(win, visibility_flags);
+        this->data_.message_queue = {
+            {.message = WM_KILLFOCUS, .wParam = 0, .lParam = 0},
+            {.message = WM_ACTIVATE, .wParam = 0, .lParam = 0},
+            {.message = WM_NCACTIVATE, .wParam = FALSE, .lParam = 0},
+            {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = 0},
+            {.message = WM_WINDOWPOSCHANGING, .wParam = 0, .lParam = this->data_.window_pos_alloc.address()},
+            {.message = WM_SHOWWINDOW, .wParam = FALSE, .lParam = 0},
+        };
+    }
+
+    void window_show_orchestrator::set_parent_erase_window(const hwnd parent) const
+    {
+        this->data_.parent_erase_window = parent;
+        this->data_.parent_erase_background_dc = syscalls::create_gdi_window_dc(this->context_, parent);
+    }
+
+    void window_show_orchestrator::window_position_completed(const bool activation_position) const
+    {
+        if (!activation_position && this->data_.parent_erase_window != 0 && this->data_.parent_erase_background_dc != 0)
+        {
+            this->data_.parent_erase_pending = true;
+        }
+    }
+
+    void window_show_orchestrator::erase_background_completed(const uint64_t result) const
+    {
+        if (this->data_.pending_erase_window == 0)
+        {
+            return;
+        }
+
+        if (auto* win = this->context_.proc.windows.get(this->data_.pending_erase_window))
+        {
+            win->erase_pending = result == 0;
+        }
+        this->data_.pending_erase_window = 0;
+    }
+
+    std::optional<window_show_step> window_show_orchestrator::advance() const
+    {
+        if (this->data_.parent_erase_pending)
+        {
+            this->data_.parent_erase_pending = false;
+            if (this->context_.proc.windows.get(this->data_.parent_erase_window))
+            {
+                return this->prepare_step(this->data_.parent_erase_window,
+                                          {.message = WM_ERASEBKGND, .wParam = this->data_.parent_erase_background_dc, .lParam = 0});
+            }
+        }
+
+        while (!this->data_.visible_descendants.empty() || !this->data_.descendant_message_queue.empty() ||
+               this->data_.descendant_erase_background_dc != 0)
+        {
+            if (this->data_.descendant_message_queue.empty())
+            {
+                this->release_descendant_dc();
+                if (this->data_.visible_descendants.empty())
+                {
+                    break;
+                }
+
+                const auto descendant_handle = this->data_.visible_descendants.back();
+                if (!this->context_.proc.windows.get(descendant_handle) ||
+                    !this->context_.proc.is_window_effectively_visible(descendant_handle))
+                {
+                    this->data_.visible_descendants.pop_back();
+                    continue;
+                }
+
+                this->build_descendant_paint(descendant_handle);
+            }
+
+            const auto descendant_handle = this->data_.visible_descendants.back();
+            if (!this->context_.proc.windows.get(descendant_handle) ||
+                !this->context_.proc.is_window_effectively_visible(descendant_handle))
+            {
+                this->data_.descendant_message_queue.clear();
+                this->release_descendant_dc();
+                this->data_.visible_descendants.pop_back();
+                continue;
+            }
+
+            const auto message = this->data_.descendant_message_queue.back();
+            this->data_.descendant_message_queue.pop_back();
+            if (this->data_.descendant_message_queue.empty())
+            {
+                this->data_.visible_descendants.pop_back();
+            }
+            return this->prepare_step(descendant_handle, message);
+        }
+
+        if (auto* win = this->context_.proc.windows.get(this->data_.handle); win && !this->data_.message_queue.empty())
+        {
+            const auto message = this->data_.message_queue.back();
+            this->data_.message_queue.pop_back();
+
+            if (message.message == WM_WINDOWPOSCHANGING)
+            {
+                this->data_.pending_window_pos_address = message.lParam;
+            }
+            if (message.message == WM_ERASEBKGND)
+            {
+                this->collect_visible_descendants(*win, this->data_.visible_descendants);
+                std::ranges::reverse(this->data_.visible_descendants);
+            }
+
+            return this->prepare_step(this->data_.handle, message);
+        }
+
+        this->release();
+        return std::nullopt;
+    }
+
+    window_show_step window_show_orchestrator::prepare_step(const hwnd handle, const qmsg message) const
+    {
+        if (message.message == WM_ERASEBKGND)
+        {
+            this->data_.pending_erase_window = handle;
+        }
+        return {.handle = handle, .message = message};
+    }
+
+    void window_show_orchestrator::build_descendant_paint(const hwnd descendant) const
+    {
+        this->data_.descendant_erase_background_dc = syscalls::create_gdi_window_dc(this->context_, descendant);
+        if (this->data_.descendant_erase_background_dc != 0)
+        {
+            this->data_.descendant_message_queue.push_back(
+                {.message = WM_ERASEBKGND, .wParam = this->data_.descendant_erase_background_dc, .lParam = 0});
+        }
+        this->data_.descendant_message_queue.push_back({.message = WM_NCPAINT, .wParam = k_hrgn_window, .lParam = 0});
+    }
+
+    void window_show_orchestrator::release_descendant_dc() const
+    {
+        if (this->data_.descendant_erase_background_dc != 0)
+        {
+            (void)syscalls::handle_NtGdiDeleteObjectApp(this->context_, static_cast<uint32_t>(this->data_.descendant_erase_background_dc));
+            this->data_.descendant_erase_background_dc = 0;
+        }
+    }
+
+    void window_show_orchestrator::release() const
+    {
+        this->release_descendant_dc();
+
+        if (this->data_.activation_window_pos_alloc)
+        {
+            this->context_.emu.pop_stack(this->data_.activation_window_pos_alloc);
+        }
+        if (this->data_.changed_window_pos_alloc)
+        {
+            this->context_.emu.pop_stack(this->data_.changed_window_pos_alloc);
+        }
+        if (this->data_.window_pos_alloc)
+        {
+            this->context_.emu.pop_stack(this->data_.window_pos_alloc);
+        }
+
+        if (this->data_.erase_background_dc != 0)
+        {
+            (void)syscalls::handle_NtGdiDeleteObjectApp(this->context_, static_cast<uint32_t>(this->data_.erase_background_dc));
+            this->data_.erase_background_dc = 0;
+        }
+        if (this->data_.parent_erase_background_dc != 0)
+        {
+            (void)syscalls::handle_NtGdiDeleteObjectApp(this->context_, static_cast<uint32_t>(this->data_.parent_erase_background_dc));
+            this->data_.parent_erase_background_dc = 0;
+        }
+    }
+
+    void window_show_orchestrator::allocate_window_positions(const window& win, const uint32_t visibility_flags) const
+    {
+        const EMU_WINDOWPOS changing_position{
+            .hwnd = win.handle,
+            .hwndInsertAfter = 0,
+            .x = 0,
+            .y = 0,
+            .cx = 0,
+            .cy = 0,
+            .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags,
+        };
+        const EMU_WINDOWPOS changed_position{
+            .hwnd = win.handle,
+            .hwndInsertAfter = 0,
+            .x = win.x,
+            .y = win.y,
+            .cx = win.width,
+            .cy = win.height,
+            .flags = SWP_NOMOVE | SWP_NOSIZE | visibility_flags | SWP_NOCLIENTSIZE | SWP_NOCLIENTMOVE,
+        };
+        this->data_.window_pos_alloc = this->context_.emu.push_stack(changing_position);
+        this->data_.changed_window_pos_alloc = this->context_.emu.push_stack(changed_position);
+    }
+
+    void window_show_orchestrator::collect_visible_descendants(const window& parent, std::vector<hwnd>& descendants) const
+    {
+        for (auto& [index, child] : this->context_.proc.windows)
+        {
+            (void)index;
+            if (child.parent_handle != parent.handle || (child.style & WS_VISIBLE) == 0 ||
+                !this->context_.proc.is_window_effectively_visible(child.handle))
+            {
+                continue;
+            }
+
+            descendants.push_back(child.handle);
+            this->collect_visible_descendants(child, descendants);
+        }
+    }
+
+} // namespace sogen

--- a/src/windows-emulator/window_show_orchestrator.hpp
+++ b/src/windows-emulator/window_show_orchestrator.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "syscall_dispatcher.hpp"
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+namespace sogen
+{
+
+    struct syscall_context;
+
+    struct window_show_step
+    {
+        hwnd handle{};
+        qmsg message{};
+    };
+
+    class window_show_orchestrator
+    {
+      public:
+        window_show_orchestrator(window_show_data& data, const syscall_context& c);
+
+        void start_show(const window& win, uint32_t visibility_flags, bool activate_window, bool emit_size_move,
+                        bool emit_activate_app) const;
+        void start_hide(const window& win, uint32_t visibility_flags) const;
+        void set_parent_erase_window(hwnd parent) const;
+        void window_position_completed(bool activation_position) const;
+        void erase_background_completed(uint64_t result) const;
+        std::optional<window_show_step> advance() const;
+        void release() const;
+
+      private:
+        void allocate_window_positions(const window& win, uint32_t visibility_flags) const;
+        void collect_visible_descendants(const window& parent, std::vector<hwnd>& descendants) const;
+        void build_descendant_paint(hwnd descendant) const;
+        void release_descendant_dc() const;
+        window_show_step prepare_step(hwnd handle, qmsg message) const;
+
+        window_show_data& data_;
+        const syscall_context& context_;
+    };
+
+} // namespace sogen
+
+// NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)


### PR DESCRIPTION
This PR builds on the sequence-accuracy fixes introduced in https://github.com/momo5502/sogen/pull/1241, further improving the accuracy of the message sequence sent by the Windows emulator.

* Window creation and visibility changes now follow a more complete native message flow:
  
  * Visible top-level windows use the same show sequence during creation as they do through "ShowWindow".
  * Showing a window includes "WM_NCPAINT" and "WM_ERASEBKGND" at the appropriate points in the sequence.
  * Visible descendants also receive non-client and background-paint messages when their parent is shown.
  * Showing a child window can erase its parent’s background before continuing the child’s paint sequence.
  * Activation and "WINDOWPOS" flags are selected based on the window type and the requested show command.

* Paint and invalidation state now behaves more like Windows:
  
  * Handling "WM_ERASEBKGND" does not clear the window’s pending update region.
  * "UpdateWindow" sends "WM_PAINT" and validates the update region through "BeginPaint".
  * Reapplying unchanged window geometry does not create a new update region.
  * Showing a previously hidden window through "SetWindowPos" avoids an additional geometry invalidation.
  * Paint tests now cover the "WM_NCPAINT", "WM_ERASEBKGND", and "WM_PAINT" sequence produced by "ShowWindow" and "UpdateWindow".

* DWM-related calls now expose the non-client-rendering behavior expected by applications:
  
  * Top-level windows receive "WM_DWMNCRENDERINGCHANGED" during creation.
  * Setting "WCA_NCRENDERING_ENABLED" or "WCA_NCRENDERING_POLICY" queues the same notification.
  * Querying "WCA_NCRENDERING_ENABLED" reports non-client rendering as enabled.
  * Window-composition attribute handling now uses the expected guest structure layout.

* A few related compatibility and cleanup issues were also fixed:
  
  * Message retrieval checks queued messages first, pending paint work second, and only then synthesizes due timer messages.
  * "WM_PARENTNOTIFY" during destruction is only sent for the child window directly passed to "DestroyWindow".
  * Desktop thread information now includes the expected flags.
  * Guest GDI allocations are released when handle creation fails or when the corresponding object is deleted.

Working on this PR made me painfully aware of how some software seems to be hanging by a thread, haha. One game would only start if it received the DWM message, while another would enter a loop if it did not receive the ERASEBKGND message, due to an invariant caused by the lack of a `BeginPaint` call.

An current message-sequence diff against native Windows can be found here: https://pastebin.com/raw/9MLkqUNe