### PR TITLE
Implement and fix miscellaneous syscalls

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -42,7 +42,7 @@ namespace sogen::whp
         constexpr uint64_t internal_page_table_base = 0x0000007000000000ull;
         constexpr uint64_t syscall_hook_virtual_address = 0xFFFF800000001000ull;
         constexpr uint64_t unmapped_guest_page = (std::numeric_limits<uint64_t>::max)();
-        constexpr UINT32 xsave_state_capacity = 960;
+        constexpr uint32_t xsave_state_capacity = 0xFFF;
 
         uint64_t align_down_to_page(const uint64_t value)
         {

--- a/src/emulator-platform/platform/gdi.hpp
+++ b/src/emulator-platform/platform/gdi.hpp
@@ -7,6 +7,7 @@ namespace sogen
 #ifndef OS_WINDOWS
 #define ANSI_CHARSET       0
 #define DEFAULT_CHARSET    1
+#define SHIFTJIS_CHARSET   128
 #define GREEK_CHARSET      161
 #define TURKISH_CHARSET    162
 #define VIETNAMESE_CHARSET 163

--- a/src/emulator-platform/platform/process.hpp
+++ b/src/emulator-platform/platform/process.hpp
@@ -1325,8 +1325,19 @@ namespace sogen
         // Followed by SYSTEM_THREAD_INFORMATION<Traits> Threads[NumberOfThreads]
     };
 
+    template <typename Traits>
+    struct SYSTEM_PAGEFILE_INFORMATION
+    {
+        ULONG NextEntryOffset;
+        ULONG TotalSize;
+        ULONG TotalInUse;
+        ULONG PeakUsage;
+        UNICODE_STRING<Traits> PageFileName;
+    };
+
     static_assert(sizeof(SYSTEM_THREAD_INFORMATION<EmulatorTraits<Emu64>>) == 0x50);
     static_assert(sizeof(SYSTEM_PROCESS_INFORMATION<EmulatorTraits<Emu64>>) == 0x100);
+    static_assert(sizeof(SYSTEM_PAGEFILE_INFORMATION<EmulatorTraits<Emu64>>) == 0x20);
 
     struct PROCESS_PRIORITY_CLASS
     {

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -56,7 +56,9 @@ namespace sogen
         uint8_t pad_1394[0x74];
         uint32_t dpi96DialogBaseUnitWidth;
         uint32_t dpi96DialogBaseUnitHeight;
-        uint8_t pad_1410[0x746];
+        uint8_t pad_1410[0x73C];
+        uint32_t asyncKeyStateGeneration;
+        uint8_t pad_1b50[0x6];
         uint16_t systemDpi;
         uint8_t pad_1b58[0x286];
         uint64_t foregroundWindow;
@@ -69,6 +71,7 @@ namespace sogen
     static_assert(offsetof(USER_SERVERINFO, defaultFontWidthScale) == 0x1390);
     static_assert(offsetof(USER_SERVERINFO, dpi96DialogBaseUnitWidth) == 0x1408);
     static_assert(offsetof(USER_SERVERINFO, dpi96DialogBaseUnitHeight) == 0x140C);
+    static_assert(offsetof(USER_SERVERINFO, asyncKeyStateGeneration) == 0x1B4C);
     static_assert(offsetof(USER_SERVERINFO, systemDpi) == 0x1B56);
     static_assert(offsetof(USER_SERVERINFO, foregroundWindow) == 0x1DE0);
     static_assert(sizeof(USER_SERVERINFO) == 0x1de8);

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -53,7 +53,10 @@ namespace sogen
         uint8_t pad_1358[0x34];
         int32_t defaultFontHeightScale;
         int32_t defaultFontWidthScale;
-        uint8_t pad_1394[0x7C2];
+        uint8_t pad_1394[0x74];
+        uint32_t dpi96DialogBaseUnitWidth;
+        uint32_t dpi96DialogBaseUnitHeight;
+        uint8_t pad_1410[0x746];
         uint16_t systemDpi;
         uint8_t pad_1b58[0x286];
         uint64_t foregroundWindow;
@@ -64,6 +67,8 @@ namespace sogen
     static_assert(offsetof(USER_SERVERINFO, ahbrSystem) == 0x1258);
     static_assert(offsetof(USER_SERVERINFO, defaultFontHeightScale) == 0x138C);
     static_assert(offsetof(USER_SERVERINFO, defaultFontWidthScale) == 0x1390);
+    static_assert(offsetof(USER_SERVERINFO, dpi96DialogBaseUnitWidth) == 0x1408);
+    static_assert(offsetof(USER_SERVERINFO, dpi96DialogBaseUnitHeight) == 0x140C);
     static_assert(offsetof(USER_SERVERINFO, systemDpi) == 0x1B56);
     static_assert(offsetof(USER_SERVERINFO, foregroundWindow) == 0x1DE0);
     static_assert(sizeof(USER_SERVERINFO) == 0x1de8);

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -180,6 +180,16 @@ namespace sogen
         hbitmap hbmpItem;
     };
 
+    struct EMU_WINDOWPLACEMENT
+    {
+        DWORD length;
+        DWORD flags;
+        DWORD showCmd;
+        POINT ptMinPosition;
+        POINT ptMaxPosition;
+        RECT rcNormalPosition;
+    };
+
 #define EMU_HWND_MESSAGE ((hwnd) - 3)
 
 #define SWP_NOCLIENTSIZE 0x0800

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -201,9 +201,11 @@ namespace sogen
 #define WS_POPUP                    0x80000000L
 #define WS_CHILD                    0x40000000L
 #define WS_VISIBLE                  0x10000000L
+#define WS_MINIMIZE                 0x20000000L
 #define WS_DISABLED                 0x08000000L
 #define WS_CLIPSIBLINGS             0x04000000L
 #define WS_CLIPCHILDREN             0x02000000L
+#define WS_MAXIMIZE                 0x01000000L
 #define WS_CAPTION                  0x00C00000L
 #define WS_BORDER                   0x00800000L
 #define WS_DLGFRAME                 0x00400000L
@@ -222,6 +224,9 @@ namespace sogen
 #define SWP_SHOWWINDOW              0x0040
 #define SWP_HIDEWINDOW              0x0080
 
+#define SW_SHOWNORMAL               1
+#define SW_SHOWMINIMIZED            2
+#define SW_SHOWMAXIMIZED            3
 #define SW_SHOWNOACTIVATE           4
 #define SW_SHOWMINNOACTIVE          7
 #define SW_SHOWNA                   8

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -494,6 +494,10 @@ namespace sogen
 
 #define MF_BYCOMMAND                0x0000
 #define MF_BYPOSITION               0x0400
+
+#define MF_ENABLED                  0x00000000L
+#define MF_GRAYED                   0x00000001L
+#define MF_DISABLED                 0x00000002L
 #endif
 
 #define WM_UAHDESTROYWINDOW 0x0090

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -704,6 +704,9 @@ namespace sogen
         buffer.write(this->last_extended_params_image_machine);
 
         buffer.write(this->next_luid);
+        buffer.write(this->uuid_seed);
+        buffer.write(this->next_uuid_time);
+        buffer.write(this->uuid_sequence);
 
         buffer.write_vector(this->default_register_set);
         buffer.write(this->spawned_thread_count);
@@ -795,6 +798,9 @@ namespace sogen
         buffer.read(this->last_extended_params_image_machine);
 
         buffer.read(this->next_luid);
+        buffer.read(this->uuid_seed);
+        buffer.read(this->next_uuid_time);
+        buffer.read(this->uuid_sequence);
 
         buffer.read_vector(this->default_register_set);
         buffer.read(this->spawned_thread_count);

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -18,6 +18,8 @@
 
 #include "apiset/apiset.hpp"
 
+#include <array>
+
 namespace sogen
 {
 
@@ -568,6 +570,9 @@ namespace sogen
         uint16_t last_extended_params_image_machine{IMAGE_FILE_MACHINE_UNKNOWN};
 
         uint64_t next_luid{0x1001};
+        std::array<uint8_t, 6> uuid_seed{};
+        uint64_t next_uuid_time{};
+        uint32_t uuid_sequence{};
     };
 
 } // namespace sogen

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -675,7 +675,7 @@ namespace sogen
         uint64_t handle_NtUserQueryWindow(const syscall_context& c, hwnd window_handle, uint32_t query_type);
         int handle_NtUserSetScrollInfo();
         BOOL handle_NtUserIsTouchWindow();
-        BOOL handle_NtUserGetWindowPlacement();
+        BOOL handle_NtUserGetWindowPlacement(const syscall_context& c, hwnd window_handle, emulator_pointer placement_address);
         BOOL handle_NtUserTrackMouseEvent();
         BOOL handle_NtUserSetWindowRgn();
         BOOL handle_NtUserAlterWindowStyle();

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -134,6 +134,10 @@ namespace sogen
         NTSTATUS handle_NtGetMUIRegistryInfo();
         NTSTATUS handle_NtIsUILanguageComitted();
         uint64_t handle_NtUserActivateKeyboardLayout(const syscall_context& c, uint64_t keyboard_layout, uint32_t flags);
+        uint64_t handle_NtUserLoadKeyboardLayoutEx(const syscall_context& c, handle file, uint32_t table_offset, emulator_pointer tables,
+                                                   uint64_t old_keyboard_layout,
+                                                   emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> keyboard_layout_id,
+                                                   uint32_t new_keyboard_layout, uint32_t flags);
         uint64_t handle_NtUserGetKeyboardLayout(const syscall_context& c, uint32_t thread_id);
         uint32_t handle_NtUserGetKeyboardLayoutList(const syscall_context& c, uint32_t buffer_count, emulator_pointer keyboard_layouts);
         BOOL handle_NtUserGetKeyboardLayoutName(const syscall_context& c, emulator_pointer name);
@@ -1703,6 +1707,7 @@ namespace sogen
         add_handler(NtUserAttachThreadInput);
         add_handler(NtUserRegisterTouchHitTestingWindow);
         add_handler(NtUserActivateKeyboardLayout);
+        add_handler(NtUserLoadKeyboardLayoutEx);
         add_handler(NtUserGetGUIThreadInfo);
         add_handler(NtNotifyChangeDirectoryFile);
         add_handler(NtUserChangeWindowMessageFilter);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -667,7 +667,7 @@ namespace sogen
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
         BOOL handle_NtUserDestroyMenu(const syscall_context& c, hmenu menu);
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
-        BOOL handle_NtUserEnableMenuItem();
+        int32_t handle_NtUserEnableMenuItem(const syscall_context& c, hmenu menu, UINT item, UINT enable);
         BOOL handle_NtUserCreateCaret();
         BOOL handle_NtUserDestroyCaret();
         BOOL handle_NtUserSetCaretPos();
@@ -711,7 +711,7 @@ namespace sogen
         BOOL handle_NtUserHwndQueryRedirectionInfo();
         BOOL handle_NtUserEnableNonClientDpiScaling();
         BOOL handle_NtUserSetImeHotKey();
-        BOOL handle_NtUserVkKeyScanEx();
+        int16_t handle_NtUserVkKeyScanEx();
         BOOL handle_NtUserSetLayeredWindowAttributes();
 
         // syscalls/gdi.cpp:

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -661,7 +661,7 @@ namespace sogen
                                               emulator_object<EMU_MENUITEMINFO> item_info,
                                               emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> item_text);
         hmenu handle_NtUserCreatePopupMenu(const syscall_context& c);
-        BOOL handle_NtUserSetMenu();
+        BOOL handle_NtUserSetMenu(const syscall_context& c, hwnd hwnd, hmenu menu, BOOL redraw);
         BOOL handle_NtUserSetMenuDefaultItem(const syscall_context& c, hmenu menu, UINT item, UINT by_position);
         BOOL handle_NtUserEndMenu();
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -477,6 +477,7 @@ namespace sogen
         hdc handle_NtUserGetWindowDC(const syscall_context& c, hwnd window);
         hwnd handle_NtUserWindowFromDC(const syscall_context& c, hdc dc);
         uint64_t handle_NtUserGetControlBrush(const syscall_context& c, hwnd window, hdc dc, uint32_t control_type);
+        BOOL handle_NtUserFillWindow(const syscall_context& c, hwnd parent_window, hwnd window, hdc dc, hbrush brush);
         BOOL handle_NtUserReleaseDC();
         hwnd handle_NtUserSetCapture(const syscall_context& c, hwnd window);
         BOOL handle_NtUserReleaseCapture(const syscall_context& c);
@@ -1477,6 +1478,7 @@ namespace sogen
         add_handler(NtUserGetWindowDC);
         add_handler(NtUserWindowFromDC);
         add_handler(NtUserGetControlBrush);
+        add_handler(NtUserFillWindow);
         add_handler(NtUserGetOemBitmapSize);
         add_handler(NtUserSetCapture);
         add_handler(NtUserReleaseCapture);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -1172,6 +1172,40 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtAllocateUuids(const syscall_context& c, const emulator_object<ULARGE_INTEGER> time,
+                                        const emulator_object<ULONG> range, const emulator_object<ULONG> sequence,
+                                        const emulator_pointer seed)
+        {
+            const auto system_time = utils::convert_to_ksystem_time(c.win_emu.clock().system_now());
+            const uint64_t current_time = (static_cast<uint64_t>(static_cast<DWORD>(system_time.High1Time)) << 32) | system_time.LowPart;
+
+            if (c.proc.next_uuid_time == 0)
+            {
+                auto seed_value = current_time ^ c.win_emu.clock().timestamp_counter() ^ c.proc.ntdll_image_base;
+                for (auto& byte : c.proc.uuid_seed)
+                {
+                    seed_value ^= seed_value << 13;
+                    seed_value ^= seed_value >> 7;
+                    seed_value ^= seed_value << 17;
+                    byte = static_cast<uint8_t>(seed_value);
+                }
+
+                c.proc.uuid_seed[0] = static_cast<uint8_t>((c.proc.uuid_seed[0] | 0x02) & ~0x01);
+                c.proc.uuid_sequence = static_cast<uint32_t>(seed_value) & 0x3FFF;
+            }
+
+            constexpr ULONG uuid_range = 10000;
+            const uint64_t uuid_time = std::max(current_time, c.proc.next_uuid_time);
+            c.proc.next_uuid_time = uuid_time + uuid_range;
+
+            time.write(ULARGE_INTEGER{.QuadPart = uuid_time});
+            range.write(uuid_range);
+            sequence.write(c.proc.uuid_sequence);
+            c.emu.write_memory(seed, c.proc.uuid_seed.data(), c.proc.uuid_seed.size());
+
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtAllocateReserveObject(const syscall_context& c, const emulator_object<handle> memory_reserve_handle,
                                                 const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
                                                 const DWORD type)
@@ -1633,6 +1667,7 @@ namespace sogen
         add_handler(NtGdiDdDDICreateDCFromMemory);
         add_handler(NtGdiDdDDIDestroyDCFromMemory);
         add_handler(NtAllocateLocallyUniqueId);
+        add_handler(NtAllocateUuids);
         add_handler(NtUserAllowSetForegroundWindow);
         add_handler(NtGdiOpenDCW);
         add_handler(NtGdiDdDDIOpenAdapterFromLuid);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -667,6 +667,7 @@ namespace sogen
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
         BOOL handle_NtUserDestroyMenu(const syscall_context& c, hmenu menu);
         BOOL handle_NtUserDrawMenuBar(const syscall_context& c, hwnd hwnd);
+        BOOL handle_NtUserEnableMenuItem();
         BOOL handle_NtUserCreateCaret();
         BOOL handle_NtUserDestroyCaret();
         BOOL handle_NtUserSetCaretPos();
@@ -708,6 +709,10 @@ namespace sogen
         BOOL handle_NtUserDisableThreadIme();
         BOOL handle_NtUserGetPointerDevices();
         BOOL handle_NtUserHwndQueryRedirectionInfo();
+        BOOL handle_NtUserEnableNonClientDpiScaling();
+        BOOL handle_NtUserSetImeHotKey();
+        BOOL handle_NtUserVkKeyScanEx();
+        BOOL handle_NtUserSetLayeredWindowAttributes();
 
         // syscalls/gdi.cpp:
         NTSTATUS handle_NtDxgkIsFeatureEnabled();
@@ -768,6 +773,7 @@ namespace sogen
                                              uint32_t file_count, uint32_t flags, uint32_t thread_id, emulator_pointer design_vector);
         uint32_t handle_NtGdiGetTextMetricsW(const syscall_context& c, hdc dc, emulator_pointer ptm, uint32_t cj);
         int32_t handle_NtGdiGetTextFaceW(const syscall_context& c, hdc dc, int32_t count, emulator_pointer face_name, BOOL alias_name);
+        uint32_t handle_NtGdiGetKerningPairs(const syscall_context& c, hdc dc, uint32_t pair_count, emulator_pointer pairs);
         uint32_t handle_NtGdiGetGlyphOutline(const syscall_context& c, hdc dc, UINT character, UINT format, emulator_pointer glyph_metrics,
                                              DWORD buffer_size, emulator_pointer buffer, emulator_pointer mat2);
         uint32_t handle_NtGdiGetOutlineTextMetricsInternalW(const syscall_context& c, hdc dc, uint32_t cj_copy, emulator_pointer metrics,
@@ -1378,6 +1384,7 @@ namespace sogen
         add_handler(NtGdiAddFontResourceW);
         add_handler(NtGdiGetTextMetricsW);
         add_handler(NtGdiGetTextFaceW);
+        add_handler(NtGdiGetKerningPairs);
         add_handler(NtGdiGetTextExtent);
         add_handler(NtGdiGetCharWidthW);
         add_handler(NtGdiGetCharABCWidthsW);
@@ -1708,6 +1715,7 @@ namespace sogen
         add_handler(NtUserRemoveMenu);
         add_handler(NtUserDestroyMenu);
         add_handler(NtUserDrawMenuBar);
+        add_handler(NtUserEnableMenuItem);
         add_handler(NtUserSetWindowCompositionAttribute);
         add_handler(NtUserGetWindowPlacement);
         add_handler(NtUserCreateCaret);
@@ -1755,6 +1763,10 @@ namespace sogen
         add_handler(NtUserDisableThreadIme);
         add_handler(NtUserGetPointerDevices);
         add_handler(NtUserHwndQueryRedirectionInfo);
+        add_handler(NtUserEnableNonClientDpiScaling);
+        add_handler(NtUserSetImeHotKey);
+        add_handler(NtUserVkKeyScanEx);
+        add_handler(NtUserSetLayeredWindowAttributes);
 
 #undef add_handler
     }

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -732,6 +732,7 @@ namespace sogen
         uint64_t handle_NtGdiCreateCompatibleBitmap(const syscall_context& c, hdc dc, uint32_t width, uint32_t height);
         uint64_t handle_NtGdiCreateBitmap(const syscall_context& c, uint32_t width, uint32_t height, uint32_t planes, uint32_t bits_pixel,
                                           emulator_pointer bits);
+        int32_t handle_NtGdiGetBitmapBits(const syscall_context& c, handle bitmap, int32_t count, emulator_pointer bits);
         uint64_t handle_NtGdiCreateDIBSection(const syscall_context& c, hdc dc, uint64_t section_app, uint32_t offset,
                                               emulator_pointer info, uint32_t usage, uint32_t header_size, uint32_t flags,
                                               uint64_t color_space, emulator_object<emulator_pointer> bits);
@@ -1357,6 +1358,7 @@ namespace sogen
         add_handler(NtGdiRemoveFontMemResourceEx);
         add_handler(NtGdiCreateCompatibleBitmap);
         add_handler(NtGdiCreateBitmap);
+        add_handler(NtGdiGetBitmapBits);
         add_handler(NtGdiCreateDIBitmapInternal);
         add_handler(NtGdiSetDIBitsToDeviceInternal);
         add_handler(NtGdiGetDIBitsInternal);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2803,6 +2803,12 @@ namespace sogen
             return required;
         }
 
+        uint32_t handle_NtGdiGetKerningPairs(const syscall_context&, const hdc /*dc*/, const uint32_t /*pair_count*/,
+                                             const emulator_pointer /*pairs*/)
+        {
+            return 0;
+        }
+
         BOOL handle_NtGdiGetTextExtent(const syscall_context& c, const hdc dc, const emulator_pointer /*text*/, const int32_t char_count,
                                        const emulator_pointer size, const ULONG /*flags*/)
         {

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2005,12 +2005,8 @@ namespace sogen
 
         int32_t handle_NtGdiGetBitmapBits(const syscall_context& c, const handle bitmap, const int32_t count, const emulator_pointer bits)
         {
-            if (bits == 0 || count <= 0)
-            {
-                return 0;
-            }
-
             const auto it = c.proc.gdi_bitmap_surfaces.find(static_cast<uint32_t>(bitmap.bits));
+
             if (it == c.proc.gdi_bitmap_surfaces.end())
             {
                 return 0;
@@ -2018,9 +2014,67 @@ namespace sogen
 
             auto& surface = it->second;
             sync_surface_from_guest_dib(c, surface);
-            const auto byte_count = std::min(static_cast<size_t>(count), surface.pixels.size() * sizeof(uint32_t));
-            c.emu.write_memory(bits, surface.pixels.data(), byte_count);
-            return static_cast<int32_t>(byte_count);
+
+            const uint32_t bpp = surface.guest_bits != 0 ? surface.guest_bpp : 32;
+
+            if (bpp != 24 && bpp != 32)
+            {
+                c.win_emu.log.warn("NtGdiGetBitmapBits: Unsupported bitmap bit depth: %u bpp", bpp);
+                return 0;
+            }
+
+            // GetBitmapBits scanlines are aligned to 16-bit boundaries.
+            const size_t stride = ((static_cast<size_t>(surface.width) * bpp + 15) / 16) * 2;
+
+            const size_t total_size = stride * surface.height;
+
+            if (total_size > static_cast<size_t>((std::numeric_limits<int32_t>::max)()))
+            {
+                return 0;
+            }
+
+            // A null output buffer is a size query.
+            if (bits == 0)
+            {
+                return static_cast<int32_t>(total_size);
+            }
+
+            const size_t copy_size = count < 0 ? total_size : std::min(static_cast<size_t>(count), total_size);
+
+            if (copy_size == 0)
+            {
+                return 0;
+            }
+
+            std::vector<uint8_t> output(total_size, 0);
+
+            for (uint32_t y = 0; y < surface.height; ++y)
+            {
+                const uint32_t source_y = surface.guest_top_down ? y : surface.height - 1 - y;
+
+                const auto* source = surface.pixels.data() + static_cast<size_t>(source_y) * surface.width;
+
+                auto* destination = output.data() + static_cast<size_t>(y) * stride;
+
+                if (bpp == 32)
+                {
+                    std::memcpy(destination, source, static_cast<size_t>(surface.width) * sizeof(uint32_t));
+                }
+                else
+                {
+                    for (uint32_t x = 0; x < surface.width; ++x)
+                    {
+                        const uint32_t pixel = source[x];
+
+                        destination[x * 3 + 0] = static_cast<uint8_t>(pixel);
+                        destination[x * 3 + 1] = static_cast<uint8_t>(pixel >> 8);
+                        destination[x * 3 + 2] = static_cast<uint8_t>(pixel >> 16);
+                    }
+                }
+            }
+
+            c.emu.write_memory(bits, output.data(), copy_size);
+            return static_cast<int32_t>(copy_size);
         }
 
         uint64_t handle_NtGdiCreateDIBSection(const syscall_context& c, const hdc /*dc*/, const uint64_t /*section_app*/,

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2003,6 +2003,26 @@ namespace sogen
             return handle_value;
         }
 
+        int32_t handle_NtGdiGetBitmapBits(const syscall_context& c, const handle bitmap, const int32_t count, const emulator_pointer bits)
+        {
+            if (bits == 0 || count <= 0)
+            {
+                return 0;
+            }
+
+            const auto it = c.proc.gdi_bitmap_surfaces.find(static_cast<uint32_t>(bitmap.bits));
+            if (it == c.proc.gdi_bitmap_surfaces.end())
+            {
+                return 0;
+            }
+
+            auto& surface = it->second;
+            sync_surface_from_guest_dib(c, surface);
+            const auto byte_count = std::min(static_cast<size_t>(count), surface.pixels.size() * sizeof(uint32_t));
+            c.emu.write_memory(bits, surface.pixels.data(), byte_count);
+            return static_cast<int32_t>(byte_count);
+        }
+
         uint64_t handle_NtGdiCreateDIBSection(const syscall_context& c, const hdc /*dc*/, const uint64_t /*section_app*/,
                                               const uint32_t /*offset*/, const emulator_pointer info, const uint32_t /*usage*/,
                                               const uint32_t header_size, const uint32_t /*flags*/, const uint64_t /*color_space*/,

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -2639,8 +2639,9 @@ namespace sogen
                                .italic = true,
                                .supports_arabic_and_hebrew = false},
                 };
-                constexpr std::array<std::pair<BYTE, std::u16string_view>, 9> scripts{
+                constexpr std::array<std::pair<BYTE, std::u16string_view>, 10> scripts{
                     std::pair{static_cast<BYTE>(ANSI_CHARSET), u"Western"sv},
+                    std::pair{static_cast<BYTE>(SHIFTJIS_CHARSET), u"Japanese"sv},
                     std::pair{static_cast<BYTE>(HEBREW_CHARSET), u"Hebrew"sv},
                     std::pair{static_cast<BYTE>(ARABIC_CHARSET), u"Arabic"sv},
                     std::pair{static_cast<BYTE>(GREEK_CHARSET), u"Greek"sv},

--- a/src/windows-emulator/syscalls/locale.cpp
+++ b/src/windows-emulator/syscalls/locale.cpp
@@ -78,6 +78,14 @@ namespace sogen
             return 0x04070407;
         }
 
+        uint64_t handle_NtUserLoadKeyboardLayoutEx(const syscall_context&, const handle /*file*/, const uint32_t /*table_offset*/,
+                                                   const emulator_pointer /*tables*/, const uint64_t /*old_keyboard_layout*/,
+                                                   const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> /*keyboard_layout_id*/,
+                                                   const uint32_t /*new_keyboard_layout*/, const uint32_t /*flags*/)
+        {
+            return 0x04070407;
+        }
+
         uint64_t handle_NtUserGetKeyboardLayout(const syscall_context&, const uint32_t /*thread_id*/)
         {
             return 0x04070407;

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -135,7 +135,7 @@ namespace sogen
                 }
 
                 KEY_FULL_INFORMATION info{};
-                info.ClassOffset = required_size;
+                info.ClassOffset = 0xFFFFFFFFu;
                 info.SubKeys = static_cast<ULONG>(hive_key->key.get_sub_key_count(hive_key->file));
                 info.Values = static_cast<ULONG>(hive_key->key.get_value_count(hive_key->file));
 

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -120,8 +120,47 @@ namespace sogen
 
             if (key_information_class == KeyFullInformation)
             {
-                c.win_emu.log.warn("Unsupported registry class: %X\n", key_information_class);
-                return STATUS_NOT_SUPPORTED;
+                const auto hive_key = c.win_emu.registry.get_hive_key(*key);
+                if (!hive_key.has_value())
+                {
+                    return STATUS_OBJECT_NAME_NOT_FOUND;
+                }
+
+                constexpr auto required_size = offsetof(KEY_FULL_INFORMATION, Class);
+                result_length.write(static_cast<ULONG>(required_size));
+
+                if (required_size > length)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                KEY_FULL_INFORMATION info{};
+                info.ClassOffset = required_size;
+                info.SubKeys = static_cast<ULONG>(hive_key->key.get_sub_key_count(hive_key->file));
+                info.Values = static_cast<ULONG>(hive_key->key.get_value_count(hive_key->file));
+
+                for (size_t i = 0; i < info.SubKeys; ++i)
+                {
+                    const auto* name = hive_key->key.get_sub_key_name(hive_key->file, i);
+                    if (name)
+                    {
+                        info.MaxNameLength = std::max(info.MaxNameLength, static_cast<ULONG>(u8_to_u16(*name).size() * sizeof(char16_t)));
+                    }
+                }
+
+                for (size_t i = 0; i < info.Values; ++i)
+                {
+                    const auto* value = hive_key->key.get_value(hive_key->file, i);
+                    if (value)
+                    {
+                        info.MaxValueNameLength =
+                            std::max(info.MaxValueNameLength, static_cast<ULONG>(u8_to_u16(value->name).size() * sizeof(char16_t)));
+                        info.MaxValueDataLength = std::max(info.MaxValueDataLength, static_cast<ULONG>(value->data.size()));
+                    }
+                }
+
+                c.emu.write_memory(key_information, &info, required_size);
+                return STATUS_SUCCESS;
             }
 
             if (key_information_class == KeyCachedInformation)

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -448,6 +448,38 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_system_pagefile_information(const syscall_context& c, const uint64_t system_information,
+                                                    const uint32_t system_information_length, const emulator_object<uint32_t> return_length)
+        {
+            using info_t = SYSTEM_PAGEFILE_INFORMATION<EmulatorTraits<Emu64>>;
+
+            constexpr std::u16string_view page_file_name{u"\\??\\C:\\pagefile.sys"};
+            constexpr auto page_file_name_size = static_cast<uint32_t>(page_file_name.size() * sizeof(char16_t));
+            constexpr auto required_length = static_cast<uint32_t>(sizeof(info_t)) + page_file_name_size;
+
+            if (return_length)
+            {
+                return_length.write(required_length);
+            }
+
+            if (system_information_length < required_length)
+            {
+                return STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            info_t info{};
+            info.TotalSize = 0x100000;
+            info.TotalInUse = 0x1000;
+            info.PeakUsage = 0x2000;
+            info.PageFileName.Length = page_file_name_size;
+            info.PageFileName.MaximumLength = page_file_name_size;
+            info.PageFileName.Buffer = system_information + sizeof(info);
+
+            c.emu.write_memory(system_information, info);
+            c.emu.write_memory(info.PageFileName.Buffer, page_file_name.data(), page_file_name_size);
+            return STATUS_SUCCESS;
+        }
+
         NTSTATUS handle_NtQuerySystemInformationEx(const syscall_context& c, const uint32_t info_class, const uint64_t input_buffer,
                                                    const uint32_t input_buffer_length, const uint64_t system_information,
                                                    const uint32_t system_information_length, const emulator_object<uint32_t> return_length)
@@ -727,14 +759,14 @@ namespace sogen
                     [&](SYSTEM_EXCEPTION_INFORMATION& info) { memset(&info, 0, sizeof(info)); });
 
             case SystemLookasideInformation:
-            case SystemPageFileInformation:
-                // Variable-length lists we don't model (per-lookaside-list stats / configured page files).
-                // Report an empty set.
                 if (return_length)
                 {
                     return_length.try_write(0);
                 }
                 return STATUS_SUCCESS;
+
+            case SystemPageFileInformation:
+                return handle_system_pagefile_information(c, system_information, system_information_length, return_length);
 
             case SystemMemoryListInformation:
                 return handle_query<SYSTEM_MEMORY_LIST_INFORMATION64>(

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1401,10 +1401,6 @@ namespace sogen
             menu_obj.init_guest();
 
             win.system_menu_handle = menu_obj.handle;
-            win.guest.access([&](USER_WINDOW& guest_win) { //
-                guest_win.spmenu = menu_obj.guest.value();
-            });
-
             return handle.bits;
         }
 
@@ -5486,8 +5482,35 @@ namespace sogen
             return handle.bits;
         }
 
-        BOOL handle_NtUserSetMenu()
+        BOOL handle_NtUserSetMenu(const syscall_context& c, const hwnd hwnd, const hmenu menu, const BOOL redraw)
         {
+            auto* win = c.proc.windows.get(hwnd);
+            if (!win)
+            {
+                set_guest_last_error(c, 1400);
+                return FALSE;
+            }
+
+            emulator_pointer menu_ptr = 0;
+            if (menu != 0)
+            {
+                const auto* menu_obj = c.proc.menus.get(menu);
+                if (!menu_obj)
+                {
+                    set_guest_last_error(c, 1401);
+                    return FALSE;
+                }
+
+                menu_ptr = menu_obj->guest.value();
+            }
+
+            win->guest.access([&](USER_WINDOW& guest_win) { guest_win.spmenu = menu_ptr; });
+
+            if (redraw != FALSE)
+            {
+                invalidate_window(c, *win);
+            }
+
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5579,9 +5579,46 @@ namespace sogen
             return TRUE;
         }
 
-        BOOL handle_NtUserEnableMenuItem()
+        int32_t handle_NtUserEnableMenuItem(const syscall_context& c, const hmenu menu, const UINT item, const UINT enable)
         {
-            return TRUE;
+            auto* menu_object = c.proc.menus.get(menu);
+            if (!menu_object)
+            {
+                return -1;
+            }
+
+            size_t index{};
+            if ((enable & MF_BYPOSITION) != 0)
+            {
+                if (item >= menu_object->items.size())
+                {
+                    return -1;
+                }
+
+                index = item;
+            }
+            else
+            {
+                const auto entry =
+                    std::ranges::find_if(menu_object->items, [&](const menu_item& candidate) { return candidate.id == item; });
+
+                if (entry == menu_object->items.end())
+                {
+                    return -1;
+                }
+
+                index = static_cast<size_t>(std::distance(menu_object->items.begin(), entry));
+            }
+
+            constexpr UINT state_mask = MF_DISABLED | MF_GRAYED;
+
+            auto& menu_item = menu_object->items[index];
+            const UINT previous_state = menu_item.state & state_mask;
+
+            menu_item.state = (menu_item.state & ~state_mask) | (enable & state_mask);
+
+            menu_object->sync_guest_item(c.win_emu.memory, index);
+            return static_cast<int32_t>(previous_state);
         }
 
         BOOL handle_NtUserCreateCaret()
@@ -5687,13 +5724,10 @@ namespace sogen
                 placement.showCmd = SW_SHOWNORMAL;
             }
 
-            // The emulator does not currently maintain separate minimized and
-            // maximized placement coordinates.
+            // TODO: The emulator does not currently maintain separate minimized and
+            //       maximized placement coordinates.
             placement.ptMinPosition = {.x = -1, .y = -1};
             placement.ptMaxPosition = {.x = -1, .y = -1};
-
-            // This is the best available restored rectangle in the current
-            // window model.
             placement.rcNormalPosition = get_window_rect(*win);
 
             if (!c.win_emu.memory.try_write_memory(placement_address, &placement, sizeof(placement)))
@@ -6309,9 +6343,9 @@ namespace sogen
             return TRUE;
         }
 
-        BOOL handle_NtUserVkKeyScanEx()
+        int16_t handle_NtUserVkKeyScanEx()
         {
-            return FALSE;
+            return -1;
         }
 
         BOOL handle_NtUserSetLayeredWindowAttributes()

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1501,6 +1501,8 @@ namespace sogen
         hdc create_gdi_window_dc(const syscall_context& c, hwnd window);
         uint32_t handle_NtGdiDeleteObjectApp(const syscall_context& c, uint32_t handle_value);
         BOOL handle_NtGdiFlush(const syscall_context& c);
+        BOOL handle_NtGdiPatBlt(const syscall_context& c, hdc dc, LONG x, LONG y, LONG width, LONG height, DWORD rop);
+        uint64_t handle_NtGdiSelectBrushLocal(const syscall_context& c, hdc dc, uint32_t brush, emulator_pointer old_brush_ptr);
         gdi_bitmap_surface* get_dc_present_surface(const syscall_context& c, hdc dc, uint32_t& present_handle);
         void draw_system_button_glyph(const syscall_context& c, hdc dc, int x, int y, uint32_t index);
         BOOL handle_NtUserRemoveMenu(const syscall_context& c, hmenu menu, UINT position, UINT flags);
@@ -1769,6 +1771,30 @@ namespace sogen
             });
 
             return brush;
+        }
+
+        BOOL handle_NtUserFillWindow(const syscall_context& c, const hwnd parent_window, const hwnd window, const hdc dc, const hbrush brush)
+        {
+            auto* win = c.proc.windows.get(window);
+            if (dc == 0 || !win || (parent_window != 0 && !c.proc.windows.get(parent_window)))
+            {
+                return FALSE;
+            }
+
+            constexpr hbrush ctlcolor_max = 7;
+            uint64_t control_brush = brush;
+            if (control_brush < ctlcolor_max)
+            {
+                control_brush = handle_NtUserGetControlBrush(c, parent_window, dc, static_cast<uint32_t>(brush));
+            }
+
+            constexpr DWORD patcopy = 0x00F00021;
+            const auto previous_brush = handle_NtGdiSelectBrushLocal(c, dc, static_cast<uint32_t>(control_brush), 0);
+            const auto client_rect = get_client_rect(*win);
+            const auto result = handle_NtGdiPatBlt(c, dc, client_rect.left, client_rect.top, client_rect.right - client_rect.left,
+                                                   client_rect.bottom - client_rect.top, patcopy);
+            handle_NtGdiSelectBrushLocal(c, dc, static_cast<uint32_t>(previous_brush), 0);
+            return result;
         }
 
         BOOL handle_NtUserReleaseDC()

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5587,8 +5587,66 @@ namespace sogen
             return FALSE;
         }
 
-        BOOL handle_NtUserGetWindowPlacement()
+        BOOL handle_NtUserGetWindowPlacement(const syscall_context& c, const hwnd window_handle, const emulator_pointer placement_address)
         {
+            if (placement_address == 0)
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return FALSE;
+            }
+
+            DWORD requested_length{};
+            if (!c.win_emu.memory.try_read_memory(placement_address, &requested_length, sizeof(requested_length)))
+            {
+                set_guest_last_error(c, 998); // ERROR_NOACCESS
+                return FALSE;
+            }
+
+            if (requested_length != sizeof(EMU_WINDOWPLACEMENT))
+            {
+                set_guest_last_error(c, 87); // ERROR_INVALID_PARAMETER
+                return FALSE;
+            }
+
+            const auto* win = c.proc.windows.get(window_handle);
+            if (!win)
+            {
+                set_guest_last_error(c, 1400); // ERROR_INVALID_WINDOW_HANDLE
+                return FALSE;
+            }
+
+            EMU_WINDOWPLACEMENT placement{};
+            placement.length = sizeof(placement);
+            placement.flags = 0;
+
+            if ((win->style & WS_MINIMIZE) != 0)
+            {
+                placement.showCmd = SW_SHOWMINIMIZED;
+            }
+            else if ((win->style & WS_MAXIMIZE) != 0)
+            {
+                placement.showCmd = SW_SHOWMAXIMIZED;
+            }
+            else
+            {
+                placement.showCmd = SW_SHOWNORMAL;
+            }
+
+            // The emulator does not currently maintain separate minimized and
+            // maximized placement coordinates.
+            placement.ptMinPosition = {.x = -1, .y = -1};
+            placement.ptMaxPosition = {.x = -1, .y = -1};
+
+            // This is the best available restored rectangle in the current
+            // window model.
+            placement.rcNormalPosition = get_window_rect(*win);
+
+            if (!c.win_emu.memory.try_write_memory(placement_address, &placement, sizeof(placement)))
+            {
+                set_guest_last_error(c, 998); // ERROR_NOACCESS
+                return FALSE;
+            }
+
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -5555,6 +5555,11 @@ namespace sogen
             return TRUE;
         }
 
+        BOOL handle_NtUserEnableMenuItem()
+        {
+            return TRUE;
+        }
+
         BOOL handle_NtUserCreateCaret()
         {
             return TRUE;
@@ -6268,6 +6273,26 @@ namespace sogen
         BOOL handle_NtUserHwndQueryRedirectionInfo()
         {
             return FALSE;
+        }
+
+        BOOL handle_NtUserEnableNonClientDpiScaling()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserSetImeHotKey()
+        {
+            return TRUE;
+        }
+
+        BOOL handle_NtUserVkKeyScanEx()
+        {
+            return FALSE;
+        }
+
+        BOOL handle_NtUserSetLayeredWindowAttributes()
+        {
+            return TRUE;
         }
     }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1773,7 +1773,8 @@ namespace sogen
             return brush;
         }
 
-        BOOL handle_NtUserFillWindow(const syscall_context& c, const hwnd parent_window, const hwnd window, const hdc dc, const hbrush brush)
+        BOOL handle_NtUserFillWindow(const syscall_context& c, const hwnd parent_window, const hwnd window, const hdc dc,
+                                     const hbrush brush)
         {
             auto* win = c.proc.windows.get(window);
             if (dc == 0 || !win || (parent_window != 0 && !c.proc.windows.get(parent_window)))

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -39,6 +39,8 @@ namespace sogen
                 srv.cHandleEntries = MAX_HANDLES - 1; //
                 srv.defaultFontHeightScale = -11;
                 srv.defaultFontWidthScale = 0;
+                srv.dpi96DialogBaseUnitWidth = 8;
+                srv.dpi96DialogBaseUnitHeight = 16;
                 srv.systemDpi = 96;
                 srv.systemMetrics[0] = 1920;  // SM_CXSCREEN
                 srv.systemMetrics[1] = 1080;  // SM_CYSCREEN

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -41,6 +41,7 @@ namespace sogen
                 srv.defaultFontWidthScale = 0;
                 srv.dpi96DialogBaseUnitWidth = 8;
                 srv.dpi96DialogBaseUnitHeight = 16;
+                srv.asyncKeyStateGeneration = 1;
                 srv.systemDpi = 96;
                 srv.systemMetrics[0] = 1920;  // SM_CXSCREEN
                 srv.systemMetrics[1] = 1080;  // SM_CYSCREEN


### PR DESCRIPTION
This PR does the following improvements to Sogen:

- [Implements `NtUserSetMenu`.](https://github.com/momo5502/sogen/pull/1268/commits/653579b3ef215444ebca9690fb08f7d25a9b23ca)
- [Implements `NtUserLoadKeyboardLayoutEx`.](https://github.com/momo5502/sogen/commit/8d8b22b225690822a71d921630227bcb07acfdb7)
- [Fixes dialog base-unit reporting.](https://github.com/momo5502/sogen/commit/e1c7dee9866e2ef442e6196ccd0aecec142c8391)
- [Implements `NtAllocateUuids`.](https://github.com/momo5502/sogen/commit/031e470272f0b8ed3ed636f1b6018912d80b74bf)
- [Implements `NtGdiGetBitmapBits`.](https://github.com/momo5502/sogen/commit/4c9f95c3dd2cc931c4d72fd7a2bc7cee34208486)
- [Implements `NtUserGetWindowPlacement`.](https://github.com/momo5502/sogen/commit/e6dc886abc6156180b386af1c9407bafbe7802a0)
- [Fixes `GetAsyncKeyState` handling for key codes below `0x20`.](https://github.com/momo5502/sogen/commit/44db393f68cb2ab4d1d81ff1ada3c4d3bed34d18)
- [Implements `NtUserFillWindow`.](https://github.com/momo5502/sogen/commit/1805b85faa64d45e1824a8173202e43147524666)
- [Adds support for `SystemPageFileInformation` in `NtQuerySystemInformation`.](https://github.com/momo5502/sogen/commit/71b2e02c47d7408098192e120e9108e04c52782a)
- [Implements `KeyFullInformation` registry-key queries.](https://github.com/momo5502/sogen/commit/0836a1323b73d2ea831ccf2a6c92bbaa17547d86)
- [Adds the Shift JIS charset to `NtGdiEnumFonts`.](https://github.com/momo5502/sogen/commit/ca78cce5249eb2da1203ff162270843104e665b0)
- [Adds additional syscall stubs.](https://github.com/momo5502/sogen/commit/c3e8272d6b371e9ce10f462db7e47b8914690e0d)